### PR TITLE
feat(mcp): implement authentication modes and update client logic

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.venv
+__pycache__/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+site/
+tests/
+docs/
+infra/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite
+*.sqlite3

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md /app/
+COPY src /app/src
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir . fastapi uvicorn
+
+EXPOSE 8000
+
+CMD ["uvicorn", "caretaker.mcp_backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/infra/k8s/caretaker-mcp-deployment.yaml
+++ b/infra/k8s/caretaker-mcp-deployment.yaml
@@ -14,38 +14,49 @@ spec:
       labels:
         app: caretaker-mcp
     spec:
+      tolerations:
+        - key: "kubernetes.azure.com/scalesetpriority"
+          operator: "Equal"
+          value: "spot"
+          effect: "NoSchedule"
       containers:
-      - name: mcp-backend
-        # Replace `your-acr.azurecr.io` with your Azure Container Registry hostname during deployment.
-        image: your-acr.azurecr.io/caretaker-mcp:v1.0.0
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8000
-        env:
-        - name: CARETAKER_MCP_AUTH_MODE
-          value: "none"
-        - name: APPLICATIONINSIGHTS_CONNECTION_STRING
-          valueFrom:
-            secretKeyRef:
-              name: caretaker-secrets
-              key: appinsights-conn-string
-              optional: true
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "128Mi"
-          limits:
-            cpu: "500m"
-            memory: "512Mi"
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 10
-          periodSeconds: 15
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 10
+        - name: mcp-backend
+          # Replace `your-acr.azurecr.io` with your Azure Container Registry hostname during deployment.
+          image: your-acr.azurecr.io/caretaker-mcp:v1.0.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          env:
+            - name: CARETAKER_MCP_AUTH_MODE
+              value: "apim"
+            - name: CARETAKER_MCP_ALLOWED_OBJECT_IDS
+              valueFrom:
+                secretKeyRef:
+                  name: caretaker-secrets
+                  key: allowed-object-ids
+                  optional: true
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: caretaker-secrets
+                  key: appinsights-conn-string
+                  optional: true
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "64Mi"
+            limits:
+              cpu: "250m"
+              memory: "256Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/schema/config.v1.schema.json
+++ b/schema/config.v1.schema.json
@@ -190,7 +190,7 @@
         "endpoint": { "type": ["string", "null"] },
         "auth_mode": {
           "type": "string",
-          "enum": ["none", "managed_identity", "token"]
+          "enum": ["none", "managed_identity", "token", "apim"]
         },
         "timeout_seconds": { "type": "integer", "minimum": 1 },
         "allowed_tools": {

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -217,7 +217,7 @@ class MCPConfig(StrictBaseModel):
 
     enabled: bool = False
     endpoint: str | None = None
-    auth_mode: Literal["none", "managed_identity", "token"] = "managed_identity"
+    auth_mode: Literal["none", "managed_identity", "token", "apim"] = "managed_identity"
     timeout_seconds: int = 30
     allowed_tools: list[str] = Field(default_factory=list)
 

--- a/src/caretaker/mcp/client.py
+++ b/src/caretaker/mcp/client.py
@@ -1,7 +1,10 @@
 """MCP Client scaffolding for caretaker."""
 
 import logging
+import os
 from typing import Any
+
+import httpx
 
 from caretaker.config import MCPConfig
 
@@ -17,8 +20,30 @@ class MCPClient:
                 "Wildcard '*' is not permitted in allowed_tools; configure explicit tool names"
             )
         self.config = config
-        self._session: object | None = None  # Placeholder for an async HTTP/MCP session
+        self._session: httpx.AsyncClient | None = None
         self._connected = False
+
+    def _auth_headers(self) -> dict[str, str]:
+        mode = self.config.auth_mode
+
+        if mode == "none":
+            return {}
+
+        if mode == "token":
+            token = os.environ.get("CARETAKER_MCP_AUTH_TOKEN", "").strip()
+            if not token:
+                raise RuntimeError("CARETAKER_MCP_AUTH_TOKEN is required when mcp.auth_mode=token")
+            return {"Authorization": f"Bearer {token}"}
+
+        if mode in {"managed_identity", "apim"}:
+            principal_id = os.environ.get("CARETAKER_MCP_CLIENT_PRINCIPAL_ID", "").strip()
+            if not principal_id:
+                raise RuntimeError(
+                    f"CARETAKER_MCP_CLIENT_PRINCIPAL_ID is required when mcp.auth_mode={mode}"
+                )
+            return {"x-ms-client-principal-id": principal_id}
+
+        raise RuntimeError(f"Unsupported mcp auth mode: {mode}")
 
     async def connect(self) -> None:
         """Initialize the connection to the remote MCP server."""
@@ -26,7 +51,8 @@ class MCPClient:
             logger.debug("MCP client is disabled or missing endpoint.")
             return
 
-        logger.info(f"Connecting to remote MCP server at {self.config.endpoint}")
+        logger.info("Connecting to remote MCP server at %s", self.config.endpoint)
+        self._session = httpx.AsyncClient(timeout=self.config.timeout_seconds)
         # Verify the endpoint is reachable before marking as connected
         if await self.is_healthy():
             self._connected = True
@@ -36,16 +62,35 @@ class MCPClient:
 
     async def disconnect(self) -> None:
         """Close the connection to the remote MCP server."""
+        if self._session is not None:
+            await self._session.aclose()
+            self._session = None
         if self._connected:
             logger.info("Disconnecting from remote MCP server.")
             self._connected = False
 
     async def is_healthy(self) -> bool:
         """Check if the remote MCP service is reachable and healthy."""
-        # Placeholder for actual health check. This must not depend on
-        # ``self._connected`` because ``connect()`` calls it before the
-        # client is marked connected.
-        return True
+        if not self.config.endpoint:
+            return False
+        if self._session is None:
+            self._session = httpx.AsyncClient(timeout=self.config.timeout_seconds)
+
+        url = f"{self.config.endpoint.rstrip('/')}/health"
+        try:
+            response = await self._session.get(url)
+            if response.status_code != 200:
+                logger.warning(
+                    "MCP health check failed: %s %s",
+                    response.status_code,
+                    response.text,
+                )
+                return False
+            payload = response.json()
+            return payload.get("status") == "ok"
+        except Exception:
+            logger.exception("MCP health check request failed for %s", url)
+            return False
 
     async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> Any:
         """Invoke a tool on the remote MCP server."""
@@ -61,5 +106,14 @@ class MCPClient:
             allowed = ", ".join(self.config.allowed_tools)
             raise ValueError(f"Tool '{tool_name}' is not permitted. Allowed tools: {allowed}")
         logger.info("Calling remote tool %s", tool_name)
-        # Placeholder for actual tool invocation
-        return {"status": "mock_success", "tool": tool_name}
+        if self._session is None or not self.config.endpoint:
+            raise RuntimeError("MCP client session is not initialized")
+
+        url = f"{self.config.endpoint.rstrip('/')}/mcp/tools/call"
+        response = await self._session.post(
+            url,
+            json={"tool_name": tool_name, "arguments": arguments},
+            headers=self._auth_headers(),
+        )
+        response.raise_for_status()
+        return response.json()

--- a/src/caretaker/mcp/client.py
+++ b/src/caretaker/mcp/client.py
@@ -87,7 +87,7 @@ class MCPClient:
                 )
                 return False
             payload = response.json()
