### PR TITLE
Sprint 3: stuck-PR age gate + retry-window reset (E1+E3)

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -85,6 +85,11 @@ class CIConfig(StrictBaseModel):
 
 
 class ReviewConfig(StrictBaseModel):
+    # NOTE: auto_approve_copilot is currently a no-op — accepted for backward
+    # compatibility with existing configs but not yet wired into the review
+    # flow. Tracked as a follow-up to Sprint 2 E2 (auto-merge after Copilot
+    # post-approval push), where the same review-state semantics need to be
+    # decided. Setting this to true today has no effect.
     auto_approve_copilot: bool = False
     nitpick_threshold: Literal["low", "high"] = "low"
 
@@ -97,6 +102,12 @@ class PRAgentConfig(StrictBaseModel):
     review: ReviewConfig = Field(default_factory=ReviewConfig)
     ownership: OwnershipConfig = Field(default_factory=OwnershipConfig)
     readiness: ReadinessConfig = Field(default_factory=ReadinessConfig)
+    # When a PR has been open this long without progressing to merge-ready and
+    # without a human review approval, escalate it to a human. Catches the
+    # long-tail abandonment cases (portfolio #4 was open 10 days; #28 was
+    # open 7 days) that the within-cycle stuck-detection doesn't see.
+    # 0 disables the gate.
+    stuck_age_hours: int = 24
 
 
 class IssueAgentLabels(StrictBaseModel):

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -181,6 +181,40 @@ class PRAgent:
 
         return report, tracked_prs
 
+    @staticmethod
+    def _pr_age_hours(pr: PullRequest) -> float:
+        """Return the PR's open age in hours, or 0.0 if created_at is missing."""
+        if pr.created_at is None:
+            return 0.0
+        created = pr.created_at
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
+        return (datetime.now(UTC) - created).total_seconds() / 3600.0
+
+    def _is_pr_stuck_by_age(self, pr: PullRequest, reviews: list[Any]) -> bool:
+        """Return True when the PR meets the stuck-by-age criteria.
+
+        Stuck means: open longer than ``stuck_age_hours`` AND no human
+        approval review on file. CI state is intentionally NOT considered —
+        a PR that's been failing for 24h with no human attention is exactly
+        what this gate catches.
+        """
+        from caretaker.github_client.models import ReviewState
+
+        age = self._pr_age_hours(pr)
+        if age < self._config.stuck_age_hours:
+            return False
+        for review in reviews or []:
+            if getattr(review, "state", None) == ReviewState.APPROVED:
+                user = getattr(review, "user", None)
+                login = getattr(user, "login", "") if user else ""
+                # Only human approvals count — bot reviewers don't count
+                if login and not (
+                    "[bot]" in login or login.startswith("copilot")
+                ):
+                    return False
+        return True
+
     async def _process_pr(
         self, pr: PullRequest, tracking: TrackedPR, report: PRAgentReport
     ) -> TrackedPR:
@@ -191,6 +225,45 @@ class PRAgent:
         # Fetch CI status and reviews
         check_runs = await self._github.get_check_runs(self._owner, self._repo, pr.head_ref)
         reviews = await self._github.get_pr_reviews(self._owner, self._repo, pr.number)
