### PR TITLE
fix(pr-agent): always ignore caretaker/pr-readiness in CI eval (self-deadlock)

### DIFF
--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -20,7 +20,13 @@ pr_agent:
     context_injection: true
   ci:
     flaky_retries: 1
-    ignore_jobs: []
+    # Ignore caretaker's own published readiness check when evaluating
+    # upstream CI. Otherwise the PR state machine sees it as pending /
+    # action_required on every cycle and never transitions to
+    # ci_failing, which deadlocks the custom-agent dispatcher against
+    # its own gate.
+    ignore_jobs:
+      - caretaker/pr-readiness
     # When the repo-wide PR CI backlog guard trips, close caretaker-managed PRs
     # instead of asking Copilot to "fix" queue pressure.
     close_managed_prs_on_backlog: true

--- a/src/caretaker/pr_agent/states.py
+++ b/src/caretaker/pr_agent/states.py
@@ -71,9 +71,23 @@ class PRStateEvaluation:
     recommended_action: str = "wait"
 
 
+_ALWAYS_IGNORED_CHECK_NAMES: frozenset[str] = frozenset(
+    {
+        # caretaker publishes its own readiness check run on every
+        # evaluation cycle. Treating it as upstream CI would create a
+        # self-gating deadlock: the PR state machine sees pending /
+        # action_required on the check caretaker itself owns, decides to
+        # wait, never transitions to ``ci_failing``, and never dispatches
+        # a fix. The check is always irrelevant to external CI health —
+        # it's strictly an output of caretaker's own evaluation.
+        "caretaker/pr-readiness",
+    }
+)
+
+
 def evaluate_ci(check_runs: list[CheckRun], ignore_jobs: list[str] | None = None) -> CIEvaluation:
     """Evaluate CI status from check runs."""
-    ignore = set(ignore_jobs or [])
+    ignore = set(ignore_jobs or []) | _ALWAYS_IGNORED_CHECK_NAMES
     relevant = [cr for cr in check_runs if cr.name not in ignore]
 
     if not relevant:


### PR DESCRIPTION
Live e2e on #431 surfaced a self-gating deadlock: caretaker's own `caretaker/pr-readiness` check is posted on every PR and is always pending/action_required while the state machine is still evaluating. `evaluate_ci` then kept returning `PENDING`, so the PR agent decided to wait — forever — and never handed the lint-failure task to the custom executor.

Adds `_ALWAYS_IGNORED_CHECK_NAMES = {'caretaker/pr-readiness'}` to `evaluate_ci` so every consumer inherits the fix without needing to touch `ci.ignore_jobs`. Also added the explicit entry to the caretaker dogfood config for documentation.

Run that proved the bug: [24706775007](https://github.com/ianlintner/caretaker/actions/runs/24706775007) — logs show `PR #431: ci_pending → ci_pending (action: wait)` despite the `lint` check being in FAILURE.

## Test plan

- [x] `uv run pytest` — 907 passed, 0 regressions.
- [ ] Next caretaker run on #431 transitions to `ci_failing` and dispatches Foundry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)