### PR TITLE
fix(setup): rename maintainer mode upgrade-only → upgrade

### DIFF
--- a/.github/skills/caretaker-setup.md
+++ b/.github/skills/caretaker-setup.md
@@ -138,7 +138,7 @@ on:
         required: false
         default: 'full'
         type: choice
-        options: [full, pr-only, issue-only, upgrade-only, dry-run]
+        options: [full, pr-only, issue-only, upgrade, dry-run]
 
 permissions:
   contents: write

--- a/setup-templates/templates/workflows/maintainer.yml
+++ b/setup-templates/templates/workflows/maintainer.yml
@@ -20,7 +20,7 @@ on:
         required: false
         default: "full"
         type: choice
-        options: [full, pr-only, issue-only, upgrade-only, dry-run]
+        options: [full, pr-only, issue-only, upgrade, dry-run]
 
 # Prevent concurrent caretaker runs so each run sees the up-to-date memory
 # store written by the previous run.


### PR DESCRIPTION
The `RunMode` enum in `src/caretaker/cli.py` defines the upgrade mode value as `"upgrade"`, but the setup template and the setup skill still list `upgrade-only` in the `workflow_dispatch` input's `choice` options. Manual dispatches with that value pass a mode string caretaker doesn't accept. This has already caused multiple Copilot self-heal PRs in consumer repos (rust-oauth2-server #175/#178, portfolio #156).

Update both sources of truth:
- `setup-templates/templates/workflows/maintainer.yml`
- `.github/skills/caretaker-setup.md`

Existing consumer workflows still carry the stale value; per-repo one-line follow-up PRs will cascade the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)