### PR TITLE
feat(github-client): rate-limit awareness + graceful cooldown

### DIFF
--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode
 
@@ -25,6 +26,11 @@ from .models import (
     User,
     is_copilot_login,
 )
+from .rate_limit import (
+    get_cooldown,
+    record_rate_limit_response,
+    record_response_headers,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +47,28 @@ class GitHubAPIError(Exception):
         self.status_code = status_code
         self.message = message
         super().__init__(f"GitHub API error {status_code}: {message}")
+
+
+class RateLimitError(GitHubAPIError):
+    """Raised when GitHub refuses a request due to primary or secondary
+    rate limiting, or when the process is short-circuiting because a
+    prior rate-limit response is still in its cooldown window.
+
+    Carries ``retry_after_seconds`` (may be ``None`` if the server
+    didn't send a hint). Callers that can defer the work should catch
+    this specifically; callers that must make the call are free to
+    let it propagate.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        *,
+        retry_after_seconds: float | None = None,
+    ) -> None:
+        super().__init__(status_code, message)
+        self.retry_after_seconds = retry_after_seconds
 
 
 class GitHubClient:
@@ -104,23 +132,52 @@ class GitHubClient:
         path: str,
         **kwargs: Any,
     ) -> Any:
+        # Short-circuit if a prior response told us to back off. Every
+        # GitHubClient in the process shares this cooldown, so one agent
+        # hitting a rate limit pauses the rest of the run instead of
+        # burning more budget fire-and-forget.
+        cooldown = get_cooldown()
+        if cooldown.is_blocked():
+            remaining = cooldown.seconds_remaining()
+            snap = cooldown.snapshot()
+            raise RateLimitError(
+                429,
+                f"Short-circuit: GitHub rate-limit cooldown still active "
+                f"({remaining:.0f}s remaining, reason={snap.get('reason')!r}).",
+                retry_after_seconds=remaining,
+            )
+
         resp = await client.request(method, path, **kwargs)
+
+        # Always sample rate-limit headers — lets us soft-throttle before
+        # the bucket hits zero.
+        record_response_headers(resp)
+
         if resp.status_code == 404:
             return None
         if resp.status_code == 429:
-            retry_after = resp.headers.get("Retry-After", "60")
-            raise GitHubAPIError(429, f"Rate limited. Retry after {retry_after}s")
+            until = record_rate_limit_response(resp, status_code=429)
+            retry_after = max(0.0, until - time.time())
+            raise RateLimitError(
+                429,
+                f"Rate limited. Retry after {retry_after:.0f}s.",
+                retry_after_seconds=retry_after,
+            )
         if resp.status_code == 403:
             # GitHub returns 403 (not 429) for installation/secondary rate limits.
-            retry_after = resp.headers.get("Retry-After")
             try:
                 body = resp.json()
                 message = body.get("message", "")
             except Exception:
                 message = resp.text
             if "rate limit" in message.lower():
-                detail = f"Retry after {retry_after}s" if retry_after else "No retry time specified"
-                raise GitHubAPIError(403, f"Rate limited. {detail}")
+                until = record_rate_limit_response(resp, status_code=403)
+                retry_after = max(0.0, until - time.time())
+                raise RateLimitError(
+                    403,
+                    f"Rate limited. Retry after {retry_after:.0f}s.",
+                    retry_after_seconds=retry_after,
+                )
             raise GitHubAPIError(resp.status_code, resp.text)
         if resp.status_code >= 400:
             raise GitHubAPIError(resp.status_code, resp.text)

--- a/src/caretaker/github_client/rate_limit.py
+++ b/src/caretaker/github_client/rate_limit.py
@@ -1,0 +1,210 @@
+"""GitHub rate-limit awareness.
+
+Shared cooldown state for every :class:`GitHubClient` in the process.
+Parses ``Retry-After`` + ``X-RateLimit-Reset`` on rate-limit responses,
+records an absolute "do not call until" timestamp, and short-circuits
+subsequent calls so agents don't burn more budget while the limit is
+in effect.
+
+Typed :class:`RateLimitError` (subclass of :class:`GitHubAPIError`)
+lets callers catch rate-limit specifically and decide between
+skipping the action, deferring to next cycle, or hard-failing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import threading
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import httpx
+
+logger = logging.getLogger(__name__)
+
+
+_LOW_REMAINING_THRESHOLD = int(os.environ.get("CARETAKER_RL_LOW_THRESHOLD", "15"))
+_SOFT_BACKOFF_SECONDS = float(os.environ.get("CARETAKER_RL_SOFT_BACKOFF_SECONDS", "2.0"))
+_MAX_COOLDOWN_SECONDS = float(os.environ.get("CARETAKER_RL_MAX_COOLDOWN_SECONDS", "3600"))
+
+
+class RateLimitCooldown:
+    """Process-wide cooldown registry.
+
+    Every :class:`GitHubClient` in the same caretaker run shares this
+    singleton via :func:`get_cooldown`. When one request hits a 429 /
+    403-rate-limit, the reset timestamp is stored here and every
+    subsequent request across every client short-circuits until the
+    window elapses. Fail-fast beats the alternative (burning 50 more
+    calls into the same limit before the agent notices).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # Unix epoch seconds past which it is safe to make a call again.
+        self._blocked_until: float = 0.0
+        # Last observed ``X-RateLimit-Remaining`` header value.
+        self._last_remaining: int | None = None
+        # Reason for the most recent block (short string, surfaced to callers).
+        self._reason: str = ""
+
+    # ── State queries ─────────────────────────────────────────────────
+
+    def is_blocked(self, *, now: float | None = None) -> bool:
+        now = now if now is not None else time.time()
+        with self._lock:
+            return now < self._blocked_until
+
+    def seconds_remaining(self, *, now: float | None = None) -> float:
+        now = now if now is not None else time.time()
+        with self._lock:
+            return max(0.0, self._blocked_until - now)
+
+    def snapshot(self) -> dict[str, float | int | str | None]:
+        """Human-readable state (for logs / admin dashboard)."""
+        with self._lock:
+            return {
+                "blocked_until": self._blocked_until,
+                "seconds_remaining": max(0.0, self._blocked_until - time.time()),
+                "last_remaining": self._last_remaining,
+                "reason": self._reason,
+            }
+
+    # ── State mutations ───────────────────────────────────────────────
+
+    def mark_blocked(self, until: float, *, reason: str = "") -> None:
+        """Record a hard block until ``until`` (unix epoch seconds)."""
+        capped = min(until, time.time() + _MAX_COOLDOWN_SECONDS)
+        with self._lock:
+            if capped > self._blocked_until:
+                self._blocked_until = capped
+                self._reason = reason or self._reason or "rate-limited"
+                logger.warning(
+                    "GitHub rate-limit cooldown engaged: blocked until %s "
+                    "(%.0fs from now) reason=%s",
+                    time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(capped)),
+                    capped - time.time(),
+                    self._reason,
+                )
+
+    def update_remaining(self, remaining: int) -> None:
+        with self._lock:
+            self._last_remaining = remaining
+
+    def reset(self) -> None:
+        """Test helper — clear all state."""
+        with self._lock:
+            self._blocked_until = 0.0
+            self._last_remaining = None
+            self._reason = ""
+
+
+_COOLDOWN = RateLimitCooldown()
+
+
+def get_cooldown() -> RateLimitCooldown:
+    return _COOLDOWN
+
+
+def reset_for_tests() -> None:
+    _COOLDOWN.reset()
+
+
+# ── Header parsing ────────────────────────────────────────────────────
+
+
+def parse_rate_limit_headers(
+    response: httpx.Response,
+    *,
+    now: float | None = None,
+) -> tuple[float | None, int | None]:
+    """Return ``(blocked_until_epoch | None, remaining | None)``.
+
+    Honours ``Retry-After`` (seconds or HTTP-date), ``X-RateLimit-Reset``
+    (unix seconds), and ``X-RateLimit-Remaining``. Takes the *later* of
+    ``Retry-After``-derived and ``X-RateLimit-Reset`` timestamps so we
+    respect whichever source says to wait longer.
+    """
+    now = now if now is not None else time.time()
+
+    headers = response.headers
+
+    blocked_candidates: list[float] = []
+
+    retry_after = headers.get("Retry-After") or headers.get("retry-after")
+    if retry_after:
+        try:
+            delta = float(retry_after)
+            blocked_candidates.append(now + delta)
+        except (TypeError, ValueError):
+            # HTTP-date format fallback.
+            with contextlib.suppress(Exception):
+                from email.utils import parsedate_to_datetime
+
+                dt = parsedate_to_datetime(retry_after)
+                if dt is not None:
+                    blocked_candidates.append(dt.timestamp())
+
+    reset_ts = headers.get("X-RateLimit-Reset") or headers.get("x-ratelimit-reset")
+    if reset_ts:
+        with contextlib.suppress(TypeError, ValueError):
+            blocked_candidates.append(float(reset_ts))
+
+    remaining_header = headers.get("X-RateLimit-Remaining") or headers.get("x-ratelimit-remaining")
+    remaining: int | None = None
+    if remaining_header:
+        try:
+            remaining = int(remaining_header)
+        except (TypeError, ValueError):
+            remaining = None
+
+    blocked_until = max(blocked_candidates) if blocked_candidates else None
+    return blocked_until, remaining
+
+
+def record_response_headers(response: httpx.Response) -> None:
+    """Update cooldown state from every response, rate-limited or not.
+
+    Called on the success path so we notice budget exhaustion *before*
+    the next request rather than after.
+    """
+    _blocked_until, remaining = parse_rate_limit_headers(response)
+    if remaining is not None:
+        _COOLDOWN.update_remaining(remaining)
+        if remaining <= _LOW_REMAINING_THRESHOLD:
+            # Soft throttle: add a small blocking window so bursts don't
+            # blow the rest of the budget in one run.
+            until = time.time() + _SOFT_BACKOFF_SECONDS
+            _COOLDOWN.mark_blocked(
+                until,
+                reason=f"soft throttle: only {remaining} requests remain",
+            )
+
+
+def record_rate_limit_response(response: httpx.Response, *, status_code: int) -> float:
+    """Record a 429 / 403-rate-limit response and return the cooldown expiry."""
+    blocked_until, remaining = parse_rate_limit_headers(response)
+    if remaining is not None:
+        _COOLDOWN.update_remaining(remaining)
+    # Fall back to a one-minute cushion when the response gives us
+    # nothing to work with. GitHub's secondary rate-limits sometimes
+    # omit the reset header entirely.
+    until = blocked_until if blocked_until is not None else time.time() + 60.0
+    _COOLDOWN.mark_blocked(
+        until,
+        reason=f"HTTP {status_code} rate-limited",
+    )
+    return until
+
+
+__all__ = [
+    "RateLimitCooldown",
+    "get_cooldown",
+    "parse_rate_limit_headers",
+    "record_rate_limit_response",
+    "record_response_headers",
+    "reset_for_tests",
+]

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -352,6 +352,27 @@ class Orchestrator:
             self._repo,
         )
 
+        # Honour any in-process rate-limit cooldown from a previous run
+        # (same runner, same python process is rare in GHA but possible
+        # for local loops or the K8s agent-worker that reuses the pod).
+        # For the common GHA case, the cooldown state starts fresh on
+        # every workflow invocation, so this is a no-op most of the
+        # time and a safety net the rest.
+        from caretaker.github_client.rate_limit import get_cooldown
+
+        _cooldown = get_cooldown()
+        if _cooldown.is_blocked():
+            remaining = _cooldown.seconds_remaining()
+            snap = _cooldown.snapshot()
+            logger.warning(
+                "Orchestrator deferring: GitHub rate-limit cooldown still active "
+                "(%.0fs remaining, reason=%s). Exiting cleanly so the next "
+                "scheduled run picks up after the window closes.",
+                remaining,
+                snap.get("reason"),
+            )
+            return 0
+
         # Load persisted state
         state = OrchestratorState()
         summary = RunSummary(mode=mode, run_at=datetime.utcnow())

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -363,13 +363,13 @@ class Orchestrator:
         _cooldown = get_cooldown()
         if _cooldown.is_blocked():
             remaining = _cooldown.seconds_remaining()
-            snap = _cooldown.snapshot()
+            cooldown_snap = _cooldown.snapshot()
             logger.warning(
                 "Orchestrator deferring: GitHub rate-limit cooldown still active "
                 "(%.0fs remaining, reason=%s). Exiting cleanly so the next "
                 "scheduled run picks up after the window closes.",
                 remaining,
-                snap.get("reason"),
+                cooldown_snap.get("reason"),
             )
             return 0
 

--- a/src/caretaker/state/tracker.py
+++ b/src/caretaker/state/tracker.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from caretaker.causal import make_causal_marker
+from caretaker.github_client.api import RateLimitError
 from caretaker.tools.github import GitHubIssueTools
 
 from .models import OrchestratorState, RunSummary
@@ -105,8 +106,16 @@ class StateTracker:
             if len(self._state.run_history) > 20:
                 self._state.run_history = self._state.run_history[-20:]
 
-        if self._tracking_issue_number is None:
-            await self._create_tracking_issue()
+        try:
+            if self._tracking_issue_number is None:
+                await self._create_tracking_issue()
+        except RateLimitError as exc:
+            logger.warning(
+                "State save skipped: GitHub rate-limit while creating tracking issue (%s). "
+                "In-memory state is intact; next successful run will persist.",
+                exc,
+            )
+            return
 
         assert self._tracking_issue_number is not None
 
@@ -120,6 +129,13 @@ class StateTracker:
                 STATE_COMMENT_MARKER,
                 body,
             )
+        except RateLimitError as exc:
+            logger.warning(
+                "State save skipped: GitHub rate-limit while upserting state comment (%s). "
+                "In-memory state is intact; next successful run will persist.",
+                exc,
+            )
+            return
         except Exception as exc:
             if _is_comment_limit_error(exc):
                 await self._rotate_tracking_issue()
@@ -142,8 +158,15 @@ class StateTracker:
         replaces the previous append-per-run pattern that drove unbounded
         comment growth.
         """
-        if self._tracking_issue_number is None:
-            await self._create_tracking_issue()
+        try:
+            if self._tracking_issue_number is None:
+                await self._create_tracking_issue()
+        except RateLimitError as exc:
+            logger.warning(
+                "Run summary post skipped: GitHub rate-limit while creating tracking issue (%s)",
+                exc,
+            )
+            return
         assert self._tracking_issue_number is not None
 
         recent = list(self._state.run_history[-_RUN_HISTORY_KEEP:])
@@ -162,6 +185,12 @@ class StateTracker:
                 RUN_HISTORY_COMMENT_MARKER,
                 body,
             )
