### PR TITLE
feat(custom-agent): Phase 2 — Claude Code hand-off executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Custom coding agent — Phase 2: Claude Code hand-off executor
+
+Second phase of the custom-coding-agent plan. `ExecutorDispatcher` now
+routes to a second non-Copilot executor that hands tasks off to the
+upstream `anthropics/claude-code-action` workflow.
+
+- New `ClaudeCodeExecutor` (`src/caretaker/claude_code_executor.py`).
+  Conforms to the same `async run(task, pr) -> ExecutorResult` shape
+  as `FoundryExecutor` so the dispatcher treats it as a peer.
+  Dispatch model: post `@claude` mention comment + apply trigger
+  label; upstream workflow produces the fix asynchronously; existing
+  `<!-- caretaker:result -->` markers close the loop.
+- New `ClaudeCodeExecutorConfig` on `MaintainerConfig.executor`:
+  `enabled`, `trigger_label` (default `claude-code`), `mention`
+  (default `@claude`), `max_attempts` (default 2). Feature is off by
+  default; `executor.provider` extended to `copilot | foundry |
+  claude_code | auto`.
+- Dispatcher adds `RouteOutcome.CLAUDE_CODE`. `provider=auto` now
+  tries Claude Code when Foundry is ineligible but Claude Code is
+  enabled, before falling to Copilot. `agent:custom` label honours
+  whichever custom executor is currently active.
+- Attempt cap prevents ping-pong: executor counts prior hand-off
+  comments (marker `<!-- caretaker:claude-code-handoff -->`); beyond
+  `max_attempts` it escalates to Copilot.
+- Tests: 12 new cases, full pytest 890 passed.
+- Plan doc Phase-2 section updated to reflect shipped state.
+
 ### Fleet Registry — opt-in cross-repo client roster
 
 New opt-in telemetry surface so an operator can see every

--- a/docs/custom-coding-agent-plan.md
+++ b/docs/custom-coding-agent-plan.md
@@ -132,18 +132,38 @@ by task type.
 No new infra. Runs inside the existing `caretaker run` invocation, i.e.
 the same GitHub Actions runner that already does orchestration.
 
-### Phase 2 — additional executors
+### Phase 2 — additional executors *(shipped)*
 
-- Extract `ExecutorProtocol` interface: `async run(task, pr) ->
-  ExecutorResult`. Foundry is one implementation.
-- Add `ClaudeCodeExecutor` that either:
-  - Triggers the upstream [`anthropics/claude-code-action`][cca] via
-    `repository_dispatch` / `workflow_dispatch`, or
-  - Drops the `claude` label on the issue for a workflow that's
-    already listening (simpler; keeps caretaker stateless).
-- Config: `executor.provider = "claude_code"` + a `claude_code` config
-  block (model, GitHub App token env var).
-- Tests.
+- `ClaudeCodeExecutor` added in `src/caretaker/claude_code_executor.py`.
+  Conforms to the same `async run(task, pr) -> ExecutorResult` shape
+  as `FoundryExecutor`, so the dispatcher routes to either with no
+  special-casing.
+- Hand-off model (simpler than running the upstream action inline):
+  executor posts a structured comment that carries `@claude` +
+  caretaker's task details, then applies a configurable trigger label
+  (`claude-code` by default). The upstream
+  [`anthropics/claude-code-action`][cca] workflow picks up the
+  mention / label and produces the fix asynchronously; caretaker's
+  existing `<!-- caretaker:result -->` state machine reads the result
+  commit back.
+- Config: `executor.provider = "claude_code"` plus a new
+  `claude_code` block (`enabled`, `trigger_label`, `mention`,
+  `max_attempts`).
+- Attempt cap: executor counts prior hand-offs on the PR via a
+  marker comment (`<!-- caretaker:claude-code-handoff -->`); beyond
+  `max_attempts` it escalates to Copilot to avoid ping-pong if the
+  upstream action can't complete the work.
+- Dispatcher extended with:
+  * `RouteOutcome.CLAUDE_CODE` — successful hand-off.
+  * `provider = "claude_code"` support.
+  * `provider = "auto"` now tries Claude Code when Foundry is
+    ineligible but Claude Code is enabled, before falling to Copilot.
+  * `agent:custom` label honours whichever custom executor is
+    currently active (Foundry first if both configured, else Claude
+    Code).
+- Tests: 12 new cases covering config defaults, comment + label
+  application, label-failure graceful degradation, attempt cap,
+  dispatcher routing through every new path.
 
 ### Phase 3 — scale out onto AKS
 

