### PR TITLE
fix(executor): recognize AZURE_AI_API_KEY for Foundry availability

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -237,6 +237,8 @@ jobs:
           # caretaker falls through to Copilot when the vars are absent.
           AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
           AZURE_AI_API_BASE: ${{ secrets.AZURE_AI_API_BASE }}
+          AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
+          AZURE_API_BASE: ${{ secrets.AZURE_API_BASE }}
           CARETAKER_EVENT_PAYLOAD: ${{ toJSON(github.event) }}
           CARETAKER_LOG_FILE: caretaker-run.log
           CARETAKER_REPORT_FILE: caretaker-report.json
@@ -301,6 +303,8 @@ jobs:
           # caretaker falls through to Copilot when the vars are absent.
           AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
           AZURE_AI_API_BASE: ${{ secrets.AZURE_AI_API_BASE }}
+          AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
+          AZURE_API_BASE: ${{ secrets.AZURE_API_BASE }}
           # Pass info about the failed run so the agent can fetch its logs
           CARETAKER_FAILED_RUN_ID: ${{ github.run_id }}
           CARETAKER_LOG_FILE: caretaker-self-heal.log

--- a/src/caretaker/llm/provider.py
+++ b/src/caretaker/llm/provider.py
@@ -237,6 +237,7 @@ class LiteLLMProvider:
                 "ANTHROPIC_API_KEY",
                 "OPENAI_API_KEY",
                 "AZURE_API_KEY",
+                "AZURE_AI_API_KEY",
                 "VERTEX_PROJECT",
                 "GOOGLE_APPLICATION_CREDENTIALS",
                 "AWS_ACCESS_KEY_ID",


### PR DESCRIPTION
## Summary

- Add `AZURE_AI_API_KEY` to `LiteLLMProvider.available`'s recognized credentials so `azure_ai/*` models (as configured in `.github/maintainer/config.yml`) actually activate the in-process FoundryExecutor instead of silently falling back to Copilot.
- Wire `AZURE_API_KEY` / `AZURE_API_BASE` into both `maintain` and `self-heal-on-failure` env in `maintainer.yml` (secrets already exist in the repo) so either credential shape works.

## Context

Latest Caretaker run logged: `executor.foundry.enabled=True but LiteLLM provider is unavailable (missing credentials or package). Routing stays on Copilot.` — the workflow was passing `AZURE_AI_API_KEY` but the availability check only looked at `AZURE_API_KEY`. `tests/test_llm.py::TestLiteLLMProvider::test_available_with_foundry_key` already encoded the intent that `AZURE_AI_API_KEY` should flip `available=True`.

## Test plan

- [x] `.venv/bin/pytest tests/test_llm.py` (21 passed)
- [x] `.venv/bin/ruff check src/caretaker/llm/provider.py`
- [ ] Post-merge: confirm Caretaker run logs show `FoundryExecutor ready:` instead of the unavailable warning