+        except RateLimitError as exc:
+            logger.warning(
+                "Run summary post skipped: GitHub rate-limit while upserting history comment (%s)",
+                exc,
+            )
+            return
         except Exception as exc:
             if _is_comment_limit_error(exc):
                 await self._rotate_tracking_issue()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,16 @@ from caretaker.github_client.models import (
     ReviewState,
     User,
 )
+from caretaker.github_client.rate_limit import reset_for_tests as _reset_rate_limit
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit_cooldown() -> None:
+    """The GitHub rate-limit cooldown is a process-wide singleton. Reset
+    before every test so state (e.g. a test intentionally triggering
+    the cooldown) doesn't leak into subsequent tests' HTTP stubs."""
+    _reset_rate_limit()
+
 
 # ── Users ────────────────────────────────────────────────────────────
 

--- a/tests/test_github_client_api.py
+++ b/tests/test_github_client_api.py
@@ -60,7 +60,15 @@ async def test_403_rate_limit_raises_githubapieerror() -> None:
     error = exc_info.value
     assert error.status_code == 403
     assert "Rate limited" in str(error)
-    assert "No retry time specified" in str(error)
+    # RateLimitError subclass carries a retry_after_seconds; when the
+    # server omits both Retry-After and X-RateLimit-Reset, the client
+    # falls back to a 60s cushion rather than propagating an
+    # unbounded "no retry time specified" sentinel.
+    from caretaker.github_client.api import RateLimitError
+
+    assert isinstance(error, RateLimitError)
+    assert error.retry_after_seconds is not None
+    assert error.retry_after_seconds > 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,198 @@
+"""Tests for GitHub rate-limit awareness (parsing + cooldown + client)."""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+
+from caretaker.github_client.api import GitHubClient, RateLimitError
+from caretaker.github_client.rate_limit import (
+    get_cooldown,
+    parse_rate_limit_headers,
+    record_response_headers,
+    reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown() -> None:
+    reset_for_tests()
+
+
+def _resp(headers: dict[str, str], status: int = 429, body: bytes = b"{}") -> httpx.Response:
+    return httpx.Response(status_code=status, headers=headers, content=body)
+
+
+# ── Header parsing ────────────────────────────────────────────────────
+
+
+def test_parse_retry_after_seconds() -> None:
+    resp = _resp({"Retry-After": "45"})
+    until, remaining = parse_rate_limit_headers(resp, now=1000.0)
+    assert until is not None
+    assert abs(until - 1045.0) < 0.001
+    assert remaining is None
+
+
+def test_parse_retry_after_http_date() -> None:
+    # Sun, 06 Nov 1994 08:49:37 GMT → epoch 784111777
+    resp = _resp({"Retry-After": "Sun, 06 Nov 1994 08:49:37 GMT"})
+    until, _ = parse_rate_limit_headers(resp, now=1000.0)
+    assert until is not None
+    assert abs(until - 784111777.0) < 1.0
+
+
+def test_parse_x_ratelimit_reset() -> None:
+    resp = _resp({"X-RateLimit-Reset": "2000"})
+    until, remaining = parse_rate_limit_headers(resp, now=1000.0)
+    assert until == 2000.0
+    assert remaining is None
+
+
+def test_parse_both_takes_later_value() -> None:
+    # Retry-After 10s → 1010; Reset 2000 → later wins.
+    resp = _resp({"Retry-After": "10", "X-RateLimit-Reset": "2000"})
+    until, _ = parse_rate_limit_headers(resp, now=1000.0)
+    assert until == 2000.0
+
+
+def test_parse_remaining() -> None:
+    resp = _resp({"X-RateLimit-Remaining": "3"})
+    _, remaining = parse_rate_limit_headers(resp)
+    assert remaining == 3
+
+
+def test_parse_invalid_remaining_returns_none() -> None:
+    resp = _resp({"X-RateLimit-Remaining": "not-a-number"})
+    _, remaining = parse_rate_limit_headers(resp)
+    assert remaining is None
+
+
+# ── Cooldown state ────────────────────────────────────────────────────
+
+
+def test_cooldown_starts_unblocked() -> None:
+    cd = get_cooldown()
+    assert cd.is_blocked() is False
+    assert cd.seconds_remaining() == 0.0
+
+
+def test_mark_blocked_sets_window() -> None:
+    cd = get_cooldown()
+    future = time.time() + 30
+    cd.mark_blocked(future, reason="test")
+    assert cd.is_blocked() is True
+    assert cd.seconds_remaining() > 25
+    assert cd.snapshot()["reason"] == "test"
+
+
+def test_mark_blocked_keeps_longer_window() -> None:
+    cd = get_cooldown()
+    cd.mark_blocked(time.time() + 10, reason="short")
+    cd.mark_blocked(time.time() + 5, reason="even shorter")
+    # The longer window (10s) must be preserved.
+    assert cd.seconds_remaining() > 8
+
+
+def test_mark_blocked_caps_at_max() -> None:
+    # MAX is one hour by default. 10x that should be clamped.
+    cd = get_cooldown()
+    cd.mark_blocked(time.time() + 36_000, reason="too long")
+    assert cd.seconds_remaining() <= 3600 + 1
+
+
+def test_record_response_headers_soft_throttles_on_low_remaining() -> None:
+    resp = _resp({"X-RateLimit-Remaining": "5"}, status=200)
+    record_response_headers(resp)
+    cd = get_cooldown()
+    assert cd.is_blocked()
+    assert cd.snapshot()["last_remaining"] == 5
+
+
+def test_record_response_headers_no_throttle_on_healthy_remaining() -> None:
+    resp = _resp({"X-RateLimit-Remaining": "4000"}, status=200)
+    record_response_headers(resp)
+    assert get_cooldown().is_blocked() is False
+
+
+# ── Client integration ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_client_raises_rate_limit_error_on_429(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # Stub credentials so the client doesn't touch env vars.
+    from caretaker.github_client.credentials import EnvCredentialsProvider
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+
+    client = GitHubClient(credentials_provider=EnvCredentialsProvider(default_token="t"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=429,
+            headers={"Retry-After": "120", "X-RateLimit-Remaining": "0"},
+            json={"message": "API rate limit exceeded"},
+        )
+
+    client._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://api.github.com"
+    )
+
+    with pytest.raises(RateLimitError) as exc_info:
+        await client._get("/test")
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.retry_after_seconds is not None
+    assert exc_info.value.retry_after_seconds > 60
+    # Second call short-circuits without hitting the transport.
+    with pytest.raises(RateLimitError) as exc_info2:
+        await client._get("/other")
+    assert "Short-circuit" in exc_info2.value.message
+
+
+@pytest.mark.asyncio
+async def test_client_raises_rate_limit_error_on_403_secondary(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from caretaker.github_client.credentials import EnvCredentialsProvider
+
+    client = GitHubClient(credentials_provider=EnvCredentialsProvider(default_token="t"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=403,
+            headers={"X-RateLimit-Reset": str(int(time.time()) + 45)},
+            json={"message": "You have exceeded a secondary rate limit"},
+        )
+
+    client._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://api.github.com"
+    )
+
+    with pytest.raises(RateLimitError) as exc_info:
+        await client._get("/test")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.retry_after_seconds is not None
+
+
+@pytest.mark.asyncio
+async def test_client_passes_through_non_rate_limited_403(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from caretaker.github_client.api import GitHubAPIError
+    from caretaker.github_client.credentials import EnvCredentialsProvider
+
+    client = GitHubClient(credentials_provider=EnvCredentialsProvider(default_token="t"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=403,
+            json={"message": "Forbidden"},
+        )
+
+    client._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://api.github.com"
+    )
+
+    with pytest.raises(GitHubAPIError) as exc_info:
+        await client._get("/test")
+    assert exc_info.value.status_code == 403
+    # Plain 403 is not a RateLimitError.
+    assert not isinstance(exc_info.value, RateLimitError)


### PR DESCRIPTION
Fixes the crash pattern observed during the live custom-agent e2e on #431:

```
File "/…/caretaker/github_client/api.py", line 123, in _request_with_client
    raise GitHubAPIError(403, f"Rate limited. {detail}")
caretaker.github_client.api.GitHubAPIError: GitHub API error 403:
    Rate limited. No retry time specified
```

Three-layer fix:
1. **Parse + remember.** New `RateLimitCooldown` singleton reads `Retry-After` + `X-RateLimit-Reset` on every response; stores a cooldown expiry. Soft-throttles at `X-RateLimit-Remaining ≤ 15` so one run can't burn the whole bucket.
2. **Short-circuit.** `GitHubClient._request_with_client` raises a typed `RateLimitError` *before* the HTTP call when the cooldown window is still open — saves quota, surfaces cleanly to callers.
3. **Skip-and-defer.** `Orchestrator.run` exits 0 if the cooldown is live at start (no self-heal cascade). `StateTracker.save` / `post_run_summary` catch `RateLimitError` on the tracking-issue paths and log-skip instead of crashing.

## Test plan
- [x] 15 new unit tests covering header parsing, cooldown state, soft throttle, client integration.
- [x] Full pytest — 922 passed, 0 regressions.
- [x] `uv run ruff check` + `ruff format` + `mypy` clean on touched modules.

## Follow-ups
- Thread cooldown state into the admin `/api/admin/state` response so the dashboard can show "cooldown active, next run will defer".
- Expose a metric so we can alert if a repo spends more than X% of wall time in cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)