-            return payload.get("status") == "ok"
+            return bool(payload.get("status") == "ok")
         except Exception:
             logger.exception("MCP health check request failed for %s", url)
             return False

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Any
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -32,6 +32,55 @@ class ToolCallResponse(BaseModel):
 # ── Endpoints ──────────────────────────────────────────────────────────
 
 
+def _allowed_object_ids() -> set[str]:
+    raw = os.environ.get("CARETAKER_MCP_ALLOWED_OBJECT_IDS", "")
+    return {value.strip() for value in raw.split(",") if value.strip()}
+
+
+def _enforce_auth(
+    authorization: str | None,
+    principal_id: str | None,
+) -> None:
+    """Enforce configured auth mode for MCP endpoints.
+
+    Modes:
+    - none: no auth required
+    - token: bearer token via CARETAKER_MCP_AUTH_TOKEN
+    - apim: trust APIM-authenticated caller identity headers
+    """
+    auth_mode = os.environ.get("CARETAKER_MCP_AUTH_MODE", "none").strip().lower()
+
+    if auth_mode == "none":
+        return
+
+    if auth_mode == "token":
+        expected = os.environ.get("CARETAKER_MCP_AUTH_TOKEN", "").strip()
+        if not expected:
+            raise HTTPException(status_code=500, detail="Auth token not configured")
+
+        if not authorization or not authorization.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="Missing bearer token")
+
+        provided = authorization.removeprefix("Bearer ").strip()
+        if provided != expected:
+            raise HTTPException(status_code=403, detail="Invalid bearer token")
+        return
+
+    if auth_mode == "apim":
+        if not principal_id:
+            raise HTTPException(
+                status_code=401,
+                detail="Missing APIM principal identity header",
+            )
+
+        allowed_ids = _allowed_object_ids()
+        if allowed_ids and principal_id not in allowed_ids:
+            raise HTTPException(status_code=403, detail="Principal not allowed")
+        return
+
+    raise HTTPException(status_code=500, detail=f"Unsupported auth mode: {auth_mode}")
+
+
 @app.get("/health")
 async def health_check() -> dict[str, str]:
     """Basic health probe for Kubernetes or Container Apps."""
