### PR TITLE
feat(frontend): dark mode + Grafana-inspired 2026 UI refresh

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,21 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>Caretaker Admin</title>
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('caretaker.theme');
+          var mode = stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system';
+          var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var resolved = mode === 'system' ? (prefersDark ? 'dark' : 'light') : mode;
+          var root = document.documentElement;
+          if (resolved === 'dark') root.classList.add('dark');
+          root.style.colorScheme = resolved;
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { SWRConfig } from 'swr'
 import { fetcher } from '@/lib/api'
+import ThemeProvider from '@/components/ThemeProvider'
 import RequireAuth from '@/components/RequireAuth'
 import Login from '@/pages/Login'
 import Dashboard from '@/pages/Dashboard'
@@ -15,24 +16,26 @@ import Config from '@/pages/Config'
 
 export default function App() {
   return (
-    <SWRConfig value={{ fetcher, revalidateOnFocus: false, shouldRetryOnError: false }}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route element={<RequireAuth />}>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/prs" element={<PRs />} />
-            <Route path="/issues" element={<Issues />} />
-            <Route path="/runs" element={<Runs />} />
-            <Route path="/memory" element={<Memory />} />
-            <Route path="/memory/:namespace" element={<Memory />} />
-            <Route path="/skills" element={<Skills />} />
-            <Route path="/agents" element={<Agents />} />
-            <Route path="/graph" element={<Graph />} />
-            <Route path="/config" element={<Config />} />
-          </Route>
-        </Routes>
-      </BrowserRouter>
-    </SWRConfig>
+    <ThemeProvider>
+      <SWRConfig value={{ fetcher, revalidateOnFocus: false, shouldRetryOnError: false }}>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route element={<RequireAuth />}>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/prs" element={<PRs />} />
+              <Route path="/issues" element={<Issues />} />
+              <Route path="/runs" element={<Runs />} />
+              <Route path="/memory" element={<Memory />} />
+              <Route path="/memory/:namespace" element={<Memory />} />
+              <Route path="/skills" element={<Skills />} />
+              <Route path="/agents" element={<Agents />} />
+              <Route path="/graph" element={<Graph />} />
+              <Route path="/config" element={<Config />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </SWRConfig>
+    </ThemeProvider>
   )
 }

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -21,47 +21,62 @@ export function DataTable<T>({
 }) {
   if (rows.length === 0) {
     return (
-      <div className="border border-[var(--color-border)] rounded-lg p-8 text-center text-sm text-[var(--color-muted-foreground)]">
+      <div className="panel p-10 text-center text-sm text-[var(--color-muted-foreground)]">
         {empty || 'No data.'}
       </div>
     )
   }
 
   return (
-    <div className="border border-[var(--color-border)] rounded-lg overflow-hidden">
-      <table className="w-full text-sm">
-        <thead className="bg-[var(--color-muted)]">
-          <tr>
-            {columns.map((c) => (
-              <th
-                key={c.key}
-                style={c.width ? { width: c.width } : undefined}
-                className="text-left px-4 py-2.5 font-medium text-[var(--color-muted-foreground)]"
-              >
-                {c.header}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row, i) => (
-            <tr
-              key={i}
-              onClick={onRowClick ? () => onRowClick(row) : undefined}
-              className={cn(
-                'border-t border-[var(--color-border)]',
-                onRowClick && 'cursor-pointer hover:bg-[var(--color-muted)]',
-              )}
-            >
+    <div className="panel overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm tnum">
+          <thead className="bg-[var(--color-muted)]/60 backdrop-blur-sm sticky top-0 z-[1]">
+            <tr>
               {columns.map((c) => (
-                <td key={c.key} className="px-4 py-2.5 align-middle">
-                  {c.render(row)}
-                </td>
+                <th
+                  key={c.key}
+                  style={c.width ? { width: c.width } : undefined}
+                  className={cn(
+                    'text-left px-4 py-2.5 font-medium',
+                    'text-[11px] uppercase tracking-[0.08em]',
+                    'text-[var(--color-muted-foreground)]',
+                    'border-b border-[var(--color-border)]',
+                  )}
+                >
+                  {c.header}
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr
+                key={i}
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                className={cn(
+                  'group border-t border-[var(--color-border)]',
+                  'transition-colors duration-[var(--motion-fast)]',
+                  onRowClick &&
+                    'cursor-pointer hover:bg-[var(--color-primary-soft)]',
+                )}
+              >
+                {columns.map((c) => (
+                  <td
+                    key={c.key}
+                    className={cn(
+                      'px-4 py-2.5 align-middle',
+                      'text-[var(--color-foreground)]',
+                    )}
+                  >
+                    {c.render(row)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import {
   LayoutDashboard,
   GitPullRequest,
@@ -10,10 +10,13 @@ import {
   Network,
   Settings,
   LogOut,
+  ChevronRight,
+  Activity,
 } from 'lucide-react'
 import { useUser } from '@/hooks/useUser'
 import { post } from '@/lib/api'
 import { cn } from '@/lib/cn'
+import ThemeToggle from '@/components/ThemeToggle'
 
 const NAV = [
   { to: '/', label: 'Overview', icon: LayoutDashboard, end: true },
@@ -27,9 +30,19 @@ const NAV = [
   { to: '/config', label: 'Config', icon: Settings },
 ]
 
+function crumbFor(pathname: string): string {
+  if (pathname === '/') return 'Overview'
+  const segment = pathname.split('/').filter(Boolean)[0] ?? ''
+  const match = NAV.find((n) => n.to.replace('/', '') === segment)
+  if (match) return match.label
+  return segment.charAt(0).toUpperCase() + segment.slice(1)
+}
+
 export default function Layout() {
   const { user, refresh } = useUser()
   const navigate = useNavigate()
+  const location = useLocation()
+  const crumb = crumbFor(location.pathname)
 
   async function handleLogout() {
     try {
@@ -43,12 +56,36 @@ export default function Layout() {
 
   return (
     <div className="flex min-h-screen">
-      <aside className="w-60 shrink-0 border-r border-[var(--color-border)] bg-[var(--color-card)] flex flex-col">
+      <aside
+        className={cn(
+          'w-60 shrink-0 flex flex-col sticky top-0 h-screen z-20',
+          'glass border-r border-[var(--color-border)]',
+        )}
+      >
         <div className="px-5 py-4 border-b border-[var(--color-border)]">
-          <h1 className="text-lg font-semibold tracking-tight">Caretaker</h1>
-          <p className="text-xs text-[var(--color-muted-foreground)]">Admin Dashboard</p>
+          <div className="flex items-center gap-2">
+            <div
+              aria-hidden
+              className="h-7 w-7 rounded-md grid place-items-center text-[var(--color-primary-foreground)]"
+              style={{
+                background:
+                  'linear-gradient(135deg, var(--color-primary), var(--color-accent))',
+                boxShadow: 'var(--shadow-glow)',
+              }}
+            >
+              <Activity className="h-4 w-4" />
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-sm font-semibold tracking-tight leading-tight">
+                Caretaker
+              </h1>
+              <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--color-muted-foreground)]">
+                Orchestrator
+              </p>
+            </div>
+          </div>
         </div>
-        <nav className="flex-1 overflow-y-auto p-3 space-y-1">
+        <nav className="flex-1 overflow-y-auto p-3 space-y-0.5">
           {NAV.map((item) => {
             const Icon = item.icon
             return (
@@ -58,15 +95,33 @@ export default function Layout() {
                 end={item.end}
                 className={({ isActive }) =>
                   cn(
-                    'flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors',
+                    'group relative flex items-center gap-2.5 px-3 py-2 rounded-[var(--radius-sm)] text-sm',
+                    'transition-colors duration-[var(--motion-fast)]',
                     isActive
-                      ? 'bg-[var(--color-primary)] text-[var(--color-primary-foreground)]'
-                      : 'text-[var(--color-foreground)] hover:bg-[var(--color-muted)]',
+                      ? 'text-[var(--color-foreground)] bg-[var(--color-primary-soft)]'
+                      : 'text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-muted)]',
                   )
                 }
               >
-                <Icon className="h-4 w-4" />
-                {item.label}
+                {({ isActive }) => (
+                  <>
+                    <span
+                      aria-hidden
+                      className={cn(
+                        'absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[2px] rounded-r-full transition-opacity',
+                        isActive ? 'opacity-100' : 'opacity-0',
+                      )}
+                      style={{ background: 'var(--color-primary)' }}
+                    />
+                    <Icon
+                      className={cn(
+                        'h-4 w-4 shrink-0',
+                        isActive && 'text-[var(--color-primary)]',
+                      )}
+                    />
+                    <span>{item.label}</span>
+                  </>
+                )}
               </NavLink>
             )
           })}
@@ -78,7 +133,7 @@ export default function Layout() {
                 <img
                   src={user.picture}
                   alt=""
-                  className="h-7 w-7 rounded-full"
+                  className="h-7 w-7 rounded-full ring-1 ring-[var(--color-border)]"
                 />
               ) : (
                 <div className="h-7 w-7 rounded-full bg-[var(--color-muted)] grid place-items-center text-xs">
@@ -86,7 +141,9 @@ export default function Layout() {
                 </div>
               )}
               <div className="flex-1 min-w-0">
-                <p className="text-xs font-medium truncate">{user.name || user.email}</p>
+                <p className="text-xs font-medium truncate">
+                  {user.name || user.email}
+                </p>
                 {user.email && (
                   <p className="text-[10px] text-[var(--color-muted-foreground)] truncate">
                     {user.email}
@@ -96,7 +153,11 @@ export default function Layout() {
             </div>
             <button
               onClick={handleLogout}
-              className="mt-1 w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-xs text-[var(--color-muted-foreground)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
+              className={cn(
+                'mt-1 w-full flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-sm)] text-xs',
+                'text-[var(--color-muted-foreground)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]',
+                'transition-colors',
+              )}
             >
               <LogOut className="h-3.5 w-3.5" />
               Sign out
@@ -104,8 +165,30 @@ export default function Layout() {
           </div>
         )}
       </aside>
-      <main className="flex-1 min-w-0">
-        <Outlet />
+      <main className="flex-1 min-w-0 flex flex-col">
+        <header
+          className={cn(
+            'sticky top-0 z-10 glass border-b border-[var(--color-border)]',
+            'flex items-center justify-between px-6 h-14',
+          )}
+        >
+          <nav
+            aria-label="Breadcrumb"
+            className="flex items-center gap-1.5 text-xs text-[var(--color-muted-foreground)]"
+          >
+            <span>Caretaker</span>
+            <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+            <span className="text-[var(--color-foreground)] font-medium">
+              {crumb}
+            </span>
+          </nav>
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+          </div>
+        </header>
+        <div className="flex-1 min-w-0">
+          <Outlet />
+        </div>
       </main>
     </div>
   )

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -10,14 +10,24 @@ export default function PageHeader({
   actions?: ReactNode
 }) {
   return (
-    <div className="flex items-start justify-between border-b border-[var(--color-border)] px-8 py-5">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+    <div className="flex items-start justify-between gap-4 border-b border-[var(--color-border)] px-6 py-5">
+      <div className="relative pl-3">
+        <span
+          aria-hidden
+          className="absolute left-0 top-1 bottom-1 w-[3px] rounded-full"
+          style={{
+            background:
+              'linear-gradient(180deg, var(--color-primary), var(--color-accent))',
+          }}
+        />
+        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
         {description && (
-          <p className="text-sm text-[var(--color-muted-foreground)] mt-1">{description}</p>
+          <p className="text-sm text-[var(--color-muted-foreground)] mt-1">
+            {description}
+          </p>
         )}
       </div>
-      {actions && <div className="flex items-center gap-2">{actions}</div>}
+      {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
     </div>
   )
 }

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -15,22 +15,24 @@ export default function Pagination({
   const hasPrev = offset > 0
   const hasNext = end < total
   return (
-    <div className="flex items-center justify-between pt-3 text-sm text-[var(--color-muted-foreground)]">
-      <span>
+    <div className="flex items-center justify-between pt-3 text-xs text-[var(--color-muted-foreground)]">
+      <span className="mono">
         {total === 0 ? 0 : offset + 1}–{end} of {total}
       </span>
       <div className="flex items-center gap-1">
         <button
+          aria-label="Previous page"
           disabled={!hasPrev}
           onClick={() => onChange(Math.max(0, offset - limit))}
-          className="p-1.5 rounded-md border border-[var(--color-border)] disabled:opacity-40 hover:bg-[var(--color-muted)]"
+          className="p-1.5 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] disabled:opacity-40 hover:bg-[var(--color-muted)] hover:border-[var(--color-border-strong)] transition-colors"
         >
           <ChevronLeft className="h-4 w-4" />
         </button>
         <button
+          aria-label="Next page"
           disabled={!hasNext}
           onClick={() => onChange(offset + limit)}
-          className="p-1.5 rounded-md border border-[var(--color-border)] disabled:opacity-40 hover:bg-[var(--color-muted)]"
+          className="p-1.5 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] disabled:opacity-40 hover:bg-[var(--color-muted)] hover:border-[var(--color-border-strong)] transition-colors"
         >
           <ChevronRight className="h-4 w-4" />
         </button>

--- a/frontend/src/components/StatPanel.tsx
+++ b/frontend/src/components/StatPanel.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from 'react'
+import { ResponsiveContainer, AreaChart, Area } from 'recharts'
+import { cn } from '@/lib/cn'
+
+type Trend = 'up' | 'down' | 'flat' | undefined
+
+export type StatPanelProps = {
+  label: string
+  value: ReactNode
+  hint?: ReactNode
+  trend?: Trend
+  deltaLabel?: string
+  sparkline?: { value: number }[]
+  accentVar?: string
+  footer?: ReactNode
+}
+
+const TREND_COLOR: Record<Exclude<Trend, undefined>, string> = {
+  up: 'var(--color-success)',
+  down: 'var(--color-destructive)',
+  flat: 'var(--color-muted-foreground)',
+}
+
+export default function StatPanel({
+  label,
+  value,
+  hint,
+  trend,
+  deltaLabel,
+  sparkline,
+  accentVar = '--chart-1',
+  footer,
+}: StatPanelProps) {
+  const accent = `var(${accentVar})`
+  const gradientId = `sp-grad-${accentVar.replace(/[^a-z0-9]/gi, '')}`
+
+  return (
+    <div className={cn('panel p-4 flex flex-col gap-3 overflow-hidden')}>
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase tracking-[0.12em] text-[var(--color-muted-foreground)] truncate">
+            {label}
+          </p>
+          <p className="stat-value mt-1 text-3xl font-semibold leading-tight tracking-tight">
+            {value}
+          </p>
+          {hint && (
+            <p className="text-xs text-[var(--color-muted-foreground)] mt-1">
+              {hint}
+            </p>
+          )}
+        </div>
+        {deltaLabel && (
+          <span
+            className="mono text-[11px] font-medium"
+            style={{ color: trend ? TREND_COLOR[trend] : 'var(--color-muted-foreground)' }}
+          >
+            {deltaLabel}
+          </span>
+        )}
+      </div>
+      {sparkline && sparkline.length > 1 && (
+        <div className="h-10 -mx-1">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart
+              data={sparkline}
+              margin={{ top: 4, right: 4, bottom: 0, left: 4 }}
+            >
+              <defs>
+                <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="0%" stopColor={accent} stopOpacity={0.45} />
+                  <stop offset="100%" stopColor={accent} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <Area
+                type="monotone"
+                dataKey="value"
+                stroke={accent}
+                strokeWidth={1.5}
+                fill={`url(#${gradientId})`}
+                isAnimationActive={false}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+      {footer && (
+        <div className="text-xs text-[var(--color-muted-foreground)]">{footer}</div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,24 +1,80 @@
+import type { CSSProperties } from 'react'
 import { cn } from '@/lib/cn'
 
-const STYLES: Record<string, string> = {
-  open: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
-  closed: 'bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300',
-  merged: 'bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300',
-  draft: 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300',
-  success: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
-  failed: 'bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300',
-  running: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+type Tone = 'success' | 'danger' | 'warning' | 'info' | 'accent' | 'neutral'
+
+const TONE_MAP: Record<string, Tone> = {
+  open: 'success',
+  passing: 'success',
+  success: 'success',
+  merged: 'accent',
+  ready: 'accent',
+  closed: 'danger',
+  failed: 'danger',
+  failing: 'danger',
+  error: 'danger',
+  escalated: 'danger',
+  pending: 'warning',
+  review_pending: 'warning',
+  warning: 'warning',
+  running: 'info',
+  ci_pending: 'info',
+  discovered: 'info',
+  draft: 'neutral',
+}
+
+const TONE_STYLE: Record<Tone, CSSProperties> = {
+  success: {
+    backgroundColor: 'var(--color-success-soft)',
+    color: 'var(--color-success)',
+    boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-success) 30%, transparent)',
+  },
+  danger: {
+    backgroundColor: 'var(--color-destructive-soft)',
+    color: 'var(--color-destructive)',
+    boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-destructive) 30%, transparent)',
+  },
+  warning: {
+    backgroundColor: 'var(--color-warning-soft)',
+    color: 'var(--color-warning)',
+    boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-warning) 30%, transparent)',
+  },
+  info: {
+    backgroundColor: 'var(--color-info-soft)',
+    color: 'var(--color-info)',
+    boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-info) 30%, transparent)',
+  },
+  accent: {
+    backgroundColor: 'var(--color-primary-soft)',
+    color: 'var(--color-primary)',
+    boxShadow: 'inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 30%, transparent)',
+  },
+  neutral: {
+    backgroundColor: 'var(--color-neutral-soft)',
+    color: 'var(--color-muted-foreground)',
+    boxShadow: 'inset 0 0 0 1px var(--color-border)',
+  },
+}
+
+function toneFor(value: string): Tone {
+  return TONE_MAP[value.toLowerCase()] ?? 'neutral'
 }
 
 export default function StatusBadge({ value }: { value: string }) {
-  const key = value.toLowerCase()
+  const tone = toneFor(value)
   return (
     <span
       className={cn(
-        'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium',
-        STYLES[key] || 'bg-[var(--color-muted)] text-[var(--color-muted-foreground)]',
+        'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full',
+        'text-[11px] font-medium uppercase tracking-[0.04em]',
       )}
+      style={TONE_STYLE[tone]}
     >
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: 'currentColor', opacity: 0.85 }}
+      />
       {value}
     </span>
   )

--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { ThemeContext, type ResolvedTheme, type ThemeMode } from '@/hooks/useTheme'
+
+const STORAGE_KEY = 'caretaker.theme'
+
+function readStoredMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'system'
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (raw === 'light' || raw === 'dark' || raw === 'system') return raw
+  return 'system'
+}
+
+function systemPrefersDark(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+function applyTheme(resolved: ResolvedTheme) {
+  const root = document.documentElement
+  root.classList.toggle('dark', resolved === 'dark')
+  root.style.colorScheme = resolved
+}
+
+export default function ThemeProvider({ children }: { children: ReactNode }) {
+  const [mode, setModeState] = useState<ThemeMode>(() => readStoredMode())
+  const [systemDark, setSystemDark] = useState<boolean>(() => systemPrefersDark())
+
+  const resolved: ResolvedTheme =
+    mode === 'system' ? (systemDark ? 'dark' : 'light') : mode
+
+  useEffect(() => {
+    applyTheme(resolved)
+  }, [resolved])
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = (e: MediaQueryListEvent) => setSystemDark(e.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  const setMode = useCallback((next: ThemeMode) => {
+    setModeState(next)
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next)
+    } catch {
+      // storage may be blocked; ignore
+    }
+  }, [])
+
+  const value = useMemo(() => ({ mode, resolved, setMode }), [mode, resolved, setMode])
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from 'react'
+import { Monitor, Moon, Sun, Check } from 'lucide-react'
+import { useTheme, type ThemeMode } from '@/hooks/useTheme'
+import { cn } from '@/lib/cn'
+
+const OPTIONS: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+]
+
+export default function ThemeToggle() {
+  const { mode, resolved, setMode } = useTheme()
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const Current = mode === 'system' ? Monitor : resolved === 'dark' ? Moon : Sun
+
+  useEffect(() => {
+    if (!open) return
+    const onClick = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-label={`Theme: ${mode}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'inline-flex items-center justify-center h-8 w-8 rounded-md',
+          'border border-[var(--color-border)] bg-[var(--color-surface)]',
+          'text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)]',
+          'hover:border-[var(--color-border-strong)] transition-colors',
+        )}
+      >
+        <Current className="h-4 w-4" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className={cn(
+            'absolute right-0 mt-2 w-40 z-30',
+            'rounded-[var(--radius-md)] border border-[var(--color-border)]',
+            'bg-[var(--color-card-elevated)] shadow-[var(--shadow-lg)] p-1',
+          )}
+        >
+          {OPTIONS.map(({ value, label, icon: Icon }) => {
+            const active = mode === value
+            return (
+              <button
+                key={value}
+                role="menuitemradio"
+                aria-checked={active}
+                onClick={() => {
+                  setMode(value)
+                  setOpen(false)
+                }}
+                className={cn(
+                  'flex items-center gap-2 w-full px-2.5 py-1.5 rounded-[var(--radius-sm)] text-sm text-left',
+                  'hover:bg-[var(--color-muted)] transition-colors',
+                  active && 'text-[var(--color-foreground)]',
+                )}
+              >
+                <Icon className="h-4 w-4 text-[var(--color-muted-foreground)]" />
+                <span className="flex-1">{label}</span>
+                {active && <Check className="h-3.5 w-3.5 text-[var(--color-primary)]" />}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+export type ResolvedTheme = 'light' | 'dark'
+
+export type ThemeContextValue = {
+  mode: ThemeMode
+  resolved: ResolvedTheme
+  setMode: (mode: ThemeMode) => void
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) {
+    throw new Error('useTheme must be used inside <ThemeProvider>')
+  }
+  return ctx
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,51 +2,273 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* ---------------------------------------------------------------------------
+   Design tokens — Grafana-inspired 2026.
+   Dark is the primary canvas; light is a well-tuned invert.
+--------------------------------------------------------------------------- */
+
 :root {
-  --color-background: #ffffff;
-  --color-foreground: #0a0a0a;
+  /* Surfaces */
+  --color-background: #f7f8fa;
+  --color-surface: #ffffff;
   --color-card: #ffffff;
-  --color-card-foreground: #0a0a0a;
-  --color-muted: #f4f4f5;
-  --color-muted-foreground: #71717a;
-  --color-border: #e4e4e7;
+  --color-card-elevated: #ffffff;
+  --color-panel: #ffffff;
+  --color-overlay: rgba(15, 18, 28, 0.4);
+
+  /* Text */
+  --color-foreground: #0f1420;
+  --color-card-foreground: #0f1420;
+  --color-muted: #eef0f4;
+  --color-muted-foreground: #5b6478;
+  --color-subtle: #8a94aa;
+
+  /* Borders / hairlines */
+  --color-border: #e3e6ec;
+  --color-border-strong: #c9cfda;
+  --color-ring: rgba(139, 92, 246, 0.45);
+
+  /* Brand / accents (Grafana-flavored: purple / cyan / green) */
   --color-primary: #6d28d9;
   --color-primary-foreground: #ffffff;
-  --color-secondary: #f4f4f5;
-  --color-secondary-foreground: #18181b;
-  --color-accent: #f4f4f5;
-  --color-accent-foreground: #18181b;
-  --color-destructive: #ef4444;
-  --color-success: #22c55e;
-  --color-warning: #eab308;
+  --color-primary-soft: rgba(109, 40, 217, 0.12);
+  --color-secondary: #eef0f4;
+  --color-secondary-foreground: #0f1420;
+  --color-accent: #0891b2;
+  --color-accent-foreground: #ffffff;
+
+  /* Semantic */
+  --color-success: #0d9f6e;
+  --color-success-soft: rgba(13, 159, 110, 0.14);
+  --color-warning: #b45309;
+  --color-warning-soft: rgba(180, 83, 9, 0.14);
+  --color-destructive: #dc2626;
+  --color-destructive-soft: rgba(220, 38, 38, 0.14);
+  --color-info: #0e7490;
+  --color-info-soft: rgba(14, 116, 144, 0.14);
+  --color-neutral-soft: rgba(99, 107, 126, 0.14);
+
+  /* Chart palette (shared light/dark; tuned for contrast both ways) */
+  --chart-1: #7c3aed;
+  --chart-2: #06b6d4;
+  --chart-3: #10b981;
+  --chart-4: #f59e0b;
+  --chart-5: #ec4899;
+  --chart-6: #3b82f6;
+
+  /* Radii */
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 20px;
+
+  /* Elevation */
+  --shadow-sm: 0 1px 2px rgba(15, 20, 32, 0.06);
+  --shadow-md: 0 8px 24px -12px rgba(15, 20, 32, 0.18);
+  --shadow-lg: 0 24px 48px -24px rgba(15, 20, 32, 0.28);
+  --shadow-glow: 0 0 0 1px var(--color-ring), 0 8px 24px -8px rgba(139, 92, 246, 0.35);
+
+  /* Motion */
+  --motion-fast: 120ms;
+  --motion-base: 180ms;
+  --motion-slow: 280ms;
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+
+  /* Typography */
+  --font-sans: "Inter", "InterVariable", ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular,
+    Menlo, Consolas, monospace;
 }
 
 .dark {
-  --color-background: #09090b;
-  --color-foreground: #fafafa;
-  --color-card: #18181b;
-  --color-card-foreground: #fafafa;
-  --color-muted: #27272a;
-  --color-muted-foreground: #a1a1aa;
-  --color-border: #27272a;
-  --color-primary: #7c3aed;
-  --color-primary-foreground: #ffffff;
-  --color-secondary: #27272a;
-  --color-secondary-foreground: #fafafa;
-  --color-accent: #27272a;
-  --color-accent-foreground: #fafafa;
-  --color-destructive: #dc2626;
-  --color-success: #16a34a;
-  --color-warning: #ca8a04;
+  /* Grafana-like layered darks */
+  --color-background: #0b0d12;
+  --color-surface: #111420;
+  --color-card: #141826;
+  --color-card-elevated: #1a1f30;
+  --color-panel: #141826;
+  --color-overlay: rgba(5, 7, 12, 0.6);
+
+  --color-foreground: #e6e9f2;
+  --color-card-foreground: #e6e9f2;
+  --color-muted: #1c2030;
+  --color-muted-foreground: #8b93a7;
+  --color-subtle: #5b6478;
+
+  --color-border: #1f2436;
+  --color-border-strong: #2a3047;
+  --color-ring: rgba(167, 139, 250, 0.55);
+
+  --color-primary: #a78bfa;
+  --color-primary-foreground: #0b0d12;
+  --color-primary-soft: rgba(167, 139, 250, 0.16);
+  --color-secondary: #1c2030;
+  --color-secondary-foreground: #e6e9f2;
+  --color-accent: #22d3ee;
+  --color-accent-foreground: #0b0d12;
+
+  --color-success: #34d399;
+  --color-success-soft: rgba(52, 211, 153, 0.14);
+  --color-warning: #fbbf24;
+  --color-warning-soft: rgba(251, 191, 36, 0.14);
+  --color-destructive: #fb7185;
+  --color-destructive-soft: rgba(251, 113, 133, 0.16);
+  --color-info: #38bdf8;
+  --color-info-soft: rgba(56, 189, 248, 0.16);
+  --color-neutral-soft: rgba(139, 147, 167, 0.14);
+
+  --chart-1: #a78bfa;
+  --chart-2: #22d3ee;
+  --chart-3: #34d399;
+  --chart-4: #fbbf24;
+  --chart-5: #f472b6;
+  --chart-6: #60a5fa;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --shadow-md: 0 8px 24px -12px rgba(0, 0, 0, 0.7);
+  --shadow-lg: 0 24px 48px -24px rgba(0, 0, 0, 0.85);
+  --shadow-glow: 0 0 0 1px var(--color-ring), 0 8px 24px -8px rgba(167, 139, 250, 0.45);
 }
 
+html,
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, sans-serif;
+  padding: 0;
   background-color: var(--color-background);
   color: var(--color-foreground);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "cv11", "ss01", "ss03";
+  transition:
+    background-color var(--motion-base) var(--ease-out),
+    color var(--motion-base) var(--ease-out);
 }
 
 #root {
   min-height: 100vh;
+}
+
+/* Tabular numbers — Grafana-style metric readability */
+.tnum,
+table,
+.stat-value {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "cv11" 1;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Hairline border helper — sharper than default 1px on hi-dpi */
+.hairline {
+  box-shadow: inset 0 0 0 1px var(--color-border);
+}
+
+/* Panel — canonical Grafana stat/chart container */
+.panel {
+  background-color: var(--color-panel);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  transition:
+    border-color var(--motion-base) var(--ease-out),
+    box-shadow var(--motion-base) var(--ease-out),
+    transform var(--motion-base) var(--ease-out);
+}
+
+.panel:hover {
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-md);
+}
+
+.panel-interactive {
+  cursor: pointer;
+}
+
+.panel-interactive:hover {
+  transform: translateY(-1px);
+}
+
+/* Glass surface — used by sidebar + top bar for 2026 feel */
+.glass {
+  background: color-mix(in srgb, var(--color-panel) 80%, transparent);
+  backdrop-filter: saturate(140%) blur(10px);
+  -webkit-backdrop-filter: saturate(140%) blur(10px);
+  border-color: var(--color-border);
+}
+
+/* Focus ring — a11y */
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-background), 0 0 0 4px var(--color-ring);
+  border-radius: var(--radius-sm);
+}
+
+/* Scrollbars (WebKit) */
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--color-border-strong);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-subtle);
+  background-clip: padding-box;
+}
+
+/* Ambient aurora accent in dark mode — subtle, Grafana-like */
+.dark body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(
+      60rem 40rem at 10% -10%,
+      rgba(167, 139, 250, 0.08),
+      transparent 60%
+    ),
+    radial-gradient(
+      40rem 30rem at 100% 0%,
+      rgba(34, 211, 238, 0.06),
+      transparent 60%
+    );
+}
+
+#root {
+  position: relative;
+  z-index: 1;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  html,
+  body,
+  .panel,
+  .panel-interactive {
+    transition: none !important;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -17,10 +17,7 @@ export default function Agents() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {(data ?? []).map((agent) => (
-              <div
-                key={agent.name}
-                className="border border-[var(--color-border)] rounded-lg p-4 bg-[var(--color-card)]"
-              >
+              <div key={agent.name} className="panel p-4">
                 <h3 className="font-medium text-sm">{agent.name}</h3>
                 <div className="mt-3 space-y-2">
                   <div>
@@ -47,7 +44,11 @@ export default function Agents() {
                         {agent.events.map((e) => (
                           <span
                             key={e}
-                            className="px-1.5 py-0.5 text-[11px] rounded bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300"
+                            className="px-1.5 py-0.5 text-[11px] rounded-[var(--radius-sm)]"
+                            style={{
+                              backgroundColor: 'var(--color-primary-soft)',
+                              color: 'var(--color-primary)',
+                            }}
                           >
                             {e}
                           </span>

--- a/frontend/src/pages/Config.tsx
+++ b/frontend/src/pages/Config.tsx
@@ -14,7 +14,7 @@ export default function Config() {
         {isLoading ? (
           <p className="text-sm text-[var(--color-muted-foreground)]">Loading…</p>
         ) : (
-          <pre className="border border-[var(--color-border)] rounded-lg p-4 bg-[var(--color-card)] text-xs font-mono overflow-auto max-h-[calc(100vh-14rem)]">
+          <pre className="panel p-4 mono text-xs overflow-auto max-h-[calc(100vh-14rem)]">
             {JSON.stringify(data, null, 2)}
           </pre>
         )}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,8 +8,10 @@ import {
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
+  Area,
 } from 'recharts'
 import PageHeader from '@/components/PageHeader'
+import StatPanel from '@/components/StatPanel'
 import type {
   Paginated,
   RunSummary,
@@ -18,15 +20,20 @@ import type {
   GoalSnapshot,
 } from '@/lib/types'
 
-function Stat({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="border border-[var(--color-border)] rounded-lg p-4 bg-[var(--color-card)]">
-      <p className="text-xs uppercase tracking-wide text-[var(--color-muted-foreground)]">
-        {label}
-      </p>
-      <p className="text-2xl font-semibold mt-1">{value}</p>
-    </div>
-  )
+function trendFromSeries(series: { value: number }[]): 'up' | 'down' | 'flat' | undefined {
+  if (series.length < 2) return undefined
+  const first = series[0].value
+  const last = series[series.length - 1].value
+  const diff = last - first
+  if (Math.abs(diff) < 0.01) return 'flat'
+  return diff > 0 ? 'up' : 'down'
+}
+
+function deltaLabel(series: { value: number }[], suffix = ''): string | undefined {
+  if (series.length < 2) return undefined
+  const diff = series[series.length - 1].value - series[0].value
+  const sign = diff > 0 ? '+' : ''
+  return `${sign}${diff.toFixed(2)}${suffix}`
 }
 
 export default function Dashboard() {
@@ -38,6 +45,13 @@ export default function Dashboard() {
   const goalIds = goals ? Object.keys(goals) : []
   const firstGoal = goalIds[0]
   const series = firstGoal && goals ? goals[firstGoal].slice(-30) : []
+  const sparkSeries = series.map((s) => ({ value: s.score }))
+  const goalTrend = trendFromSeries(sparkSeries)
+  const goalDelta = deltaLabel(sparkSeries)
+
+  const errorCount = latestRun?.errors?.length ?? 0
+  const escalations =
+    (latestRun?.prs_escalated ?? 0) + (latestRun?.issues_escalated ?? 0)
 
   return (
     <>
@@ -45,92 +59,193 @@ export default function Dashboard() {
         title="Overview"
         description="Real-time snapshot of the caretaker orchestrator."
       />
-      <div className="p-8 space-y-6">
+      <div className="p-6 space-y-6">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          <Stat label="Tracked PRs" value={prs?.total ?? '—'} />
-          <Stat label="Tracked issues" value={issues?.total ?? '—'} />
-          <Stat
-            label="Last run merged"
-            value={latestRun?.prs_merged ?? '—'}
+          <StatPanel
+            label="Tracked PRs"
+            value={prs?.total ?? '—'}
+            hint="Currently monitored"
+            accentVar="--chart-1"
           />
-          <Stat
+          <StatPanel
+            label="Tracked issues"
+            value={issues?.total ?? '—'}
+            hint="Awaiting triage or in-flight"
+            accentVar="--chart-2"
+          />
+          <StatPanel
+            label="Merged last run"
+            value={latestRun?.prs_merged ?? '—'}
+            hint={
+              latestRun
+                ? `${latestRun.prs_monitored} PRs monitored`
+                : 'No runs recorded yet'
+            }
+            accentVar="--chart-3"
+          />
+          <StatPanel
             label="Goal health"
             value={
               latestRun?.goal_health != null
                 ? latestRun.goal_health.toFixed(2)
                 : '—'
             }
+            hint={firstGoal ? `Primary goal: ${firstGoal}` : undefined}
+            trend={goalTrend}
+            deltaLabel={goalDelta}
+            sparkline={sparkSeries}
+            accentVar="--chart-1"
           />
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <div className="border border-[var(--color-border)] rounded-lg p-5 bg-[var(--color-card)]">
-            <h2 className="text-sm font-medium mb-3">Latest run</h2>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <div className="panel p-5 lg:col-span-1">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold tracking-tight">Latest run</h2>
+              <Link
+                to="/runs"
+                className="text-[11px] text-[var(--color-primary)] hover:underline"
+              >
+                History →
+              </Link>
+            </div>
             {latestRun ? (
-              <dl className="grid grid-cols-2 gap-y-2 text-sm">
+              <dl className="mt-3 grid grid-cols-2 gap-y-2 text-sm">
                 <dt className="text-[var(--color-muted-foreground)]">Ran at</dt>
-                <dd>{new Date(latestRun.run_at).toLocaleString()}</dd>
+                <dd className="mono">{new Date(latestRun.run_at).toLocaleString()}</dd>
                 <dt className="text-[var(--color-muted-foreground)]">Mode</dt>
-                <dd>{latestRun.mode}</dd>
+                <dd className="mono">{latestRun.mode}</dd>
                 <dt className="text-[var(--color-muted-foreground)]">PRs monitored</dt>
-                <dd>{latestRun.prs_monitored}</dd>
+                <dd className="mono">{latestRun.prs_monitored}</dd>
                 <dt className="text-[var(--color-muted-foreground)]">Issues triaged</dt>
-                <dd>{latestRun.issues_triaged}</dd>
+                <dd className="mono">{latestRun.issues_triaged}</dd>
                 <dt className="text-[var(--color-muted-foreground)]">Escalations</dt>
-                <dd>{latestRun.prs_escalated + latestRun.issues_escalated}</dd>
+                <dd
+                  className="mono"
+                  style={{
+                    color:
+                      escalations > 0 ? 'var(--color-warning)' : undefined,
+                  }}
+                >
+                  {escalations}
+                </dd>
                 <dt className="text-[var(--color-muted-foreground)]">Errors</dt>
-                <dd>{latestRun.errors?.length ?? 0}</dd>
+                <dd
+                  className="mono"
+                  style={{
+                    color:
+                      errorCount > 0 ? 'var(--color-destructive)' : undefined,
+                  }}
+                >
+                  {errorCount}
+                </dd>
               </dl>
             ) : (
-              <p className="text-sm text-[var(--color-muted-foreground)]">
+              <p className="mt-3 text-sm text-[var(--color-muted-foreground)]">
                 No runs recorded yet.
               </p>
             )}
-            <Link
-              to="/runs"
-              className="mt-4 inline-block text-xs text-[var(--color-primary)] hover:underline"
-            >
-              View run history →
-            </Link>
           </div>
 
-          <div className="border border-[var(--color-border)] rounded-lg p-5 bg-[var(--color-card)]">
-            <h2 className="text-sm font-medium">
-              Goal: <span className="font-normal">{firstGoal ?? '—'}</span>
-            </h2>
+          <div className="panel p-5 lg:col-span-2">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-sm font-semibold tracking-tight">
+                  Goal score
+                </h2>
+                <p className="text-xs text-[var(--color-muted-foreground)] mt-0.5">
+                  {firstGoal ?? 'No goal recorded'}
+                </p>
+              </div>
+              {goalDelta && (
+                <span
+                  className="mono text-xs font-medium"
+                  style={{
+                    color:
+                      goalTrend === 'up'
+                        ? 'var(--color-success)'
+                        : goalTrend === 'down'
+                          ? 'var(--color-destructive)'
+                          : 'var(--color-muted-foreground)',
+                  }}
+                >
+                  {goalDelta}
+                </span>
+              )}
+            </div>
             {series.length > 0 ? (
-              <div className="h-48 mt-3">
+              <div className="h-56 mt-3">
                 <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={series}>
+                  <LineChart
+                    data={series}
+                    margin={{ top: 8, right: 8, bottom: 0, left: -12 }}
+                  >
+                    <defs>
+                      <linearGradient id="goal-area" x1="0" x2="0" y1="0" y2="1">
+                        <stop offset="0%" stopColor="var(--chart-1)" stopOpacity={0.3} />
+                        <stop offset="100%" stopColor="var(--chart-1)" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
                     <CartesianGrid
-                      strokeDasharray="3 3"
+                      strokeDasharray="2 4"
                       stroke="var(--color-border)"
+                      vertical={false}
                     />
                     <XAxis
                       dataKey="timestamp"
                       tickFormatter={(v) =>
-                        new Date(v as string).toLocaleDateString()
+                        new Date(v as string).toLocaleDateString(undefined, {
+                          month: 'short',
+                          day: 'numeric',
+                        })
                       }
-                      tick={{ fontSize: 10 }}
+                      tick={{ fontSize: 10, fill: 'var(--color-muted-foreground)' }}
+                      stroke="var(--color-border)"
+                      tickLine={false}
+                      axisLine={false}
                     />
-                    <YAxis domain={[0, 1]} tick={{ fontSize: 10 }} />
+                    <YAxis
+                      domain={[0, 1]}
+                      tick={{ fontSize: 10, fill: 'var(--color-muted-foreground)' }}
+                      stroke="var(--color-border)"
+                      tickLine={false}
+                      axisLine={false}
+                      width={36}
+                    />
                     <Tooltip
+                      cursor={{ stroke: 'var(--color-border-strong)' }}
+                      contentStyle={{
+                        background: 'var(--color-card-elevated)',
+                        border: '1px solid var(--color-border)',
+                        borderRadius: 'var(--radius-sm)',
+                        fontSize: 12,
+                        color: 'var(--color-foreground)',
+                        boxShadow: 'var(--shadow-md)',
+                      }}
                       labelFormatter={(v) =>
                         new Date(v as string).toLocaleString()
                       }
                     />
+                    <Area
+                      type="monotone"
+                      dataKey="score"
+                      stroke="transparent"
+                      fill="url(#goal-area)"
+                      isAnimationActive={false}
+                    />
                     <Line
                       type="monotone"
                       dataKey="score"
-                      stroke="var(--color-primary)"
+                      stroke="var(--chart-1)"
                       strokeWidth={2}
                       dot={false}
+                      isAnimationActive={false}
                     />
                   </LineChart>
                 </ResponsiveContainer>
               </div>
             ) : (
-              <p className="text-sm text-[var(--color-muted-foreground)] mt-2">
+              <p className="mt-3 text-sm text-[var(--color-muted-foreground)]">
                 No goal history yet.
               </p>
             )}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { Navigate } from 'react-router-dom'
-import { LogIn } from 'lucide-react'
+import { Activity, LogIn } from 'lucide-react'
 import { useUser } from '@/hooks/useUser'
 
 export default function Login() {
@@ -16,15 +16,34 @@ export default function Login() {
   if (user) return <Navigate to="/" replace />
 
   return (
-    <div className="min-h-screen grid place-items-center p-6">
-      <div className="w-full max-w-sm border border-[var(--color-border)] rounded-xl p-8 bg-[var(--color-card)]">
+    <div className="min-h-screen relative grid place-items-center p-6 overflow-hidden">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(40rem 28rem at 30% 10%, var(--color-primary-soft), transparent 60%), radial-gradient(36rem 24rem at 80% 90%, var(--color-info-soft), transparent 60%)',
+        }}
+      />
+      <div className="panel glass relative w-full max-w-sm p-8">
+        <div
+          aria-hidden
+          className="h-10 w-10 rounded-[var(--radius-md)] grid place-items-center mb-4 text-[var(--color-primary-foreground)]"
+          style={{
+            background:
+              'linear-gradient(135deg, var(--color-primary), var(--color-accent))',
+            boxShadow: 'var(--shadow-glow)',
+          }}
+        >
+          <Activity className="h-5 w-5" />
+        </div>
         <h1 className="text-2xl font-semibold tracking-tight">Caretaker</h1>
         <p className="text-sm text-[var(--color-muted-foreground)] mt-1">
           Admin dashboard. Sign in to continue.
         </p>
         <a
           href="/api/auth/login"
-          className="mt-6 w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-md bg-[var(--color-primary)] text-[var(--color-primary-foreground)] hover:opacity-90 text-sm font-medium"
+          className="mt-6 w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-[var(--radius-md)] bg-[var(--color-primary)] text-[var(--color-primary-foreground)] hover:opacity-90 text-sm font-medium transition-opacity"
         >
           <LogIn className="h-4 w-4" />
           Sign in with SSO


### PR DESCRIPTION
## Summary

Level up the admin dashboard with a full theme system and a denser, more modern visual language inspired by Grafana's 2026 aesthetic.

- **Dark / light / system theme**, persisted in `localStorage` and synced live with `prefers-color-scheme`. Pre-hydration inline script in `index.html` prevents any flash of incorrect theme.
- **Theme toggle** (Sun / Moon / Monitor) wired into a new top bar with breadcrumbs.
- **Design token system** in `index.css` — layered surfaces, semantic colors, chart palette, radii, shadows, motion, typography — with tuned dark (near-black / purple / cyan) and light palettes.
- **Component refresh** — glass sidebar with gradient logo + accent-bar active nav, hairline `DataTable` with sticky header and tabular numerics, gradient-accent `PageHeader`, Grafana-style `StatPanel` with sparklines + trend deltas, themed Recharts.
- **StatusBadge, Pagination, Login, Agents, Config, Dashboard** migrated to CSS-variable tokens — no more hardcoded Tailwind color classes. Reduced-motion gate + focus rings for a11y.

## Screenshots

| Light | Dark |
| --- | --- |
| Login renders on soft off-white with gradient mark and primary-soft button. | Layered near-black surfaces, aurora radial accents, purple/cyan brand gradient. |

*(Captured locally via the Chrome MCP smoke test on the `/login` route; happy to attach PNGs if desired.)*

## Test plan

- [ ] `cd frontend && npm run lint` passes
- [ ] `cd frontend && npm run build` produces a clean production bundle
- [ ] Open the dashboard in Chrome, toggle between Light / Dark / System and confirm:
  - [ ] Theme persists across full reload (localStorage key `caretaker.theme`)
  - [ ] In System mode, flipping the OS theme updates the UI live
  - [ ] No FOUC on initial load in either theme
- [ ] Sanity check every route (Overview, PRs, Issues, Runs, Memory, Skills, Agents, Graph, Config, Login) in both themes
- [ ] Verify keyboard navigation reaches the theme toggle and its `aria-*` attributes reflect state
- [ ] Confirm `prefers-reduced-motion` disables the panel / transition animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)