--- a/src/caretaker/claude_code_executor.py
+++ b/src/caretaker/claude_code_executor.py
@@ -1,0 +1,203 @@
+"""Claude Code hand-off executor.
+
+Caretaker's own tool-loop lives in :mod:`caretaker.foundry.executor`. The
+*Claude Code* executor is a thin hand-off: it tags the host PR / issue
+with a configurable trigger label and posts a structured mention comment
+that the upstream `anthropics/claude-code-action`_ workflow picks up.
+
+Design choices:
+
+* **No inline execution.** Caretaker does not spawn Claude Code itself.
+  The consumer repo is expected to have the upstream action installed;
+  caretaker just steers tasks at it. This keeps caretaker backend-agnostic
+  and avoids a second model-provider credential to manage.
+* **Async hand-off.** The upstream action runs in its own workflow and
+  posts its own commit + result comment. Caretaker's PR state machine
+  already tracks those via the ``<!-- caretaker:result -->`` markers, so
+  the hand-off looks identical to any other async executor.
+* **COMPLETED on successful hand-off.** We treat the dispatch itself as
+  the unit of work; failures to apply the label / post the comment
+  escalate back to Copilot the same way a Foundry failure does.
+* **Attempt cap.** If caretaker re-routes the same task to Claude Code
+  more than ``config.max_attempts`` times without an upstream resolution,
+  we stop re-triggering and escalate. Prevents the trigger-label →
+  no-op → re-trigger loop if the upstream action is unavailable.
+
+.. _anthropics/claude-code-action: https://github.com/anthropics/claude-code-action
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from caretaker.foundry.executor import (
+    CodingTask,
+    ExecutorOutcome,
+    ExecutorResult,
+)
+
+if TYPE_CHECKING:
+    from caretaker.config import ClaudeCodeExecutorConfig
+    from caretaker.github_client.api import GitHubClient
+    from caretaker.github_client.models import PullRequest
+
+logger = logging.getLogger(__name__)
+
+
+CLAUDE_CODE_HANDOFF_MARKER = "<!-- caretaker:claude-code-handoff -->"
+
+
+def _build_handoff_comment(
+    *, mention: str, task: CodingTask, attempt: int, max_attempts: int
+) -> str:
+    """Format the structured hand-off comment the upstream action consumes."""
+    lines = [
+        CLAUDE_CODE_HANDOFF_MARKER,
+        f"{mention} caretaker is handing this task off to claude-code.",
+        "",
+        f"**task_type**: `{task.task_type.value}`",
+        f"**job**: `{task.job_name}`",
+        f"**attempt**: {attempt}/{max_attempts}",
+        "",
+        "**Instructions:**",
+        task.instructions or "(none)",
+    ]
+    if task.error_output:
+        snippet = task.error_output.strip()
+        if len(snippet) > 4000:
+            snippet = snippet[:4000] + "\n…(truncated)"
+        lines.extend(["", "**Error output:**", "```", snippet, "```"])
+    if task.context:
+        lines.extend(["", "**Additional context:**", task.context.strip()])
+    lines.extend(
+        [
+            "",
+            "_Applied by caretaker's ClaudeCodeExecutor. The upstream "
+            "`anthropics/claude-code-action` workflow will produce the "
+            "fix as its own commit; caretaker's state machine will pick "
+            "up the result from the usual `caretaker:result` markers._",
+        ]
+    )
+    return "\n".join(lines)
+
+
+class ClaudeCodeExecutor:
+    """Hand-off executor that steers tasks at ``anthropics/claude-code-action``.
+
+    The executor conforms to the same ``async run(task, pr) -> ExecutorResult``
+    shape as :class:`caretaker.foundry.executor.FoundryExecutor`, so
+    :class:`~caretaker.foundry.dispatcher.ExecutorDispatcher` can route to
+    either without special-casing.
+    """
+
+    def __init__(
+        self,
+        *,
+        github: GitHubClient,
+        owner: str,
+        repo: str,
+        config: ClaudeCodeExecutorConfig,
+    ) -> None:
+        self._github = github
+        self._owner = owner
+        self._repo = repo
+        self._config = config
+
+    @property
+    def config(self) -> ClaudeCodeExecutorConfig:
+        return self._config
+
+    async def run(self, task: CodingTask, pr: PullRequest) -> ExecutorResult:
+        """Apply the trigger label + post the hand-off comment.
+
+        Returns :class:`ExecutorResult` with outcome:
+
+        * ``COMPLETED`` — label applied and comment posted successfully.
+        * ``ESCALATED`` — attempt cap hit, caller should escalate to Copilot.
+        * ``FAILED``    — GitHub API error; caller should escalate.
+        """
+        if not self._config.enabled:
+            logger.debug("ClaudeCodeExecutor.run called while config.enabled=False; escalating")
+            return ExecutorResult(
+                outcome=ExecutorOutcome.ESCALATED,
+                reason="claude_code.enabled=False",
+            )
+
+        # Attempt cap. We count prior hand-offs via the marker comment on
+        # the PR; a GH API call per dispatch is fine because this path is
+        # low-frequency.
+        attempt = await self._count_prior_handoffs(pr.number) + 1
+        if attempt > self._config.max_attempts:
+            logger.info(
+                "Claude Code hand-off capped on PR #%s (attempt %d > max %d); escalating",
+                pr.number,
+                attempt,
+                self._config.max_attempts,
+            )
+            return ExecutorResult(
+                outcome=ExecutorOutcome.ESCALATED,
+                reason=(
+                    f"claude_code attempt cap hit ({attempt} > "
+                    f"{self._config.max_attempts}); escalating to Copilot"
+                ),
+            )
+
+        body = _build_handoff_comment(
+            mention=self._config.mention,
+            task=task,
+            attempt=attempt,
+            max_attempts=self._config.max_attempts,
+        )
+
+        try:
+            comment = await self._github.add_issue_comment(self._owner, self._repo, pr.number, body)
+        except Exception as exc:  # defensive; escalate rather than raise
+            logger.exception("ClaudeCodeExecutor: add_issue_comment failed: %s", exc)
+            return ExecutorResult(
+                outcome=ExecutorOutcome.FAILED,
+                reason=f"claude_code comment failed: {exc}",
+            )
+
+        try:
+            await self._github.add_labels(
+                self._owner, self._repo, pr.number, [self._config.trigger_label]
+            )
+        except Exception as exc:
+            # Comment is already posted; the upstream action may still
+            # pick up via the mention. Log and continue — treat as COMPLETED
+            # but note the label failure in the reason.
+            logger.warning(
+                "ClaudeCodeExecutor: add_labels(%s) failed on PR #%s: %s",
+                self._config.trigger_label,
+                pr.number,
+                exc,
+            )
+            return ExecutorResult(
+                outcome=ExecutorOutcome.COMPLETED,
+                reason=(f"claude_code dispatched via mention (label apply failed: {exc})"),
+                comment_id=getattr(comment, "id", None),
+                iterations=attempt,
+            )
+
+        return ExecutorResult(
+            outcome=ExecutorOutcome.COMPLETED,
+            reason=f"claude_code dispatched (attempt {attempt}/{self._config.max_attempts})",
+            comment_id=getattr(comment, "id", None),
+            iterations=attempt,
+        )
+
+    async def _count_prior_handoffs(self, pr_number: int) -> int:
+        """Return the number of caretaker claude-code hand-off comments on the PR."""
+        try:
+            comments = await self._github.get_pr_comments(self._owner, self._repo, pr_number)
+        except Exception as exc:
+            logger.debug("ClaudeCodeExecutor: could not list comments: %s", exc)
+            return 0
+        return sum(1 for c in comments if CLAUDE_CODE_HANDOFF_MARKER in (c.body or ""))
+
+
+__all__ = [
+    "CLAUDE_CODE_HANDOFF_MARKER",
+    "ClaudeCodeExecutor",
+]

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -634,11 +634,46 @@ class FoundryExecutorConfig(StrictBaseModel):
     request_timeout_seconds: float = 120.0
 
 
+class ClaudeCodeExecutorConfig(StrictBaseModel):
+    """Configuration for the opt-in ``claude-code-action`` hand-off executor.
+
+    Caretaker does not run Claude Code inline; instead, when this executor
+    is selected for a task, it applies a configurable *trigger label* to
+    the host PR / issue, and posts a structured hand-off comment. The
+    upstream [``anthropics/claude-code-action``][cca] workflow, installed
+    separately in the consumer repo, listens for that label (or the `@claude`
+    mention in the comment) and produces the fix asynchronously.
+
+    The caretaker state machine then tracks the resulting commit / PR
+    through the same ``<!-- caretaker:result -->`` markers it already uses
+    for the Copilot + Foundry paths.
+
+    Feature is entirely opt-in: ``enabled = False`` by default; in addition
+    the consumer repo must have the upstream action installed and
+    authorised on its own.
+
+    [cca]: https://github.com/anthropics/claude-code-action
+    """
+
+    enabled: bool = False
+    # Label caretaker applies to trigger the upstream workflow.
+    trigger_label: str = "claude-code"
+    # Mention string included in the hand-off comment so the upstream
+    # auto-detector can pick it up even if a repo has a different label
+    # listener name configured.
+    mention: str = "@claude"
+    # Maximum attempts per task before caretaker stops re-applying the
+    # trigger label; prevents ping-pong if the upstream action can't
+    # complete the work.
+    max_attempts: int = 2
+
+
 class ExecutorConfig(StrictBaseModel):
     """Top-level switch deciding how coding tasks are executed."""
 
-    provider: Literal["copilot", "foundry", "auto"] = "copilot"
+    provider: Literal["copilot", "foundry", "claude_code", "auto"] = "copilot"
     foundry: FoundryExecutorConfig = Field(default_factory=FoundryExecutorConfig)
+    claude_code: ClaudeCodeExecutorConfig = Field(default_factory=ClaudeCodeExecutorConfig)
 
 
 class MaintainerConfig(StrictBaseModel):

--- a/src/caretaker/foundry/dispatcher.py
+++ b/src/caretaker/foundry/dispatcher.py
@@ -27,6 +27,7 @@ from caretaker.foundry.executor import CodingTask, ExecutorOutcome, ExecutorResu
 from caretaker.llm.copilot import CopilotTask, TaskType
 
 if TYPE_CHECKING:
+    from caretaker.claude_code_executor import ClaudeCodeExecutor
     from caretaker.config import ExecutorConfig
     from caretaker.foundry.executor import FoundryExecutor
     from caretaker.github_client.models import Comment, PullRequest
@@ -39,8 +40,9 @@ class RouteOutcome(StrEnum):
     """How a task was actually dispatched."""
 
     FOUNDRY = "FOUNDRY"  # Foundry handled it end-to-end
+    CLAUDE_CODE = "CLAUDE_CODE"  # claude-code-action hand-off dispatched
     COPILOT = "COPILOT"  # Copilot comment was posted (legacy path)
-    COPILOT_FALLBACK = "COPILOT_FALLBACK"  # Foundry escalated; Copilot posted
+    COPILOT_FALLBACK = "COPILOT_FALLBACK"  # custom executor escalated; Copilot posted
     REFUSED = "REFUSED"  # Label-based quarantine refused dispatch
 
 
@@ -114,9 +116,11 @@ class ExecutorDispatcher:
         config: ExecutorConfig,
         foundry_executor: FoundryExecutor | None,
         copilot_protocol: CopilotProtocol,
+        claude_code_executor: ClaudeCodeExecutor | None = None,
     ) -> None:
         self._config = config
         self._foundry = foundry_executor
+        self._claude_code = claude_code_executor
         self._copilot = copilot_protocol
 
     @property
@@ -134,6 +138,16 @@ class ExecutorDispatcher:
         if not self._config.foundry.enabled:
             return False
         return coding_task.task_type.value in self._config.foundry.allowed_task_types
+
+    def claude_code_eligible(self) -> bool:
+        """Return True if a Claude Code hand-off is configured and available."""
+        return self._claude_code is not None and self._config.claude_code.enabled
+
+    def _custom_executor_available(self) -> bool:
+        """Is at least one non-Copilot executor wired up?"""
+        return (
+            self._foundry is not None and self._config.foundry.enabled
+        ) or self.claude_code_eligible()
 
     async def route(
         self,
@@ -165,10 +179,10 @@ class ExecutorDispatcher:
                 reason="agent:quarantine label present",
             )
         if override == LABEL_AGENT_CUSTOM:
-            if self._foundry is None or not self._config.foundry.enabled:
+            if not self._custom_executor_available():
                 logger.warning(
-                    "agent:custom label on PR #%s but custom executor "
-                    "unavailable; falling back to Copilot",
+                    "agent:custom label on PR #%s but no custom executor "
+                    "is enabled; falling back to Copilot",
                     pr.number,
                 )
                 return await self._post_copilot(
@@ -177,16 +191,49 @@ class ExecutorDispatcher:
                     reason="agent:custom label set but custom executor unavailable",
                     is_fallback=True,
                 )
-            return await self._run_foundry(
+            # When both Foundry and Claude Code are configured, respect the
+            # ``executor.provider`` setting to decide which wins. If the
+            # provider is ``copilot`` (the original default) but the label
+            # says custom, prefer whichever custom executor is enabled.
+            if self.provider == "claude_code" and self.claude_code_eligible():
+                return await self._run_claude_code(
+                    pr, copilot_task, effective_task, reason="agent:custom label"
+                )
+            if self._foundry is not None and self._config.foundry.enabled:
+                return await self._run_foundry(
+                    pr, copilot_task, effective_task, reason="agent:custom label"
+                )
+            return await self._run_claude_code(
                 pr, copilot_task, effective_task, reason="agent:custom label"
             )
         if override == LABEL_AGENT_COPILOT:
             return await self._post_copilot(pr, copilot_task, reason="agent:copilot label")
 
+        # Claude Code provider — dispatch via label + mention comment.
+        if self.provider == "claude_code":
+            if not self.claude_code_eligible():
+                logger.warning(
+                    "executor.provider='claude_code' but claude_code.enabled=False "
+                    "or executor missing; routing to Copilot"
+                )
+                return await self._post_copilot(pr, copilot_task, reason="claude_code disabled")
+            return await self._run_claude_code(
+                pr, copilot_task, effective_task, reason="provider=claude_code"
+            )
+
         if self.provider == "copilot" or self._foundry is None:
             return await self._post_copilot(pr, copilot_task, reason="provider=copilot")
 
         if self.provider == "auto" and not self.foundry_eligible(effective_task):
+            # When auto-routing and Foundry is ineligible, try Claude Code
+            # as the next-cheapest custom executor before falling to Copilot.
+            if self.claude_code_eligible():
+                return await self._run_claude_code(
+                    pr,
+                    copilot_task,
+                    effective_task,
+                    reason="auto: foundry ineligible, claude_code eligible",
+                )
             return await self._post_copilot(
                 pr, copilot_task, reason="auto: task not Foundry-eligible"
             )
@@ -200,6 +247,49 @@ class ExecutorDispatcher:
 
         return await self._run_foundry(
             pr, copilot_task, effective_task, reason=f"provider={self.provider}"
+        )
+
+    async def _run_claude_code(
+        self,
+        pr: PullRequest,
+        copilot_task: CopilotTask,
+        effective_task: CodingTask,
+        *,
+        reason: str,
+    ) -> RouteResult:
+        """Invoke the Claude Code hand-off executor and handle fallback."""
+        assert self._claude_code is not None
+        try:
+            cc_result = await self._claude_code.run(effective_task, pr)
+        except Exception as exc:
+            logger.exception("ClaudeCodeExecutor.run raised: %s", exc)
+            return await self._post_copilot(
+                pr,
+                copilot_task,
+                reason=f"claude_code raised: {exc}",
+                is_fallback=True,
+            )
+
+        if cc_result.outcome == ExecutorOutcome.COMPLETED:
+            return RouteResult(
+                outcome=RouteOutcome.CLAUDE_CODE,
+                foundry_result=cc_result,  # reuse field; same shape
+                reason=f"{reason}: claude_code dispatched",
+            )
+
+        # ESCALATED / FAILED → fall back to Copilot.
+        logger.info(
+            "ClaudeCode outcome=%s reason=%s — falling back to Copilot",
+            cc_result.outcome,
+            cc_result.reason,
+        )
+        fallback_task = self._augment_copilot_task(copilot_task, cc_result)
+        return await self._post_copilot(
+            pr,
+            fallback_task,
+            reason=f"{reason}: claude_code {cc_result.outcome.value}: {cc_result.reason}",
+            is_fallback=True,
+            foundry_result=cc_result,
         )
 
     async def _run_foundry(

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -250,7 +250,11 @@ class Orchestrator:
         """
         executor_cfg = config.executor
         # Zero-config: exit preserves the legacy path (no dispatcher).
