### PR TITLE
feat(memory-graph): M3 — tenant scoping + new node types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,43 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Memory graph — M3: tenant scoping + new node types
+
+Third milestone of the memory-graph plan. The graph gains a dedicated
+`:Repo` tenant anchor, three attribution node types that were sitting
+in the plan waiting for a home, and a `repo` scalar on every node so
+cypher queries can scope by tenant in a single `WHERE n.repo = $repo`
+clause.
+
+- New `NodeType` values: `REPO`, `COMMENT`, `CHECK_RUN`, `EXECUTOR`.
+  Uniqueness constraints shipped for each label in
+  `GraphStore.ensure_indexes`.
+- `GraphBuilder.full_sync` now takes an `owner/name` slug via a new
+  `repo=` kwarg (defaults to `"unknown/unknown"` for legacy callers),
+  merges a single `:Repo` node first, and stamps `repo=<slug>` onto
+  every downstream node merge (`:Agent`, `:PR`, `:Issue`, `:Goal`,
+  `:Run`, `:Skill`, `:CausalEvent`, and the synthetic `goal:overall`).
+- PR attribution: when `TrackedPR.owned_by` is one of `copilot`,
+  `foundry`, `claude_code` the builder mints an `:Executor{provider}`
+  node plus a `(PR)-[:HANDLED_BY {valid_from}]->(Executor)` edge
+  (bitemporal, using `ownership_acquired_at` when known). The default
+  `"caretaker"` ownership — i.e. no external delegation — is skipped
+  so queries like "which executor fixed this PR" don't have to filter
+  the self-ownership case.
+- `CheckRun` node emission deferred to M5 alongside the live event
+  feed — `TrackedPR` carries only a `ci_attempts` counter, so the
+  per-check metadata the schema calls for isn't available from state
+  alone. Label + constraint are shipped now so M5 can merge straight
+  in.
+- `admin.state_loader.build_refresh_task` now passes the actual
+  `owner/name` slug through to the builder so the admin reconciliation
+  loop produces a tenant-scoped subgraph in Neo4j.
+- 7 new tests in `tests/test_graph_builder_m3.py` cover Repo-node
+  merge with a real slug, the `unknown/unknown` fallback, tenant
+  `repo` scalar on every node, Executor + HANDLED_BY for each of the
+  three external providers, and the no-executor case for
+  `owned_by="caretaker"`.
+
 ### Memory graph — M2: missing edges + bitemporal edge properties
 
 Second milestone of the memory-graph plan. The writer + builder now

--- a/src/caretaker/admin/state_loader.py
+++ b/src/caretaker/admin/state_loader.py
@@ -109,6 +109,7 @@ def build_refresh_task(data: AdminDataAccess) -> asyncio.Task[None] | None:
             counts = await GraphBuilder(persistent_store).full_sync(
                 state,
                 causal_store=data.causal_store,
+                repo=f"{owner}/{name}",
             )
             logger.debug("Graph sync counts: %s", counts)
         except Exception:

--- a/src/caretaker/graph/builder.py
+++ b/src/caretaker/graph/builder.py
@@ -77,6 +77,16 @@ _MODE_TO_AGENTS: dict[str, tuple[str, ...]] = {
 }
 
 
+# M3: ``owned_by`` values in :class:`TrackedPR` are free-form strings, but
+# in the wild they collapse to one of four constants: ``copilot``,
+# ``foundry``, ``claude_code`` (external executors), and ``caretaker``
+# (the orchestrator itself — i.e. no delegation). Only the first three
+# are modelled as :class:`NodeType.EXECUTOR` nodes with a ``HANDLED_BY``
+# edge; ``caretaker`` and any unknown value is treated as "no executor"
+# so we don't pollute the graph with spurious self-loops.
+_EXECUTOR_PROVIDERS: frozenset[str] = frozenset({"copilot", "foundry", "claude_code"})
+
+
 class GraphBuilder:
     """Populates the Neo4j graph from caretaker data sources."""
 
@@ -88,8 +98,17 @@ class GraphBuilder:
         state: OrchestratorState,
         insight_store: Any | None = None,
         causal_store: CausalEventStore | None = None,
+        repo: str | None = None,
     ) -> dict[str, int]:
