### PR TITLE
fix(deploy): wire MCP ServiceAccount + agent-worker manifest

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -93,6 +93,14 @@ jobs:
 
       - name: Apply manifests
         run: |
+          # ServiceAccounts and RBAC must exist before the Deployment is
+          # (re)created, otherwise the pod fails to start with
+          # ``ServiceAccount "caretaker-mcp" not found``.
+          kubectl apply \
+            -n "${{ vars.CARETAKER_MCP_NAMESPACE }}" \
+            -f infra/k8s/caretaker-mcp-serviceaccount.yaml \
+            -f infra/k8s/caretaker-agent-worker.yaml
+
           # `replace --force` deletes and recreates the Deployment to reconcile
           # stale unmanaged fields from a prior manual `kubectl apply` — a
           # regular apply/server-side-apply cannot remove an unmanaged `value`

--- a/infra/k8s/caretaker-mcp-deployment.yaml
+++ b/infra/k8s/caretaker-mcp-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: caretaker-mcp
     spec:
+      serviceAccountName: caretaker-mcp
       tolerations:
         - key: "kubernetes.azure.com/scalesetpriority"
           operator: "Equal"

--- a/infra/k8s/caretaker-mcp-serviceaccount.yaml
+++ b/infra/k8s/caretaker-mcp-serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Dedicated ServiceAccount for the caretaker-mcp pod.
+#
+# The MCP pod mounts this SA so the agent-worker RoleBinding (see
+# `caretaker-agent-worker.yaml`) can grant only the caretaker-mcp
+# identity the ability to create `batch/v1 Job` resources in the
+# namespace. Without a dedicated SA the Deployment runs as `default`,
+# which either gets too many permissions via broader bindings or,
+# more commonly, gets none at all — `kubectl create job …` from the
+# MCP pod then fails with 403 and the Phase 3 launcher returns a
+# 503 to the admin UI.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: caretaker-mcp
+  labels:
+    app: caretaker-mcp


### PR DESCRIPTION
Follows up Phase 3 (#428) so the on-demand K8s worker actually works after `deploy-mcp.yml` runs. Two small gaps:

1. MCP Deployment had no `serviceAccountName`, so the RoleBinding that grants Job creation (targets `caretaker-mcp`) had no subject to bind to — calls from the pod would 403.
2. Deploy workflow didn't apply `caretaker-agent-worker.yaml`.

Adds a dedicated `caretaker-mcp` ServiceAccount, sets it on the Deployment, and apples SA + agent-worker manifest before the Deployment replace.

## Test plan

- [x] `kubectl apply --dry-run=client` across all four manifests — no errors.
- [ ] Manual: run `deploy-mcp.yml` workflow post-merge, verify the MCP pod comes up with `sa: caretaker-mcp` and `POST /api/admin/agent-tasks` spawns a Job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)