-        if executor_cfg.provider == "copilot" and not executor_cfg.foundry.enabled:
+        if (
+            executor_cfg.provider == "copilot"
+            and not executor_cfg.foundry.enabled
+            and not executor_cfg.claude_code.enabled
+        ):
             return None
 
         copilot_protocol = CopilotProtocol(github, owner, repo)
@@ -287,10 +291,27 @@ class Orchestrator:
                     executor_cfg.foundry.allowed_task_types,
                 )
 
+        claude_code_executor = None
+        if executor_cfg.claude_code.enabled:
+            from caretaker.claude_code_executor import ClaudeCodeExecutor
+
+            claude_code_executor = ClaudeCodeExecutor(
+                github=github,
+                owner=owner,
+                repo=repo,
+                config=executor_cfg.claude_code,
+            )
+            logger.info(
+                "ClaudeCodeExecutor ready: trigger_label=%s mention=%s",
+                executor_cfg.claude_code.trigger_label,
+                executor_cfg.claude_code.mention,
+            )
+
         return ExecutorDispatcher(
             config=executor_cfg,
             foundry_executor=foundry_executor,
             copilot_protocol=copilot_protocol,
+            claude_code_executor=claude_code_executor,
         )
 
     @classmethod

--- a/tests/test_claude_code_executor.py
+++ b/tests/test_claude_code_executor.py
@@ -1,0 +1,312 @@
+"""Tests for the Claude Code hand-off executor + dispatcher wiring."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from caretaker.claude_code_executor import (
+    CLAUDE_CODE_HANDOFF_MARKER,
+    ClaudeCodeExecutor,
+)
+from caretaker.config import (
+    ClaudeCodeExecutorConfig,
+    ExecutorConfig,
+    FoundryExecutorConfig,
+)
+from caretaker.foundry.dispatcher import (
+    LABEL_AGENT_CUSTOM,
+    ExecutorDispatcher,
+    RouteOutcome,
+)
+from caretaker.foundry.executor import (
+    CodingTask,
+    ExecutorOutcome,
+    ExecutorResult,
+)
+from caretaker.github_client.models import Comment, Label, PullRequest, User
+from caretaker.llm.copilot import CopilotTask, TaskType
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _coding_task(task_type: TaskType = TaskType.LINT_FAILURE) -> CodingTask:
+    return CodingTask(
+        task_type=task_type,
+        job_name="lint",
+        error_output="E501",
+        instructions="fix line length",
+    )
+
+
+def _copilot_task(task_type: TaskType = TaskType.LINT_FAILURE) -> CopilotTask:
+    return CopilotTask(
+        task_type=task_type,
+        job_name="lint",
+        error_output="E501",
+        instructions="fix line length",
+        attempt=1,
+        max_attempts=2,
+    )
+
+
+def _pr(number: int = 42, labels: list[str] | None = None) -> PullRequest:
+    return PullRequest(
+        number=number,
+        title="test",
+        body="",
+        state="open",
+        user=User(login="dev", id=1),
+        head_ref="feat",
+        head_sha="abc",
+        base_ref="main",
+        labels=[Label(name=n) for n in (labels or [])],
+    )
+
+
+def _comment(cid: int = 1) -> Comment:
+    return Comment(
+        id=cid,
+        user=User(login="caretaker-bot", id=99, type="Bot"),
+        body=CLAUDE_CODE_HANDOFF_MARKER,
+        created_at=datetime(2026, 4, 21, tzinfo=UTC),
+    )
+
+
+# ── Config ────────────────────────────────────────────────────────────────
+
+
+def test_config_defaults_disabled() -> None:
+    cfg = ExecutorConfig()
+    assert cfg.claude_code.enabled is False
+    assert cfg.claude_code.trigger_label == "claude-code"
+    assert cfg.claude_code.mention == "@claude"
+    assert cfg.claude_code.max_attempts == 2
+
+
+def test_provider_literal_accepts_claude_code() -> None:
+    cfg = ExecutorConfig(provider="claude_code")
+    assert cfg.provider == "claude_code"
+
+
+# ── Executor behaviour ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_executor_disabled_escalates() -> None:
+    github = MagicMock()
+    github.add_issue_comment = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.get_pr_comments = AsyncMock(return_value=[])
+    executor = ClaudeCodeExecutor(
+        github=github,
+        owner="o",
+        repo="r",
+        config=ClaudeCodeExecutorConfig(enabled=False),
+    )
+    result = await executor.run(_coding_task(), _pr())
+    assert result.outcome == ExecutorOutcome.ESCALATED
+    github.add_issue_comment.assert_not_called()
+    github.add_labels.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_executor_posts_comment_and_applies_label() -> None:
+    github = MagicMock()
+    github.add_issue_comment = AsyncMock(return_value=_comment(cid=777))
+    github.add_labels = AsyncMock(return_value=[Label(name="claude-code")])
+    github.get_pr_comments = AsyncMock(return_value=[])
+    executor = ClaudeCodeExecutor(
+        github=github,
+        owner="o",
+        repo="r",
+        config=ClaudeCodeExecutorConfig(enabled=True),
+    )
+    result = await executor.run(_coding_task(), _pr(42))
+    assert result.outcome == ExecutorOutcome.COMPLETED
+    assert result.comment_id == 777
+    github.add_issue_comment.assert_awaited_once()
+    args = github.add_issue_comment.await_args.args
+    assert args[:3] == ("o", "r", 42)
+    body = args[3]
+    assert CLAUDE_CODE_HANDOFF_MARKER in body
+    assert "@claude" in body
+    assert "LINT_FAILURE" in body
+    github.add_labels.assert_awaited_once_with("o", "r", 42, ["claude-code"])
+
+
+@pytest.mark.asyncio
+async def test_executor_label_failure_still_completes_via_mention() -> None:
+    github = MagicMock()
+    github.add_issue_comment = AsyncMock(return_value=_comment())
+    github.add_labels = AsyncMock(side_effect=RuntimeError("permissions"))
+    github.get_pr_comments = AsyncMock(return_value=[])
+    executor = ClaudeCodeExecutor(
+        github=github,
+        owner="o",
+        repo="r",
+        config=ClaudeCodeExecutorConfig(enabled=True),
+    )
+    result = await executor.run(_coding_task(), _pr())
+    assert result.outcome == ExecutorOutcome.COMPLETED
+    assert "label apply failed" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_executor_comment_failure_fails() -> None:
+    github = MagicMock()
+    github.add_issue_comment = AsyncMock(side_effect=RuntimeError("api down"))
+    github.add_labels = AsyncMock()
+    github.get_pr_comments = AsyncMock(return_value=[])
+    executor = ClaudeCodeExecutor(
+        github=github,
+        owner="o",
+        repo="r",
+        config=ClaudeCodeExecutorConfig(enabled=True),
+    )
+    result = await executor.run(_coding_task(), _pr())
+    assert result.outcome == ExecutorOutcome.FAILED
+    github.add_labels.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_attempt_cap_escalates() -> None:
+    # Two prior hand-offs on the PR; max_attempts=2 → this call should escalate.
+    prior = [_comment(cid=1), _comment(cid=2)]
+    github = MagicMock()
+    github.get_pr_comments = AsyncMock(return_value=prior)
+    github.add_issue_comment = AsyncMock()
+    github.add_labels = AsyncMock()
+    executor = ClaudeCodeExecutor(
+        github=github,
+        owner="o",
+        repo="r",
+        config=ClaudeCodeExecutorConfig(enabled=True, max_attempts=2),
+    )
+    result = await executor.run(_coding_task(), _pr())
+    assert result.outcome == ExecutorOutcome.ESCALATED
+    assert "cap hit" in result.reason
+    github.add_issue_comment.assert_not_called()
+
+
+# ── Dispatcher routing ────────────────────────────────────────────────────
+
+
+def _dispatcher(
+    provider: str = "claude_code",
+    claude_code_enabled: bool = True,
+    foundry_enabled: bool = False,
+    executor: ClaudeCodeExecutor | None = None,
+) -> tuple[ExecutorDispatcher, MagicMock, MagicMock]:
+    cfg = ExecutorConfig(
+        provider=provider,  # type: ignore[arg-type]
+        foundry=FoundryExecutorConfig(enabled=foundry_enabled),
+        claude_code=ClaudeCodeExecutorConfig(enabled=claude_code_enabled),
+    )
+    copilot = MagicMock()
+    copilot.post_task = AsyncMock(return_value=_comment())
+    if executor is None:
+        executor = MagicMock()
+        executor.run = AsyncMock(
+            return_value=ExecutorResult(
+                outcome=ExecutorOutcome.COMPLETED,
+                reason="dispatched",
+                comment_id=555,
+            )
+        )
+        # ClaudeCodeExecutor accesses .config via @property on the real
+        # class; we don't touch it from the dispatcher so the mock is fine.
+    foundry = None
+    if foundry_enabled:
+        foundry = MagicMock()
+        foundry.run = AsyncMock(
+            return_value=ExecutorResult(outcome=ExecutorOutcome.COMPLETED, reason="ok")
+        )
+    dispatcher = ExecutorDispatcher(
+        config=cfg,
+        foundry_executor=foundry,
+        copilot_protocol=copilot,
+        claude_code_executor=executor,
+    )
+    return dispatcher, copilot, executor
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_claude_code_provider_routes_to_claude() -> None:
+    dispatcher, copilot, executor = _dispatcher()
+    route = await dispatcher.route(pr=_pr(), copilot_task=_copilot_task())
+    assert route.outcome == RouteOutcome.CLAUDE_CODE
+    executor.run.assert_awaited_once()
+    copilot.post_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_claude_code_misconfig_falls_to_copilot() -> None:
+    # provider says claude_code but feature is disabled → Copilot.
+    dispatcher, copilot, executor = _dispatcher(claude_code_enabled=False)
+    route = await dispatcher.route(pr=_pr(), copilot_task=_copilot_task())
+    assert route.outcome == RouteOutcome.COPILOT
+    copilot.post_task.assert_awaited_once()
+    executor.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_claude_code_escalation_falls_back() -> None:
+    executor = MagicMock()
+    executor.run = AsyncMock(
+        return_value=ExecutorResult(
+            outcome=ExecutorOutcome.ESCALATED,
+            reason="attempt cap hit",
+        )
+    )
+    dispatcher, copilot, _ = _dispatcher(executor=executor)
+    route = await dispatcher.route(pr=_pr(), copilot_task=_copilot_task())
+    assert route.outcome == RouteOutcome.COPILOT_FALLBACK
+    copilot.post_task.assert_awaited_once()
+    # The Copilot fallback task should carry the escalation context.
+    posted = copilot.post_task.await_args.args[1]
+    assert "attempted this task and escalated" in posted.context
+
+
+@pytest.mark.asyncio
+async def test_agent_custom_label_prefers_claude_when_it_is_the_provider() -> None:
+    # Foundry also enabled; provider=claude_code → claude wins.
+    dispatcher, copilot, executor = _dispatcher(foundry_enabled=True)
+    route = await dispatcher.route(
+        pr=_pr(labels=[LABEL_AGENT_CUSTOM]),
+        copilot_task=_copilot_task(),
+    )
+    assert route.outcome == RouteOutcome.CLAUDE_CODE
+    executor.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_provider_falls_to_claude_when_foundry_ineligible() -> None:
+    # provider=auto, foundry restricted to a task type our task doesn't match,
+    # claude_code enabled → claude picks it up before Copilot.
+    cfg = ExecutorConfig(
+        provider="auto",
+        foundry=FoundryExecutorConfig(enabled=True, allowed_task_types=["UPGRADE"]),
+        claude_code=ClaudeCodeExecutorConfig(enabled=True),
+    )
+    copilot = MagicMock()
+    copilot.post_task = AsyncMock(return_value=_comment())
+    foundry = MagicMock()
+    foundry.run = AsyncMock()
+    claude = MagicMock()
+    claude.run = AsyncMock(
+        return_value=ExecutorResult(outcome=ExecutorOutcome.COMPLETED, reason="dispatched")
+    )
+    dispatcher = ExecutorDispatcher(
+        config=cfg,
+        foundry_executor=foundry,
+        copilot_protocol=copilot,
+        claude_code_executor=claude,
+    )
+    route = await dispatcher.route(pr=_pr(), copilot_task=_copilot_task(TaskType.LINT_FAILURE))
+    assert route.outcome == RouteOutcome.CLAUDE_CODE
+    foundry.run.assert_not_called()
+    claude.run.assert_awaited_once()
+    copilot.post_task.assert_not_called()


### PR DESCRIPTION
## Summary

Phase 2 of `docs/custom-coding-agent-plan.md`. `ExecutorDispatcher` now routes to a second non-Copilot executor that hands tasks off to the upstream `anthropics/claude-code-action` workflow.

Design: a thin hand-off rather than running Claude Code inline. The executor posts a structured `@claude` mention comment + applies a trigger label; the upstream action (which consumers install themselves) produces the fix; caretaker's existing `<!-- caretaker:result -->` state machine closes the loop.

## What changes

- New `ClaudeCodeExecutor` conforming to the same `async run(task, pr) -> ExecutorResult` shape as `FoundryExecutor`.
- New `ClaudeCodeExecutorConfig` on `MaintainerConfig.executor` (disabled by default, configurable trigger label + mention + attempt cap).
- `executor.provider` literal extended to `copilot | foundry | claude_code | auto`.
- `RouteOutcome.CLAUDE_CODE`.
- `agent:custom` label routes to whichever custom executor is active.
- `provider=auto` tries Claude Code when Foundry is ineligible but Claude Code is enabled, before falling to Copilot.
- Attempt cap via marker comment prevents ping-pong when the upstream action can't complete.
- Plan doc Phase-2 section updated to reflect shipped state; CHANGELOG entry added.

## Test plan

- [x] 12 new tests (`tests/test_claude_code_executor.py`) — all pass.
- [x] Full pytest suite — 890 passed, 0 regressions.
- [x] `uv run ruff check` + `ruff format` clean.
- [x] `uv run mypy` clean on touched modules.
- [ ] Manual: enable `claude_code` on a dev repo that has `anthropics/claude-code-action` installed, verify the mention comment fires and the upstream workflow produces a PR.

## Follow-ups (Phase 3+)

- MCP backend endpoint + K8s Job creation for the on-demand worker (manifest is already in `infra/k8s/caretaker-agent-worker.yaml` from Phase 1).
- Single-issue `--mode custom-agent` CLI entry for the consumer-side `agent-custom.yml` workflow.
- Extract an explicit `ExecutorProtocol` if / when a third executor shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)