### PR TITLE
Ghapps

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -72,10 +72,17 @@ jobs:
         run: |
           pip install .
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CARETAKER_APP_ID }}
+          private-key: ${{ secrets.CARETAKER_APP_PRIVATE_KEY }}
+
       - name: Run
         id: caretaker_run
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Fine-grained PAT for a real write-capable user or machine user.
           # Caretaker uses this for Copilot issue assignment and @copilot comments
           # that must not be authored as github-actions[bot].
@@ -127,9 +134,16 @@ jobs:
       - name: Install caretaker (dogfood)
         run: pip install .
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CARETAKER_APP_ID }}
+          private-key: ${{ secrets.CARETAKER_APP_PRIVATE_KEY }}
+
       - name: Self-heal — analyse own failure
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Fine-grained PAT for a real write-capable user or machine user.
           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ Thumbs.db
 site/
 .gitignore
 .caretaker-memory.db*
-.pem
+*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Thumbs.db
 site/
 .gitignore
 .caretaker-memory.db*
+.pem

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -116,10 +116,16 @@ class GitHubClient:
         return resp.json()
 
     async def _request(self, method: str, path: str, **kwargs: Any) -> Any:
-        return await self._request_with_client(self._client, method, path, **kwargs)
+        token = await self._creds.default_token()
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = f"Bearer {token}"
+        return await self._request_with_client(self._client, method, path, headers=headers, **kwargs)
 
     async def _copilot_request(self, method: str, path: str, **kwargs: Any) -> Any:
-        return await self._request_with_client(self._copilot_client, method, path, **kwargs)
+        token = await self._creds.copilot_token()
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = f"Bearer {token}"
+        return await self._request_with_client(self._client, method, path, headers=headers, **kwargs)
 
     async def _get(self, path: str, **kwargs: Any) -> Any:
         cache_key = self._make_cache_key(path, kwargs)

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -50,27 +50,25 @@ class GitHubClient:
         self,
         token: str | None = None,
         copilot_token: str | None = None,
+        credentials_provider: GitHubCredentialsProvider | None = None,
     ) -> None:
-        self._token = token or os.environ.get("GITHUB_TOKEN") or os.environ.get("COPILOT_PAT", "")
-        if not self._token:
-            raise ValueError("GITHUB_TOKEN or COPILOT_PAT is required")
-        self._copilot_token = copilot_token or os.environ.get("COPILOT_PAT") or self._token
-        self._client = self._build_client(self._token)
-        self._copilot_client = (
-            self._client
-            if self._copilot_token == self._token
-            else self._build_client(self._copilot_token)
-        )
+        if credentials_provider is not None:
+            self._creds: GitHubCredentialsProvider = credentials_provider
+        else:
+            # Backward-compat: wrap string tokens or fall back to env vars.
+            self._creds = EnvCredentialsProvider(
+                default_token=token, copilot_token=copilot_token
+            )
+        self._client = self._build_client()
         # In-process read cache: avoids redundant GET calls within a single run.
         # Keys are "path?param=value&..." strings; values are parsed JSON responses.
         self._read_cache: dict[str, Any] = {}
 
     @staticmethod
-    def _build_client(token: str) -> httpx.AsyncClient:
+    def _build_client() -> httpx.AsyncClient:
         return httpx.AsyncClient(
             base_url=API_BASE,
             headers={
-                "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
                 "X-GitHub-Api-Version": "2022-11-28",
             },
@@ -78,8 +76,6 @@ class GitHubClient:
         )
 
     async def close(self) -> None:
-        if self._copilot_client is not self._client:
-            await self._copilot_client.aclose()
         await self._client.aclose()
 
     async def __aenter__(self) -> GitHubClient:

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -56,9 +56,7 @@ class GitHubClient:
             self._creds: GitHubCredentialsProvider = credentials_provider
         else:
             # Backward-compat: wrap string tokens or fall back to env vars.
-            self._creds = EnvCredentialsProvider(
-                default_token=token, copilot_token=copilot_token
-            )
+            self._creds = EnvCredentialsProvider(default_token=token, copilot_token=copilot_token)
         self._client = self._build_client()
         # In-process read cache: avoids redundant GET calls within a single run.
         # Keys are "path?param=value&..." strings; values are parsed JSON responses.
@@ -119,13 +117,17 @@ class GitHubClient:
         token = await self._creds.default_token()
         headers = kwargs.pop("headers", {})
         headers["Authorization"] = f"Bearer {token}"
