### PR TITLE
feat(docs_agent): skip changelog update if entry for the week already

### DIFF
--- a/src/caretaker/docs_agent/agent.py
+++ b/src/caretaker/docs_agent/agent.py
@@ -99,6 +99,7 @@ class DocsAgent:
             return report
 
         # Build changelog entry
+        week_str = datetime.now(UTC).strftime("%Y-W%V")
         changelog_entry = _build_changelog_entry(merged_prs)
 
         # Get current CHANGELOG.md contents
@@ -109,13 +110,19 @@ class DocsAgent:
             current_content = ""
             current_sha = None
 
+        # Guard: if this week's heading is already committed, nothing to do.
+        if f"## [{week_str}]" in current_content:
+            logger.info(
+                "Docs agent: CHANGELOG already has entry for %s — skipping", week_str
+            )
+            return report
+
         new_content = _prepend_changelog_entry(current_content, changelog_entry)
         if new_content == current_content:
             logger.info("Docs agent: changelog already up to date")
             return report
 
         # Create a branch and commit the update
-        week_str = datetime.now(UTC).strftime("%Y-W%V")
         branch_name = f"docs/changelog-{week_str}"
 
         skip_file_write = False

--- a/src/caretaker/docs_agent/agent.py
+++ b/src/caretaker/docs_agent/agent.py
@@ -112,9 +112,7 @@ class DocsAgent:
 
         # Guard: if this week's heading is already committed, nothing to do.
         if f"## [{week_str}]" in current_content:
-            logger.info(
-                "Docs agent: CHANGELOG already has entry for %s — skipping", week_str
-            )
+            logger.info("Docs agent: CHANGELOG already has entry for %s — skipping", week_str)
             return report
 
         new_content = _prepend_changelog_entry(current_content, changelog_entry)

--- a/src/caretaker/upgrade_agent/planner.py
+++ b/src/caretaker/upgrade_agent/planner.py
@@ -191,8 +191,10 @@ class UpgradePlanner:
         target: Release,
     ) -> int:
         """Create an upgrade issue and return its number."""
-        # Check if an upgrade issue already exists for this version
-        issues = await self._issues.list()
+        # Check if an upgrade issue already exists for this version (open or closed).
+        # Using state="all" prevents re-creating the issue when a previous attempt was
+        # closed without completing the upgrade, which would spawn duplicate Copilot PRs.
+        issues = await self._issues.list(state="all")
         for issue in issues:
             if f"Upgrade to v{target.version}" in issue.title and issue.is_maintainer_issue:
                 logger.info(

--- a/tests/test_docs_agent.py
+++ b/tests/test_docs_agent.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -177,6 +179,31 @@ class TestDocsAgentRun:
 
         # should return the existing PR number, not create a new one
         assert report.doc_pr_opened == 55
+        gh.create_pull_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_changelog_already_has_week_entry(self) -> None:
+        """If CHANGELOG.md already contains this week's ## heading, no new PR is opened."""
+        week_str = datetime.now(UTC).strftime("%Y-W%V")
+        changelog_with_entry = f"# Changelog\n\n## [{week_str}] — 2026-01-01\n- some entry\n"
+
+        merged = [_pr(10, "feat: cool feature", merged_at="2024-01-10T12:00:00+00:00")]
+        gh = make_github()
+        # Simulate the CHANGELOG already containing the week heading
+        gh.get_file_contents.return_value = {
+            "content": base64.b64encode(changelog_with_entry.encode()).decode(),
+            "sha": "existingsha",
+        }
+        agent = DocsAgent(github=gh, owner="o", repo="r")
+
+        with (
+            patch.object(agent, "_get_recently_merged_prs", return_value=merged),
+            patch.object(agent, "_find_open_docs_prs", return_value=[]),
+        ):
+            report = await agent.run()
+
+        assert report.doc_pr_opened is None
+        assert report.changelog_updated is False
         gh.create_pull_request.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/test_upgrade_agent/test_planner.py
+++ b/tests/test_upgrade_agent/test_planner.py
@@ -73,6 +73,35 @@ class TestUpgradePlanner:
         assert number == 10
         github.create_issue.assert_not_called()
 
+    async def test_does_not_recreate_issue_when_previous_is_closed(self) -> None:
+        """A closed upgrade issue for this version must prevent a new one being opened.
+
+        This is the root cause of the duplicate-Copilot-PR problem: when an
+        upgrade issue was closed (e.g. the PR failed) caretaker previously
+        ignored it and created a fresh issue, causing @copilot to open yet
+        another PR.  With state="all" in the issues query the closed issue is
+        found and re-used instead.
+        """
+        github = AsyncMock()
+        planner = UpgradePlanner(github=github, owner="o", repo="r")
+        target = Release(
+            version="1.5.0",
+            min_compatible="1.0.0",
+            changelog_url="https://example.com/changelog",
+        )
+        closed_issue = make_issue(10, "Upgrade to v1.5.0", maintainer=True)
+        closed_issue.state = "closed"
+        github.list_issues.return_value = [closed_issue]
+
+        number = await planner.create_upgrade_issue("1.4.0", target)
+
+        assert number == 10
+        github.create_issue.assert_not_called()
+        # Confirm the query was made with state="all"
+        github.list_issues.assert_awaited_once()
+        call_kwargs = github.list_issues.call_args.kwargs
+        assert call_kwargs.get("state") == "all"
+
     async def test_creates_new_issue_for_upgrade(self) -> None:
         github = AsyncMock()
         planner = UpgradePlanner(github=github, owner="o", repo="r")


### PR DESCRIPTION
This pull request introduces important improvements to both the docs changelog automation and the upgrade issue creation logic. It ensures that duplicate changelog entries and upgrade issues are not created, and adds comprehensive tests to verify this behavior.

**Docs changelog automation:**

* Added a guard in `DocsAgent` to skip updating `CHANGELOG.md` if this week's heading already exists, preventing duplicate weekly entries. [[1]](diffhunk://#diff-14ad1b1f74e6d8ddc877cd8bf8a46022f7dd4093d97cbbe2aa4ab52ab77c04ecR102) [[2]](diffhunk://#diff-14ad1b1f74e6d8ddc877cd8bf8a46022f7dd4093d97cbbe2aa4ab52ab77c04ecR113-L118)
* Added a new test `test_skips_when_changelog_already_has_week_entry` to verify that no new PR is created if the changelog already contains the current week's entry.
* Added necessary imports in the test file for date handling and base64 encoding.

**Upgrade issue creation:**

* Changed the upgrade planner to query issues with `state="all"` (including closed issues), ensuring that a new upgrade issue is not created if a closed one already exists for the same version. This prevents duplicate Copilot PRs.
* Added a test `test_does_not_recreate_issue_when_previous_is_closed` to confirm that closed upgrade issues are detected and reused, and that the issues query includes `state="all"`.… exists

fix(upgrade_agent): prevent duplicate upgrade issues by checking closed state