-        """Perform a full graph sync.  Returns counts of created entities."""
+        """Perform a full graph sync.  Returns counts of created entities.
+
+        ``repo`` is the ``owner/name`` slug for the tenant being synced.
+        When provided, a dedicated ``:Repo`` node is merged and every
+        other node gains a ``repo`` scalar so cypher queries can scope
+        by tenant (M3 of the memory-graph plan). Defaults to
+        ``"unknown/unknown"`` so the builder stays callable from legacy
+        call sites that have not yet been threaded with the slug.
+        """
         counts: dict[str, int] = {
             "agents": 0,
             "prs": 0,
@@ -98,10 +117,24 @@ class GraphBuilder:
             "skills": 0,
             "runs": 0,
             "causal_events": 0,
+            "executors": 0,
             "edges": 0,
         }
 
         await self._store.ensure_indexes()
+
+        # 0. Tenant Repo node. Every other node merged below carries
+        # ``repo=<slug>`` so the whole per-tenant subgraph is scopable.
+        # Callers that haven't yet been plumbed with the slug get the
+        # ``unknown/unknown`` placeholder — easier to detect in prod
+        # than silently dropping the scope property.
+        repo_slug = repo or "unknown/unknown"
+        repo_id = f"repo:{repo_slug}"
+        await self._store.merge_node(
+            NodeType.REPO,
+            repo_id,
+            {"slug": repo_slug, "repo": repo_slug},
+        )
 
         # 1. Agents
         for agent_name, modes in AGENT_MODES.items():
@@ -113,6 +146,7 @@ class GraphBuilder:
                     "name": agent_name,
                     "modes": list(modes),
                     "events": events,
+                    "repo": repo_slug,
                 },
             )
             counts["agents"] += 1
@@ -132,6 +166,7 @@ class GraphBuilder:
                     "ci_attempts": pr.ci_attempts,
                     "fix_cycles": pr.fix_cycles,
                     "escalated": pr.escalated,
+                    "repo": repo_slug,
                 },
             )
             counts["prs"] += 1
@@ -147,6 +182,47 @@ class GraphBuilder:
                 )
                 counts["edges"] += 1
 
+            # M3: PR → Executor attribution. ``owned_by`` narrows to one
+            # of the known providers before we merge an :Executor node;
+            # ``caretaker`` (self) and unknown values skip the edge so
+            # queries like "which executor fixed this PR" don't have to
+            # filter out the default no-delegation case.
+            if pr.owned_by in _EXECUTOR_PROVIDERS:
+                executor_id = f"executor:{pr.owned_by}"
+                await self._store.merge_node(
+                    NodeType.EXECUTOR,
+                    executor_id,
+                    {
+                        "provider": pr.owned_by,
+                        "repo": repo_slug,
+                    },
+                )
+                counts["executors"] += 1
+                # Use ownership_acquired_at when known so ``valid_from``
+                # marks when this executor actually took the PR, not
+                # when the sync happened to notice.
+                acquired = (
+                    pr.ownership_acquired_at.isoformat() if pr.ownership_acquired_at else None
+                )
+                await self._store.merge_edge(
+                    NodeType.PR,
+                    pr_id,
+                    NodeType.EXECUTOR,
+                    executor_id,
+                    RelType.HANDLED_BY,
+                    _bitemporal(valid_from=acquired),
+                )
+                counts["edges"] += 1
+
+            # NOTE: ``:CheckRun`` node emission (name / conclusion /
+            # run_id / PR→CheckRun edge) lives with the live event
+            # feed planned for M5 — :class:`TrackedPR` tracks
+            # ``ci_attempts`` as a counter but doesn't carry the
+            # per-check metadata the schema calls for, so synthesising
+            # one here would mean inventing data. Skipped
+            # intentionally; the constraint + NodeType are shipped
+            # now so the M5 writer has something to merge into.
+
         # 3. Tracked Issues
         for number, issue in state.tracked_issues.items():
             issue_id = f"issue:{number}"
@@ -158,6 +234,7 @@ class GraphBuilder:
                     "state": issue.state,
                     "classification": issue.classification,
                     "escalated": issue.escalated,
+                    "repo": repo_slug,
                 },
             )
             counts["issues"] += 1
@@ -203,7 +280,7 @@ class GraphBuilder:
         await self._store.merge_node(
             NodeType.GOAL,
             "goal:overall",
-            {"name": "overall", "aggregate": True},
+            {"name": "overall", "aggregate": True, "repo": repo_slug},
         )
         counts["goals"] += 1
         for goal_id, snapshots in state.goal_history.items():
@@ -216,6 +293,7 @@ class GraphBuilder:
                     "score": latest.score if latest else 0.0,
                     "status": latest.status if latest else "unknown",
                     "history_length": len(snapshots),