-        return await self._request_with_client(self._client, method, path, headers=headers, **kwargs)
+        return await self._request_with_client(
+            self._client, method, path, headers=headers, **kwargs
+        )
 
     async def _copilot_request(self, method: str, path: str, **kwargs: Any) -> Any:
         token = await self._creds.copilot_token()
         headers = kwargs.pop("headers", {})
         headers["Authorization"] = f"Bearer {token}"
-        return await self._request_with_client(self._client, method, path, headers=headers, **kwargs)
+        return await self._request_with_client(
+            self._client, method, path, headers=headers, **kwargs
+        )
 
     async def _get(self, path: str, **kwargs: Any) -> Any:
         cache_key = self._make_cache_key(path, kwargs)
@@ -408,7 +410,11 @@ class GitHubClient:
 
     async def approve_workflow_run(self, owner: str, repo: str, run_id: int) -> bool:
         """Approve a workflow run for a fork pull request."""
-        response = await self._client.post(f"/repos/{owner}/{repo}/actions/runs/{run_id}/approve")
+        token = await self._creds.default_token()
+        response = await self._client.post(
+            f"/repos/{owner}/{repo}/actions/runs/{run_id}/approve",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         if response.status_code == 404:
             return False
         if response.status_code == 204:

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode
 
@@ -14,6 +13,7 @@ from caretaker.tools.github import CopilotAgentAssignment
 if TYPE_CHECKING:
     from caretaker.tools.github import GitHubRepositoryTools
 
+from .credentials import EnvCredentialsProvider, GitHubCredentialsProvider
 from .models import (
     CheckRun,
     Comment,

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -13,7 +13,9 @@ from caretaker import __version__
 from caretaker.agent_protocol import AgentContext
 from caretaker.agents import EVENT_AGENT_MAP, build_registry
 from caretaker.config import MaintainerConfig
+from caretaker.github_app import AppJWTSigner, GitHubAppCredentialsProvider, InstallationTokenMinter
 from caretaker.github_client.api import GitHubClient
+from caretaker.github_client.credentials import ChainCredentialsProvider, EnvCredentialsProvider
 from caretaker.goals.definitions import build_goals
 from caretaker.goals.engine import GoalContext, GoalEngine
 from caretaker.llm.router import LLMRouter
@@ -63,6 +65,72 @@ def _extract_pr_number(event_type: str, payload: dict[str, Any]) -> int | None:
     except (KeyError, TypeError, ValueError):
         pass
     return None
+
+
+def _build_credentials_provider(
+    config: MaintainerConfig,
+) -> EnvCredentialsProvider | ChainCredentialsProvider | GitHubAppCredentialsProvider:
+    """Build the appropriate credentials provider based on config and environment.
+
+    When ``config.github_app.enabled`` is ``True`` and the required env vars
+    are present, returns a :class:`GitHubAppCredentialsProvider` that mints
+    short-lived installation tokens on demand.  A :class:`ChainCredentialsProvider`
+    wraps the App provider with an :class:`EnvCredentialsProvider` fallback so
+    existing ``GITHUB_TOKEN`` / ``COPILOT_PAT`` workflows continue to work
+    during roll-out.
+
+    ``COPILOT_PAT`` is forwarded to the App provider as a ``user_token_supplier``
+    so that Copilot assignment (which still requires a user identity) keeps
+    working when the PAT is configured.
+    """
+    app_cfg = config.github_app
+    if not app_cfg.enabled:
+        return EnvCredentialsProvider()
+
+    # Resolve App ID: prefer env var override, fall back to config value.
+    app_id_str = os.environ.get("CARETAKER_GITHUB_APP_ID", "")
+    app_id: int | None = int(app_id_str) if app_id_str.isdigit() else app_cfg.app_id
+    private_key = os.environ.get(app_cfg.private_key_env, "")
+    installation_id_str = os.environ.get("CARETAKER_GITHUB_APP_INSTALLATION_ID", "")
+
+    if not app_id or not private_key or not installation_id_str.isdigit():
+        logger.warning(
+            "github_app.enabled=true but required env vars are missing "
+            "(CARETAKER_GITHUB_APP_ID / %s / CARETAKER_GITHUB_APP_INSTALLATION_ID). "
+            "Falling back to GITHUB_TOKEN / COPILOT_PAT.",
+            app_cfg.private_key_env,
+        )
+        return EnvCredentialsProvider()
+
+    installation_id = int(installation_id_str)
+    signer = AppJWTSigner(app_id=app_id, private_key_pem=private_key)
+    minter = InstallationTokenMinter(
+        signer=signer,
+        refresh_skew_seconds=app_cfg.installation_token_refresh_skew_seconds,
+    )
+
+    # Use COPILOT_PAT as a user-identity token for Copilot assignment when set.
+    async def _copilot_pat_supplier(_installation_id: int) -> str:
+        return os.environ.get("COPILOT_PAT", "")
+
+    app_provider = GitHubAppCredentialsProvider(
+        minter=minter,
+        default_installation_id=installation_id,
+        user_token_supplier=_copilot_pat_supplier,
+    )
+    logger.info(
+        "Using GitHub App credentials (app_id=%s, installation_id=%s)",
+        app_id,
+        installation_id,
+    )
+    # ChainCredentialsProvider falls back to env PAT if App minting fails.
+    # EnvCredentialsProvider construction is guarded — it's optional when App is the sole source.
+    try:
+        env_fallback = EnvCredentialsProvider()
+        return ChainCredentialsProvider([app_provider, env_fallback])
+    except ValueError:
+        # Neither GITHUB_TOKEN nor COPILOT_PAT is set; use App-only mode.
+        return app_provider
 
 
 class Orchestrator:
@@ -125,10 +193,6 @@ class Orchestrator:
         """Create an orchestrator from a YAML config file path."""
         config = MaintainerConfig.from_yaml(path)
 
-        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("COPILOT_PAT", "")
-        if not token:
-            raise RuntimeError("GITHUB_TOKEN or COPILOT_PAT environment variable is required")
-
         owner = os.environ.get("GITHUB_REPOSITORY_OWNER", "")
         repo_name = os.environ.get("GITHUB_REPOSITORY_NAME", "")
 
@@ -143,7 +207,7 @@ class Orchestrator:
                     "GITHUB_REPOSITORY_NAME environment variables are required"
                 )
 
-        github = GitHubClient(token=token, copilot_token=os.environ.get("COPILOT_PAT"))
+        github = GitHubClient(credentials_provider=_build_credentials_provider(config))
         return cls(config=config, github=github, owner=owner, repo=repo_name)
 
     async def run(

--- a/tests/test_github_client_api.py
+++ b/tests/test_github_client_api.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from caretaker.github_client.api import GitHubAPIError, GitHubClient
+from caretaker.github_client.credentials import StaticCredentialsProvider
 
 
 def _make_response(status_code: int, json_body: dict | None = None, text: str = "") -> MagicMock:
@@ -126,45 +127,39 @@ async def test_429_raises_githubapieerror_with_retry_after() -> None:
 
 @pytest.mark.asyncio
 async def test_add_issue_comment_routes_copilot_mentions_through_copilot_client() -> None:
-    default_client = AsyncMock()
-    default_client.request = AsyncMock(return_value=_make_response(201, _comment_payload("bot")))
-    copilot_client = AsyncMock()
-    copilot_client.request = AsyncMock(return_value=_make_response(201, _comment_payload("me")))
+    mock_creds = AsyncMock(spec=StaticCredentialsProvider)
+    mock_creds.default_token = AsyncMock(return_value="default-token")
+    mock_creds.copilot_token = AsyncMock(return_value="user-pat")
 
-    with patch.object(
-        GitHubClient,
-        "_build_client",
-        side_effect=[default_client, copilot_client],
-    ):
-        gh = GitHubClient(token="default-token", copilot_token="user-pat")
+    gh = GitHubClient(credentials_provider=mock_creds)
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=_make_response(201, _comment_payload("me")))
+    gh._client = mock_client
 
     comment = await gh.add_issue_comment("o", "r", 7, "@copilot please fix this")
 
-    copilot_client.request.assert_awaited_once()
-    default_client.request.assert_not_awaited()
+    mock_creds.copilot_token.assert_awaited_once()
+    mock_creds.default_token.assert_not_awaited()
     assert comment.user.login == "me"
 
 
 @pytest.mark.asyncio
 async def test_add_issue_comment_uses_default_client_for_regular_comments() -> None:
-    default_client = AsyncMock()
-    default_client.request = AsyncMock(
+    mock_creds = AsyncMock(spec=StaticCredentialsProvider)
+    mock_creds.default_token = AsyncMock(return_value="default-token")
+    mock_creds.copilot_token = AsyncMock(return_value="user-pat")
+
+    gh = GitHubClient(credentials_provider=mock_creds)
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
         return_value=_make_response(201, _comment_payload("github-actions[bot]"))
     )
-    copilot_client = AsyncMock()
-    copilot_client.request = AsyncMock(return_value=_make_response(201, _comment_payload("me")))
-
-    with patch.object(
-        GitHubClient,
-        "_build_client",
-        side_effect=[default_client, copilot_client],
-    ):
-        gh = GitHubClient(token="default-token", copilot_token="user-pat")
+    gh._client = mock_client
 
     comment = await gh.add_issue_comment("o", "r", 7, "Regular maintainer note")
 
-    default_client.request.assert_awaited_once()
-    copilot_client.request.assert_not_awaited()
+    mock_creds.default_token.assert_awaited_once()
+    mock_creds.copilot_token.assert_not_awaited()
     assert comment.user.login == "github-actions[bot]"
 
 


### PR DESCRIPTION
This pull request introduces support for using GitHub App authentication in addition to existing personal access token (PAT) workflows. It refactors the `GitHubClient` to use a credentials provider abstraction, enabling dynamic selection and minting of tokens (including GitHub App installation tokens) at runtime. The orchestrator now automatically chooses the appropriate authentication method based on configuration and environment variables, with fallbacks for backward compatibility. Tests have been updated to reflect these changes.

**GitHub App authentication and credentials provider abstraction:**

* Added a credentials provider abstraction (`GitHubCredentialsProvider`, `EnvCredentialsProvider`, etc.) to `GitHubClient`, allowing dynamic token retrieval and support for GitHub App installation tokens. The client no longer directly reads tokens from environment variables but instead uses the provider interface. (`src/caretaker/github_client/api.py`, [[1]](diffhunk://#diff-d9a2e69f9c8a1ff46a743936e803f0c34c55aa9d73a2bbd8616ee3168d95a95fR16) [[2]](diffhunk://#diff-d9a2e69f9c8a1ff46a743936e803f0c34c55aa9d73a2bbd8616ee3168d95a95fR53-L82) [[3]](diffhunk://#diff-d9a2e69f9c8a1ff46a743936e803f0c34c55aa9d73a2bbd8616ee3168d95a95fL123-R130) [[4]](diffhunk://#diff-d9a2e69f9c8a1ff46a743936e803f0c34c55aa9d73a2bbd8616ee3168d95a95fL409-R417)
* Implemented `_build_credentials_provider` in the orchestrator to select the appropriate credentials provider (GitHub App or environment-based) based on configuration and environment variables, with fallback and logging for missing variables. (`src/caretaker/orchestrator.py`, [src/caretaker/orchestrator.pyR70-R135](diffhunk://#diff-c085313e4a68c0d3d90a1a776d90c1f7c4235711763d74f9e20f4d17fe073905R70-R135))

**Workflow and configuration changes:**

* Updated GitHub Actions workflow (`.github/workflows/maintainer.yml`) to generate and use a GitHub App token via `actions/create-github-app-token@v2`, setting `GITHUB_TOKEN` for subsequent steps. (`.github/workflows/maintainer.yml`, [[1]](diffhunk://#diff-9ed605f90236faa47c402c079736144808e303a81c19de9e1c9ba3f71c73aa23R75-R85) [[2]](diffhunk://#diff-9ed605f90236faa47c402c079736144808e303a81c19de9e1c9ba3f71c73aa23R137-R146)
* Refactored orchestrator setup to remove direct token fetching from environment variables and instead use the new credentials provider abstraction when constructing the `GitHubClient`. (`src/caretaker/orchestrator.py`, [[1]](diffhunk://#diff-c085313e4a68c0d3d90a1a776d90c1f7c4235711763d74f9e20f4d17fe073905L128-L131) [[2]](diffhunk://#diff-c085313e4a68c0d3d90a1a776d90c1f7c4235711763d74f9e20f4d17fe073905L146-R210)

**Testing updates:**

* Updated tests to use a mock credentials provider instead of patching client construction, ensuring correct token selection logic is exercised in the new architecture. (`tests/test_github_client_api.py`, [tests/test_github_client_api.pyL129-R162](diffhunk://#diff-4ef4337fecd14ba3a2704321490523f4fb792ad0b45e23af6ff412520192401cL129-R162))

These changes lay the groundwork for secure, flexible authentication using GitHub Apps while maintaining compatibility with existing token-based workflows.