### PR TITLE
Enable Foundry executor (auto routing)

### DIFF
--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -106,3 +106,13 @@ llm:
     - ci_log_analysis
     - architectural_review
     - issue_decomposition
+
+executor:
+  provider: auto
+  foundry:
+    enabled: true
+    model: azure_ai/gpt-4o
+    allowed_task_types:
+      - LINT_FAILURE
+      - REVIEW_COMMENT
+    route_same_repo_only: true


### PR DESCRIPTION
## Summary
- Activates the Foundry in-process coding executor merged in #393
- Routes `LINT_FAILURE` and `REVIEW_COMMENT` tasks through Azure AI Foundry; everything else continues to fall through to Copilot
- `route_same_repo_only: true` blocks fork PRs (installation tokens can't push)

## Test plan
- [ ] CI passes
- [ ] After merge, next failing-lint PR should be fixed by Foundry rather than @copilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)