### PR TITLE
fix(pr-agent): single caretaker status comment + configurable review gate

### DIFF
--- a/src/caretaker/admin/auth.py
+++ b/src/caretaker/admin/auth.py
@@ -168,9 +168,11 @@ async def login(request: Request) -> RedirectResponse:
 
     state = secrets.token_urlsafe(32)
     code_verifier = secrets.token_urlsafe(64)
-    code_challenge = base64.urlsafe_b64encode(
-        hashlib.sha256(code_verifier.encode()).digest()
-    ).rstrip(b"=").decode()
+    code_challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
 
     if _redis:
         await _redis.set(f"{_SESSION_PREFIX}state:{state}", "1", ex=300)

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -574,6 +574,20 @@ class GitHubClient:
         )
         return self._parse_comment(data)
 
+    async def edit_issue_comment(
+        self,
+        owner: str,
+        repo: str,
+        comment_id: int,
+        body: str,
+    ) -> Comment:
+        """Edit an existing issue/PR comment by id via PATCH."""
+        data = await self._patch(
+            f"/repos/{owner}/{repo}/issues/comments/{comment_id}",
+            json={"body": body},
+        )
+        return self._parse_comment(data)
+
     async def add_labels(
         self, owner: str, repo: str, number: int, labels: list[str]
     ) -> list[Label]:

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -492,7 +492,5 @@ if _cors_origins:
 # ── SPA catchall (must be last) ──────────────────────────────────────
 
 
