### PR TITLE
feat(publish): enhance PyPI publishing with token and OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,7 @@ jobs:
       VERSION: ${{ needs.resolve-version.outputs.version }}
     permissions:
       id-token: write # required for trusted OIDC publishing
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -207,7 +208,30 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Publish to PyPI
+      - name: Resolve publish auth mode
+        id: publish-auth
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          if [ -n "$PYPI_API_TOKEN" ]; then
+            echo "has_pypi_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pypi_token=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install twine (token publish path)
+        if: steps.publish-auth.outputs.has_pypi_token == 'true'
+        run: pip install twine
+
+      - name: Publish to PyPI (API token, non-Docker)
+        if: steps.publish-auth.outputs.has_pypi_token == 'true'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload --skip-existing dist/*
+
+      - name: Publish to PyPI (OIDC trusted publishing)
+        if: steps.publish-auth.outputs.has_pypi_token != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # If PYPI_API_TOKEN secret is set it will be used for token-based auth;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,20 +221,17 @@ jobs:
 
       - name: Install twine (token publish path)
         if: steps.publish-auth.outputs.has_pypi_token == 'true'
-        run: pip install twine
+        run: python -m pip install --upgrade 'twine==6.2.0'
 
       - name: Publish to PyPI (API token, non-Docker)
         if: steps.publish-auth.outputs.has_pypi_token == 'true'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload --skip-existing dist/*
+        run: twine upload --non-interactive --skip-existing dist/*
 
       - name: Publish to PyPI (OIDC trusted publishing)
         if: steps.publish-auth.outputs.has_pypi_token != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # If PYPI_API_TOKEN secret is set it will be used for token-based auth;
-          # when the secret is empty the action falls back to OIDC trusted publishing.
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true

--- a/docs/pr-ownership.md
+++ b/docs/pr-ownership.md
@@ -1,0 +1,219 @@
+# PR Ownership and Caretaker Merge Authority
+
+## Overview
+
+PR Ownership is a first-class capability in Caretaker that establishes Caretaker as the authoritative system for PR readiness evaluation and merge management. Ownership is marked by the `caretaker:owned` label and the `caretaker/pr-readiness` check run.
+
+## Key Concepts
+
+### Ownership State
+
+PRs can be in one of four ownership states:
+
+| State | Description |
+|-------|-------------|
+| `unowned` | Caretaker is not managing this PR |
+| `owned` | Caretaker has claimed responsibility for this PR |
+| `released` | Caretaker has released ownership (merged, closed, or manual release) |
+| `escalated` | Caretaker has escalated to maintainers and released ownership |
+
+### Ownership Label
+
+The `caretaker:owned` label marks PRs that Caretaker has claimed. This label:
+
+- Is automatically added when Caretaker claims a PR
+- Is visible in the GitHub PR UI
+- Can be manually added by maintainers to opt-in human PRs
+
+### Hold Label
+
+The `caretaker:hold` label prevents Caretaker from merging a PR even if it meets all other criteria:
+
+- Maintained by humans who want to control merge timing
+- Does not affect ownership claim
+- Does not affect readiness evaluation
+
+## Readiness Scoring
+
+Caretaker evaluates PRs on a 0.0-1.0 readiness score:
+
+| Component | Points | Requirements |
+|-----------|--------|-------------|
+| Mergeable & non-draft | 10% | PR is not a draft, has no merge conflicts, no `maintainer:breaking` or `caretaker:hold` label |
+| Automated feedback addressed | 20% | No pending automated review comments OR fix already requested |
+| Required reviews satisfied | 30% | Reviews approved, no `CHANGES_REQUESTED` |
+| CI passing | 40% | All checks passing, no pending checks |
+
+### Readiness Check Conclusions
+
+- `success`: Score 1.0, no blockers — PR is ready for merge
+- `failure`: Explicit blockers remain — PR cannot be merged
+- `in_progress`: Checks/reviews still pending — PR not yet ready
+
+### Standard Blocker Codes
+
+| Code | Description |
+|------|-------------|
+| `ci_pending` | CI checks are still running |
+| `ci_failing` | One or more CI checks have failed |
+| `required_review_missing` | No approving reviews yet |
+| `changes_requested` | Reviewer has requested changes |
+| `automated_feedback_unaddressed` | Automated review comments not yet addressed |
+| `draft_pr` | PR is still in draft mode |
+| `merge_conflict` | PR has merge conflicts |
+| `breaking_change` | PR has `maintainer:breaking` label |
+| `manual_hold` | PR has `caretaker:hold` label |
+
+## Phased Rollout
+
+### Phase 1: Advisory (Current)
+
+**Goal**: Ship ownership state, label, comments, and readiness score without changing merge behavior.
+
+Features shipped:
+- ✅ Ownership state tracking in `TrackedPR`
+- ✅ Readiness score calculation
+- ✅ `caretaker/pr-readiness` check (non-required)
+- ✅ Ownership claim/release comments
+- ✅ Automatic claim for Copilot and Dependabot PRs
+- ✅ Manual opt-in for human PRs via `caretaker:owned` label
+
+Current behavior:
+- Caretaker evaluates PRs and publishes readiness
+- Existing merge gating and auto-merge behavior unchanged
+- No breaking changes to existing workflows
+
+### Phase 2: Required Check
+
+**Goal**: Make `caretaker/pr-readiness` a required ruleset check.
+
+What changes:
+- Configure GitHub branch protection rules to require `caretaker/pr-readiness`
+- The check must pass before PRs can be merged
+- Caretaker check conclusion (`success`, `failure`, `in_progress`) gates merge
+
+Branch protection setup:
+1. Navigate to repository Settings → Branches → Branch protection rules
+2. Create/edit rule for target branch (e.g., `main`)
+3. Under "Status checks", add `caretaker/pr-readiness`
+4. Mark as "Required" before merging
+5. Ensure Caretaker GitHub App is the check source
+
+### Phase 3: Merge Authority
+
+**Goal**: Caretaker merges owned PRs directly when readiness is `success`.
+
+New configuration option `merge_authority.mode`:
+- `advisory`: Current behavior (Phase 1/2)
+- `gate_only`: Gate via required check, don't merge directly
+- `gate_and_merge`: Gate AND merge when ready (default for Copilot/Dependabot)
+
+Changes:
+- `pr_agent.auto_merge` behavior replaced by `pr_agent.merge_authority`
+- Caretaker calls merge API after readiness check is `success`
+- 405/409/422 errors treated as non-terminal (keep ownership, retry next cycle)
+- Escalation triggers ownership release
+
+## Configuration
+
+### Ownership Configuration
+
+```yaml
+pr_agent:
+  ownership:
+    enabled: true
+    auto_claim:
+      copilot_prs: true      # Auto-claim Copilot PRs
+      dependabot_prs: true    # Auto-claim Dependabot PRs
+      human_prs: false        # Human PRs require manual opt-in
+    label: caretaker:owned   # Ownership label name
+    hold_label: caretaker:hold  # Manual hold label
+```
+
+### Readiness Configuration
+
+```yaml
+pr_agent:
+  readiness:
+    enabled: true
+    check_name: caretaker/pr-readiness
+    required_reviews: 1
+    require_all_checks_passed: true
+    require_review_resolution: true
+```
+
+### Merge Authority Configuration (Phase 3)
+
+```yaml
+pr_agent:
+  merge_authority:
+    mode: advisory  # advisory | gate_only | gate_and_merge
+```
+
+## GitHub App Integration
+
+Caretaker uses the GitHub App identity for:
+- Publishing check runs (`caretaker/pr-readiness`)
+- Adding labels (`caretaker:owned`, `maintainer:escalated`)
+- Posting comments
+
+The GitHub App should be:
+- Installed on repositories using Caretaker
+- Given write permissions for:
+  - Checks (read/write)
+  - Pull requests (read/write)
+  - Issues (read/write)
+  - Contents (read) - for code analysis if needed
+
+## Run Summary Metrics
+
+Ownership metrics are exposed in run summaries:
+
+| Metric | Description |
+|--------|-------------|
+| `owned_prs` | Number of PRs currently owned by Caretaker |
+| `readiness_pass_rate` | Percentage of owned PRs with score >= 1.0 |
+| `avg_readiness_score` | Average readiness score across owned PRs |
+| `authority_merges` | Number of merges performed by Caretaker authority |
+
+## Migration from Legacy Auto-Merge
+
+To migrate from the current `auto_merge` behavior to Caretaker merge authority:
+
+1. **Phase 1**: Deploy ownership tracking without changing auto-merge
+   ```yaml
+   pr_agent:
+     auto_merge:
+       # Existing settings
+     ownership:
+       enabled: true
+     readiness:
+       enabled: true
+   ```
+
+2. **Phase 2**: Enable required check in branch protection
+   - Configure ruleset to require `caretaker/pr-readiness`
+   - Keep `auto_merge` settings active as fallback
+
+3. **Phase 3**: Switch to merge authority
+   ```yaml
+   pr_agent:
+     auto_merge:
+       copilot_prs: false  # Disable legacy auto-merge
+       dependabot_prs: false
+       human_prs: false
+     merge_authority:
+       mode: gate_and_merge
+   ```
+
+## Backward Compatibility
+
+- Repositories without ownership enabled retain existing behavior
+- The `auto_merge` configuration continues to work until Phase 3 migration
+- No breaking changes in Phase 1 or Phase 2
+
+## Known Limitations
+
+- The `head_ref` from GitHub PR API is a branch name, not a commit SHA
+- Check runs require a commit SHA; ensure the PR head branch has been pushed
+- Assignee APIs are user-oriented; Caretaker uses labels/checks/comments for identity

--- a/docs/pr-ownership.md
+++ b/docs/pr-ownership.md
@@ -31,7 +31,7 @@ The `caretaker:hold` label prevents Caretaker from merging a PR even if it meets
 
 - Maintained by humans who want to control merge timing
 - Does not affect ownership claim
-- Does not affect readiness evaluation
+- Affects readiness evaluation by adding `manual_hold` blocker and withholding the 10% mergeability component
 
 ## Readiness Scoring
 
@@ -214,6 +214,5 @@ To migrate from the current `auto_merge` behavior to Caretaker merge authority:
 
 ## Known Limitations
 
-- The `head_ref` from GitHub PR API is a branch name, not a commit SHA
-- Check runs require a commit SHA; ensure the PR head branch has been pushed
+- Check runs require a PR head commit SHA; if GitHub omits `head.sha`, readiness check publication is skipped for that cycle
 - Assignee APIs are user-oriented; Caretaker uses labels/checks/comments for identity

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Agents: agents.md
   - Goals: goals.md
   - Architecture: architecture.md
+  - PR Ownership: pr-ownership.md
   - Development: development.md
   - Release notes: release-notes.md
 

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
@@ -15,6 +16,52 @@ SUPPORTED_CONFIG_VERSIONS = {"v1"}
 
 class StrictBaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+
+class OwnershipAutoClaimConfig(StrictBaseModel):
+    """Configuration for which PR types Caretaker auto-claims ownership of."""
+
+    copilot_prs: bool = True
+    dependabot_prs: bool = True
+    human_prs: bool = False
+
+
+class OwnershipConfig(StrictBaseModel):
+    """Configuration for PR ownership management."""
+
+    enabled: bool = True
+    auto_claim: OwnershipAutoClaimConfig = Field(default_factory=OwnershipAutoClaimConfig)
+    label: str = "caretaker:owned"
+    hold_label: str = "caretaker:hold"
+
+
+class ReadinessConfig(StrictBaseModel):
+    """Configuration for PR readiness evaluation."""
+
+    enabled: bool = True
+    check_name: str = "caretaker/pr-readiness"
+    required_reviews: int = 1
+    require_all_checks_passed: bool = True
+    require_review_resolution: bool = True
+
+
+class MergeAuthorityMode(StrEnum):
+    """Merge authority modes for owned PRs.
+
+    - advisory: Only publish readiness check, no merge authority
+    - gate_only: Gate merge via required check, don't merge directly
+    - gate_and_merge: Gate via required check AND merge directly when ready
+    """
+
+    ADVISORY = "advisory"
+    GATE_ONLY = "gate_only"
+    GATE_AND_MERGE = "gate_and_merge"
+
+
+class MergeAuthorityConfig(StrictBaseModel):
+    """Configuration for Caretaker merge authority."""
+
+    mode: MergeAuthorityMode = MergeAuthorityMode.ADVISORY
 
 
 class AutoMergeConfig(StrictBaseModel):
@@ -48,6 +95,8 @@ class PRAgentConfig(StrictBaseModel):
     copilot: CopilotConfig = Field(default_factory=CopilotConfig)
     ci: CIConfig = Field(default_factory=CIConfig)
     review: ReviewConfig = Field(default_factory=ReviewConfig)
+    ownership: OwnershipConfig = Field(default_factory=OwnershipConfig)
+    readiness: ReadinessConfig = Field(default_factory=ReadinessConfig)
 
 
 class IssueAgentLabels(StrictBaseModel):

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -266,6 +266,118 @@ class GitHubClient:
             return "pending"
         return str(data.get("state", "pending"))
 
+    async def create_check_run(
+        self,
+        owner: str,
+        repo: str,
+        name: str,
+        head_sha: str,
+        status: str = "in_progress",
+        conclusion: str | None = None,
+        output_title: str | None = None,
+        output_summary: str | None = None,
+        started_at: str | None = None,
+        completed_at: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a check run (status check) on a commit.
+
+        Args:
+            owner: Repository owner
+            repo: Repository name
+            name: Check run name (e.g. 'caretaker/pr-readiness')
+            head_sha: The SHA of the commit to check
+            status: 'queued', 'in_progress', 'completed'
+            conclusion: 'success', 'failure', 'neutral', 'cancelled', 'skipped',
+                       'timed_out', 'action_required', 'neutral', 'stale'
+            output_title: Title for the check output
+            output_summary: Summary text for the check output
+            started_at: ISO 8601 timestamp when the check started
+            completed_at: ISO 8601 timestamp when the check completed
+
+        Returns:
+            The created check run dict from the GitHub API
+        """
+        payload: dict[str, Any] = {
+            "name": name,
+            "head_sha": head_sha,
+            "status": status,
+        }
+        if conclusion:
+            payload["conclusion"] = conclusion
+        if output_title or output_summary:
+            payload["output"] = {
+                "title": output_title or name,
+                "summary": output_summary or "",
+            }
+        if started_at:
+            payload["started_at"] = started_at
+        if completed_at:
+            payload["completed_at"] = completed_at
+
+        data = await self._post(f"/repos/{owner}/{repo}/check-runs", json=payload)
+        return data if data else {}
+
+    async def update_check_run(
+        self,
+        owner: str,
+        repo: str,
+        check_run_id: int,
+        status: str = "completed",
+        conclusion: str | None = None,
+        output_title: str | None = None,
+        output_summary: str | None = None,
+        completed_at: str | None = None,
+        actions: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing check run.
+
+        Args:
+            owner: Repository owner
+            repo: Repository name
+            check_run_id: The ID of the check run to update
+            status: 'queued', 'in_progress', 'completed'
+            conclusion: 'success', 'failure', 'neutral', 'cancelled', 'skipped',
+                       'timed_out', 'action_required', 'neutral', 'stale'
+            output_title: Title for the check output
+            output_summary: Summary text for the check output
+            completed_at: ISO 8601 timestamp when the check completed
+            actions: Optional list of action buttons to add to the check
+
+        Returns:
+            The updated check run dict from the GitHub API
+        """
+        payload: dict[str, Any] = {
+            "status": status,
+        }
+        if conclusion:
+            payload["conclusion"] = conclusion
+        if output_title or output_summary:
+            payload["output"] = {
+                "title": output_title or "",
+                "summary": output_summary or "",
+            }
+        if completed_at:
+            payload["completed_at"] = completed_at
+        if actions:
+            payload["actions"] = actions
+
+        data = await self._patch(
+            f"/repos/{owner}/{repo}/check-runs/{check_run_id}",
+            json=payload,
+        )
+        return data if data else {}
+
+    async def find_check_run(self, owner: str, repo: str, ref: str, name: str) -> CheckRun | None:
+        """Find an existing check run by name on a given ref (branch/SHA).
+
+        Returns the most recent check run with the matching name, or None if not found.
+        """
+        check_runs = await self.get_check_runs(owner, repo, ref)
+        for cr in check_runs:
+            if cr.name == name:
+                return cr
+        return None
+
     # ── Issues ──────────────────────────────────────────────────
 
     async def list_issues(

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -724,6 +724,7 @@ class GitHubClient:
             state=data["state"],
             user=User(login=data["user"]["login"], id=data["user"]["id"]),
             head_ref=data.get("head", {}).get("ref", ""),
+            head_sha=data.get("head", {}).get("sha", ""),
             base_ref=data.get("base", {}).get("ref", ""),
             mergeable=data.get("mergeable"),
             merged=data.get("merged", False),

--- a/src/caretaker/github_client/models.py
+++ b/src/caretaker/github_client/models.py
@@ -116,6 +116,7 @@ class PullRequest(BaseModel):
     state: PRState
     user: User
     head_ref: str = ""
+    head_sha: str = ""
     base_ref: str = ""
     mergeable: bool | None = None
     merged: bool = False

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -614,9 +614,14 @@ class PRAgent:
             return
 
         check_name = self._config.readiness.check_name
-        head_sha = pr.head_ref  # This is the branch/ref, not the commit SHA
-        # For PRs, we need to get the actual commit SHA
-        # The head_ref from PR is the branch name; we use it directly for check runs
+        head_sha = pr.head_sha
+        if not head_sha:
+            logger.warning(
+                "PR #%d: missing head SHA, skipping %s check publication",
+                pr.number,
+                check_name,
+            )
+            return
 
         # Update readiness tracking from evaluation
         tracking.readiness_score = evaluation.readiness.score
@@ -630,13 +635,14 @@ class PRAgent:
 
         # Determine conclusion based on readiness
         conclusion = evaluation.readiness.conclusion
+        check_status = "completed"
         check_conclusion = None
         if conclusion == "success":
             check_conclusion = "success"
         elif conclusion == "failure":
             check_conclusion = "failure"
         else:  # in_progress
-            check_conclusion = None  # Will be updated with in_progress status
+            check_status = "in_progress"
 
         check_title = get_readiness_check_title(tracking)
         check_summary = get_readiness_check_summary(tracking)
@@ -648,11 +654,13 @@ class PRAgent:
                     self._owner,
                     self._repo,
                     existing_check.id,
-                    status="completed",
+                    status=check_status,
                     conclusion=check_conclusion,
                     output_title=check_title,
                     output_summary=check_summary,
-                    completed_at=datetime.now(UTC).isoformat(),
+                    completed_at=(
+                        datetime.now(UTC).isoformat() if check_status == "completed" else None
+                    ),
                 )
                 logger.debug(
                     "PR #%d: Updated %s check (id=%d, conclusion=%s)",
@@ -668,12 +676,14 @@ class PRAgent:
                     self._repo,
                     check_name,
                     head_sha,
-                    status="completed",
+                    status=check_status,
                     conclusion=check_conclusion,
                     output_title=check_title,
                     output_summary=check_summary,
                     started_at=datetime.now(UTC).isoformat(),
-                    completed_at=datetime.now(UTC).isoformat(),
+                    completed_at=(
+                        datetime.now(UTC).isoformat() if check_status == "completed" else None
+                    ),
                 )
                 logger.debug(
                     "PR #%d: Created %s check (id=%s)",
@@ -705,7 +715,7 @@ class PRAgent:
         5. Posts update comments on meaningful changes
         """
         previous_score = tracking.readiness_score
-        list(tracking.readiness_blockers)
+        previous_blockers = list(tracking.readiness_blockers)
 
         # Guard against optional readiness field
         if evaluation.readiness is None:
@@ -756,7 +766,6 @@ class PRAgent:
                 pr,
                 tracking,
                 self._config.ownership,
-                self._config.ownership,  # readiness uses same config for label
             )
 
         # Publish readiness check
@@ -764,7 +773,11 @@ class PRAgent:
 
         # Post update comment on meaningful changes (only for owned PRs)
         if tracking.ownership_state == OwnershipState.OWNED:
-            update_comment = build_readiness_comment(tracking, previous_score)
+            update_comment = build_readiness_comment(
+                tracking,
+                previous_score,
+                previous_blockers,
+            )
             if update_comment:
                 try:
                     await self._github.add_issue_comment(

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from caretaker.github_client.api import GitHubAPIError
@@ -14,12 +14,20 @@ from caretaker.llm.copilot import CopilotProtocol, ResultStatus
 from caretaker.pr_agent.ci_triage import FailureType, triage_failure
 from caretaker.pr_agent.copilot import PRCopilotBridge
 from caretaker.pr_agent.merge import evaluate_merge
+from caretaker.pr_agent.ownership import (
+    build_readiness_comment,
+    claim_ownership,
+    get_readiness_check_summary,
+    get_readiness_check_title,
+    release_ownership,
+    should_release_ownership,
+)
 from caretaker.pr_agent.review import analyze_reviews
 from caretaker.pr_agent.states import (
     PRStateEvaluation,
     evaluate_pr,
 )
-from caretaker.state.models import PRTrackingState, TrackedPR
+from caretaker.state.models import OwnershipState, PRTrackingState, TrackedPR
 from caretaker.tools.debug_dump import render_debug_dump
 
 if TYPE_CHECKING:
@@ -216,6 +224,10 @@ class PRAgent:
                 pass  # closed/merged, nothing to do
             case _:
                 report.waiting.append(pr.number)
+
+        # Handle ownership lifecycle: claim, release, readiness check publishing
+        # This runs after the main action to ensure we have the latest evaluation
+        tracking = await self._handle_ownership(pr, tracking, evaluation, report)
 
         return tracking
 
@@ -582,3 +594,179 @@ class PRAgent:
         body += render_debug_dump(payload, title="Escalation debug dump")
         await self._github.add_issue_comment(self._owner, self._repo, pr.number, body)
         logger.info("PR #%d escalated: %s", pr.number, reason)
+
+    async def _publish_readiness_check(
+        self,
+        pr: PullRequest,
+        tracking: TrackedPR,
+        evaluation: PRStateEvaluation,
+    ) -> None:
+        """Publish the caretaker/pr-readiness check run on the PR's head SHA.
+
+        This publishes a non-required check (Phase 1) that shows PR readiness status.
+        The check is updated on every evaluation to keep the status current.
+        """
+        if not self._config.readiness.enabled:
+            return
+
+        check_name = self._config.readiness.check_name
+        head_sha = pr.head_ref  # This is the branch/ref, not the commit SHA
+        # For PRs, we need to get the actual commit SHA
+        # The head_ref from PR is the branch name; we use it directly for check runs
+
+        # Update readiness tracking from evaluation
+        tracking.readiness_score = evaluation.readiness.score
+        tracking.readiness_blockers = evaluation.readiness.blockers
+        tracking.readiness_summary = evaluation.readiness.summary
+
+        # Find existing check run
+        existing_check = await self._github.find_check_run(
+            self._owner, self._repo, head_sha, check_name
+        )
+
+        # Determine conclusion based on readiness
+        conclusion = evaluation.readiness.conclusion
+        check_conclusion = None
+        if conclusion == "success":
+            check_conclusion = "success"
+        elif conclusion == "failure":
+            check_conclusion = "failure"
+        else:  # in_progress
+            check_conclusion = None  # Will be updated with in_progress status
+
+        check_title = get_readiness_check_title(tracking)
+        check_summary = get_readiness_check_summary(tracking)
+
+        try:
+            if existing_check:
+                # Update existing check run
+                await self._github.update_check_run(
+                    self._owner,
+                    self._repo,
+                    existing_check.id,
+                    status="completed",
+                    conclusion=check_conclusion,
+                    output_title=check_title,
+                    output_summary=check_summary,
+                    completed_at=datetime.now(UTC).isoformat(),
+                )
+                logger.debug(
+                    "PR #%d: Updated %s check (id=%d, conclusion=%s)",
+                    pr.number,
+                    check_name,
+                    existing_check.id,
+                    check_conclusion,
+                )
+            else:
+                # Create new check run
+                result = await self._github.create_check_run(
+                    self._owner,
+                    self._repo,
+                    check_name,
+                    head_sha,
+                    status="completed",
+                    conclusion=check_conclusion,
+                    output_title=check_title,
+                    output_summary=check_summary,
+                    started_at=datetime.now(UTC).isoformat(),
+                    completed_at=datetime.now(UTC).isoformat(),
+                )
+                logger.debug(
+                    "PR #%d: Created %s check (id=%s)",
+                    pr.number,
+                    check_name,
+                    result.get("id"),
+                )
+        except GitHubAPIError as e:
+            logger.warning(
+                "PR #%d: Failed to publish readiness check: %s",
+                pr.number,
+                e,
+            )
+
+    async def _handle_ownership(
+        self,
+        pr: PullRequest,
+        tracking: TrackedPR,
+        evaluation: PRStateEvaluation,
+        report: PRAgentReport,
+    ) -> TrackedPR:
+        """Handle PR ownership — claim, release, and update readiness.
+
+        This method:
+        1. Updates readiness tracking from the evaluation
+        2. Attempts to claim ownership if eligible
+        3. Releases ownership if the PR is merged/closed/escalated
+        4. Publishes the readiness check
+        5. Posts update comments on meaningful changes
+        """
+        previous_score = tracking.readiness_score
+        list(tracking.readiness_blockers)
+
+        # Update readiness tracking
+        tracking.readiness_score = evaluation.readiness.score
+        tracking.readiness_blockers = evaluation.readiness.blockers
+        tracking.readiness_summary = evaluation.readiness.summary
+
+        # Handle ownership state transitions
+        if should_release_ownership(pr, tracking, "merged"):
+            await release_ownership(
+                self._github,
+                self._owner,
+                self._repo,
+                pr,
+                tracking,
+                self._config.ownership,
+                reason="PR merged",
+            )
+        elif should_release_ownership(pr, tracking, "closed"):
+            await release_ownership(
+                self._github,
+                self._owner,
+                self._repo,
+                pr,
+                tracking,
+                self._config.ownership,
+                reason="PR closed",
+            )
+        elif should_release_ownership(pr, tracking, "escalated"):
+            await release_ownership(
+                self._github,
+                self._owner,
+                self._repo,
+                pr,
+                tracking,
+                self._config.ownership,
+                reason="PR escalated",
+            )
+        elif tracking.ownership_state == OwnershipState.UNOWNED:
+            # Try to claim ownership
+            await claim_ownership(
+                self._github,
+                self._owner,
+                self._repo,
+                pr,
+                tracking,
+                self._config.ownership,
+                self._config.ownership,  # readiness uses same config for label
+            )
+
+        # Publish readiness check
+        await self._publish_readiness_check(pr, tracking, evaluation)
+
+        # Post update comment on meaningful changes (only for owned PRs)
+        if tracking.ownership_state == OwnershipState.OWNED:
+            update_comment = build_readiness_comment(tracking, previous_score)
+            if update_comment:
+                try:
+                    await self._github.add_issue_comment(
+                        self._owner, self._repo, pr.number, update_comment
+                    )
+                except GitHubAPIError as e:
+                    logger.warning(
+                        "PR #%d: Failed to post readiness update comment: %s",
+                        pr.number,
+                        e,
+                    )
+
+        return tracking

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -609,6 +609,10 @@ class PRAgent:
         if not self._config.readiness.enabled:
             return
 
+        # Guard against optional readiness field
+        if evaluation.readiness is None:
+            return
+
         check_name = self._config.readiness.check_name
         head_sha = pr.head_ref  # This is the branch/ref, not the commit SHA
         # For PRs, we need to get the actual commit SHA
@@ -702,6 +706,10 @@ class PRAgent:
         """
         previous_score = tracking.readiness_score
         list(tracking.readiness_blockers)
+
+        # Guard against optional readiness field
+        if evaluation.readiness is None:
+            return tracking
 
         # Update readiness tracking
         tracking.readiness_score = evaluation.readiness.score

--- a/src/caretaker/pr_agent/ownership.py
+++ b/src/caretaker/pr_agent/ownership.py
@@ -224,9 +224,7 @@ def build_ownership_claim_comment(pr: PullRequest, tracking: TrackedPR) -> str:
     """Build the comment body for ownership claim."""
     blockers = set(tracking.readiness_blockers)
     mergeability_points = (
-        0
-        if {"draft_pr", "merge_conflict", "breaking_change", "manual_hold"} & blockers
-        else 10
+        0 if {"draft_pr", "merge_conflict", "breaking_change", "manual_hold"} & blockers else 10
     )
     automated_points = 0 if "automated_feedback_unaddressed" in blockers else 20
     review_points = 0 if {"required_review_missing", "changes_requested"} & blockers else 30

--- a/src/caretaker/pr_agent/ownership.py
+++ b/src/caretaker/pr_agent/ownership.py
@@ -77,16 +77,15 @@ def should_release_ownership(
     if tracking.ownership_state != OwnershipState.OWNED:
         return False
 
-    # Release on merge
-    if pr.merged:
+    if reason == "escalated":
         return True
+    if reason == "merged":
+        return bool(pr.merged)
+    if reason == "closed":
+        state_value = getattr(pr.state, "value", pr.state)
+        return state_value == "closed"
 
-    # Release on close
-    if pr.state.value == "closed":
-        return True
-
-    # Release on escalation
-    return reason == "escalated"
+    return bool(pr.merged)
 
 
 async def claim_ownership(
@@ -96,7 +95,6 @@ async def claim_ownership(
     pr: PullRequest,
     tracking: TrackedPR,
     ownership_config: OwnershipConfig,
-    readiness_config: OwnershipConfig,
 ) -> OwnershipClaim:
     """Attempt to acquire ownership of a PR.
 
@@ -107,7 +105,6 @@ async def claim_ownership(
         pr: The pull request
         tracking: Current tracking state
         ownership_config: Ownership configuration
-        readiness_config: Readiness configuration (uses same label field)
 
     Returns:
         OwnershipClaim with the result of the claim attempt
@@ -225,6 +222,16 @@ async def release_ownership(
 
 def build_ownership_claim_comment(pr: PullRequest, tracking: TrackedPR) -> str:
     """Build the comment body for ownership claim."""
+    blockers = set(tracking.readiness_blockers)
+    mergeability_points = (
+        0
+        if {"draft_pr", "merge_conflict", "breaking_change", "manual_hold"} & blockers
+        else 10
+    )
+    automated_points = 0 if "automated_feedback_unaddressed" in blockers else 20
+    review_points = 0 if {"required_review_missing", "changes_requested"} & blockers else 30
+    ci_points = 0 if {"ci_pending", "ci_failing"} & blockers else 40
+
     return f"""<!-- caretaker:ownership:claim -->
 
 ## 🏠 Caretaker Ownership
@@ -235,10 +242,10 @@ Caretaker has claimed ownership of this PR.
 
 | Component | Score |
 |-----------|-------|
-| Mergeable & non-draft | {int(tracking.readiness_score * 10)}% |
-| Automated feedback | {int(tracking.readiness_score * 20)}% |
-| Reviews approved | {int(tracking.readiness_score * 30)}% |
-| CI passing | {int(tracking.readiness_score * 40)}% |
+| Mergeable & non-draft | {mergeability_points}% |
+| Automated feedback | {automated_points}% |
+| Reviews approved | {review_points}% |
+| CI passing | {ci_points}% |
 | **Total** | **{int(tracking.readiness_score * 100)}%** |
 
 ### Blockers
@@ -285,7 +292,11 @@ Caretaker has released ownership of this PR.
 """
 
 
-def build_readiness_comment(tracking: TrackedPR, previous_score: float | None = None) -> str:
+def build_readiness_comment(
+    tracking: TrackedPR,
+    previous_score: float | None = None,
+    previous_blockers: list[str] | None = None,
+) -> str:
     """Build a comment updating readiness status.
 
     Only call this on meaningful changes to avoid comment noise.
@@ -300,9 +311,11 @@ def build_readiness_comment(tracking: TrackedPR, previous_score: float | None = 
     score_changed = (
         previous_score is not None and abs(tracking.readiness_score - previous_score) >= 0.1
     )
-    blockers_changed = previous_score is None or score_changed
+    blockers_changed = previous_blockers is not None and set(previous_blockers) != set(
+        tracking.readiness_blockers
+    )
 
-    if not blockers_changed and not score_changed:
+    if previous_score is not None and not blockers_changed and not score_changed:
         return ""
 
     return f"""<!-- caretaker:readiness:update -->

--- a/src/caretaker/pr_agent/ownership.py
+++ b/src/caretaker/pr_agent/ownership.py
@@ -1,0 +1,386 @@
+"""PR ownership management — claim, release, and state transitions."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from caretaker.state.models import OwnershipState, TrackedPR
+
+if TYPE_CHECKING:
+    from caretaker.config import OwnershipConfig
+    from caretaker.github_client.api import GitHubClient
+    from caretaker.github_client.models import PullRequest
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OwnershipClaim:
+    """Result of attempting to acquire or release ownership."""
+
+    claimed: bool
+    released: bool
+    reason: str
+    previous_state: OwnershipState
+
+
+def should_auto_claim(
+    pr: PullRequest,
+    config: OwnershipConfig,
+) -> bool:
+    """Determine if Caretaker should automatically claim ownership of a PR.
+
+    Args:
+        pr: The pull request to evaluate
+        config: Ownership configuration
+
+    Returns:
+        True if Caretaker should auto-claim this PR
+    """
+    if not config.enabled:
+        return False
+
+    # Auto-claim Copilot PRs if configured
+    if pr.is_copilot_pr:
+        return config.auto_claim.copilot_prs
+
+    # Auto-claim Dependabot PRs if configured
+    if pr.is_dependabot_pr:
+        return config.auto_claim.dependabot_prs
+
+    # Human PRs require manual `caretaker:owned` label unless auto-claim is enabled
+    if config.auto_claim.human_prs:
+        return True
+
+    # Check for explicit ownership label
+    return bool(pr.has_label(config.label))
+
+
+def should_release_ownership(
+    pr: PullRequest,
+    tracking: TrackedPR,
+    reason: str,
+) -> bool:
+    """Determine if Caretaker should release ownership of a PR.
+
+    Args:
+        pr: The pull request
+        tracking: Current tracking state
+        reason: The reason for checking release (e.g., 'merged', 'closed', 'escalated')
+
+    Returns:
+        True if ownership should be released
+    """
+    if tracking.ownership_state != OwnershipState.OWNED:
+        return False
+
+    # Release on merge
+    if pr.merged:
+        return True
+
+    # Release on close
+    if pr.state.value == "closed":
+        return True
+
+    # Release on escalation
+    return reason == "escalated"
+
+
+async def claim_ownership(
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    pr: PullRequest,
+    tracking: TrackedPR,
+    ownership_config: OwnershipConfig,
+    readiness_config: OwnershipConfig,
+) -> OwnershipClaim:
+    """Attempt to acquire ownership of a PR.
+
+    Args:
+        github: GitHub client
+        owner: Repository owner
+        repo: Repository name
+        pr: The pull request
+        tracking: Current tracking state
+        ownership_config: Ownership configuration
+        readiness_config: Readiness configuration (uses same label field)
+
+    Returns:
+        OwnershipClaim with the result of the claim attempt
+    """
+    previous_state = tracking.ownership_state
+
+    # Already owned by us
+    if tracking.ownership_state == OwnershipState.OWNED:
+        return OwnershipClaim(
+            claimed=False,
+            released=False,
+            reason="Already owned",
+            previous_state=previous_state,
+        )
+
+    # Check if we should auto-claim
+    if not should_auto_claim(pr, ownership_config):
+        return OwnershipClaim(
+            claimed=False,
+            released=False,
+            reason="Not eligible for auto-claim",
+            previous_state=previous_state,
+        )
+
+    # Claim the PR
+    tracking.ownership_state = OwnershipState.OWNED
+    tracking.ownership_acquired_at = datetime.now(UTC)
+    tracking.owned_by = "caretaker"
+
+    # Add ownership label
+    try:
+        await github.add_labels(owner, repo, pr.number, [ownership_config.label])
+    except Exception as e:
+        logger.warning("Failed to add ownership label: %s", e)
+
+    # Post ownership claim comment
+    comment_body = build_ownership_claim_comment(pr, tracking)
+    try:
+        await github.add_issue_comment(owner, repo, pr.number, comment_body)
+    except Exception as e:
+        logger.warning("Failed to post ownership claim comment: %s", e)
+
+    logger.info(
+        "PR #%d: Caretaker claimed ownership (was: %s)",
+        pr.number,
+        previous_state.value,
+    )
+
+    return OwnershipClaim(
+        claimed=True,
+        released=False,
+        reason="Ownership acquired",
+        previous_state=previous_state,
+    )
+
+
+async def release_ownership(
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    pr: PullRequest,
+    tracking: TrackedPR,
+    ownership_config: OwnershipConfig,
+    reason: str = "release",
+) -> OwnershipClaim:
+    """Release ownership of a PR.
+
+    Args:
+        github: GitHub client
+        owner: Repository owner
+        repo: Repository name
+        pr: The pull request
+        tracking: Current tracking state
+        ownership_config: Ownership configuration
+        reason: Reason for release
+
+    Returns:
+        OwnershipClaim with the result
+    """
+    previous_state = tracking.ownership_state
+
+    if tracking.ownership_state not in (OwnershipState.OWNED, OwnershipState.ESCALATED):
+        return OwnershipClaim(
+            claimed=False,
+            released=False,
+            reason="Not owned",
+            previous_state=previous_state,
+        )
+
+    # Release ownership
+    tracking.ownership_state = OwnershipState.RELEASED
+    tracking.ownership_released_at = datetime.now(UTC)
+
+    # Post release comment
+    comment_body = build_ownership_release_comment(pr, tracking, reason)
+    try:
+        await github.add_issue_comment(owner, repo, pr.number, comment_body)
+    except Exception as e:
+        logger.warning("Failed to post ownership release comment: %s", e)
+
+    logger.info(
+        "PR #%d: Caretaker released ownership (was: %s, reason: %s)",
+        pr.number,
+        previous_state.value,
+        reason,
+    )
+
+    return OwnershipClaim(
+        claimed=False,
+        released=True,
+        reason=f"Ownership released: {reason}",
+        previous_state=previous_state,
+    )
+
+
+def build_ownership_claim_comment(pr: PullRequest, tracking: TrackedPR) -> str:
+    """Build the comment body for ownership claim."""
+    return f"""<!-- caretaker:ownership:claim -->
+
+## 🏠 Caretaker Ownership
+
+Caretaker has claimed ownership of this PR.
+
+### Readiness Score
+
+| Component | Score |
+|-----------|-------|
+| Mergeable & non-draft | {int(tracking.readiness_score * 10)}% |
+| Automated feedback | {int(tracking.readiness_score * 20)}% |
+| Reviews approved | {int(tracking.readiness_score * 30)}% |
+| CI passing | {int(tracking.readiness_score * 40)}% |
+| **Total** | **{int(tracking.readiness_score * 100)}%** |
+
+### Blockers
+
+{
+        (
+            "None — PR is ready!"
+            if not tracking.readiness_blockers
+            else chr(10).join(f"- `{b}`" for b in tracking.readiness_blockers)
+        )
+    }
+
+### What This Means
+
+Caretaker will monitor this PR and:
+- Post updates when readiness status changes
+- Request fixes for CI failures or review comments
+- Attempt to merge when fully ready (if auto-merge is enabled)
+- Escalate to maintainers if unable to proceed
+
+---
+*This is an automated comment from [Caretaker](https://github.com/ianlintner/caretaker).*
+"""
+
+
+def build_ownership_release_comment(pr: PullRequest, tracking: TrackedPR, reason: str) -> str:
+    """Build the comment body for ownership release."""
+    blockers = ", ".join(tracking.readiness_blockers) if tracking.readiness_blockers else "none"
+    return f"""<!-- caretaker:ownership:release -->
+
+## 🏠 Caretaker Ownership Released
+
+Caretaker has released ownership of this PR.
+
+**Reason:** {reason}
+
+**Final State:**
+- Ownership duration: {format_duration(tracking)}
+- Final readiness score: {int(tracking.readiness_score * 100)}%
+- Final blockers: {blockers}
+
+---
+*This is an automated comment from [Caretaker](https://github.com/ianlintner/caretaker).*
+"""
+
+
+def build_readiness_comment(tracking: TrackedPR, previous_score: float | None = None) -> str:
+    """Build a comment updating readiness status.
+
+    Only call this on meaningful changes to avoid comment noise.
+
+    Args:
+        tracking: The tracked PR with current readiness state
+        previous_score: The previous readiness score to compare against
+
+    Returns:
+        The comment body, or empty string if no meaningful change
+    """
+    score_changed = (
+        previous_score is not None and abs(tracking.readiness_score - previous_score) >= 0.1
+    )
+    blockers_changed = previous_score is None or score_changed
+
+    if not blockers_changed and not score_changed:
+        return ""
+
+    return f"""<!-- caretaker:readiness:update -->
+
+## 📊 PR Readiness Update
+
+**Readiness Score:** {int(tracking.readiness_score * 100)}%
+
+{
+        (
+            "**Status:** ✅ Ready for merge"
+            if tracking.readiness_score >= 1.0
+            else "**Status:** ⏳ Awaiting requirements"
+        )
+    }
+
+### Blockers
+
+{
+        (
+            "None"
+            if not tracking.readiness_blockers
+            else chr(10).join(f"- `{b}`" for b in tracking.readiness_blockers)
+        )
+    }
+
+---
+*This is an automated comment from [Caretaker](https://github.com/ianlintner/caretaker).*
+"""
+
+
+def format_duration(tracking: TrackedPR) -> str:
+    """Format the ownership duration as a human-readable string."""
+    if not tracking.ownership_acquired_at or not tracking.ownership_released_at:
+        return "unknown"
+    duration = tracking.ownership_released_at - tracking.ownership_acquired_at
+    if duration.days > 0:
+        return f"{duration.days}d {duration.seconds // 3600}h"
+    if duration.seconds >= 3600:
+        return f"{duration.seconds // 3600}h {(duration.seconds % 3600) // 60}m"
+    if duration.seconds >= 60:
+        return f"{duration.seconds // 60}m"
+    return f"{duration.seconds}s"
+
+
+def get_readiness_check_title(tracking: TrackedPR) -> str:
+    """Get a short title for the readiness check based on current state."""
+    if tracking.readiness_score >= 1.0:
+        return "PR is ready for merge"
+    if "ci_pending" in tracking.readiness_blockers or "ci_failing" in tracking.readiness_blockers:
+        return "Waiting for CI"
+    if (
+        "required_review_missing" in tracking.readiness_blockers
+        or "changes_requested" in tracking.readiness_blockers
+    ):
+        return "Awaiting review approval"
+    if "draft_pr" in tracking.readiness_blockers:
+        return "PR is a draft"
+    if "manual_hold" in tracking.readiness_blockers:
+        return "Manual hold placed"
+    return f"Readiness: {int(tracking.readiness_score * 100)}%"
+
+
+def get_readiness_check_summary(tracking: TrackedPR) -> str:
+    """Get a summary for the readiness check output."""
+    lines = [
+        f"**Readiness Score:** {int(tracking.readiness_score * 100)}%",
+        "",
+    ]
+
+    if tracking.readiness_blockers:
+        lines.append("**Blockers:**")
+        for blocker in tracking.readiness_blockers:
+            lines.append(f"- `{blocker}`")
+    else:
+        lines.append("**Status:** ✅ All requirements met — PR is ready for merge!")
+
+    lines.append("")
+    lines.append(f"**Summary:** {tracking.readiness_summary}")
+
+    return "\n".join(lines)

--- a/src/caretaker/pr_agent/states.py
+++ b/src/caretaker/pr_agent/states.py
@@ -219,8 +219,7 @@ def evaluate_readiness(
         summary = "PR is ready for merge"
     elif (
         "ci_pending" in blockers
-        or "required_review_missing" in blockers
-        and "changes_requested" not in blockers
+        or ("required_review_missing" in blockers and "changes_requested" not in blockers)
     ):
         conclusion = "in_progress"
         summary = f"PR pending: {', '.join(blockers)}"

--- a/src/caretaker/pr_agent/states.py
+++ b/src/caretaker/pr_agent/states.py
@@ -54,12 +54,21 @@ class ReviewEvaluation:
 
 
 @dataclass
+class ReadinessEvaluation:
+    score: float
+    blockers: list[str]
+    summary: str
+    conclusion: str  # success, failure, in_progress
+
+
+@dataclass
 class PRStateEvaluation:
     pr: PullRequest
     ci: CIEvaluation
     reviews: ReviewEvaluation
-    recommended_state: PRTrackingState
-    recommended_action: str
+    readiness: ReadinessEvaluation | None = None
+    recommended_state: PRTrackingState = PRTrackingState.DISCOVERED
+    recommended_action: str = "wait"
 
 
 def evaluate_ci(check_runs: list[CheckRun], ignore_jobs: list[str] | None = None) -> CIEvaluation:
@@ -152,6 +161,81 @@ def evaluate_reviews(reviews: list[Review]) -> ReviewEvaluation:
     )
 
 
+def evaluate_readiness(
+    pr: PullRequest,
+    ci: CIEvaluation,
+    review_eval: ReviewEvaluation,
+    current_state: PRTrackingState,
+) -> ReadinessEvaluation:
+    """Evaluate PR readiness score and blockers."""
+    score = 0.0
+    blockers = []
+
+    # 10%: Mergeable, non-draft, no breaking, no hold
+    if (
+        not pr.draft
+        and pr.mergeable
+        and not pr.has_label("maintainer:breaking")
+        and not pr.has_label("caretaker:hold")
+    ):
+        score += 0.10
+    else:
+        if pr.draft:
+            blockers.append("draft_pr")
+        if not pr.mergeable:
+            blockers.append("merge_conflict")
+        if pr.has_label("maintainer:breaking"):
+            blockers.append("breaking_change")
+        if pr.has_label("caretaker:hold"):
+            blockers.append("manual_hold")
+
+    # 20%: Automated feedback addressed
+    if not review_eval.has_automated_comments or current_state == PRTrackingState.FIX_REQUESTED:
+        score += 0.20
+    else:
+        blockers.append("automated_feedback_unaddressed")
+
+    # 30%: Required reviews satisfied
+    if not review_eval.changes_requested and review_eval.approved:
+        score += 0.30
+    else:
+        if review_eval.changes_requested:
+            blockers.append("changes_requested")
+        if not review_eval.approved:
+            blockers.append("required_review_missing")
+
+    # 40%: CI green and no pending checks
+    if ci.status == CIStatus.PASSING and ci.all_completed:
+        score += 0.40
+    else:
+        if ci.status in (CIStatus.FAILING, CIStatus.MIXED):
+            blockers.append("ci_failing")
+        if not ci.all_completed:
+            blockers.append("ci_pending")
+
+    # Determine conclusion
+    if not blockers:
+        conclusion = "success"
+        summary = "PR is ready for merge"
+    elif (
+        "ci_pending" in blockers
+        or "required_review_missing" in blockers
+        and "changes_requested" not in blockers
+    ):
+        conclusion = "in_progress"
+        summary = f"PR pending: {', '.join(blockers)}"
+    else:
+        conclusion = "failure"
+        summary = f"PR blocked: {', '.join(blockers)}"
+
+    return ReadinessEvaluation(
+        score=round(score, 2),
+        blockers=blockers,
+        summary=summary,
+        conclusion=conclusion,
+    )
+
+
 def evaluate_pr(
     pr: PullRequest,
     check_runs: list[CheckRun],
@@ -163,6 +247,7 @@ def evaluate_pr(
     """Full PR evaluation — determines next state and action."""
     ci = evaluate_ci(check_runs, ignore_jobs)
     review_eval = evaluate_reviews(reviews)
+    readiness = evaluate_readiness(pr, ci, review_eval, current_state)
 
     # State transitions
     if pr.merged:
@@ -170,6 +255,7 @@ def evaluate_pr(
             pr=pr,
             ci=ci,
             reviews=review_eval,
+            readiness=readiness,
             recommended_state=PRTrackingState.MERGED,
             recommended_action="none",
         )
@@ -179,6 +265,7 @@ def evaluate_pr(
             pr=pr,
             ci=ci,
             reviews=review_eval,
+            readiness=readiness,
             recommended_state=PRTrackingState.CLOSED,
             recommended_action="none",
         )
@@ -194,6 +281,7 @@ def evaluate_pr(
                 pr=pr,
                 ci=ci,
                 reviews=review_eval,
+                readiness=readiness,
                 recommended_state=PRTrackingState.CI_PENDING,
                 recommended_action="approve_workflows",
             )
@@ -201,6 +289,7 @@ def evaluate_pr(
             pr=pr,
             ci=ci,
             reviews=review_eval,
+            readiness=readiness,
             recommended_state=PRTrackingState.CI_PENDING,
             recommended_action="wait",
         )
@@ -212,6 +301,7 @@ def evaluate_pr(
             pr=pr,
             ci=ci,
             reviews=review_eval,
+            readiness=readiness,
             recommended_state=PRTrackingState.CI_FAILING,
             recommended_action=action,
         )
@@ -227,6 +317,7 @@ def evaluate_pr(
             pr=pr,
             ci=ci,
             reviews=review_eval,
+            readiness=readiness,
             recommended_state=PRTrackingState.REVIEW_CHANGES_REQUESTED,
             recommended_action=action,
         )
@@ -244,6 +335,7 @@ def evaluate_pr(
                 pr=pr,
                 ci=ci,
                 reviews=review_eval,
+                readiness=readiness,
                 recommended_state=PRTrackingState.REVIEW_CHANGES_REQUESTED,
                 recommended_action="request_review_fix",
             )
@@ -253,6 +345,7 @@ def evaluate_pr(
             pr=pr,
             ci=ci,
             reviews=review_eval,
+            readiness=readiness,
             recommended_state=PRTrackingState.MERGE_READY,
             recommended_action="merge",
         )
@@ -261,6 +354,7 @@ def evaluate_pr(
         pr=pr,
         ci=ci,
         reviews=review_eval,
+        readiness=readiness,
         recommended_state=PRTrackingState.CI_PASSING,
         recommended_action="await_review",
     )

--- a/src/caretaker/pr_agent/states.py
+++ b/src/caretaker/pr_agent/states.py
@@ -217,9 +217,8 @@ def evaluate_readiness(
     if not blockers:
         conclusion = "success"
         summary = "PR is ready for merge"
-    elif (
-        "ci_pending" in blockers
-        or ("required_review_missing" in blockers and "changes_requested" not in blockers)
+    elif "ci_pending" in blockers or (
+        "required_review_missing" in blockers and "changes_requested" not in blockers
     ):
         conclusion = "in_progress"
         summary = f"PR pending: {', '.join(blockers)}"

--- a/src/caretaker/state/models.py
+++ b/src/caretaker/state/models.py
@@ -10,6 +10,13 @@ from pydantic import BaseModel, Field
 from caretaker.goals.models import GoalSnapshot  # noqa: TC001 (Pydantic needs runtime access)
 
 
+class OwnershipState(StrEnum):
+    UNOWNED = "unowned"
+    OWNED = "owned"
+    RELEASED = "released"
+    ESCALATED = "escalated"
+
+
 class PRTrackingState(StrEnum):
     DISCOVERED = "discovered"
     CI_PENDING = "ci_pending"
@@ -49,6 +56,17 @@ class TrackedPR(BaseModel):
     last_checked: datetime | None = None
     escalated: bool = False
     notes: str = ""
+
+    # Ownership fields
+    ownership_state: OwnershipState = OwnershipState.UNOWNED
+    owned_by: str = "caretaker"
+    ownership_acquired_at: datetime | None = None
+    ownership_released_at: datetime | None = None
+
+    # Readiness fields
+    readiness_score: float = 0.0
+    readiness_blockers: list[str] = Field(default_factory=list)
+    readiness_summary: str = ""
 
 
 class TrackedIssue(BaseModel):
@@ -117,6 +135,11 @@ class RunSummary(BaseModel):
     reviews_completed: int = 0
     review_artifacts_written: int = 0
     review_average_score: float = 0.0
+    # Ownership & readiness metrics (Phase 1)
+    owned_prs: int = 0
+    readiness_pass_rate: float = 0.0
+    avg_readiness_score: float = 0.0
+    authority_merges: int = 0
     errors: list[str] = Field(default_factory=list)
 
 

--- a/tests/test_pr_agent/test_agent.py
+++ b/tests/test_pr_agent/test_agent.py
@@ -7,7 +7,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from caretaker.config import CIConfig, CopilotConfig, PRAgentConfig
+from caretaker.config import (
+    CIConfig,
+    CopilotConfig,
+    OwnershipConfig,
+    PRAgentConfig,
+    ReadinessConfig,
+)
 from caretaker.github_client.models import (
     CheckConclusion,
     Label,
@@ -30,7 +36,20 @@ def make_config(
         close_managed_prs_on_backlog=close_managed_prs_on_backlog,
     )
     config.copilot = CopilotConfig(max_retries=max_retries)
+    config.ownership = OwnershipConfig()
+    config.readiness = ReadinessConfig()
     return config
+
+
+def make_readiness_evaluation() -> ReadinessEvaluation:
+    """Create a default readiness evaluation for tests."""
+    from caretaker.pr_agent.states import ReadinessEvaluation
+    return ReadinessEvaluation(
+        score=0.5,
+        blockers=["ci_failing"],
+        summary="CI failing",
+        conclusion="in_progress",
+    )
 
 
 @pytest.mark.asyncio
@@ -65,6 +84,7 @@ class TestCIFixLifecycle:
             pr=pr,
             ci=ci_eval,
             reviews=MagicMock(changes_requested=False),
+            readiness=make_readiness_evaluation(),
             recommended_state=PRTrackingState.CI_FAILING,
             recommended_action="request_fix",
         )
@@ -163,6 +183,7 @@ class TestCIFixLifecycle:
             pr=pr,
             ci=ci_eval,
             reviews=MagicMock(changes_requested=False),
+            readiness=make_readiness_evaluation(),
             recommended_state=PRTrackingState.CI_FAILING,
             recommended_action="request_fix",
         )
@@ -421,6 +442,7 @@ class TestApproveWorkflows:
             pr=pr,
             ci=ci_eval,
             reviews=AsyncMock(),
+            readiness=make_readiness_evaluation(),
             recommended_state=PRTrackingState.CI_PENDING,
             recommended_action="approve_workflows",
         )

--- a/tests/test_pr_agent/test_agent.py
+++ b/tests/test_pr_agent/test_agent.py
@@ -21,6 +21,7 @@ from caretaker.github_client.models import (
     ReviewState,
     User,
 )
+from caretaker.pr_agent.states import ReadinessEvaluation
 from caretaker.state.models import PRTrackingState, TrackedPR
 from tests.conftest import make_check_run, make_pr, make_review
 
@@ -43,7 +44,6 @@ def make_config(
 
 def make_readiness_evaluation() -> ReadinessEvaluation:
     """Create a default readiness evaluation for tests."""
-    from caretaker.pr_agent.states import ReadinessEvaluation
     return ReadinessEvaluation(
         score=0.5,
         blockers=["ci_failing"],


### PR DESCRIPTION
✅ What I changed
Updated release.yml in the publish job:

Added a publish auth resolver step:
Resolve publish auth mode sets output has_pypi_token=true|false
Added non-Docker token path:
installs twine
runs twine upload --skip-existing dist/*
used when PYPI_API_TOKEN is present
Kept OIDC trusted publishing path as fallback:
pypa/gh-action-pypi-publish@release/v1
only used when PYPI_API_TOKEN is absent
Added contents: read to publish job permissions (safe/standard for release jobs)