+
+        # Stuck-PR age gate (E1): if the PR has been open for longer than
+        # ``stuck_age_hours`` AND no human approval AND no recent merge
+        # transition, escalate to a human. Catches long-tail abandonment
+        # (portfolio #4 was open 10 days; #28 was open 7 days). Skipped if
+        # already escalated (terminal) or PR is closed/merged.
+        if (
+            self._config.stuck_age_hours > 0
+            and not tracking.escalated
+            and tracking.state
+            not in (PRTrackingState.ESCALATED, PRTrackingState.MERGED, PRTrackingState.CLOSED)
+            and self._is_pr_stuck_by_age(pr, reviews)
+        ):
+            await self._escalate(
+                pr,
+                f"Open >{self._config.stuck_age_hours}h with no human approval — needs review",
+                debug_data={
+                    "pr_age_hours": self._pr_age_hours(pr),
+                    "stuck_age_hours": self._config.stuck_age_hours,
+                    "fix_cycles": tracking.fix_cycles,
+                    "copilot_attempts": tracking.copilot_attempts,
+                },
+            )
+            tracking.state = PRTrackingState.ESCALATED
+            tracking.escalated = True
+            report.escalated.append(pr.number)
+            # Still flow through ownership handling so the status comment
+            # transitions to "released — escalated" cleanly.
+            evaluation = evaluate_pr(
+                pr=pr,
+                check_runs=check_runs,
+                reviews=reviews,
+                current_state=tracking.state,
+                ignore_jobs=self._config.ci.ignore_jobs,
+                auto_approve_workflows=self._config.ci.auto_approve_workflows,
+                required_reviews=self._config.readiness.required_reviews,
+            )
+            tracking = await self._handle_ownership(pr, tracking, evaluation, report)
+            return tracking
 
         # Evaluate PR state
         evaluation = evaluate_pr(
@@ -392,6 +465,27 @@ class PRAgent:
             report.waiting.append(pr.number)
             return tracking
 
+        # E3: when the prior attempt is older than retry_window_hours, reset
+        # the attempt counter — old failures shouldn't compound to escalation
+        # on long-lived PRs that genuinely needed time.
+        window_h = self._config.copilot.retry_window_hours
+        if (
+            window_h > 0
+            and tracking.copilot_attempts > 0
+            and tracking.last_copilot_attempt_at is not None
+        ):
+            last = tracking.last_copilot_attempt_at
+            if last.tzinfo is None:
+                last = last.replace(tzinfo=UTC)
+            age_h = (datetime.now(UTC) - last).total_seconds() / 3600.0
+            if age_h >= window_h:
+                logger.info(
+                    "PR #%d: resetting copilot_attempts (last attempt %.1fh ago, "
+                    "outside %dh retry window)",
+                    pr.number, age_h, window_h,
+                )
+                tracking.copilot_attempts = 0
+
         # Check if we've exceeded Copilot retry limit
         if tracking.copilot_attempts >= self._config.copilot.max_retries:
             logger.warning(
@@ -448,6 +542,7 @@ class PRAgent:
             tracking.last_task_comment_id = result.comment_id
             tracking.state = PRTrackingState.FIX_REQUESTED
             tracking.last_state_change_at = datetime.utcnow()
+            tracking.last_copilot_attempt_at = datetime.now(UTC)
             report.fix_requested.append(pr.number)
             logger.info(
                 "PR #%d: CI fix requested (attempt %d/%d)",
@@ -601,6 +696,7 @@ class PRAgent:
         )
         tracking.copilot_attempts = attempt
         tracking.last_task_comment_id = result.comment_id
+        tracking.last_copilot_attempt_at = datetime.now(UTC)
         tracking.state = PRTrackingState.FIX_REQUESTED
         report.fix_requested.append(pr.number)
 

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -209,9 +209,7 @@ class PRAgent:
                 user = getattr(review, "user", None)
                 login = getattr(user, "login", "") if user else ""
                 # Only human approvals count — bot reviewers don't count
-                if login and not (
-                    "[bot]" in login or login.startswith("copilot")
-                ):
+                if login and not ("[bot]" in login or login.startswith("copilot")):
                     return False
         return True
 
@@ -482,7 +480,9 @@ class PRAgent:
                 logger.info(
                     "PR #%d: resetting copilot_attempts (last attempt %.1fh ago, "
                     "outside %dh retry window)",
-                    pr.number, age_h, window_h,
+                    pr.number,
+                    age_h,
+                    window_h,
                 )
                 tracking.copilot_attempts = 0
 

--- a/src/caretaker/state/models.py
+++ b/src/caretaker/state/models.py
@@ -52,6 +52,12 @@ class TrackedPR(BaseModel):
     merged_at: datetime | None = None
     ci_attempts: int = 0
     copilot_attempts: int = 0
+    # Timestamp of the most recent @copilot fix-request comment posted on
+    # this PR. Used by `retry_window_hours`: when the prior attempt was
+    # longer ago than the window, copilot_attempts resets to 0 instead of
+    # tripping max_retries. This avoids escalating long-lived PRs whose
+    # earlier failed attempts have aged out of relevance.
+    last_copilot_attempt_at: datetime | None = None
     last_task_comment_id: int | None = None
     last_checked: datetime | None = None
     escalated: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,9 +55,15 @@ def make_pr(
     merged: bool = False,
     mergeable: bool | None = True,
     head_ref: str = "feature",
+    created_at: datetime | None = None,
 ) -> PullRequest:
     if user is None:
         user = User(login="dev-user", id=3, type="User")
+    # Default to "just now" so the stuck-PR age gate doesn't fire on tests
+    # that don't care about age. Pass an explicit ancient datetime to test
+    # age-related behavior.
+    if created_at is None:
+        created_at = datetime.now(UTC)
     return PullRequest(
         number=number,
         title=f"PR #{number}",
@@ -70,8 +76,8 @@ def make_pr(
         merged=merged,
         draft=draft,
         labels=labels or [],
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
-        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+        created_at=created_at,
+        updated_at=created_at,
         html_url=f"https://github.com/test/repo/pull/{number}",
     )
 

--- a/tests/test_pr_agent/test_agent.py
+++ b/tests/test_pr_agent/test_agent.py
@@ -1214,3 +1214,234 @@ class TestHandleEventPRNumberExtraction:
         pr_calls = [c for c in mock_run_one.call_args_list if c.args[0].name == "pr"]
         assert len(pr_calls) == 1
         assert pr_calls[0].kwargs.get("event_payload") == {"_pr_number": 33}
+
+
+@pytest.mark.asyncio
+class TestStuckPRAgeGate:
+    """Sprint 3 E1: escalate PRs open longer than stuck_age_hours that have
+    no human approval. Catches portfolio #4 (10 days), #28 (7 days)."""
+
+    async def _run_process_pr(self, pr, tracking, config, *, reviews=None):
+        from caretaker.pr_agent.agent import PRAgent, PRAgentReport
+
+        github = AsyncMock()
+        github.get_check_runs = AsyncMock(return_value=[])
+        github.get_pr_reviews = AsyncMock(return_value=reviews or [])
+        agent = PRAgent(github=github, owner="o", repo="r", config=config)
+        report = PRAgentReport()
+        updated = await agent._process_pr(pr, tracking, report)
+        return updated, report, agent
+
+    async def test_old_pr_with_no_human_approval_escalates(self) -> None:
+        from datetime import timedelta
+
+        pr = make_pr(
+            number=1,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=48),  # 48h old, threshold 24h
+        )
+        tracking = TrackedPR(number=1)
+        config = make_config()
+        config.stuck_age_hours = 24
+
+        updated, report, _ = await self._run_process_pr(pr, tracking, config)
+
+        assert updated.state == PRTrackingState.ESCALATED
+        assert updated.escalated is True
+        assert 1 in report.escalated
+
+    async def test_recent_pr_does_not_escalate(self) -> None:
+        from datetime import timedelta
+
+        pr = make_pr(
+            number=2,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=2),  # well under 24h
+        )
+        tracking = TrackedPR(number=2)
+        config = make_config()
+        config.stuck_age_hours = 24
+
+        updated, report, _ = await self._run_process_pr(pr, tracking, config)
+        assert updated.state != PRTrackingState.ESCALATED
+        assert 2 not in report.escalated
+
+    async def test_old_pr_with_human_approval_does_not_escalate(self) -> None:
+        from datetime import timedelta
+
+        pr = make_pr(
+            number=3,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(days=5),
+        )
+        human_approval = make_review(
+            user=User(login="ian", id=10, type="User"),
+            state=ReviewState.APPROVED,
+        )
+        tracking = TrackedPR(number=3)
+        config = make_config()
+        config.stuck_age_hours = 24
+
+        updated, report, _ = await self._run_process_pr(
+            pr, tracking, config, reviews=[human_approval]
+        )
+
+        # Human approved → not stuck, regardless of age
+        assert updated.state != PRTrackingState.ESCALATED
+        assert 3 not in report.escalated
+
+    async def test_bot_approval_does_not_count_as_human_signal(self) -> None:
+        from datetime import timedelta
+
+        pr = make_pr(
+            number=4,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=48),
+        )
+        bot_approval = make_review(
+            user=User(login="copilot-pull-request-reviewer[bot]", id=99, type="Bot"),
+            state=ReviewState.APPROVED,
+        )
+        tracking = TrackedPR(number=4)
+        config = make_config()
+        config.stuck_age_hours = 24
+
+        updated, report, _ = await self._run_process_pr(
+            pr, tracking, config, reviews=[bot_approval]
+        )
+        assert updated.state == PRTrackingState.ESCALATED
+        assert 4 in report.escalated
+
+    async def test_already_escalated_pr_is_not_re_escalated(self) -> None:
+        from datetime import timedelta
+
+        pr = make_pr(
+            number=5,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(days=5),
+        )
+        tracking = TrackedPR(number=5, escalated=True, state=PRTrackingState.ESCALATED)
+        config = make_config()
+        config.stuck_age_hours = 24
+
+        _updated, report, _ = await self._run_process_pr(pr, tracking, config)
+        # report.escalated should NOT include this PR (no re-escalation)
+        assert 5 not in report.escalated
+
+    async def test_gate_disabled_when_stuck_age_hours_zero(self) -> None:
+        from datetime import timedelta
+
+        pr = make_pr(
+            number=6,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(days=30),
+        )
+        tracking = TrackedPR(number=6)
+        config = make_config()
+        config.stuck_age_hours = 0  # disabled
+
+        _updated, report, _ = await self._run_process_pr(pr, tracking, config)
+        assert 6 not in report.escalated
+
+
+@pytest.mark.asyncio
+class TestRetryWindowHours:
+    """Sprint 3 E3: when the prior copilot attempt is older than
+    retry_window_hours, copilot_attempts resets to 0 instead of escalating."""
+
+    async def _run_handle_ci_fix(self, pr, tracking, config):
+        from caretaker.pr_agent.agent import PRAgent, PRAgentReport
+        from caretaker.pr_agent.states import CIEvaluation, CIStatus, PRStateEvaluation
+
+        github = AsyncMock()
+        agent = PRAgent(github=github, owner="o", repo="r", config=config)
+        failed_run = make_check_run(name="lint", conclusion=CheckConclusion.FAILURE)
+        ci_eval = CIEvaluation(
+            status=CIStatus.FAILING,
+            failed_runs=[failed_run],
+            pending_runs=[],
+            passed_runs=[],
+            action_required_runs=[],
+            all_completed=True,
+        )
+        evaluation = PRStateEvaluation(
+            pr=pr,
+            ci=ci_eval,
+            reviews=MagicMock(changes_requested=False),
+            readiness=make_readiness_evaluation(),
+            recommended_state=PRTrackingState.CI_FAILING,
+            recommended_action="request_fix",
+        )
+        mock_result = MagicMock()
+        mock_result.comment_id = 99
+        agent._copilot_bridge.request_ci_fix = AsyncMock(return_value=mock_result)
+        agent._copilot_bridge._protocol._github = github
+        report = PRAgentReport()
+        updated = await agent._handle_ci_fix(pr, evaluation, tracking, report)
+        return updated, report, agent
+
+    async def test_old_attempt_resets_counter_instead_of_escalating(self) -> None:
+        from datetime import timedelta
+
+        copilot_user = User(login="copilot[bot]", id=1, type="Bot")
+        pr = make_pr(number=10, user=copilot_user)
+        tracking = TrackedPR(
+            number=10,
+            copilot_attempts=2,
+            last_copilot_attempt_at=datetime.now(UTC) - timedelta(hours=48),
+        )
+        config = make_config(max_retries=2)
+        config.copilot.retry_window_hours = 24
+
+        updated, report, agent = await self._run_handle_ci_fix(pr, tracking, config)
+
+        assert updated.state != PRTrackingState.ESCALATED
+        assert 10 not in report.escalated
+        assert 10 in report.fix_requested
+        agent._copilot_bridge.request_ci_fix.assert_awaited_once()
+        assert updated.copilot_attempts == 1
+
+    async def test_recent_attempt_within_window_still_escalates(self) -> None:
+        from datetime import timedelta
+
+        copilot_user = User(login="copilot[bot]", id=1, type="Bot")
+        pr = make_pr(number=11, user=copilot_user)
+        tracking = TrackedPR(
+            number=11,
+            copilot_attempts=2,
+            last_copilot_attempt_at=datetime.now(UTC) - timedelta(hours=2),
+        )
+        config = make_config(max_retries=2)
+        config.copilot.retry_window_hours = 24
+
+        updated, report, _agent = await self._run_handle_ci_fix(pr, tracking, config)
+        assert updated.state == PRTrackingState.ESCALATED
+        assert 11 in report.escalated
+
+    async def test_window_zero_disables_reset(self) -> None:
+        from datetime import timedelta
+
+        copilot_user = User(login="copilot[bot]", id=1, type="Bot")
+        pr = make_pr(number=12, user=copilot_user)
+        tracking = TrackedPR(
+            number=12,
+            copilot_attempts=2,
+            last_copilot_attempt_at=datetime.now(UTC) - timedelta(days=30),
+        )
+        config = make_config(max_retries=2)
+        config.copilot.retry_window_hours = 0
+
+        updated, report, _agent = await self._run_handle_ci_fix(pr, tracking, config)
+        assert updated.state == PRTrackingState.ESCALATED
+        assert 12 in report.escalated
+
+    async def test_attempt_records_timestamp(self) -> None:
+        copilot_user = User(login="copilot[bot]", id=1, type="Bot")
+        pr = make_pr(number=13, user=copilot_user)
+        tracking = TrackedPR(number=13)
+        config = make_config(max_retries=2)
+
+        updated, _report, _agent = await self._run_handle_ci_fix(pr, tracking, config)
+        assert updated.last_copilot_attempt_at is not None
+        delta = (datetime.now(UTC) - updated.last_copilot_attempt_at).total_seconds()
+        assert 0 <= delta < 5