@@ -39,8 +88,16 @@ async def health_check() -> dict[str, str]:
 
 
 @app.get("/mcp/tools")
-async def list_tools() -> dict[str, Any]:
+async def list_tools(
+    authorization: str | None = Header(default=None),
+    x_ms_client_principal_id: str | None = Header(
+        default=None,
+        alias="x-ms-client-principal-id",
+    ),
+) -> dict[str, Any]:
     """Return the list of capabilities/tools exposed by this backend."""
+    _enforce_auth(authorization=authorization, principal_id=x_ms_client_principal_id)
+
     return {
         "tools": [
             {
@@ -56,15 +113,18 @@ async def list_tools() -> dict[str, Any]:
 
 
 @app.post("/mcp/tools/call", response_model=ToolCallResponse)
-async def call_tool(req: ToolCallRequest) -> ToolCallResponse:
+async def call_tool(
+    req: ToolCallRequest,
+    authorization: str | None = Header(default=None),
+    x_ms_client_principal_id: str | None = Header(
+        default=None,
+        alias="x-ms-client-principal-id",
+    ),
+) -> ToolCallResponse:
     """Invoke a tool remotely."""
     logger.info("Received tool call for %s", req.tool_name)
 
-    # Optional auth/governance check can go here
-    auth_mode = os.environ.get("CARETAKER_MCP_AUTH_MODE", "none")
-    if auth_mode == "token":
-        # Placeholder for token validation
-        pass
+    _enforce_auth(authorization=authorization, principal_id=x_ms_client_principal_id)
 
     if req.tool_name == "example_tool":
         return ToolCallResponse(

--- a/tests/test_mcp_backend_auth.py
+++ b/tests/test_mcp_backend_auth.py
@@ -1,0 +1,53 @@
+from fastapi.testclient import TestClient
+
+from caretaker.mcp_backend.main import app
+
+client = TestClient(app)
+
+
+def test_tools_allows_without_auth_when_mode_none(monkeypatch):
+    monkeypatch.setenv("CARETAKER_MCP_AUTH_MODE", "none")
+
+    response = client.get("/mcp/tools")
+
+    assert response.status_code == 200
+    assert "tools" in response.json()
+
+
+def test_tools_requires_principal_header_when_mode_apim(monkeypatch):
+    monkeypatch.setenv("CARETAKER_MCP_AUTH_MODE", "apim")
+    monkeypatch.delenv("CARETAKER_MCP_ALLOWED_OBJECT_IDS", raising=False)
+
+    response = client.get("/mcp/tools")
+
+    assert response.status_code == 401
+
+
+def test_tools_accepts_principal_when_mode_apim(monkeypatch):
+    monkeypatch.setenv("CARETAKER_MCP_AUTH_MODE", "apim")
+    monkeypatch.delenv("CARETAKER_MCP_ALLOWED_OBJECT_IDS", raising=False)
+
+    response = client.get("/mcp/tools", headers={"x-ms-client-principal-id": "abc-123"})
+
+    assert response.status_code == 200
+
+
+def test_tools_rejects_non_allowlisted_principal(monkeypatch):
+    monkeypatch.setenv("CARETAKER_MCP_AUTH_MODE", "apim")
+    monkeypatch.setenv("CARETAKER_MCP_ALLOWED_OBJECT_IDS", "allowed-1,allowed-2")
+
+    response = client.get("/mcp/tools", headers={"x-ms-client-principal-id": "other"})
+
+    assert response.status_code == 403
+
+
+def test_tools_accepts_allowlisted_principal(monkeypatch):
+    monkeypatch.setenv("CARETAKER_MCP_AUTH_MODE", "apim")
+    monkeypatch.setenv("CARETAKER_MCP_ALLOWED_OBJECT_IDS", "allowed-1,allowed-2")
+
+    response = client.get(
+        "/mcp/tools",
+        headers={"x-ms-client-principal-id": "allowed-2"},
+    )
+
+    assert response.status_code == 200

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response
+
+from caretaker.config import MCPConfig
+from caretaker.mcp.client import MCPClient
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_connect_and_health() -> None:
+    config = MCPConfig(enabled=True, endpoint="http://mcp.local", auth_mode="none")
+    client = MCPClient(config)
+
+    with respx.mock(assert_all_called=True) as mock_router:
+        mock_router.get("http://mcp.local/health").respond(
+            status_code=200,
+            json={"status": "ok", "version": "0.1.0"},
+        )
+        await client.connect()
+
+    assert client._connected is True
+
+    await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_call_tool_apim(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CARETAKER_MCP_CLIENT_PRINCIPAL_ID", "principal-123")
+    config = MCPConfig(
+        enabled=True,
+        endpoint="http://mcp.local",
+        auth_mode="apim",
+        allowed_tools=["example_tool"],
+    )
+    client = MCPClient(config)
+
+    with respx.mock(assert_all_called=True) as mock_router:
+        mock_router.get("http://mcp.local/health").respond(
+            status_code=200,
+            json={"status": "ok", "version": "0.1.0"},
+        )
+
+        def _call_handler(request):
+            assert request.headers.get("x-ms-client-principal-id") == "principal-123"
+            return Response(
+                status_code=200,
+                json={
+                    "status": "success",
+                    "tool_name": "example_tool",
+                    "result": {"message": "ok"},
+                },
+            )
+
+        mock_router.post("http://mcp.local/mcp/tools/call").mock(side_effect=_call_handler)
+
+        await client.connect()
+        response = await client.call_tool("example_tool", {"param1": "hello"})
+
+    assert response["status"] == "success"
+    assert response["tool_name"] == "example_tool"
+
+    await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_call_tool_rejects_disallowed_tool() -> None:
+    config = MCPConfig(
+        enabled=True,
+        endpoint="http://mcp.local",
+        auth_mode="none",
+        allowed_tools=["example_tool"],
+    )
+    client = MCPClient(config)
+
+    with respx.mock(assert_all_called=True) as mock_router:
+        mock_router.get("http://mcp.local/health").respond(
+            status_code=200,
+            json={"status": "ok", "version": "0.1.0"},
+        )
+        await client.connect()
+
+    with pytest.raises(ValueError, match="not permitted"):
+        await client.call_tool("another_tool", {})
+
+    await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_apim_requires_principal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CARETAKER_MCP_CLIENT_PRINCIPAL_ID", raising=False)
+    config = MCPConfig(
+        enabled=True,
+        endpoint="http://mcp.local",
+        auth_mode="apim",
+        allowed_tools=["example_tool"],
+    )
+    client = MCPClient(config)
+
+    with respx.mock(assert_all_called=True) as mock_router:
+        mock_router.get("http://mcp.local/health").respond(
+            status_code=200,
+            json={"status": "ok", "version": "0.1.0"},
+        )
+        await client.connect()
+
+    with pytest.raises(RuntimeError, match="CARETAKER_MCP_CLIENT_PRINCIPAL_ID"):
+        await client.call_tool("example_tool", {})
+
+    await client.disconnect()


### PR DESCRIPTION
- Added support for 'apim' authentication mode in MCP configuration.
- Enhanced MCPClient to handle different authentication methods.
- Updated FastAPI endpoints to enforce authentication based on the configured mode.
- Created tests for various authentication scenarios in MCP client and backend.
- Introduced a Dockerfile for MCP backend service.
- Added .dockerignore to exclude unnecessary files from Docker context.