### PR TITLE
feat(fleet-registry): opt-in cross-repo client roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fleet Registry — opt-in cross-repo client roster
+
+New opt-in telemetry surface so an operator can see every
+caretaker-managed repository in one dashboard without running an
+org-wide GitHub crawl.
+
+- **Emitter** — at the end of each successful `caretaker run`, if
+  `fleet_registry.enabled: true` and `fleet_registry.endpoint` is set,
+  the orchestrator POSTs a small JSON heartbeat with the repo slug,
+  caretaker version, run mode, enabled agents, and 20 curated
+  `RunSummary` counters. HMAC-SHA256 signed with the optional
+  `CARETAKER_FLEET_SECRET` shared secret. Fail-open: network /
+  configuration errors log a warning and never fail the run.
+- **Backend** — new `POST /api/fleet/heartbeat` (unauthenticated, HMAC
+  verified when the backend also has `CARETAKER_FLEET_SECRET` set) and
+  `GET /api/admin/fleet`, `/api/admin/fleet/summary`,
+  `/api/admin/fleet/{owner}/{repo}` behind the existing OIDC gate.
+  First cut uses an async-safe in-memory `FleetRegistryStore` —
+  persistence can plug in later without changing the API.
+- **Dashboard** — new `/fleet` route with StatPanel strip (total,
+  stale >7d, version mix, opt-in status) + hairline DataTable of every
+  known client.
+- **Opt-in, off by default.** No heartbeat unless both `enabled` and
+  `endpoint` are set; caretaker never phones home.
+- **Docs** — `docs/fleet-registry.md` walks through configuration,
+  operation, payload shape, and design notes.
+
 ### Sprint B3 + F3 — causal-chain audit trail
 
 Every caretaker-authored write now carries a hidden `<!-- caretaker:causal

--- a/docs/fleet-registry.md
+++ b/docs/fleet-registry.md
@@ -1,0 +1,135 @@
+# Fleet Registry
+
+Opt-in, per-repository heartbeat that lets an operator see every
+caretaker-managed repository in one dashboard without running a
+cross-org GitHub crawl.
+
+## How it works
+
+```
+consumer repo                                central caretaker backend
+┌──────────────────────┐        heartbeat    ┌────────────────────────────┐
+│ caretaker run        │  ──── POST /api/── ▶│ /api/fleet/heartbeat       │
+│  …end of run loop…   │   fleet/heartbeat   │   (unauthenticated,        │
+│ emit_heartbeat()     │                     │    HMAC-verified if        │
+└──────────────────────┘                     │    CARETAKER_FLEET_SECRET  │
+                                             │    is set)                 │
+                                             │                            │
+                                             │ in-memory FleetRegistry    │
+                                             │ ▲                          │
+                                             │ │                          │
+                                             │ │ read (OIDC-authed)       │
+                                             │ │                          │
+                                             │ /api/admin/fleet           │
+                                             │ /api/admin/fleet/summary   │
+                                             │ /api/admin/fleet/{repo}    │
+                                             └────────────────────────────┘
+                                                       ▲
+                                                       │
+                                                  admin dashboard
+                                                    /fleet route
+```
+
+The feature is **off by default**. Caretaker never phones home unless
+the consumer sets both `fleet_registry.enabled: true` and a concrete
+`fleet_registry.endpoint` URL.
+
+## Configuring a consumer
+
+Add to your repo's `.github/maintainer/config.yml`:
+
+```yaml
+fleet_registry:
+  enabled: true
+  endpoint: https://caretaker-admin.example.com/api/fleet/heartbeat
+  # Optional. When set the emitter signs the payload with HMAC-SHA256
+  # and forwards the digest in X-Caretaker-Signature. The backend
+  # verifies before recording.
+  secret_env: CARETAKER_FLEET_SECRET
+  # Optional. Default False. When True the heartbeat body includes
+  # the full RunSummary dump (every counter, goal metric, and error
+  # list). Keep the default for public OSS fleets; enable only when
+  # you control both sides.
+  include_full_summary: false
+  timeout_seconds: 5.0
+```
+
+If `CARETAKER_FLEET_SECRET` is exported in the workflow environment,
+every heartbeat is signed:
+
+```yaml
+# .github/workflows/maintainer.yml
+- name: Run caretaker
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    CARETAKER_FLEET_SECRET: ${{ secrets.CARETAKER_FLEET_SECRET }}
+    # …
+  run: caretaker run --config .github/maintainer/config.yml
+```
+
+## Operating the backend
+
+The heartbeat receiver is part of the same FastAPI app as the admin
+dashboard. It's always mounted, regardless of `CARETAKER_ADMIN_ENABLED`,
+so consumers can register even against a headless MCP deployment.
+
+Set the shared secret on the backend environment to enforce HMAC:
+
+```bash
+export CARETAKER_FLEET_SECRET="…a-strong-shared-secret…"
+```
+
+Without a backend-side secret, the receiver accepts unsigned requests
+(useful for private-network deployments and bootstrapping, *not* for
+public internet-facing backends).
+
+## Payload shape
+
+```json
+{
+  "schema_version": 1,
+  "repo": "ianlintner/demo",
+  "caretaker_version": "0.11.0",
+  "run_at": "2026-04-20T23:00:00+00:00",
+  "mode": "full",
+  "enabled_agents": ["pr_agent", "issue_agent", "upgrade_agent"],
+  "goal_health": 0.82,
+  "error_count": 0,
+  "counters": {
+    "prs_monitored": 3,
+    "prs_merged": 1,
+    "issues_triaged": 2,
+    "…": "20 curated counters from RunSummary"
+  }
+}
+```
+
+Unknown fields are accepted — the backend tolerates forward-compatible
+additions to keep old backends working against newer emitters.
+
+## Dashboard
+
+The admin dashboard gets a new **Fleet** route under the main nav with:
+
+- Four StatPanels (registered repos, stale >7d, version mix, opt-in
+  status).
+- A hairline DataTable of every known client (repo, version, last
+  mode, goal health, error count, agent count, heartbeat count, last
+  seen).
+
+Stale clients (no heartbeat in ≥7 days) are flagged so you can chase
+down a silent consumer.
+
+## Design notes
+
+- **Opt-in, off by default.** No heartbeat without explicit config.
+- **Fail-open.** Network, auth, or serialization errors are logged at
+  `WARNING` and swallowed. A fleet-registry problem can never fail the
+  orchestrator run loop.
+- **In-memory store (for now).** The first cut persists only for the
+  lifetime of the backend process. A future revision can plug the same
+  `FleetRegistryStore` interface into the SQLite / Mongo backends that
+  already back `state/` and `evolution/`.
+- **No auto-discovery.** We chose the client-push model over a backend
+  poll so operators without org-wide read PATs can still run a fleet
+  dashboard.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Memory from '@/pages/Memory'
 import Skills from '@/pages/Skills'
 import Agents from '@/pages/Agents'
 import Graph from '@/pages/Graph'
+import Fleet from '@/pages/Fleet'
 import Config from '@/pages/Config'
 
 export default function App() {
@@ -31,6 +32,7 @@ export default function App() {
               <Route path="/skills" element={<Skills />} />
               <Route path="/agents" element={<Agents />} />
               <Route path="/graph" element={<Graph />} />
+              <Route path="/fleet" element={<Fleet />} />
               <Route path="/config" element={<Config />} />
             </Route>
           </Routes>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import {
   Sparkles,
   Users,
   Network,
+  Boxes,
   Settings,
   LogOut,
   ChevronRight,
@@ -27,6 +28,7 @@ const NAV = [
   { to: '/skills', label: 'Skills', icon: Sparkles },
   { to: '/agents', label: 'Agents', icon: Users },
   { to: '/graph', label: 'Graph', icon: Network },
+  { to: '/fleet', label: 'Fleet', icon: Boxes },
   { to: '/config', label: 'Config', icon: Settings },
 ]
 

--- a/frontend/src/pages/Fleet.tsx
+++ b/frontend/src/pages/Fleet.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react'
+import useSWR from 'swr'
+import PageHeader from '@/components/PageHeader'
+import StatPanel from '@/components/StatPanel'
+import { DataTable, type Column } from '@/components/DataTable'
+import Pagination from '@/components/Pagination'
+import StatusBadge from '@/components/StatusBadge'
+
+type FleetClient = {
+  repo: string
+  caretaker_version: string
+  last_seen: string
+  first_seen: string
+  last_mode: string
+  enabled_agents: string[]
+  last_goal_health: number | null
+  last_error_count: number
+  last_counters: Record<string, number>
+  heartbeats_seen: number
+}
+
+type FleetList = {
+  items: FleetClient[]
+  total: number
+  offset: number
+  limit: number
+}
+
+type FleetSummary = {
+  total_clients: number
+  stale_clients: number
+  stale_threshold_days: number
+  version_distribution: Record<string, number>
+}
+
+function timeAgo(iso: string): string {
+  const t = new Date(iso).getTime()
+  if (!Number.isFinite(t)) return '—'
+  const delta = Date.now() - t
+  if (delta < 60_000) return 'just now'
+  const m = Math.floor(delta / 60_000)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  return `${d}d ago`
+}
+
+const COLUMNS: Column<FleetClient>[] = [
+  {
+    key: 'repo',
+    header: 'Repository',
+    render: (r) => <span className="mono text-xs">{r.repo}</span>,
+  },
+  {
+    key: 'version',
+    header: 'Version',
+    render: (r) => <span className="mono text-xs">{r.caretaker_version}</span>,
+  },
+  {
+    key: 'mode',
+    header: 'Last Mode',
+    render: (r) => <StatusBadge value={r.last_mode} />,
+  },
+  {
+    key: 'goal_health',
+    header: 'Goal Health',
+    render: (r) => (
+      <span className="mono text-xs">
+        {r.last_goal_health != null ? r.last_goal_health.toFixed(2) : '—'}
+      </span>
+    ),
+  },
+  {
+    key: 'errors',
+    header: 'Errors',
+    render: (r) => (
+      <span
+        className="mono text-xs"
+        style={{
+          color:
+            r.last_error_count > 0 ? 'var(--color-destructive)' : undefined,
+        }}
+      >
+        {r.last_error_count}
+      </span>
+    ),
+  },
+  {
+    key: 'agents',
+    header: 'Agents',
+    render: (r) => (
+      <span className="text-xs text-[var(--color-muted-foreground)]">
+        {r.enabled_agents.length}
+      </span>
+    ),
+  },
+  {
+    key: 'heartbeats',
+    header: 'Heartbeats',
+    render: (r) => <span className="mono text-xs">{r.heartbeats_seen}</span>,
+  },
+  {
+    key: 'last_seen',
+    header: 'Last Seen',
+    render: (r) => (
+      <span
+        className="text-xs text-[var(--color-muted-foreground)]"
+        title={r.last_seen}
+      >
+        {timeAgo(r.last_seen)}
+      </span>
+    ),
+  },
+]
+
+export default function Fleet() {
+  const [offset, setOffset] = useState(0)
+  const limit = 50
+
+  const { data: list, isLoading } = useSWR<FleetList>(
+    `/api/admin/fleet?offset=${offset}&limit=${limit}`,
+  )
+  const { data: summary } = useSWR<FleetSummary>('/api/admin/fleet/summary')
+
+  const versions = summary?.version_distribution ?? {}
+  const versionLabel = Object.entries(versions)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 3)
+    .map(([v, n]) => `${v} (${n})`)
+    .join(' · ')
+
+  return (
+    <>
+      <PageHeader
+        title="Fleet"
+        description="Consumer repositories that opted in to report heartbeats to this backend."
+      />
+      <div className="p-6 space-y-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <StatPanel
+            label="Registered repos"
+            value={summary?.total_clients ?? '—'}
+            hint="Reporting heartbeats to this backend"
+            accentVar="--chart-1"
+          />
+          <StatPanel
+            label="Stale"
+            value={summary?.stale_clients ?? '—'}
+            hint={`No heartbeat in ${summary?.stale_threshold_days ?? 7} days`}
+            accentVar="--chart-4"
+          />
+          <StatPanel
+            label="Versions in fleet"
+            value={Object.keys(versions).length || '—'}
+            hint={versionLabel || 'No heartbeats yet'}
+            accentVar="--chart-2"
+          />
+          <StatPanel
+            label="Opt-in status"
+            value={
+              summary?.total_clients != null
+                ? summary.total_clients > 0
+                  ? 'Active'
+                  : 'Waiting'
+                : '—'
+            }
+            hint="Heartbeat endpoint: /api/fleet/heartbeat"
+            accentVar="--chart-3"
+          />
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-[var(--color-muted-foreground)]">
+            Loading…
+          </p>
+        ) : (
+          <>
+            <DataTable
+              columns={COLUMNS}
+              rows={list?.items ?? []}
+              empty="No consumer repositories have registered yet. Set caretaker's fleet_registry.enabled = true and point fleet_registry.endpoint at this backend to opt in."
+            />
+            {list && list.total > limit && (
+              <Pagination
+                offset={list.offset}
+                limit={list.limit}
+                total={list.total}
+                onChange={setOffset}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -515,6 +515,37 @@ class TelemetryConfig(StrictBaseModel):
     application_insights_connection_string_env: str = "APPLICATIONINSIGHTS_CONNECTION_STRING"
 
 
+class FleetRegistryConfig(StrictBaseModel):
+    """Opt-in fleet registry.
+
+    When ``enabled`` is ``True`` and ``endpoint`` is set, each successful
+    orchestrator run POSTs a small JSON heartbeat to a central caretaker
+    backend so an operator can see every consumer repo in one dashboard.
+
+    The feature is entirely opt-in: the default ``enabled = False`` keeps
+    caretaker's current behavior byte-identical. The endpoint URL is
+    intentionally not given a default — caretaker never phones home
+    unless the consumer explicitly configures a destination.
+
+    ``secret_env`` names an environment variable whose value is used as
+    an HMAC-SHA256 shared secret. When set, the emitter signs the POST
+    body and forwards the hex digest in ``X-Caretaker-Signature``; the
+    backend verifies before recording. When unset, heartbeats are
+    delivered without authentication (suitable for private networks /
+    trusted origins only).
+    """
+
+    enabled: bool = False
+    endpoint: str | None = None
+    secret_env: str = "CARETAKER_FLEET_SECRET"
+    timeout_seconds: float = 5.0
+    # When ``True`` the heartbeat body includes the full ``RunSummary``
+    # dump; when ``False`` only the curated set of summary counters is
+    # sent. Default False to minimise the risk of surfacing repo-private
+    # details (error log snippets, etc.) through the central dashboard.
+    include_full_summary: bool = False
+
+
 class GitHubAppConfig(StrictBaseModel):
     """Configuration for the optional GitHub App front-end.
 
@@ -630,6 +661,7 @@ class MaintainerConfig(StrictBaseModel):
     audit_log: AuditLogConfig = Field(default_factory=AuditLogConfig)
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     telemetry: TelemetryConfig = Field(default_factory=TelemetryConfig)
+    fleet_registry: FleetRegistryConfig = Field(default_factory=FleetRegistryConfig)
     github_app: GitHubAppConfig = Field(default_factory=GitHubAppConfig)
     admin_dashboard: AdminDashboardConfig = Field(default_factory=AdminDashboardConfig)
     graph_store: GraphStoreConfig = Field(default_factory=GraphStoreConfig)

--- a/src/caretaker/fleet/__init__.py
+++ b/src/caretaker/fleet/__init__.py
@@ -1,0 +1,28 @@
+"""Opt-in fleet-registry heartbeat emitter, store, and HTTP surface."""
+
+from caretaker.fleet.api import admin_router, public_router
+from caretaker.fleet.emitter import (
+    FleetHeartbeat,
+    build_heartbeat,
+    emit_heartbeat,
+    sign_payload,
+)
+from caretaker.fleet.store import (
+    FleetClient,
+    FleetRegistryStore,
+    get_store,
+    reset_store_for_tests,
+)
+
+__all__ = [
+    "FleetClient",
+    "FleetHeartbeat",
+    "FleetRegistryStore",
+    "admin_router",
+    "build_heartbeat",
+    "emit_heartbeat",
+    "get_store",
+    "public_router",
+    "reset_store_for_tests",
+    "sign_payload",
+]

--- a/src/caretaker/fleet/api.py
+++ b/src/caretaker/fleet/api.py
@@ -1,0 +1,167 @@
+"""HTTP surface for the opt-in fleet registry.
+
+Two routers:
+
+* ``public_router`` — the unauthenticated ``POST /api/fleet/heartbeat``
+  endpoint that consumer caretaker runs POST to. HMAC verification is
+  optional and controlled by the ``CARETAKER_FLEET_SECRET`` environment
+  variable on the backend. When set, requests must carry a matching
+  ``X-Caretaker-Signature`` header.
+* ``admin_router`` — authenticated list/summary endpoints consumed by
+  the admin dashboard. Mounted under the ``/api/admin/fleet`` prefix.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from caretaker.fleet.emitter import sign_payload
+from caretaker.fleet.store import FleetRegistryStore, get_store
+
+logger = logging.getLogger(__name__)
+
+
+SECRET_ENV = "CARETAKER_FLEET_SECRET"
+SIGNATURE_HEADER = "X-Caretaker-Signature"
+
+
+public_router = APIRouter(prefix="/api/fleet", tags=["fleet"])
+admin_router = APIRouter(prefix="/api/admin/fleet", tags=["fleet"])
+
+
+def _verify_signature_if_required(body: bytes, header: str | None) -> None:
+    """Enforce HMAC only when a secret is configured on the backend.
+
+    When the backend has no ``CARETAKER_FLEET_SECRET`` set we accept
+    unsigned requests (convenient for trusted-network deployments and
+    for bootstrapping). When the secret is set, the header becomes
+    mandatory and must verify.
+    """
+    secret = os.environ.get(SECRET_ENV, "").strip()
+    if not secret:
+        return
+    if not header:
+        raise HTTPException(status_code=401, detail="missing signature header")
+    provided = header.strip()
+    if provided.startswith("sha256="):
+        provided = provided[len("sha256=") :]
+    expected = sign_payload(body, secret)
+    if not hmac.compare_digest(provided.lower(), expected.lower()):
+        raise HTTPException(status_code=401, detail="invalid signature")
+
+
+@public_router.post("/heartbeat")
+async def receive_heartbeat(request: Request) -> dict[str, Any]:
+    """Record a heartbeat from a consumer caretaker run."""
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=400, detail="empty body")
+    _verify_signature_if_required(body, request.headers.get(SIGNATURE_HEADER))
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="payload must be a JSON object")
+
+    store: FleetRegistryStore = get_store()
+    try:
+        record = await store.record_heartbeat(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {"ok": True, "repo": record.repo, "heartbeats_seen": record.heartbeats_seen}
+
+
+# ── Admin (authenticated) endpoints ───────────────────────────────────────
+
+
+def _auth_dependency() -> Any:
+    """Import ``require_session`` lazily so fleet works even when the
+    admin package isn't configured (e.g. headless MCP deployment)."""
+    from caretaker.admin.auth import require_session
+
+    return Depends(require_session)
+
+
+# Module-level singleton. Resolved once at import time. Tests that want
+# to bypass OIDC override the dependency with ``app.dependency_overrides``.
+_REQUIRE_SESSION = _auth_dependency()
+
+
+@admin_router.get("")
+async def list_fleet(
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=500),
+    version: str | None = Query(default=None, description="Filter by caretaker version"),
+    _user: Any = _REQUIRE_SESSION,
+) -> dict[str, Any]:
+    """Paginated list of known client repos, newest-heartbeat first."""
+    store = get_store()
+    clients = await store.list_clients()
+    if version:
+        clients = [c for c in clients if c.caretaker_version == version]
+    total = len(clients)
+    window = clients[offset : offset + limit]
+    return {
+        "items": [c.to_dict() for c in window],
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+    }
+
+
+@admin_router.get("/summary")
+async def fleet_summary(
+    _user: Any = _REQUIRE_SESSION,
+) -> dict[str, Any]:
+    """Small rollup for the dashboard header — total, version mix, stale."""
+    from datetime import timedelta
+
+    store = get_store()
+    clients = await store.list_clients()
+    stale = await store.stale_clients(threshold=timedelta(days=7))
+    version_counts: dict[str, int] = {}
+    for c in clients:
+        version_counts[c.caretaker_version] = version_counts.get(c.caretaker_version, 0) + 1
+    return {
+        "total_clients": len(clients),
+        "stale_clients": len(stale),
+        "stale_threshold_days": 7,
+        "version_distribution": version_counts,
+    }
+
+
+@admin_router.get("/{owner}/{repo}")
+async def get_fleet_client(
+    owner: str,
+    repo: str,
+    _user: Any = _REQUIRE_SESSION,
+) -> dict[str, Any]:
+    """Detail view for a single repo."""
+    store = get_store()
+    record = await store.get_client(f"{owner}/{repo}")
+    if record is None:
+        raise HTTPException(status_code=404, detail="repo not registered")
+    return record.to_dict()
+
+
+__all__ = [
+    "admin_router",
+    "public_router",
+]
+
+
+# Safety: ensure sign_payload is importable for the HMAC check above
+# without creating a cycle on module-load (emitter imports from
+# caretaker.config which is already loaded by the time this module is
+# imported from FastAPI startup).
+assert callable(sign_payload)
+assert callable(hashlib.sha256)

--- a/src/caretaker/fleet/emitter.py
+++ b/src/caretaker/fleet/emitter.py
@@ -1,0 +1,214 @@
+"""Opt-in fleet-registry heartbeat emitter.
+
+The emitter is intentionally small and fail-open: a misconfigured or
+unreachable fleet endpoint must never fail a caretaker run. All errors
+are logged at ``WARNING`` and swallowed.
+
+See :class:`caretaker.config.FleetRegistryConfig` for the user-facing
+configuration surface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import importlib.metadata
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from caretaker.config import FleetRegistryConfig, MaintainerConfig
+    from caretaker.state.models import RunSummary
+
+logger = logging.getLogger(__name__)
+
+
+_COUNTERS = (
+    "prs_monitored",
+    "prs_merged",
+    "prs_escalated",
+    "issues_triaged",
+    "issues_assigned",
+    "issues_closed",
+    "issues_escalated",
+    "orphaned_prs",
+    "prs_fix_requested",
+    "build_failures_detected",
+    "self_heal_failures_analyzed",
+    "security_findings_found",
+    "dependency_prs_reviewed",
+    "docs_prs_analyzed",
+    "charlie_managed_issues",
+    "charlie_managed_prs",
+    "stale_issues_warned",
+    "escalation_items_found",
+    "owned_prs",
+    "authority_merges",
+)
+
+
+def _caretaker_version() -> str:
+    try:
+        return importlib.metadata.version("caretaker-github")
+    except importlib.metadata.PackageNotFoundError:
+        try:
+            return importlib.metadata.version("caretaker")
+        except importlib.metadata.PackageNotFoundError:
+            return "unknown"
+
+
+def _enabled_agents(config: MaintainerConfig) -> list[str]:
+    """Return the names of agents whose ``enabled`` flag is True."""
+    names: list[str] = []
+    for attr in (
+        "pr_agent",
+        "issue_agent",
+        "upgrade_agent",
+        "devops_agent",
+        "self_heal_agent",
+        "security_agent",
+        "dependency_agent",
+        "docs_agent",
+        "charlie_agent",
+        "stale_agent",
+        "review_agent",
+        "principal_agent",
+        "test_agent",
+        "refactor_agent",
+        "perf_agent",
+        "migration_agent",
+    ):
+        block = getattr(config, attr, None)
+        if block is not None and getattr(block, "enabled", False):
+            names.append(attr)
+    return names
+
+
+class FleetHeartbeat(BaseModel):
+    """Canonical heartbeat payload.
+
+    Backwards compat: the backend MUST tolerate unknown fields. Keep
+    the counters set flat; nest anything richer under ``summary`` so
+    older backends that pin the counters schema still parse.
+    """
+
+    schema_version: int = 1
+    repo: str
+    caretaker_version: str
+    run_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    mode: str = "full"
+    enabled_agents: list[str] = Field(default_factory=list)
+    goal_health: float | None = None
+    error_count: int = 0
+    counters: dict[str, int] = Field(default_factory=dict)
+    summary: dict[str, Any] | None = None
+
+
+def build_heartbeat(
+    config: MaintainerConfig,
+    summary: RunSummary,
+    *,
+    repo: str | None = None,
+    include_full_summary: bool | None = None,
+) -> FleetHeartbeat:
+    """Assemble the heartbeat payload from a finished run."""
+    slug = repo or os.environ.get("GITHUB_REPOSITORY") or "unknown/unknown"
+    counters = {k: int(getattr(summary, k, 0) or 0) for k in _COUNTERS}
+    want_full = (
+        include_full_summary
+        if include_full_summary is not None
+        else config.fleet_registry.include_full_summary
+    )
+    full = summary.model_dump(mode="json") if want_full else None
+    return FleetHeartbeat(
+        repo=slug,
+        caretaker_version=_caretaker_version(),
+        run_at=summary.run_at if summary.run_at.tzinfo else summary.run_at.replace(tzinfo=UTC),
+        mode=summary.mode,
+        enabled_agents=_enabled_agents(config),
+        goal_health=summary.goal_health,
+        error_count=len(summary.errors or []),
+        counters=counters,
+        summary=full,
+    )
+
+
+def sign_payload(body: bytes, secret: str) -> str:
+    """Compute the hex HMAC-SHA256 signature forwarded in the header."""
+    return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+async def emit_heartbeat(
+    config: MaintainerConfig,
+    summary: RunSummary,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> bool:
+    """POST a heartbeat to the configured fleet endpoint.
+
+    Returns ``True`` on a 2xx response, ``False`` otherwise. Never raises:
+    network or configuration problems are logged at ``WARNING`` and
+    swallowed so a failure to register never fails the orchestrator run.
+    """
+    fleet: FleetRegistryConfig = config.fleet_registry
+    if not fleet.enabled:
+        return False
+    endpoint = fleet.endpoint
+    if not endpoint:
+        logger.debug("fleet_registry.enabled but endpoint is empty; skipping")
+        return False
+
+    try:
+        heartbeat = build_heartbeat(config, summary)
+    except Exception as exc:  # defensive: never break the run loop
+        logger.warning("fleet heartbeat: failed to build payload: %s", exc)
+        return False
+
+    body = heartbeat.model_dump_json().encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    secret = os.environ.get(fleet.secret_env, "").strip()
+    if secret:
+        headers["X-Caretaker-Signature"] = "sha256=" + sign_payload(body, secret)
+
+    owns_client = client is None
+    try:
+        if owns_client:
+            client = httpx.AsyncClient(timeout=fleet.timeout_seconds)
+        assert client is not None  # narrow for type-checkers
+        try:
+            resp = await client.post(endpoint, content=body, headers=headers)
+        finally:
+            if owns_client:
+                await client.aclose()
+        if 200 <= resp.status_code < 300:
+            logger.info(
+                "fleet heartbeat: registered %s with %s (status %d)",
+                heartbeat.repo,
+                endpoint,
+                resp.status_code,
+            )
+            return True
+        logger.warning(
+            "fleet heartbeat: non-2xx response from %s (status %d, body=%r)",
+            endpoint,
+            resp.status_code,
+            resp.text[:200],
+        )
+        return False
+    except httpx.HTTPError as exc:
+        logger.warning("fleet heartbeat: transport error to %s: %s", endpoint, exc)
+        return False
+    except Exception as exc:  # fail-open: protect the run loop
+        logger.warning("fleet heartbeat: unexpected error: %s", exc)
+        return False
+
+
+def heartbeat_as_dict(heartbeat: FleetHeartbeat) -> dict[str, Any]:
+    """Small helper for callers that want the JSON-safe dict."""
+    return json.loads(heartbeat.model_dump_json())

--- a/src/caretaker/fleet/emitter.py
+++ b/src/caretaker/fleet/emitter.py
@@ -211,4 +211,5 @@ async def emit_heartbeat(
 
 def heartbeat_as_dict(heartbeat: FleetHeartbeat) -> dict[str, Any]:
     """Small helper for callers that want the JSON-safe dict."""
-    return json.loads(heartbeat.model_dump_json())
+    result: dict[str, Any] = json.loads(heartbeat.model_dump_json())
+    return result

--- a/src/caretaker/fleet/store.py
+++ b/src/caretaker/fleet/store.py
@@ -1,0 +1,137 @@
+"""In-memory fleet-registry store.
+
+A simple dict keyed by repo slug. Replaceable with a persistent
+backend later (SQLite, Mongo) without changing the API surface —
+``FleetRegistryStore`` is the one seam the endpoints and admin API
+depend on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FleetClient:
+    """Represents one known consumer repo.
+
+    ``heartbeats_seen`` is monotonically incremented on every accepted
+    heartbeat; ``last_seen`` is the wall-clock of the most recent one.
+    """
+
+    repo: str
+    caretaker_version: str
+    last_seen: datetime
+    first_seen: datetime
+    last_mode: str = "full"
+    enabled_agents: list[str] = field(default_factory=list)
+    last_goal_health: float | None = None
+    last_error_count: int = 0
+    last_counters: dict[str, int] = field(default_factory=dict)
+    last_summary: dict[str, Any] | None = None
+    heartbeats_seen: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repo": self.repo,
+            "caretaker_version": self.caretaker_version,
+            "last_seen": self.last_seen.isoformat(),
+            "first_seen": self.first_seen.isoformat(),
+            "last_mode": self.last_mode,
+            "enabled_agents": list(self.enabled_agents),
+            "last_goal_health": self.last_goal_health,
+            "last_error_count": self.last_error_count,
+            "last_counters": dict(self.last_counters),
+            "last_summary": self.last_summary,
+            "heartbeats_seen": self.heartbeats_seen,
+        }
+
+
+class FleetRegistryStore:
+    """Async-safe in-memory fleet registry."""
+
+    def __init__(self) -> None:
+        self._clients: dict[str, FleetClient] = {}
+        self._lock = asyncio.Lock()
+
+    async def record_heartbeat(self, payload: dict[str, Any]) -> FleetClient:
+        """Persist (or refresh) a client from a raw heartbeat payload.
+
+        Returns the stored record.
+        """
+        repo = str(payload.get("repo") or "").strip()
+        if not repo:
+            raise ValueError("heartbeat missing 'repo'")
+
+        now = datetime.now(UTC)
+        run_at_raw = payload.get("run_at")
+        try:
+            run_at = (
+                datetime.fromisoformat(run_at_raw.replace("Z", "+00:00"))
+                if isinstance(run_at_raw, str)
+                else now
+            )
+        except ValueError:
+            run_at = now
+
+        if run_at.tzinfo is None:
+            run_at = run_at.replace(tzinfo=UTC)
+
+        async with self._lock:
+            existing = self._clients.get(repo)
+            record = FleetClient(
+                repo=repo,
+                caretaker_version=str(payload.get("caretaker_version", "unknown")),
+                last_seen=run_at,
+                first_seen=existing.first_seen if existing else run_at,
+                last_mode=str(payload.get("mode", "full")),
+                enabled_agents=list(payload.get("enabled_agents") or []),
+                last_goal_health=payload.get("goal_health"),
+                last_error_count=int(payload.get("error_count") or 0),
+                last_counters=dict(payload.get("counters") or {}),
+                last_summary=payload.get("summary"),
+                heartbeats_seen=(existing.heartbeats_seen if existing else 0) + 1,
+            )
+            self._clients[repo] = record
+            return record
+
+    async def list_clients(self) -> list[FleetClient]:
+        async with self._lock:
+            return sorted(self._clients.values(), key=lambda c: c.last_seen, reverse=True)
+
+    async def get_client(self, repo: str) -> FleetClient | None:
+        async with self._lock:
+            return self._clients.get(repo)
+
+    async def remove_client(self, repo: str) -> bool:
+        async with self._lock:
+            return self._clients.pop(repo, None) is not None
+
+    async def size(self) -> int:
+        async with self._lock:
+            return len(self._clients)
+
+    async def stale_clients(self, *, threshold: timedelta) -> list[FleetClient]:
+        cutoff = datetime.now(UTC) - threshold
+        async with self._lock:
+            return [c for c in self._clients.values() if c.last_seen < cutoff]
+
+
+# Module-level singleton. Tests can monkey-patch this or call reset().
+_STORE = FleetRegistryStore()
+
+
+def get_store() -> FleetRegistryStore:
+    return _STORE
+
+
+def reset_store_for_tests() -> None:
+    """Test helper — replace the module singleton with a fresh store."""
+    global _STORE  # noqa: PLW0603
+    _STORE = FleetRegistryStore()

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -56,6 +56,19 @@ _ADMIN_STATIC_DIR = Path(__file__).resolve().parent.parent / "admin" / "static"
 @asynccontextmanager
 async def _lifespan(application: FastAPI):  # type: ignore[no-untyped-def]
     """App lifespan: initialise admin dashboard if configured."""
+    # Unconditionally register the unauthenticated fleet-heartbeat
+    # receiver so consumer caretaker runs can register themselves
+    # regardless of whether the full admin dashboard is enabled on
+    # this backend instance. The corresponding *admin* list endpoints
+    # are mounted inside the admin branch below.
+    try:
+        from caretaker.fleet import public_router as fleet_public_router
+
+        application.include_router(fleet_public_router)
+        logger.info("Fleet registry heartbeat endpoint enabled")
+    except Exception:
+        logger.warning("Failed to initialise fleet heartbeat endpoint", exc_info=True)
+
     admin_enabled = os.environ.get("CARETAKER_ADMIN_ENABLED", "").lower() in ("1", "true", "yes")
 
     if admin_enabled:
@@ -99,6 +112,18 @@ async def _lifespan(application: FastAPI):  # type: ignore[no-untyped-def]
 
             application.include_router(admin_auth.router)
             application.include_router(admin_api.router)
+
+            # Fleet registry — authenticated list endpoints for the
+            # admin dashboard. The public heartbeat receiver is
+            # registered below (outside the admin gate) so consumer CI
+            # runners can post without a session cookie.
+            try:
+                from caretaker.fleet import admin_router as fleet_admin_router
+
+                application.include_router(fleet_admin_router)
+                logger.info("Fleet registry admin API enabled")
+            except Exception:
+                logger.warning("Failed to initialise fleet admin API", exc_info=True)
 
             # Mount graph API if Neo4j is configured
             neo4j_url = os.environ.get("NEO4J_URL", "")

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -506,6 +506,17 @@ class Orchestrator:
         # Persist state (save also appends summary to history)
         await self._state_tracker.save(summary)
 
+        # Opt-in fleet-registry heartbeat. Fail-open: the emitter logs
+        # and swallows any error so a missing / misconfigured endpoint
+        # can never fail the orchestrator run.
+        if self._config.fleet_registry.enabled:
+            try:
+                from caretaker.fleet import emit_heartbeat
+
+                await emit_heartbeat(self._config, summary)
+            except Exception as e:
+                logger.warning("Fleet heartbeat failed: %s", e)
+
         # Save memory store snapshot (for artifact upload / rollback)
         if self._memory is not None:
             self._memory.prune_expired()

--- a/tests/test_fleet_registry.py
+++ b/tests/test_fleet_registry.py
@@ -1,0 +1,299 @@
+"""Tests for the opt-in fleet-registry feature.
+
+Covers:
+* Config defaults are safe (feature disabled unless explicitly enabled).
+* Emitter fails open on unreachable endpoints / network errors.
+* HMAC signing produces a deterministic hex digest the backend can
+  verify with ``hmac.compare_digest``.
+* ``POST /api/fleet/heartbeat`` records clients into the singleton
+  store; ``GET /api/admin/fleet`` (when configured) reads them back.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from caretaker.config import FleetRegistryConfig, MaintainerConfig
+from caretaker.fleet import (
+    FleetHeartbeat,
+    build_heartbeat,
+    emit_heartbeat,
+    get_store,
+    public_router,
+    reset_store_for_tests,
+    sign_payload,
+)
+from caretaker.state.models import RunSummary
+
+# ── Config defaults ───────────────────────────────────────────────────────
+
+
+def test_fleet_config_defaults_disabled() -> None:
+    cfg = MaintainerConfig()
+    assert cfg.fleet_registry.enabled is False
+    assert cfg.fleet_registry.endpoint is None
+    assert cfg.fleet_registry.secret_env == "CARETAKER_FLEET_SECRET"
+    assert cfg.fleet_registry.include_full_summary is False
+
+
+def test_fleet_config_round_trip(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    yaml_path = tmp_path / "config.yml"
+    yaml_path.write_text(
+        "version: v1\n"
+        "fleet_registry:\n"
+        "  enabled: true\n"
+        "  endpoint: https://example.invalid/api/fleet/heartbeat\n"
+    )
+    cfg = MaintainerConfig.from_yaml(yaml_path)
+    assert cfg.fleet_registry.enabled is True
+    assert cfg.fleet_registry.endpoint == "https://example.invalid/api/fleet/heartbeat"
+
+
+# ── Heartbeat builder ─────────────────────────────────────────────────────
+
+
+def _summary_fixture() -> RunSummary:
+    return RunSummary(
+        run_at=datetime(2026, 4, 20, 23, 0, 0, tzinfo=UTC),
+        mode="full",
+        prs_monitored=3,
+        prs_merged=1,
+        issues_triaged=2,
+        goal_health=0.82,
+        errors=["boom"],
+    )
+
+
+def test_build_heartbeat_shape(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "ianlintner/demo")
+    cfg = MaintainerConfig(fleet_registry=FleetRegistryConfig(enabled=True))
+    hb = build_heartbeat(cfg, _summary_fixture())
+    assert isinstance(hb, FleetHeartbeat)
+    assert hb.repo == "ianlintner/demo"
+    assert hb.mode == "full"
+    assert hb.counters["prs_monitored"] == 3
+    assert hb.counters["prs_merged"] == 1
+    assert hb.counters["issues_triaged"] == 2
+    assert hb.goal_health == pytest.approx(0.82)
+    assert hb.error_count == 1
+    assert hb.summary is None  # include_full_summary default False
+
+
+def test_build_heartbeat_full_summary_opt_in(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "ianlintner/demo")
+    cfg = MaintainerConfig(
+        fleet_registry=FleetRegistryConfig(enabled=True, include_full_summary=True)
+    )
+    hb = build_heartbeat(cfg, _summary_fixture())
+    assert hb.summary is not None
+    assert hb.summary["prs_monitored"] == 3
+
+
+# ── HMAC signing ──────────────────────────────────────────────────────────
+
+
+def test_sign_payload_matches_stdlib_hmac() -> None:
+    body = b'{"repo":"a/b"}'
+    secret = "s3cret"
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    assert sign_payload(body, secret) == expected
+
+
+# ── Emitter fail-open behaviour ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_emitter_returns_false_when_disabled() -> None:
+    cfg = MaintainerConfig()  # default disabled
+    assert await emit_heartbeat(cfg, _summary_fixture()) is False
+
+
+@pytest.mark.asyncio
+async def test_emitter_returns_false_when_endpoint_empty() -> None:
+    cfg = MaintainerConfig(fleet_registry=FleetRegistryConfig(enabled=True))
+    assert await emit_heartbeat(cfg, _summary_fixture()) is False
+
+
+@pytest.mark.asyncio
+async def test_emitter_fails_open_on_transport_error(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "ianlintner/demo")
+    cfg = MaintainerConfig(
+        fleet_registry=FleetRegistryConfig(
+            enabled=True,
+            endpoint="http://127.0.0.1:1/doesnotexist",  # reserved port
+            timeout_seconds=0.5,
+        )
+    )
+    # Must return False, never raise.
+    result = await emit_heartbeat(cfg, _summary_fixture())
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_emitter_posts_signed_request(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "ianlintner/demo")
+    monkeypatch.setenv("CARETAKER_FLEET_SECRET", "s3cret")
+    cfg = MaintainerConfig(
+        fleet_registry=FleetRegistryConfig(
+            enabled=True,
+            endpoint="https://fleet.example/heartbeat",
+        )
+    )
+
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = request.content
+        return httpx.Response(202, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        ok = await emit_heartbeat(cfg, _summary_fixture(), client=client)
+    assert ok is True
+    assert captured["url"] == "https://fleet.example/heartbeat"
+    body = captured["body"]
+    assert isinstance(body, (bytes, bytearray))
+    sig = captured["headers"]["x-caretaker-signature"]  # httpx lowercases
+    assert sig.startswith("sha256=")
+    expected = hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+    assert sig.split("=", 1)[1] == expected
+
+
+# ── Backend endpoints ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fleet_client(monkeypatch):  # type: ignore[no-untyped-def]
+    """FastAPI client that mounts the public + admin routers without
+    the full MCP lifespan (which pulls in OIDC config). Admin endpoints
+    are exercised with the dependency override shortcut."""
+    from caretaker.admin import auth as admin_auth
+    from caretaker.fleet import admin_router
+
+    reset_store_for_tests()
+    monkeypatch.delenv("CARETAKER_FLEET_SECRET", raising=False)
+
+    app = FastAPI()
+    app.include_router(public_router)
+    app.include_router(admin_router)
+
+    # Bypass OIDC — the admin endpoints call ``require_session`` which
+    # in turn depends on a session cookie. Override it so the test can
+    # exercise the admin surface without spinning up OIDC.
+    async def _fake_user():  # noqa: ANN202
+        return admin_auth.UserInfo(sub="test", email="test@example.com", name="Test", picture=None)
+
+    app.dependency_overrides[admin_auth.require_session] = _fake_user
+    return TestClient(app)
+
+
+def test_heartbeat_roundtrip_no_secret(fleet_client) -> None:  # type: ignore[no-untyped-def]
+    body = {
+        "schema_version": 1,
+        "repo": "ianlintner/demo",
+        "caretaker_version": "0.11.0",
+        "run_at": datetime.now(UTC).isoformat(),
+        "mode": "full",
+        "enabled_agents": ["pr_agent", "issue_agent"],
+        "goal_health": 0.9,
+        "error_count": 0,
+        "counters": {"prs_monitored": 2},
+    }
+    resp = fleet_client.post("/api/fleet/heartbeat", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["repo"] == "ianlintner/demo"
+
+    listed = fleet_client.get("/api/admin/fleet")
+    assert listed.status_code == 200
+    payload = listed.json()
+    assert payload["total"] == 1
+    assert payload["items"][0]["repo"] == "ianlintner/demo"
+    assert payload["items"][0]["last_counters"]["prs_monitored"] == 2
+
+    summary = fleet_client.get("/api/admin/fleet/summary")
+    assert summary.status_code == 200
+    s = summary.json()
+    assert s["total_clients"] == 1
+    assert s["version_distribution"] == {"0.11.0": 1}
+
+
+def test_heartbeat_rejects_missing_signature_when_secret_configured(  # type: ignore[no-untyped-def]
+    fleet_client, monkeypatch
+) -> None:
+    monkeypatch.setenv("CARETAKER_FLEET_SECRET", "s3cret")
+    resp = fleet_client.post(
+        "/api/fleet/heartbeat", json={"repo": "a/b", "caretaker_version": "0.11.0"}
+    )
+    assert resp.status_code == 401
+
+
+def test_heartbeat_accepts_valid_signature(fleet_client, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("CARETAKER_FLEET_SECRET", "s3cret")
+    body = json.dumps({"repo": "a/b", "caretaker_version": "0.11.0"}).encode()
+    sig = "sha256=" + hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+    resp = fleet_client.post(
+        "/api/fleet/heartbeat",
+        content=body,
+        headers={"Content-Type": "application/json", "X-Caretaker-Signature": sig},
+    )
+    assert resp.status_code == 200
+
+
+def test_heartbeat_rejects_invalid_signature(fleet_client, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("CARETAKER_FLEET_SECRET", "s3cret")
+    body = json.dumps({"repo": "a/b", "caretaker_version": "0.11.0"}).encode()
+    resp = fleet_client.post(
+        "/api/fleet/heartbeat",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Caretaker-Signature": "sha256=deadbeef",
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_heartbeat_rejects_empty_body(fleet_client) -> None:  # type: ignore[no-untyped-def]
+    resp = fleet_client.post(
+        "/api/fleet/heartbeat",
+        content=b"",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+def test_heartbeat_rejects_missing_repo(fleet_client) -> None:  # type: ignore[no-untyped-def]
+    resp = fleet_client.post(
+        "/api/fleet/heartbeat",
+        json={"caretaker_version": "0.11.0"},
+    )
+    assert resp.status_code == 400
+
+
+def test_admin_single_repo_fetch(fleet_client) -> None:  # type: ignore[no-untyped-def]
+    fleet_client.post(
+        "/api/fleet/heartbeat",
+        json={"repo": "ianlintner/demo", "caretaker_version": "0.11.0"},
+    )
+    resp = fleet_client.get("/api/admin/fleet/ianlintner/demo")
+    assert resp.status_code == 200
+    assert resp.json()["repo"] == "ianlintner/demo"
+
+    missing = fleet_client.get("/api/admin/fleet/other/missing")
+    assert missing.status_code == 404
+
+
+def test_store_singleton_survives_test_reset() -> None:
+    store = get_store()
+    reset_store_for_tests()
+    assert get_store() is not store


### PR DESCRIPTION
## Summary

New opt-in telemetry surface — each consumer repo's successful `caretaker run` can POST a heartbeat to a central caretaker backend so an operator sees every managed repo in one dashboard without an org-wide GitHub crawl.

- **Off by default.** No heartbeat unless both `fleet_registry.enabled: true` and `fleet_registry.endpoint: <url>` are set.
- **Fail-open.** Network / config / serialization errors log a warning and are swallowed; the fleet feature can never fail the orchestrator run.
- **Opt-in full-summary.** By default only 20 curated counters are sent. `include_full_summary: true` adds the full `RunSummary`.
- **Optional HMAC.** `CARETAKER_FLEET_SECRET` on the consumer signs payloads with HMAC-SHA256 in `X-Caretaker-Signature`; the backend verifies when the same secret is set there.

## Surfaces

### Python
- `caretaker.config.FleetRegistryConfig` — new StrictBaseModel on `MaintainerConfig`.
- `caretaker.fleet.{emitter, store, api}` — emitter + in-memory store + FastAPI routers.
- Orchestrator hook: fires after `_state_tracker.save(summary)`.

### HTTP
- `POST /api/fleet/heartbeat` — public, HMAC-gated if backend has secret.
- `GET /api/admin/fleet` — paginated list, OIDC-authed.
- `GET /api/admin/fleet/summary` — total / stale / version mix.
- `GET /api/admin/fleet/{owner}/{repo}` — detail view.

### Admin dashboard
- New `/fleet` route + NAV entry. StatPanel strip + hairline DataTable.

## Test plan

- [x] `uv run pytest tests/test_fleet_registry.py` — 17 new tests pass.
- [x] Full pytest suite — 851 passed, no regressions.
- [x] `uv run ruff check` clean on touched files.
- [x] `npm run lint` + `npm run build` clean.
- [ ] Smoke: flip `fleet_registry.enabled: true` with a mock endpoint in a downstream repo, verify heartbeat arrives and the admin UI row populates.

## Docs

See `docs/fleet-registry.md` for architecture diagram, config sample, payload shape, and design notes. CHANGELOG entry under `[Unreleased]`.

## Follow-ups (out of scope)

- Persistent backend: swap the in-memory `FleetRegistryStore` for SQLite / Mongo using the same interface.
- Per-repo token minting (admin-issued) as an alternative to the single shared secret.
- Backend poll fallback for operators with org-wide read PATs who prefer pull over push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)