### PR TITLE
fix(workflow): install llm-multi extra so Foundry executor is reachable

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -247,7 +247,11 @@ jobs:
 
       - name: Install caretaker (dogfood)
         run: |
-          pip install .
+          # ``llm-multi`` pulls in LiteLLM so the in-process Foundry
+          # executor can talk to Azure AI Foundry / Anthropic / OpenAI.
+          # Without it the orchestrator logs "LiteLLM provider is
+          # unavailable" and every dispatch falls through to Copilot.
+          pip install ".[llm-multi]"
 
       - name: Generate GitHub App token
         id: app-token

--- a/setup-templates/templates/workflows/maintainer.yml
+++ b/setup-templates/templates/workflows/maintainer.yml
@@ -110,6 +110,14 @@ jobs:
         run: |
           VERSION=$(cat .github/maintainer/.version)
           pip install "git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
+          # LiteLLM is the ``llm-multi`` extra from caretaker's
+          # pyproject.toml; installing it separately keeps the install
+          # line above compatible with both the pre- and post-v0.8.1
+          # distribution rename (``caretaker`` vs ``caretaker-github``).
+          # Harmless when ``executor.foundry.enabled=false`` — no model
+          # is called — but required when the repo opts into the
+          # custom coding agent (see docs/custom-coding-agent-plan.md).
+          pip install "litellm>=1.50,<2"
 
       - name: Run
         env:
@@ -158,6 +166,14 @@ jobs:
         run: |
           VERSION=$(cat .github/maintainer/.version)
           pip install "git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
+          # LiteLLM is the ``llm-multi`` extra from caretaker's
+          # pyproject.toml; installing it separately keeps the install
+          # line above compatible with both the pre- and post-v0.8.1
+          # distribution rename (``caretaker`` vs ``caretaker-github``).
+          # Harmless when ``executor.foundry.enabled=false`` — no model
+          # is called — but required when the repo opts into the
+          # custom coding agent (see docs/custom-coding-agent-plan.md).
+          pip install "litellm>=1.50,<2"
 
       - name: Self-heal — analyse own failure
         env:


### PR DESCRIPTION
Discovered during live e2e on #431: caretaker's workflow logs

```
executor.foundry.enabled=True but LiteLLM provider is unavailable
(missing credentials or package). Routing stays on Copilot.
```

Both `ANTHROPIC_API_KEY` and `AZURE_AI_API_KEY` are present as repo secrets. The missing piece is the `litellm` package — it's the only thing in the `llm-multi` extras group. The workflow was running `pip install .`, skipping it.

- Dogfood workflow now installs `.[llm-multi]`.
- Consumer template does a separate `pip install litellm>=1.50,<2` after the git-URL install so the fix works across the pre/post-v0.8.1 distribution rename.

Must land on main so PR #431's next caretaker run sees the fix (GHA reads the workflow YAML from the base ref on `pull_request` events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)