### PR TITLE
chore: bump version to 0.6.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caretaker"
-version = "0.6.4"
+version = "0.6.5"
 description = "Autonomous GitHub repository maintenance powered by Copilot"
 readme = "README.md"
 license = "MIT"

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,13 @@
 {
   "releases": [
     {
+      "version": "0.6.5",
+      "min_compatible": "0.6.5",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.6.5",
+      "upgrade_notes": "Update to 0.6.5.",
+      "breaking": false
+    },
+    {
       "version": "0.6.4",
       "min_compatible": "0.6.4",
       "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.6.4",

--- a/src/caretaker/__init__.py
+++ b/src/caretaker/__init__.py
@@ -1,3 +1,3 @@
 """caretaker: Autonomous GitHub repository maintenance powered by Copilot."""
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"


### PR DESCRIPTION
Automated version bump to 0.6.5 triggered by the release workflow.