+                    "repo": repo_slug,
                 },
             )
             counts["goals"] += 1
@@ -259,6 +337,7 @@ class GraphBuilder:
                     "goal_health": run.goal_health if run.goal_health is not None else 0.0,
                     "escalation_rate": run.escalation_rate,
                     "valid_from": run_at_iso,
+                    "repo": repo_slug,
                 },
             )
             counts["runs"] += 1
@@ -313,6 +392,7 @@ class GraphBuilder:
                             "confidence": skill.confidence,
                             "success_count": skill.success_count,
                             "fail_count": skill.fail_count,
+                            "repo": repo_slug,
                         },
                     )
                     counts["skills"] += 1
@@ -349,6 +429,7 @@ class GraphBuilder:
                         "ref_kind": event.ref.kind,
                         "ref_number": event.ref.number if event.ref.number is not None else 0,
                         "observed_at": event.observed_at.isoformat() if event.observed_at else "",
+                        "repo": repo_slug,
                     },
                 )
                 counts["causal_events"] += 1
@@ -370,7 +451,7 @@ class GraphBuilder:
 
         logger.info(
             "Graph sync complete: %d agents, %d PRs, %d issues, %d goals, "
-            "%d skills, %d runs, %d causal events, %d edges",
+            "%d skills, %d runs, %d causal events, %d executors, %d edges",
             counts["agents"],
             counts["prs"],
             counts["issues"],
@@ -378,6 +459,7 @@ class GraphBuilder:
             counts["skills"],
             counts["runs"],
             counts["causal_events"],
+            counts["executors"],
             counts["edges"],
         )
         return counts

--- a/src/caretaker/graph/models.py
+++ b/src/caretaker/graph/models.py
@@ -17,6 +17,20 @@ class NodeType(StrEnum):
     AUDIT_EVENT = "AuditEvent"
     MUTATION = "Mutation"
     CAUSAL_EVENT = "CausalEvent"
+    # ── Added in M3 of the memory-graph plan ────────────────────────────
+    # Tenant + attribution nodes. Every other node in the graph also
+    # grows a ``repo`` scalar so cypher queries can scope via
+    # ``WHERE n.repo = $repo``; the dedicated ``:Repo`` node is the
+    # anchor point for the future ``BELONGS_TO`` edge and cross-repo
+    # fleet queries. ``Comment`` and ``CheckRun`` complete the PR /
+    # Issue attribution chain so "which comment spawned this chain?"
+    # and "which check failed on this PR?" are one-hop queries.
+    # ``Executor`` captures copilot / foundry / claude_code provenance
+    # on the PR it handled.
+    REPO = "Repo"
+    COMMENT = "Comment"
+    CHECK_RUN = "CheckRun"
+    EXECUTOR = "Executor"
 
 
 class RelType(StrEnum):

--- a/src/caretaker/graph/store.py
+++ b/src/caretaker/graph/store.py
@@ -46,6 +46,11 @@ class GraphStore:
             "CREATE CONSTRAINT IF NOT EXISTS FOR (e:AuditEvent) REQUIRE e.id IS UNIQUE",
             "CREATE CONSTRAINT IF NOT EXISTS FOR (m:Mutation) REQUIRE m.id IS UNIQUE",
             "CREATE CONSTRAINT IF NOT EXISTS FOR (c:CausalEvent) REQUIRE c.id IS UNIQUE",
+            # M3: tenant + attribution node constraints.
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (r:Repo) REQUIRE r.id IS UNIQUE",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (c:Comment) REQUIRE c.id IS UNIQUE",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (cr:CheckRun) REQUIRE cr.id IS UNIQUE",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (e:Executor) REQUIRE e.id IS UNIQUE",
         ]
         async with self._driver.session(database=self._database) as session:
             for q in queries:

--- a/tests/test_graph_builder_m3.py
+++ b/tests/test_graph_builder_m3.py
@@ -1,0 +1,186 @@
+"""Tests for M3 of the memory-graph plan — tenant scoping + new node types.
+
+M3 adds four node types (``:Repo``, ``:Comment``, ``:CheckRun``, ``:Executor``)
+and threads an ``owner/name`` slug through the builder so every merged node
+carries a ``repo`` scalar for tenant-scoped cypher queries. These tests
+mirror the ``RecordingStore`` fake pattern used by the M2 suite.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from caretaker.goals.models import GoalSnapshot
+from caretaker.graph.builder import GraphBuilder
+from caretaker.graph.models import NodeType, RelType
+from caretaker.state.models import (
+    IssueTrackingState,
+    OrchestratorState,
+    OwnershipState,
+    PRTrackingState,
+    RunSummary,
+    TrackedIssue,
+    TrackedPR,
+)
+
+
+class RecordingStore:
+    """Fake :class:`GraphStore` — records all merge calls."""
+
+    def __init__(self) -> None:
+        self.nodes: list[tuple[str, str, dict[str, Any]]] = []
+        self.edges: list[tuple[str, str, str, str, str, dict[str, Any]]] = []
+        self.indexes_ensured = False
+
+    async def ensure_indexes(self) -> None:
+        self.indexes_ensured = True
+
+    async def merge_node(self, label: str, node_id: str, props: dict[str, Any]) -> None:
+        self.nodes.append((label, node_id, props))
+
+    async def merge_edge(
+        self,
+        source_label: str,
+        source_id: str,
+        target_label: str,
+        target_id: str,
+        rel_type: str,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        self.edges.append(
+            (source_label, source_id, target_label, target_id, rel_type, properties or {})
+        )
+
+
+def _sample_state(*, owned_by: str = "caretaker") -> OrchestratorState:
+    state = OrchestratorState()
+    state.tracked_prs[42] = TrackedPR(
+        number=42,
+        state=PRTrackingState.CI_PASSING,
+        ownership_state=OwnershipState.OWNED,
+        owned_by=owned_by,
+        ownership_acquired_at=datetime(2026, 4, 20, 11, 30, tzinfo=UTC),
+    )
+    state.tracked_issues[7] = TrackedIssue(
+        number=7,
+        state=IssueTrackingState.PR_OPENED,
+        assigned_pr=42,
+    )
+    state.goal_history["ci_health"] = [
+        GoalSnapshot(goal_id="ci_health", score=0.9, status="satisfied"),
+    ]
+    state.run_history.append(
+        RunSummary(
+            run_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+            mode="pr",
+            prs_merged=1,
+            goal_health=0.87,
+            escalation_rate=0.1,
+        )
+    )
+    return state
+
+
+_EdgeTuple = tuple[str, str, str, str, str, dict[str, Any]]
+
+
+def _edges_of(store: RecordingStore, rel: str) -> list[_EdgeTuple]:
+    return [e for e in store.edges if e[4] == rel]
+
+
+def _nodes_of(store: RecordingStore, label: str) -> list[tuple[str, str, dict[str, Any]]]:
+    return [n for n in store.nodes if n[0] == label]
+
+
+@pytest.mark.asyncio
+async def test_repo_node_merged_with_owner_name_slug() -> None:
+    """A single ``:Repo`` node lands with the slug passed via ``repo=``."""
+    store = RecordingStore()
+    await GraphBuilder(store).full_sync(_sample_state(), repo="acme/widgets")
+
+    repos = _nodes_of(store, NodeType.REPO.value)
+    assert len(repos) == 1
+    _, node_id, props = repos[0]
+    assert node_id == "repo:acme/widgets"
+    assert props["slug"] == "acme/widgets"
+    assert props["repo"] == "acme/widgets"
+
+
+@pytest.mark.asyncio
+async def test_repo_defaults_to_placeholder_when_omitted() -> None:
+    """Legacy callers without the slug get the ``unknown/unknown`` fallback."""
+    store = RecordingStore()
+    await GraphBuilder(store).full_sync(_sample_state())
+
+    repos = _nodes_of(store, NodeType.REPO.value)
+    assert len(repos) == 1
+    assert repos[0][1] == "repo:unknown/unknown"
+    assert repos[0][2]["slug"] == "unknown/unknown"
+
+
+@pytest.mark.asyncio
+async def test_every_emitted_node_has_repo_property() -> None:
+    """Tenant scoping — every merged node advertises its ``repo`` slug."""
+    store = RecordingStore()
+    await GraphBuilder(store).full_sync(_sample_state(), repo="acme/widgets")
+
+    for label, node_id, props in store.nodes:
+        assert "repo" in props, f"{label} node {node_id!r} missing repo scalar"
+        assert props["repo"] == "acme/widgets"
+
+
+@pytest.mark.asyncio
+async def test_executor_node_and_handled_by_edge_for_copilot_pr() -> None:
+    """``owned_by="copilot"`` mints an Executor node + PR-HANDLED_BY-Executor edge."""
+    store = RecordingStore()
+    await GraphBuilder(store).full_sync(_sample_state(owned_by="copilot"), repo="acme/widgets")
+
+    executors = _nodes_of(store, NodeType.EXECUTOR.value)
+    assert len(executors) == 1
+    _, node_id, props = executors[0]
+    assert node_id == "executor:copilot"
+    assert props["provider"] == "copilot"
+    assert props["repo"] == "acme/widgets"
+
+    handled = _edges_of(store, RelType.HANDLED_BY.value)
+    assert len(handled) == 1
+    source_label, source_id, target_label, target_id, _, edge_props = handled[0]
+    assert (source_label, target_label) == (NodeType.PR, NodeType.EXECUTOR)
+    assert (source_id, target_id) == ("pr:42", "executor:copilot")
+    # valid_from is stamped from ownership_acquired_at (M2 bitemporal).
+    assert edge_props["valid_from"] == "2026-04-20T11:30:00+00:00"
+    assert "observed_at" in edge_props
+
+
+@pytest.mark.asyncio
+async def test_no_executor_edge_for_caretaker_self_ownership() -> None:
+    """``owned_by="caretaker"`` is the default (no delegation) — no Executor node."""
+    store = RecordingStore()
+    await GraphBuilder(store).full_sync(_sample_state(owned_by="caretaker"), repo="acme/widgets")
+
+    assert _nodes_of(store, NodeType.EXECUTOR.value) == []
+    assert _edges_of(store, RelType.HANDLED_BY.value) == []
+
+
+@pytest.mark.asyncio
+async def test_foundry_and_claude_code_also_mint_executors() -> None:
+    """The full set of external providers is recognised."""
+    for provider in ("foundry", "claude_code"):
+        store = RecordingStore()
+        await GraphBuilder(store).full_sync(_sample_state(owned_by=provider), repo="acme/widgets")
+        executor_ids = {n[1] for n in _nodes_of(store, NodeType.EXECUTOR.value)}
+        assert executor_ids == {f"executor:{provider}"}
+        assert len(_edges_of(store, RelType.HANDLED_BY.value)) == 1
+
+
+@pytest.mark.asyncio
+async def test_repo_node_is_merged_before_other_nodes() -> None:
+    """``:Repo`` is node 0 so downstream merges can reference it if needed."""
+    store = RecordingStore()
+    await GraphBuilder(store).full_sync(_sample_state(), repo="acme/widgets")
+
+    assert store.nodes[0][0] == NodeType.REPO.value
+    assert store.nodes[0][1] == "repo:acme/widgets"


### PR DESCRIPTION
## Summary

Third milestone of the memory-graph plan (`docs/memory-graph-plan.md`). Adds tenant scoping via a `Repo` node and introduces the `Comment`, `CheckRun`, and `Executor` node types the §3.1 catalog calls for. Every existing node now carries a `repo` scalar so Cypher queries can scope per tenant.

## Changes

- **`NodeType` enum** gains `REPO`, `COMMENT`, `CHECK_RUN`, `EXECUTOR`.
- **`GraphStore.ensure_indexes`** adds four uniqueness constraints for the new labels.
- **`GraphBuilder.full_sync(..., repo=...)`** now merges a `:Repo` node first, stamps `repo=<slug>` on every other node, and mints an `:Executor` node + `(PR)-[:HANDLED_BY {valid_from}]->(Executor)` edge when `TrackedPR.owned_by` is one of `copilot`, `foundry`, `claude_code`. Skipped for `caretaker` (default no-delegation).
- **`admin.state_loader`** threads `f"{owner}/{name}"` into the builder.
- **CheckRun emission deliberately deferred** to M5 (live events) with inline rationale — `TrackedPR` doesn't carry enough check metadata to synthesise a useful node during full-sync.
- **7 new tests** in `tests/test_graph_builder_m3.py` cover Repo slug, `unknown/unknown` fallback, per-node `repo` scalar, copilot/foundry/claude_code executor paths with bitemporal `valid_from`, no-executor for `caretaker`, and Repo merged first.

## Why this ordering

M4 (compaction) and M6 (fleet graph) both query on `repo` to keep tenant data isolated. M5 (core memory) attaches `AgentCoreMemory` nodes to the owning `Repo`. Shipping tenant scoping first prevents a second migration when those land.

## Test plan

- [x] `ruff check` + `ruff format --check` on M3 scope — clean
- [x] `mypy src/caretaker/graph src/caretaker/admin/state_loader.py` — clean
- [x] `pytest tests/test_graph_builder_m3.py tests/test_graph_builder_m2.py tests/test_graph_writer.py` — 20 passed
- [x] Full suite: 927 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)