### PR DESCRIPTION
## Summary

Sprint 3 of the noise-reduction plan. Two final P2 items, plus a deprecation note on an unused config field. Builds on neither Sprint 1 (#404) nor Sprint 2 (#406) directly — branched from main, no overlap.

## Items

| ID | Fix | Evidence |
|---|---|---|
| **E1** | `stuck_age_hours` (default 24) — escalate PRs open longer than threshold without human approval | portfolio #4 (10d open then closed unmerged), #28 (7d, copilot, closed after Ian asked for fixes) |
| **E3** | Wire previously-unused `retry_window_hours` (default 24) — reset `copilot_attempts` when last attempt aged out | Long-lived PRs whose earlier failed attempts shouldn't compound to escalation |
| **cleanup** | Document `auto_approve_copilot` as no-op pending Sprint 2 E2 follow-up | config.py:88 — defined but never referenced |

## What's new

- `PRAgent._pr_age_hours` + `_is_pr_stuck_by_age` helpers (bot reviewers don't count as human approval)
- `TrackedPR.last_copilot_attempt_at` timestamp field, set in both CI-fix and review-fix paths
- 10 new tests (6 stuck-PR + 4 retry-window)
- `conftest.make_pr` default `created_at` is now "now" so existing tests don't accidentally trigger the new gate

## Items NOT in this PR

- **B3** (causal token in markers) — deferred. The stated value was belt-and-suspenders for B1 (Sprint 1 dispatch-guard), but B1 already filters every `<!-- caretaker:* -->` comment regardless of token. The remaining value of B3 is observability (causal-chain reconstruction), which overlaps with **F3** (admin dashboard audit view) and is better implemented alongside frontend work, not as a comment-marker change.
- **F1+F2+F3** (admin dashboard fan-out / storm metrics / causal-chain audit view) — frontend scope; the backend metrics already exist in `RunSummary`, the UI is the missing piece.
- **E2** (auto-merge after Copilot post-approval push) — diagnose-first per the original plan and advisor feedback. portfolio #151's exact merge-block reason needs investigation in `pr_agent/merge.py:26-76` before committing to a fix.

## Test plan

- [x] Full test suite green: 722 passed (`uv run pytest`)
- [x] ruff clean (`uv run ruff check .`)
- [ ] Merge after Sprint 1 (#404) and Sprint 2 (#406) merge — order doesn't matter (independent branches), but releasing all three together as v0.10.0 is the deployment goal

## Risks

- **E1**: a PR genuinely stuck on legitimate review backlog gets escalated to human → noise. Mitigation: the gate only fires once per PR (sets `escalated=True`), and humans can always remove the `maintainer:escalated` label to reset.
- **E3**: the reset semantics could mask a *consistently failing* PR (e.g. broken every 25h forever). Mitigation: `fix_cycles` and the within-cycle stuck detection still apply. The window only buys the bot one *fresh* set of attempts after a long gap.
- **make_pr default change**: any test that *intended* to test old-PR behavior with the previous implicit default now passes a fresh PR. Grep showed no such tests in this codebase, but worth a final review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)