-
-
 # Entrypoint for local testing:
 # uvicorn src.caretaker.mcp_backend.main:app --reload

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -15,12 +15,13 @@ from caretaker.pr_agent.ci_triage import FailureType, triage_failure
 from caretaker.pr_agent.copilot import PRCopilotBridge
 from caretaker.pr_agent.merge import evaluate_merge
 from caretaker.pr_agent.ownership import (
-    build_readiness_comment,
+    build_status_comment,
     claim_ownership,
     get_readiness_check_summary,
     get_readiness_check_title,
     release_ownership,
     should_release_ownership,
+    upsert_status_comment,
 )
 from caretaker.pr_agent.review import analyze_reviews
 from caretaker.pr_agent.states import (
@@ -199,6 +200,7 @@ class PRAgent:
             current_state=tracking.state,
             ignore_jobs=self._config.ci.ignore_jobs,
             auto_approve_workflows=self._config.ci.auto_approve_workflows,
+            required_reviews=self._config.readiness.required_reviews,
         )
 
         logger.info(
@@ -763,11 +765,8 @@ class PRAgent:
         2. Attempts to claim ownership if eligible
         3. Releases ownership if the PR is merged/closed/escalated
         4. Publishes the readiness check
-        5. Posts update comments on meaningful changes
+        5. Edits the single caretaker status comment in place
         """
-        previous_score = tracking.readiness_score
-        previous_blockers = list(tracking.readiness_blockers)
-
         # Guard against optional readiness field
         if evaluation.readiness is None:
             return tracking
@@ -822,23 +821,26 @@ class PRAgent:
         # Publish readiness check
         await self._publish_readiness_check(pr, tracking, evaluation)
 
-        # Post update comment on meaningful changes (only for owned PRs)
-        if tracking.ownership_state == OwnershipState.OWNED:
-            update_comment = build_readiness_comment(
-                tracking,
-                previous_score,
-                previous_blockers,
-            )
-            if update_comment:
-                try:
-                    await self._github.add_issue_comment(
-                        self._owner, self._repo, pr.number, update_comment
-                    )
-                except GitHubAPIError as e:
-                    logger.warning(
-                        "PR #%d: Failed to post readiness update comment: %s",
-                        pr.number,
-                        e,
-                    )
+        # Edit the single caretaker status comment in place for owned, still-open
+        # PRs. This keeps one living comment that transitions through
+        # ⏳ monitoring → ✅ ready for merge, rather than appending a new comment
+        # on every evaluation. release_ownership handles the terminal body
+        # (merged / closed / escalated) when the PR reaches a final state.
+        is_terminal = bool(pr.merged) or getattr(pr.state, "value", pr.state) == "closed"
+        if tracking.ownership_state == OwnershipState.OWNED and not is_terminal:
+            try:
+                await upsert_status_comment(
+                    self._github,
+                    self._owner,
+                    self._repo,
+                    pr.number,
+                    build_status_comment(pr, tracking),
+                )
+            except GitHubAPIError as e:
+                logger.warning(
+                    "PR #%d: Failed to upsert caretaker status comment: %s",
+                    pr.number,
+                    e,
+                )
 
         return tracking

--- a/src/caretaker/pr_agent/ownership.py
+++ b/src/caretaker/pr_agent/ownership.py
@@ -1,4 +1,16 @@
-"""PR ownership management — claim, release, and state transitions."""
+"""PR ownership management — claim, release, and state transitions.
+
+This module posts **one caretaker comment per PR** (the "status comment"),
+identified by :data:`STATUS_COMMENT_MARKER`, and edits it in place as the PR
+progresses through its lifecycle (claim → readiness updates → merge-ready →
+released). Callers should use :func:`upsert_status_comment`; direct calls to
+``add_issue_comment`` are reserved for other non-status comments.
+
+Legacy markers from previous versions (``caretaker:ownership:claim``,
+``caretaker:readiness:update``, ``caretaker:ownership:release``) are still
+matched when searching for an existing comment, so PRs opened before this
+change get their older comment edited instead of a second comment appended.
+"""
 
 from __future__ import annotations
 
@@ -12,9 +24,67 @@ from caretaker.state.models import OwnershipState, TrackedPR
 if TYPE_CHECKING:
     from caretaker.config import OwnershipConfig
     from caretaker.github_client.api import GitHubClient
-    from caretaker.github_client.models import PullRequest
+    from caretaker.github_client.models import Comment, PullRequest
 
 logger = logging.getLogger(__name__)
+
+# Canonical marker for the single caretaker status comment per PR.
+STATUS_COMMENT_MARKER = "<!-- caretaker:status -->"
+
+# Legacy markers still recognized so PRs created before the unified status
+# comment migrate cleanly: if we find an old claim/readiness/release comment,
+# we edit it with the new body (which carries STATUS_COMMENT_MARKER).
+_LEGACY_STATUS_MARKERS: tuple[str, ...] = (
+    "<!-- caretaker:ownership:claim -->",
+    "<!-- caretaker:readiness:update -->",
+    "<!-- caretaker:ownership:release -->",
+)
+
+
+async def find_status_comment(
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    pr_number: int,
+) -> Comment | None:
+    """Return the caretaker status comment on a PR, if any.
+
+    Prefers the new :data:`STATUS_COMMENT_MARKER`; falls back to any legacy
+    marker so that pre-migration PRs can be updated in place instead of
+    accumulating a second comment.
+
+    When multiple matching comments exist (leftover from the pre-idempotency
+    bug), the one with the highest id (most recent) is returned.
+    """
+    comments = await github.get_pr_comments(owner, repo, pr_number)
+    match: Comment | None = None
+    for c in comments:
+        body = c.body or ""
+        is_status = STATUS_COMMENT_MARKER in body or any(m in body for m in _LEGACY_STATUS_MARKERS)
+        if is_status and (match is None or c.id > match.id):
+            match = c
+    return match
+
+
+async def upsert_status_comment(
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    body: str,
+) -> None:
+    """Post or edit the single caretaker status comment for a PR.
+
+    If no status comment exists, a new one is posted. Otherwise the existing
+    comment is edited in place (or left untouched if the body is identical).
+    """
+    existing = await find_status_comment(github, owner, repo, pr_number)
+    if existing is None:
+        await github.add_issue_comment(owner, repo, pr_number, body)
+        return
+    if (existing.body or "").strip() == body.strip():
+        return
+    await github.edit_issue_comment(owner, repo, existing.id, body)
 
 
 @dataclass
@@ -31,31 +101,19 @@ def should_auto_claim(
     pr: PullRequest,
     config: OwnershipConfig,
 ) -> bool:
-    """Determine if Caretaker should automatically claim ownership of a PR.
-
-    Args:
-        pr: The pull request to evaluate
-        config: Ownership configuration
-
-    Returns:
-        True if Caretaker should auto-claim this PR
-    """
+    """Determine if Caretaker should automatically claim ownership of a PR."""
     if not config.enabled:
         return False
 
-    # Auto-claim Copilot PRs if configured
     if pr.is_copilot_pr:
         return config.auto_claim.copilot_prs
 
-    # Auto-claim Dependabot PRs if configured
     if pr.is_dependabot_pr:
         return config.auto_claim.dependabot_prs
 
-    # Human PRs require manual `caretaker:owned` label unless auto-claim is enabled
     if config.auto_claim.human_prs:
         return True
 
-    # Check for explicit ownership label
     return bool(pr.has_label(config.label))
 
 
@@ -64,16 +122,7 @@ def should_release_ownership(
     tracking: TrackedPR,
     reason: str,
 ) -> bool:
-    """Determine if Caretaker should release ownership of a PR.
-
-    Args:
-        pr: The pull request
-        tracking: Current tracking state
-        reason: The reason for checking release (e.g., 'merged', 'closed', 'escalated')
-
-    Returns:
-        True if ownership should be released
-    """
+    """Determine if Caretaker should release ownership of a PR."""
     if tracking.ownership_state != OwnershipState.OWNED:
         return False
 
@@ -96,22 +145,9 @@ async def claim_ownership(
     tracking: TrackedPR,
     ownership_config: OwnershipConfig,
 ) -> OwnershipClaim:
-    """Attempt to acquire ownership of a PR.
-
-    Args:
-        github: GitHub client
-        owner: Repository owner
-        repo: Repository name
-        pr: The pull request
-        tracking: Current tracking state
-        ownership_config: Ownership configuration
-
-    Returns:
-        OwnershipClaim with the result of the claim attempt
-    """
+    """Attempt to acquire ownership of a PR and post the initial status comment."""
     previous_state = tracking.ownership_state
 
-    # Already owned by us
     if tracking.ownership_state == OwnershipState.OWNED:
         return OwnershipClaim(
             claimed=False,
@@ -120,7 +156,6 @@ async def claim_ownership(
             previous_state=previous_state,
         )
 
-    # Check if we should auto-claim
     if not should_auto_claim(pr, ownership_config):
         return OwnershipClaim(
             claimed=False,
@@ -129,23 +164,21 @@ async def claim_ownership(
             previous_state=previous_state,
         )
 
-    # Claim the PR
     tracking.ownership_state = OwnershipState.OWNED
     tracking.ownership_acquired_at = datetime.now(UTC)
     tracking.owned_by = "caretaker"
 
-    # Add ownership label
     try:
         await github.add_labels(owner, repo, pr.number, [ownership_config.label])
     except Exception as e:
         logger.warning("Failed to add ownership label: %s", e)
 
-    # Post ownership claim comment
-    comment_body = build_ownership_claim_comment(pr, tracking)
     try:
-        await github.add_issue_comment(owner, repo, pr.number, comment_body)
+        await upsert_status_comment(
+            github, owner, repo, pr.number, build_status_comment(pr, tracking)
+        )
     except Exception as e:
-        logger.warning("Failed to post ownership claim comment: %s", e)
+        logger.warning("Failed to post caretaker status comment: %s", e)
 
     logger.info(
         "PR #%d: Caretaker claimed ownership (was: %s)",
@@ -170,20 +203,7 @@ async def release_ownership(
     ownership_config: OwnershipConfig,
     reason: str = "release",
 ) -> OwnershipClaim:
-    """Release ownership of a PR.
-
-    Args:
-        github: GitHub client
-        owner: Repository owner
-        repo: Repository name
-        pr: The pull request
-        tracking: Current tracking state
-        ownership_config: Ownership configuration
-        reason: Reason for release
-
-    Returns:
-        OwnershipClaim with the result
-    """
+    """Release ownership of a PR and flip the status comment to its terminal body."""
     previous_state = tracking.ownership_state
 
     if tracking.ownership_state not in (OwnershipState.OWNED, OwnershipState.ESCALATED):
@@ -194,16 +214,14 @@ async def release_ownership(
             previous_state=previous_state,
         )
 
-    # Release ownership
     tracking.ownership_state = OwnershipState.RELEASED
     tracking.ownership_released_at = datetime.now(UTC)
 
-    # Post release comment
-    comment_body = build_ownership_release_comment(pr, tracking, reason)
     try:
-        await github.add_issue_comment(owner, repo, pr.number, comment_body)
+        body = build_status_comment(pr, tracking, release_reason=reason)
+        await upsert_status_comment(github, owner, repo, pr.number, body)
     except Exception as e:
-        logger.warning("Failed to post ownership release comment: %s", e)
+        logger.warning("Failed to update caretaker status comment on release: %s", e)
 
     logger.info(
         "PR #%d: Caretaker released ownership (was: %s, reason: %s)",
@@ -220,8 +238,34 @@ async def release_ownership(
     )
 
 
-def build_ownership_claim_comment(pr: PullRequest, tracking: TrackedPR) -> str:
-    """Build the comment body for ownership claim."""
+def _status_line(pr: PullRequest, tracking: TrackedPR, release_reason: str | None) -> str:
+    """Render the one-line status heading for the status comment."""
+    if release_reason:
+        if bool(getattr(pr, "merged", False)):
+            return "**Status:** 🎉 Merged — caretaker has released ownership"
+        pr_state = getattr(pr.state, "value", pr.state)
+        if pr_state == "closed":
+            return "**Status:** 🚫 Closed without merge — caretaker has released ownership"
+        if release_reason == "PR escalated" or tracking.escalated:
+            return "**Status:** ⚠️ Escalated to maintainers — caretaker has released ownership"
+        return f"**Status:** 🔓 Released — {release_reason}"
+
+    if tracking.readiness_score >= 1.0:
+        return "**Status:** ✅ Ready for merge — all requirements satisfied"
+    return "**Status:** ⏳ Monitoring — awaiting requirements"
+
+
+def build_status_comment(
+    pr: PullRequest,
+    tracking: TrackedPR,
+    release_reason: str | None = None,
+) -> str:
+    """Render the unified caretaker status comment body.
+
+    This single body is edited in place as the PR progresses — there is no
+    separate claim / readiness / release comment. The header and status line
+    reflect the current phase (monitoring / ready for merge / released).
+    """
     blockers = set(tracking.readiness_blockers)
     mergeability_points = (
         0 if {"draft_pr", "merge_conflict", "breaking_change", "manual_hold"} & blockers else 10
@@ -229,14 +273,37 @@ def build_ownership_claim_comment(pr: PullRequest, tracking: TrackedPR) -> str:
     automated_points = 0 if "automated_feedback_unaddressed" in blockers else 20
     review_points = 0 if {"required_review_missing", "changes_requested"} & blockers else 30
     ci_points = 0 if {"ci_pending", "ci_failing"} & blockers else 40
+    total_pct = int(tracking.readiness_score * 100)
 
-    return f"""<!-- caretaker:ownership:claim -->
+    blockers_section = (
+        "None — PR is ready!"
+        if not tracking.readiness_blockers
+        else "\n".join(f"- `{b}`" for b in tracking.readiness_blockers)
+    )
 
-## 🏠 Caretaker Ownership
+    ownership_lines = [f"- **Owner:** {tracking.owned_by}"]
+    if tracking.ownership_acquired_at:
+        ownership_lines.append(
+            f"- **Claimed:** {tracking.ownership_acquired_at.strftime('%Y-%m-%d %H:%M UTC')}"
+        )
+    if tracking.ownership_released_at:
+        ownership_lines.append(
+            f"- **Released:** {tracking.ownership_released_at.strftime('%Y-%m-%d %H:%M UTC')} "
+            f"({release_reason or 'released'})"
+        )
+        ownership_lines.append(f"- **Duration:** {format_duration(tracking)}")
 
-Caretaker has claimed ownership of this PR.
+    ownership_block = "\n".join(ownership_lines)
 
-### Readiness Score
+    return f"""{STATUS_COMMENT_MARKER}
+
+## 🏠 Caretaker Status
+
+{_status_line(pr, tracking, release_reason)}
+
+**Readiness Score:** {total_pct}%
+
+### Readiness Breakdown
 
 | Component | Score |
 |-----------|-------|
@@ -244,104 +311,18 @@ Caretaker has claimed ownership of this PR.
 | Automated feedback | {automated_points}% |
 | Reviews approved | {review_points}% |
 | CI passing | {ci_points}% |
-| **Total** | **{int(tracking.readiness_score * 100)}%** |
+| **Total** | **{total_pct}%** |
 
 ### Blockers
 
-{
-        (
-            "None — PR is ready!"
-            if not tracking.readiness_blockers
-            else chr(10).join(f"- `{b}`" for b in tracking.readiness_blockers)
-        )
-    }
+{blockers_section}
 
-### What This Means
+### Ownership
 
-Caretaker will monitor this PR and:
-- Post updates when readiness status changes
-- Request fixes for CI failures or review comments
-- Attempt to merge when fully ready (if auto-merge is enabled)
-- Escalate to maintainers if unable to proceed
+{ownership_block}
 
 ---
-*This is an automated comment from [Caretaker](https://github.com/ianlintner/caretaker).*
-"""
-
-
-def build_ownership_release_comment(pr: PullRequest, tracking: TrackedPR, reason: str) -> str:
-    """Build the comment body for ownership release."""
-    blockers = ", ".join(tracking.readiness_blockers) if tracking.readiness_blockers else "none"
-    return f"""<!-- caretaker:ownership:release -->
-
-## 🏠 Caretaker Ownership Released
-
-Caretaker has released ownership of this PR.
-
-**Reason:** {reason}
-
-**Final State:**
-- Ownership duration: {format_duration(tracking)}
-- Final readiness score: {int(tracking.readiness_score * 100)}%
-- Final blockers: {blockers}
-
----
-*This is an automated comment from [Caretaker](https://github.com/ianlintner/caretaker).*
-"""
-
-
-def build_readiness_comment(
-    tracking: TrackedPR,
-    previous_score: float | None = None,
-    previous_blockers: list[str] | None = None,
-) -> str:
-    """Build a comment updating readiness status.
-
-    Only call this on meaningful changes to avoid comment noise.
-
-    Args:
-        tracking: The tracked PR with current readiness state
-        previous_score: The previous readiness score to compare against
-
-    Returns:
-        The comment body, or empty string if no meaningful change
-    """
-    score_changed = (
-        previous_score is not None and abs(tracking.readiness_score - previous_score) >= 0.1
-    )
-    blockers_changed = previous_blockers is not None and set(previous_blockers) != set(
-        tracking.readiness_blockers
-    )
-
-    if previous_score is not None and not blockers_changed and not score_changed:
-        return ""
-
-    return f"""<!-- caretaker:readiness:update -->
-
-## 📊 PR Readiness Update
-
-**Readiness Score:** {int(tracking.readiness_score * 100)}%
-
-{
-        (
-            "**Status:** ✅ Ready for merge"
-            if tracking.readiness_score >= 1.0
-            else "**Status:** ⏳ Awaiting requirements"
-        )
-    }
-
-### Blockers
-
-{
-        (
-            "None"
-            if not tracking.readiness_blockers
-            else chr(10).join(f"- `{b}`" for b in tracking.readiness_blockers)
-        )
-    }
-
----
-*This is an automated comment from [Caretaker](https://github.com/ianlintner/caretaker).*
+*This comment is edited in place as the PR progresses. Automated by [Caretaker](https://github.com/ianlintner/caretaker).*
 """
 
 

--- a/src/caretaker/pr_agent/states.py
+++ b/src/caretaker/pr_agent/states.py
@@ -166,8 +166,16 @@ def evaluate_readiness(
     ci: CIEvaluation,
     review_eval: ReviewEvaluation,
     current_state: PRTrackingState,
+    required_reviews: int = 1,
 ) -> ReadinessEvaluation:
-    """Evaluate PR readiness score and blockers."""
+    """Evaluate PR readiness score and blockers.
+
+    Args:
+        required_reviews: Minimum approving reviews required for the review-points
+            component. When ``0`` (repo doesn't require reviews), the review
+            component passes automatically and ``required_review_missing`` is not
+            added as a blocker. An explicit ``changes_requested`` review still blocks.
+    """
     score = 0.0
     blockers = []
 
@@ -196,14 +204,16 @@ def evaluate_readiness(
     else:
         blockers.append("automated_feedback_unaddressed")
 
-    # 30%: Required reviews satisfied
-    if not review_eval.changes_requested and review_eval.approved:
-        score += 0.30
+    # 30%: Required reviews satisfied. When required_reviews is 0, the repo
+    # does not require approving reviews, so this component passes unless a
+    # reviewer has explicitly requested changes.
+    reviews_required = required_reviews > 0
+    if review_eval.changes_requested:
+        blockers.append("changes_requested")
+    elif reviews_required and not review_eval.approved:
+        blockers.append("required_review_missing")
     else:
-        if review_eval.changes_requested:
-            blockers.append("changes_requested")
-        if not review_eval.approved:
-            blockers.append("required_review_missing")
+        score += 0.30
 
     # 40%: CI green and no pending checks
     if ci.status == CIStatus.PASSING and ci.all_completed:
@@ -242,11 +252,12 @@ def evaluate_pr(
     current_state: PRTrackingState,
     ignore_jobs: list[str] | None = None,
     auto_approve_workflows: bool = False,
+    required_reviews: int = 1,
 ) -> PRStateEvaluation:
     """Full PR evaluation — determines next state and action."""
     ci = evaluate_ci(check_runs, ignore_jobs)
     review_eval = evaluate_reviews(reviews)
-    readiness = evaluate_readiness(pr, ci, review_eval, current_state)
+    readiness = evaluate_readiness(pr, ci, review_eval, current_state, required_reviews)
 
     # State transitions
     if pr.merged:

--- a/tests/test_github_client_api.py
+++ b/tests/test_github_client_api.py
@@ -163,6 +163,28 @@ async def test_add_issue_comment_uses_default_client_for_regular_comments() -> N
     assert comment.user.login == "github-actions[bot]"
 
 
+@pytest.mark.asyncio
+async def test_edit_issue_comment_sends_patch() -> None:
+    """edit_issue_comment issues PATCH to /issues/comments/:id and returns the Comment."""
+    with patch.dict("os.environ", {"GITHUB_TOKEN": "fake-token"}):
+        gh = GitHubClient(token="fake-token")
+
+    payload = _comment_payload("github-actions[bot]")
+    payload["body"] = "new body"
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=_make_response(200, payload))
+    gh._client = mock_client
+
+    comment = await gh.edit_issue_comment("o", "r", 123, "new body")
+
+    assert comment.id == 123
+    assert comment.body == "new body"
+    call = mock_client.request.await_args
+    assert call.args[0] == "PATCH"
+    assert call.args[1].endswith("/repos/o/r/issues/comments/123")
+    assert call.kwargs["json"] == {"body": "new body"}
+
+
 # ── In-process read cache ─────────────────────────────────────────────────────
 
 

--- a/tests/test_pr_agent/test_ownership.py
+++ b/tests/test_pr_agent/test_ownership.py
@@ -1,0 +1,229 @@
+"""Tests for unified caretaker status comment (claim/readiness/release).
+
+Verifies the Phase-F fix for PR #172: a single caretaker:status comment is
+posted and edited in place across a PR's lifecycle instead of appending a new
+claim/readiness/release comment on every evaluation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from caretaker.config import OwnershipConfig
+from caretaker.github_client.models import Comment, User
+from caretaker.pr_agent.ownership import (
+    STATUS_COMMENT_MARKER,
+    build_status_comment,
+    claim_ownership,
+    find_status_comment,
+    release_ownership,
+    upsert_status_comment,
+)
+from caretaker.state.models import OwnershipState, TrackedPR
+from tests.conftest import make_pr
+
+
+def _comment(id_: int, body: str) -> Comment:
+    return Comment(
+        id=id_,
+        user=User(login="github-actions[bot]", id=0, type="Bot"),
+        body=body,
+        created_at=datetime(2026, 4, 19, tzinfo=UTC),
+    )
+
+
+def _mock_github(existing: list[Comment] | None = None) -> AsyncMock:
+    gh = AsyncMock()
+    gh.get_pr_comments = AsyncMock(return_value=list(existing or []))
+    gh.add_issue_comment = AsyncMock()
+    gh.edit_issue_comment = AsyncMock()
+    gh.add_labels = AsyncMock()
+    return gh
+
+
+# ── find_status_comment ───────────────────────────────────────────────────────
+
+
+class TestFindStatusComment:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_marker(self) -> None:
+        gh = _mock_github([_comment(1, "random human comment")])
+        assert await find_status_comment(gh, "o", "r", 1) is None
+
+    @pytest.mark.asyncio
+    async def test_finds_by_new_marker(self) -> None:
+        gh = _mock_github([_comment(7, f"{STATUS_COMMENT_MARKER}\nbody")])
+        found = await find_status_comment(gh, "o", "r", 1)
+        assert found is not None and found.id == 7
+
+    @pytest.mark.asyncio
+    async def test_finds_by_legacy_claim_marker(self) -> None:
+        """Pre-migration PRs still have an old caretaker:ownership:claim comment."""
+        gh = _mock_github([_comment(3, "<!-- caretaker:ownership:claim -->\n...")])
+        found = await find_status_comment(gh, "o", "r", 1)
+        assert found is not None and found.id == 3
+
+    @pytest.mark.asyncio
+    async def test_finds_by_legacy_readiness_marker(self) -> None:
+        gh = _mock_github([_comment(4, "<!-- caretaker:readiness:update -->\n...")])
+        found = await find_status_comment(gh, "o", "r", 1)
+        assert found is not None and found.id == 4
+
+    @pytest.mark.asyncio
+    async def test_returns_most_recent_when_duplicates_exist(self) -> None:
+        gh = _mock_github(
+            [
+                _comment(10, "<!-- caretaker:ownership:claim -->\nold"),
+                _comment(15, "<!-- caretaker:ownership:claim -->\nnewer"),
+                _comment(12, "<!-- caretaker:readiness:update -->\nmiddle"),
+            ]
+        )
+        found = await find_status_comment(gh, "o", "r", 1)
+        assert found is not None and found.id == 15
+
+
+# ── upsert_status_comment ─────────────────────────────────────────────────────
+
+
+class TestUpsertStatusComment:
+    @pytest.mark.asyncio
+    async def test_posts_new_when_none_exists(self) -> None:
+        gh = _mock_github([])
+        await upsert_status_comment(gh, "o", "r", 1, "body")
+        gh.add_issue_comment.assert_awaited_once_with("o", "r", 1, "body")
+        gh.edit_issue_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_edits_when_body_differs(self) -> None:
+        gh = _mock_github([_comment(42, f"{STATUS_COMMENT_MARKER}\nold")])
+        await upsert_status_comment(gh, "o", "r", 1, f"{STATUS_COMMENT_MARKER}\nnew")
+        gh.edit_issue_comment.assert_awaited_once()
+        args = gh.edit_issue_comment.await_args.args
+        assert args[2] == 42
+        assert "new" in args[3]
+        gh.add_issue_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_body_unchanged(self) -> None:
+        body = f"{STATUS_COMMENT_MARKER}\nsame"
+        gh = _mock_github([_comment(42, body)])
+        await upsert_status_comment(gh, "o", "r", 1, body)
+        gh.add_issue_comment.assert_not_awaited()
+        gh.edit_issue_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_migrates_legacy_claim_comment_in_place(self) -> None:
+        """Legacy claim comment is edited, not duplicated by a new status comment."""
+        gh = _mock_github([_comment(99, "<!-- caretaker:ownership:claim -->\nold")])
+        await upsert_status_comment(gh, "o", "r", 1, f"{STATUS_COMMENT_MARKER}\nnew")
+        gh.edit_issue_comment.assert_awaited_once()
+        gh.add_issue_comment.assert_not_awaited()
+
+
+# ── claim_ownership ───────────────────────────────────────────────────────────
+
+
+def _copilot_pr(number: int = 100, draft: bool = False) -> object:
+    return make_pr(
+        number=number,
+        user=User(login="copilot-swe-agent[bot]", id=1, type="Bot"),
+        draft=draft,
+    )
+
+
+class TestClaimOwnershipIdempotent:
+    @pytest.mark.asyncio
+    async def test_first_claim_posts_new_comment(self) -> None:
+        gh = _mock_github([])
+        tracking = TrackedPR(number=100)
+        result = await claim_ownership(gh, "o", "r", _copilot_pr(), tracking, OwnershipConfig())
+        assert result.claimed is True
+        gh.add_issue_comment.assert_awaited_once()
+        gh.edit_issue_comment.assert_not_awaited()
+        posted_body = gh.add_issue_comment.await_args.args[3]
+        assert STATUS_COMMENT_MARKER in posted_body
+
+    @pytest.mark.asyncio
+    async def test_second_claim_edits_existing_no_duplicate(self) -> None:
+        """If a second claim ever fires (stale state, concurrent worker),
+        it must edit the existing status comment rather than append."""
+        existing_body = f"{STATUS_COMMENT_MARKER}\nstub"
+        gh = _mock_github([_comment(55, existing_body)])
+        tracking = TrackedPR(number=100)
+        await claim_ownership(gh, "o", "r", _copilot_pr(), tracking, OwnershipConfig())
+        gh.add_issue_comment.assert_not_awaited()
+        gh.edit_issue_comment.assert_awaited_once()
+        assert gh.edit_issue_comment.await_args.args[2] == 55
+
+
+# ── release_ownership flips comment body ──────────────────────────────────────
+
+
+class TestReleaseFlipsStatusBody:
+    @pytest.mark.asyncio
+    async def test_release_edits_existing_status_comment(self) -> None:
+        """Merge/close doesn't add a fourth comment — it edits the same one."""
+        existing_body = f"{STATUS_COMMENT_MARKER}\nmonitoring"
+        gh = _mock_github([_comment(88, existing_body)])
+        tracking = TrackedPR(
+            number=100,
+            ownership_state=OwnershipState.OWNED,
+            ownership_acquired_at=datetime.now(UTC),
+        )
+        pr = make_pr(number=100, merged=True, user=User(login="dev", id=3))
+        result = await release_ownership(
+            gh, "o", "r", pr, tracking, OwnershipConfig(), reason="PR merged"
+        )
+        assert result.released is True
+        gh.edit_issue_comment.assert_awaited_once()
+        assert gh.edit_issue_comment.await_args.args[2] == 88
+        new_body = gh.edit_issue_comment.await_args.args[3]
+        assert "🎉 Merged" in new_body
+
+
+# ── build_status_comment transitions ──────────────────────────────────────────
+
+
+class TestBuildStatusCommentTransitions:
+    def test_monitoring_body_when_score_below_one(self) -> None:
+        tracking = TrackedPR(
+            number=1,
+            readiness_score=0.2,
+            readiness_blockers=["ci_pending"],
+            ownership_state=OwnershipState.OWNED,
+            ownership_acquired_at=datetime(2026, 4, 19, 12, 0, tzinfo=UTC),
+        )
+        body = build_status_comment(make_pr(number=1), tracking)
+        assert STATUS_COMMENT_MARKER in body
+        assert "⏳ Monitoring" in body
+        assert "`ci_pending`" in body
+        assert "20%" in body
+
+    def test_ready_body_when_score_one(self) -> None:
+        tracking = TrackedPR(
+            number=1,
+            readiness_score=1.0,
+            readiness_blockers=[],
+            ownership_state=OwnershipState.OWNED,
+            ownership_acquired_at=datetime(2026, 4, 19, 12, 0, tzinfo=UTC),
+        )
+        body = build_status_comment(make_pr(number=1), tracking)
+        assert "✅ Ready for merge" in body
+        assert "None — PR is ready!" in body
+
+    def test_merged_body_includes_duration_and_merge_emoji(self) -> None:
+        tracking = TrackedPR(
+            number=1,
+            readiness_score=1.0,
+            ownership_state=OwnershipState.RELEASED,
+            ownership_acquired_at=datetime(2026, 4, 19, 12, 0, tzinfo=UTC),
+            ownership_released_at=datetime(2026, 4, 19, 15, 30, tzinfo=UTC),
+        )
+        pr = make_pr(number=1, merged=True)
+        body = build_status_comment(pr, tracking, release_reason="PR merged")
+        assert "🎉 Merged" in body
+        assert "Released:" in body
+        assert "Duration:" in body

--- a/tests/test_pr_agent/test_states.py
+++ b/tests/test_pr_agent/test_states.py
@@ -427,3 +427,54 @@ class TestEvaluatePRReviewGuards:
         # Should fall through to merge — bot comments already addressed
         assert result.recommended_action in ("merge", "await_review")
         assert result.recommended_action != "request_review_fix"
+
+
+class TestReadinessRequiredReviews:
+    """Readiness scoring respects the required_reviews config knob.
+
+    Regression for rust-oauth2-server PR #172 where the score stayed stuck at
+    20% on a solo-dev repo because `required_review_missing` was unconditionally
+    added whenever no reviewer had approved.
+    """
+
+    def test_required_reviews_zero_grants_review_points_without_approval(self) -> None:
+        """When required_reviews=0, a PR with no reviews still scores the 30% review component."""
+        pr = make_pr()
+        checks = [make_check_run(name="test")]  # passing
+        result = evaluate_pr(
+            pr,
+            checks,
+            [],  # no reviews at all
+            PRTrackingState.CI_PASSING,
+            required_reviews=0,
+        )
+        assert result.readiness is not None
+        assert "required_review_missing" not in result.readiness.blockers
+        # 10 (mergeable) + 20 (no automated feedback) + 30 (reviews waived) + 40 (CI) = 100
+        assert result.readiness.score == 1.0
+        assert result.recommended_state == PRTrackingState.MERGE_READY
+
+    def test_required_reviews_zero_still_blocks_on_changes_requested(self) -> None:
+        """Even with required_reviews=0, an explicit changes-requested review blocks."""
+        pr = make_pr()
+        checks = [make_check_run(name="test")]
+        reviews = [make_review(state=ReviewState.CHANGES_REQUESTED, body="nope")]
+        result = evaluate_pr(
+            pr,
+            checks,
+            reviews,
+            PRTrackingState.CI_PASSING,
+            required_reviews=0,
+        )
+        assert result.readiness is not None
+        assert "changes_requested" in result.readiness.blockers
+        assert "required_review_missing" not in result.readiness.blockers
+
+    def test_required_reviews_default_one_still_adds_blocker(self) -> None:
+        """Default behavior (required_reviews=1) is unchanged — missing review blocks."""
+        pr = make_pr()
+        checks = [make_check_run(name="test")]
+        result = evaluate_pr(pr, checks, [], PRTrackingState.CI_PASSING)  # default=1
+        assert result.readiness is not None
+        assert "required_review_missing" in result.readiness.blockers
+        assert result.readiness.score < 1.0


### PR DESCRIPTION
## Summary

- Unify caretaker's per-PR footprint into **one** status comment (`<!-- caretaker:status -->`) that is edited in place across the PR lifecycle (monitoring → ready-for-merge → merged/closed/escalated), instead of appending new claim / readiness / release comments on every evaluation.
- Make the 30% "reviews approved" readiness component **opt-in** via `readiness.required_reviews`: when set to `0`, the `required_review_missing` blocker is no longer added, so solo-dev repos that don't require reviews can actually reach 100%.
- Add `GitHubClient.edit_issue_comment` (PATCH) to enable idempotent comment management.

## Context — what prompted this

On [rust-oauth2-server#172](https://github.com/ianlintner/rust-oauth2-server/pull/172) (a 2-line rustfmt fix), caretaker's behavior was poor:

| Before | After |
|--------|-------|
| **12 comments in 10 minutes** — 6× identical "🏠 Caretaker Ownership" claims + 6× identical "📊 Readiness Update" (all 20%, same blockers) | **1 caretaker comment** per PR, edited in place as state changes |
| Readiness score stuck at **20%** with `required_review_missing` as a blocker even though the repo doesn't require reviews | Score reaches **100%** when `required_reviews: 0` is configured |
| Silent at 19:35 UTC; PR merged at 23:12 with **no success/merge acknowledgment** | Status comment flips to "🎉 Merged" body on release |

Root causes: `claim_ownership` and the readiness-update posting site both called `add_issue_comment` unconditionally with no idempotency guard, and `evaluate_readiness` unconditionally added `required_review_missing` whenever no reviewer had approved.

## Changes

- `src/caretaker/github_client/api.py` — new `edit_issue_comment` (PATCH `/issues/comments/:id`).
- `src/caretaker/pr_agent/ownership.py` — rewrite around a single `caretaker:status` comment:
  - `STATUS_COMMENT_MARKER` + legacy markers (`ownership:claim`, `readiness:update`, `ownership:release`) for backward-compatible discovery.
  - `find_status_comment` / `upsert_status_comment` helpers.
  - `build_status_comment(pr, tracking, release_reason=...)` renders the unified body (header, status line, score breakdown table, blockers, ownership metadata). Monitoring / ready / released bodies are the same comment at different phases.
  - `claim_ownership` and `release_ownership` both upsert the single status comment instead of posting new ones.
- `src/caretaker/pr_agent/agent.py` — `_handle_ownership` upserts the status comment for owned, still-open PRs instead of appending a readiness update per run.
- `src/caretaker/pr_agent/states.py` — `evaluate_readiness` / `evaluate_pr` now accept `required_reviews`; threaded from `config.readiness.required_reviews`.

## Migration

Caretaker already writes HTML markers on its comments (the three legacy markers above). On a PR that already has one or more legacy-marker comments, `find_status_comment` returns the most recent match and `upsert_status_comment` edits it in place with the new unified body — no extra comment is appended. PRs with zero existing comments get a single new `caretaker:status` comment.

Zombies from the pre-fix duplicate-posting bug (e.g. 11 extra comments on rust-oauth2-server#172) are left as historical artifacts — they're only read, never rewritten.

## Explicitly deferred

- **PR-level concurrency lock.** Two workers racing to evaluate the same PR before either has posted can still produce 2 comments. Plan Phase 5. Mitigation after this PR: post/edit races become idempotent no-ops rather than visible duplicates.
- **Cached `last_status_comment_id` on `TrackedPR`.** Every evaluation currently lists PR comments once; could mirror the existing `last_task_comment_id` to skip the GET on the hot path.
- **Legacy-zombie cleanup.** Could sweep and delete leftover duplicate comments from the pre-fix window; not implemented here.

## Test plan

- [x] `uv run pytest` — 712 passed
- [x] `uv run ruff check` on modified files — clean
- [x] `uv run mypy src/caretaker/pr_agent src/caretaker/github_client/api.py` — clean
- New tests (19):
  - `tests/test_github_client_api.py::test_edit_issue_comment_sends_patch`
  - `tests/test_pr_agent/test_ownership.py` — `find_status_comment` (new + legacy markers, most-recent-wins across duplicates), `upsert_status_comment` (new / edit / noop / legacy migration), `claim_ownership` idempotency, release flips body, `build_status_comment` phase transitions
  - `tests/test_pr_agent/test_states.py::TestReadinessRequiredReviews` — `required_reviews=0` grants review points, still blocks on explicit changes-requested, default=1 unchanged
- [ ] Manual validation: the *next* real PR in this repo should show exactly one caretaker status comment that edits in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)