### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caretaker"
-version = "0.7.0"
+version = "0.7.1"
 description = "Autonomous GitHub repository maintenance powered by Copilot"
 readme = "README.md"
 license = "MIT"

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,13 @@
 {
   "releases": [
     {
+      "version": "0.7.1",
+      "min_compatible": "0.7.1",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.7.1",
+      "upgrade_notes": "Update to 0.7.1.",
+      "breaking": false
+    },
+    {
       "version": "0.7.0",
       "min_compatible": "0.7.0",
       "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.7.0",

--- a/src/caretaker/__init__.py
+++ b/src/caretaker/__init__.py
@@ -1,3 +1,3 @@
 """caretaker: Autonomous GitHub repository maintenance powered by Copilot."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"


### PR DESCRIPTION
Automated version bump to 0.7.1 triggered by the release workflow.