### PR TITLE
feat(memory-graph): M4 — tiered compaction + salience scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,45 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Memory graph — M4: tiered compaction + salience scoring
+
+Fourth milestone of the memory-graph plan (`docs/memory-graph-plan.md`
+§4). Turns the unbounded tier-0 firehose of `:Run` / `:AuditEvent` /
+`:CausalEvent` nodes into a bounded, tiered memory: runs older than 30
+days roll up into weekly `:RunSummaryWeek` nodes and low-salience rows
+get pruned on a nightly heartbeat. Goals, skills, and pinned nodes are
+never candidates — safety over completeness.
+
+- New `NodeType.RUN_SUMMARY_WEEK` plus `RelType.LEARNED_IN` so the
+  skill crystalliser can link a promoted skill back to the ISO-week
+  rollup it was learned in. Uniqueness constraint shipped in
+  `GraphStore.ensure_indexes`.
+- New `src/caretaker/graph/compaction.py`: pure-stdlib
+  `compute_salience` implementing the weighted sum from the plan
+  (`0.3 * escalation_count + 0.3 * unexpected_outcome +
+  0.2 * recency_decay + 0.2 * connectivity`), plus async
+  `compact_tier0_to_tier1`, `prune_low_salience`, and a `run_nightly`
+  one-shot that chains them. Every pruning path is gated on the
+  `pinned: true` flag, a 30-day age cutoff, and tenant scoping via
+  `n.repo = $repo` so cross-tenant data can't leak into another
+  repo's compaction.
+- New `GraphStore.list_nodes_with_properties` + `delete_node`
+  compaction primitives so the cypher stays out of the compaction
+  module and unit tests can swap in a fake store trivially.
+- New `POST /api/admin/graph/compact {repo}` endpoint mounted on the
+  existing OIDC-gated router, returning the same `{rolled_up_runs,
+  pruned}` counter dict the nightly loop emits.
+- `admin.state_loader.build_refresh_task` now fires
+  `compaction.run_nightly` at most once every 24 hours, tracked via a
+  monotonic timestamp in the refresh-loop closure. All failures are
+  logged and swallowed — a degraded Neo4j must never wedge the
+  refresh task.
+- 10 new tests in `tests/test_graph_compaction.py` exercise salience
+  bounds, escalation-count dominance, weekly rollup counters, the
+  age + pinned + label-whitelist pruning gates, and the nightly
+  orchestrator's combined behaviour via a `RecordingCompactionStore`
+  extending the M3 fake-store pattern.
+
 ### Memory graph — M8: OTel GenAI span instrumentation
 
 Eighth milestone of the memory-graph plan (`docs/memory-graph-plan.md`

--- a/src/caretaker/admin/graph_api.py
+++ b/src/caretaker/admin/graph_api.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 
 from caretaker.admin.auth import UserInfo, require_session
+from caretaker.graph import compaction
 from caretaker.graph.models import GraphStats, SubGraph  # noqa: TC001 (response models)
 from caretaker.graph.store import GraphStore  # noqa: TC001 (runtime-used)
 
@@ -101,3 +102,37 @@ async def pr_lifecycle(
 ) -> SubGraph:
     """Return the full lifecycle graph for a PR."""
     return await _get_store().get_neighbors(f"pr:{number}", depth=2)
+
+
+# ── Compaction (M4) ────────────────────────────────────────────────────────
+
+
+# Mounted on a sibling ``/api/admin`` path rather than ``/api/graph`` so
+# it sits alongside the rest of the dashboard's state-mutation endpoints
+# (see ``admin.api``). The OIDC session dependency is identical so the
+# same allowlist governs who can kick off compaction.
+admin_router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+
+@admin_router.post("/graph/compact")
+async def trigger_graph_compaction(
+    payload: dict[str, Any] = Body(..., description="{'repo': 'owner/name'}"),
+    _user: UserInfo = Depends(require_session),
+) -> dict[str, int]:
+    """Run the nightly compaction pass on-demand.
+
+    Rolls up the last ISO week of ``:Run`` nodes for ``repo`` into a
+    single ``:RunSummaryWeek`` node then prunes low-salience tier-0
+    rows older than 30 days. Returns the same counter dict that the
+    24-hour heartbeat emits so operators can compare on-demand vs
+    nightly runs.
+    """
+    repo = str(payload.get("repo", "")).strip()
+    if not repo or "/" not in repo:
+        raise HTTPException(
+            status_code=400,
+            detail="Body requires {'repo': '<owner>/<name>'}",
+        )
+    counts = await compaction.run_nightly(_get_store(), repo)
+    logger.info("Manual graph compaction on %s: %s", repo, counts)
+    return counts

--- a/src/caretaker/admin/state_loader.py
+++ b/src/caretaker/admin/state_loader.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from typing import TYPE_CHECKING, Any
 
 from caretaker.github_app import (
@@ -87,6 +88,12 @@ def build_refresh_task(data: AdminDataAccess) -> asyncio.Task[None] | None:
     # nonlocal-assignable variable so the closure below can mutate it.
     persistent_store: Any = None
     writer_started = False
+    # M4: track the wall-clock of the last nightly compaction pass so the
+    # refresh loop only kicks it off once every 24h even though the loop
+    # itself runs every minute. Stored as a monotonic timestamp so clock
+    # skew on the host doesn't cause us to skip or double-fire.
+    last_compaction_at: float | None = None
+    compaction_interval_seconds = 24 * 60 * 60
 
     async def _sync_graph(state) -> None:  # type: ignore[no-untyped-def]
         """Best-effort Neo4j sync. Swallows all errors — graph is optional."""
@@ -114,6 +121,35 @@ def build_refresh_task(data: AdminDataAccess) -> asyncio.Task[None] | None:
             logger.debug("Graph sync counts: %s", counts)
         except Exception:
             logger.warning("Graph sync failed", exc_info=True)
+
+    async def _maybe_run_compaction() -> None:
+        """Fire :func:`compaction.run_nightly` at most once per 24h.
+
+        Compaction is best-effort (``docs/memory-graph-plan.md`` §10):
+        a Neo4j hiccup must never wedge the refresh loop, so every
+        failure is logged and swallowed. The last-run timestamp is
+        tracked in the closure scope rather than on the store to keep
+        the scheduling state local to the refresh task.
+        """
+        nonlocal last_compaction_at
+        if persistent_store is None:
+            return
+        now = time.monotonic()
+        if last_compaction_at is not None and (
+            now - last_compaction_at < compaction_interval_seconds
+        ):
+            return
+        try:
+            from caretaker.graph import compaction
+
+            counts = await compaction.run_nightly(persistent_store, f"{owner}/{name}")
+            logger.info("Nightly graph compaction for %s: %s", repo, counts)
+        except Exception:
+            logger.warning("Nightly graph compaction failed for %s", repo, exc_info=True)
+        finally:
+            # Mark the attempt regardless of outcome so a persistently
+            # broken Neo4j doesn't turn the loop into a hot spin.
+            last_compaction_at = now
 
     async def _loop() -> None:
         # WARNING level so the line is visible under uvicorn's default
@@ -147,6 +183,7 @@ def build_refresh_task(data: AdminDataAccess) -> asyncio.Task[None] | None:
                         len(state.run_history),
                     )
                 await _sync_graph(state)
+                await _maybe_run_compaction()
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/src/caretaker/graph/compaction.py
+++ b/src/caretaker/graph/compaction.py
@@ -1,0 +1,531 @@
+"""Tiered compaction + salience scoring — Milestone M4 of the memory-graph plan.
+
+The per-tenant Neo4j graph grows without bound in its tier-0 form (raw
+``:Run`` / ``:AuditEvent`` / ``:CausalEvent`` rows). M4 adds the
+forgetting policy called out in ``docs/memory-graph-plan.md`` §4:
+
+* **Tier 0 → Tier 1** — a nightly rollup collapses every ``:Run`` in a
+  given ISO week into a single ``:RunSummaryWeek{repo, week_of, ...}``
+  node. The week node carries aggregated counters so the admin
+  dashboard can keep rendering weekly telemetry after the raw rows
+  have been evicted.
+* **Tier 1 → Tier 2** — skills already persisted in ``InsightStore``
+  are the durable procedural distillation. This module does not
+  promote skills itself; it only ships the ``LEARNED_IN`` edge type
+  (see :class:`caretaker.graph.models.RelType`) so the crystalliser
+  can link a skill back to the week it was learned in.
+* **Pruning** — after the rollup has landed, runs / causal events /
+  audit events older than ``cutoff_days`` are deleted when their
+  salience score falls below the per-tenant threshold. Any node
+  carrying ``pinned: true`` is preserved unconditionally, and
+  ``:Goal`` + ``:Skill`` nodes are never candidates for deletion
+  (safety over completeness — ``docs/memory-graph-plan.md`` §4.1
+  lists these as immutable exemptions).
+
+Salience scoring (:func:`compute_salience`) is pure stdlib — the
+formula is the weighted sum in ``docs/memory-graph-plan.md`` §4.2:
+
+    salience = 0.3 * escalation_count
+             + 0.3 * unexpected_outcome
+             + 0.2 * recency_decay
+             + 0.2 * connectivity
+
+Each component is normalised to ``[0, 1]`` before weighting so the
+total is also bounded there, making the threshold configuration
+tenant-portable.
+
+Contract for call sites: :func:`run_nightly` is best-effort. It is
+invoked on a 24-hour heartbeat from the admin refresh loop and from
+the ``POST /api/admin/graph/compact`` endpoint. Both paths swallow
+exceptions — compaction drift is auto-healed on the next tick, and we
+never want a slow Neo4j to wedge the orchestrator.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from typing import TYPE_CHECKING, Any, Protocol
+
+from caretaker.graph.models import GraphNode, NodeType
+
+if TYPE_CHECKING:
+    from caretaker.state.models import RunSummary
+
+logger = logging.getLogger(__name__)
+
+
+# ── Store surface ────────────────────────────────────────────────────────────
+#
+# The compaction routines take a :class:`GraphStore`-shaped object rather
+# than the concrete class so unit tests can pass a fake that records the
+# mutations. Only the subset actually used here is in the protocol — this
+# keeps the surface narrow and the test fake small.
+
+
+class _SupportsCompaction(Protocol):
+    async def merge_node(self, label: str, node_id: str, properties: dict[str, Any]) -> None: ...
+
+    async def list_nodes_with_properties(
+        self,
+        label: str,
+        *,
+        where: str | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]: ...
+
+    async def delete_node(self, label: str, node_id: str) -> None: ...
+
+
+# ── Salience scoring ────────────────────────────────────────────────────────
+
+# The weights below are load-bearing: the task spec requires them to sum
+# to ``1.0`` so the resulting salience lies in ``[0, 1]`` whenever every
+# component is itself normalised to ``[0, 1]``. Keep in sync with the
+# prose in ``docs/memory-graph-plan.md`` §4.2.
+_W_ESCALATION = 0.3
+_W_UNEXPECTED = 0.3
+_W_RECENCY = 0.2
+_W_CONNECTIVITY = 0.2
+
+# Normalisation caps — picked so "a full run's worth of escalations /
+# errors / neighbours" maps onto 1.0. The exact values are heuristics,
+# not a contract; they only matter insofar as they give
+# ``compute_salience`` a monotone, bounded output.
+_ESCALATION_NORM_CAP = 10.0
+_CONNECTIVITY_NORM_CAP = 20.0
+_RECENCY_HALF_LIFE_DAYS = 30.0
+
+
+@dataclass(frozen=True)
+class _SalienceInputs:
+    """Normalised components of :func:`compute_salience`.
+
+    Exposed via the dataclass so tests / operators can introspect
+    intermediate values without re-deriving them from the weighted sum.
+    """
+
+    escalation_count: float
+    unexpected_outcome: float
+    recency_decay: float
+    connectivity: float
+
+
+def _normalise(value: float, cap: float) -> float:
+    """Clamp ``value / cap`` to ``[0, 1]``. Zero-cap falls back to zero."""
+    if cap <= 0 or not math.isfinite(value):
+        return 0.0
+    ratio = value / cap
+    if ratio < 0.0:
+        return 0.0
+    if ratio > 1.0:
+        return 1.0
+    return ratio
+
+
+def _age_days(run_at: datetime | None, *, now: datetime | None = None) -> float:
+    """Age in days between ``run_at`` and ``now`` (``UTC`` fallback).
+
+    Naive datetimes are treated as UTC — the orchestrator historically
+    emits a mix of aware / naive timestamps (see the 2026-W17 refactor
+    in ``state/models.py``) and compaction must not crash on the older
+    rows.
+    """
+    if run_at is None:
+        return float("inf")
+    reference = now or datetime.now(UTC)
+    if run_at.tzinfo is None:
+        run_at = run_at.replace(tzinfo=UTC)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=UTC)
+    delta = reference - run_at
+    return max(delta.total_seconds() / 86400.0, 0.0)
+
+
+def _run_escalation_count(run: Any) -> int:
+    """Sum every per-agent escalation counter on a ``RunSummary`` duck.
+
+    The runtime type is :class:`caretaker.state.models.RunSummary` but
+    callers occasionally pass a dict loaded from Neo4j (``list_nodes_
+    with_properties`` returns raw property bags). We treat both
+    uniformly via ``getattr`` / ``dict.get`` so the scorer works
+    against either shape without the caller having to rehydrate the
+    pydantic model.
+    """
+    fields = (
+        "prs_escalated",
+        "issues_escalated",
+        "stale_assignments_escalated",
+        "goal_escalation_count",
+        "escalation_items_found",
+    )
+    total = 0
+    for name in fields:
+        value = _get(run, name, 0)
+        try:
+            total += int(value or 0)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _run_unexpected_outcome(run: Any) -> float:
+    """Score ``run``'s "did something surprising happen?" in ``[0, 1]``.
+
+    Signals (highest-weight first):
+
+    * ``errors`` list is non-empty → 1.0 (hard failure recorded).
+    * ``escalation_rate`` ≥ 0.5 → 1.0 (majority of items escalated).
+    * otherwise we fall back to the escalation-rate verbatim since it's
+      already a ratio.
+    """
+    errors = _get(run, "errors", None)
+    if errors:
+        # ``errors`` may arrive as a list or a JSON-encoded string when
+        # rehydrated from Neo4j; both non-empty cases count as hard.
+        try:
+            if len(errors) > 0:
+                return 1.0
+        except TypeError:
+            return 1.0
+    rate = _get(run, "escalation_rate", 0.0) or 0.0
+    try:
+        rate_f = float(rate)
+    except (TypeError, ValueError):
+        return 0.0
+    if rate_f >= 0.5:
+        return 1.0
+    if rate_f < 0.0:
+        return 0.0
+    return rate_f
+
+
+def _get(obj: Any, name: str, default: Any) -> Any:
+    """``getattr`` → ``dict.get`` fallback so RunSummary + dicts both work."""
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def compute_salience(
+    run: RunSummary | dict[str, Any] | Any,
+    *,
+    connectivity: int | None = None,
+    now: datetime | None = None,
+) -> float:
+    """Return the salience of ``run`` in ``[0, 1]``.
+
+    ``run`` may be a :class:`RunSummary`, a plain dict (as returned by
+    ``GraphStore.list_nodes_with_properties``), or any object exposing
+    the same attribute names. ``connectivity`` is the degree of the
+    corresponding ``:Run`` / ``:CausalEvent`` node in the causal-chain
+    subgraph; when the caller does not have it we read ``connectivity``
+    off the object itself (defaulting to zero — unknown degree is
+    treated as low salience, which is conservative for pruning).
+
+    The individual components are each normalised to ``[0, 1]`` so that
+    the weighted sum stays bounded. See module docstring for the
+    weights.
+    """
+    inputs = _SalienceInputs(
+        escalation_count=_normalise(_run_escalation_count(run), _ESCALATION_NORM_CAP),
+        unexpected_outcome=max(0.0, min(1.0, _run_unexpected_outcome(run))),
+        recency_decay=math.exp(
+            -_age_days(_coerce_datetime(_get(run, "run_at", None)), now=now)
+            / _RECENCY_HALF_LIFE_DAYS
+        ),
+        connectivity=_normalise(
+            float(connectivity if connectivity is not None else _get(run, "connectivity", 0) or 0),
+            _CONNECTIVITY_NORM_CAP,
+        ),
+    )
+    salience = (
+        _W_ESCALATION * inputs.escalation_count
+        + _W_UNEXPECTED * inputs.unexpected_outcome
+        + _W_RECENCY * inputs.recency_decay
+        + _W_CONNECTIVITY * inputs.connectivity
+    )
+    # Floating-point drift from the weighted sum can push the value a
+    # hair outside ``[0, 1]``; clamp so the contract with the threshold
+    # check in :func:`prune_low_salience` is watertight.
+    if salience < 0.0:
+        return 0.0
+    if salience > 1.0:
+        return 1.0
+    return salience
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    """Best-effort parse of an ISO-8601 string or pass-through datetime."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+# ── Tier-0 → Tier-1 rollup ──────────────────────────────────────────────────
+
+
+def _iso_week_bounds(week_of: date) -> tuple[datetime, datetime, str]:
+    """Return ``[start, end)`` UTC datetimes + canonical ``YYYY-WNN`` key.
+
+    ``week_of`` is normalised to the Monday at the start of its ISO week
+    so callers can pass any day and still land on the same bucket.
+    """
+    iso_year, iso_week, _ = week_of.isocalendar()
+    monday = date.fromisocalendar(iso_year, iso_week, 1)
+    start = datetime(monday.year, monday.month, monday.day, tzinfo=UTC)
+    end = start + timedelta(days=7)
+    key = f"{iso_year:04d}-W{iso_week:02d}"
+    return start, end, key
+
+
+async def compact_tier0_to_tier1(
+    store: _SupportsCompaction,
+    repo: str,
+    week_of: date,
+) -> GraphNode:
+    """Merge a ``:RunSummaryWeek`` rollup for ``repo`` and the ISO week of ``week_of``.
+
+    Scans every ``:Run{repo=$repo}`` node whose ``run_at`` falls inside
+    the ISO week containing ``week_of`` and aggregates them into a
+    single tier-1 node carrying:
+
+    * ``run_count`` — number of runs rolled up.
+    * ``prs_merged_total`` / ``issues_triaged_total`` — summed
+      counters.
+    * ``escalation_rate_mean`` — arithmetic mean of per-run escalation
+      rates (``0.0`` for an empty bucket).
+    * ``top_skill_ids`` — kept as an empty list here so the upstream
+      skill-crystalliser can populate it when it promotes a weekly
+      skill via the new ``LEARNED_IN`` edge. Kept as a property (not
+      an edge) because an empty list is cheaper to write than a round
+      trip through the driver.
+
+    Returns the merged :class:`GraphNode` so call sites can log or
+    surface it via the admin API.
+    """
+    start, end, key = _iso_week_bounds(week_of)
+
+    runs = await store.list_nodes_with_properties(
+        NodeType.RUN.value,
+        where=(
+            "n.repo = $repo AND n.run_at >= $start AND n.run_at < $end "
+            "AND n.run_at IS NOT NULL AND n.run_at <> ''"
+        ),
+        params={
+            "repo": repo,
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        },
+    )
+
+    run_count = len(runs)
+    prs_merged_total = 0
+    issues_triaged_total = 0
+    escalation_rates: list[float] = []
+    for row in runs:
+        prs_merged_total += int(row.get("prs_merged") or 0)
+        issues_triaged_total += int(row.get("issues_triaged") or 0)
+        rate = row.get("escalation_rate")
+        if rate is None:
+            continue
+        try:
+            escalation_rates.append(float(rate))
+        except (TypeError, ValueError):
+            continue
+
+    escalation_rate_mean = (
+        sum(escalation_rates) / len(escalation_rates) if escalation_rates else 0.0
+    )
+
+    node_id = f"runweek:{repo}:{key}"
+    properties: dict[str, Any] = {
+        "repo": repo,
+        "week_of": start.date().isoformat(),
+        "week_key": key,
+        "run_count": run_count,
+        "prs_merged_total": prs_merged_total,
+        "issues_triaged_total": issues_triaged_total,
+        "escalation_rate_mean": escalation_rate_mean,
+        "top_skill_ids": [],
+        "rolled_up_at": datetime.now(UTC).isoformat(),
+    }
+    await store.merge_node(NodeType.RUN_SUMMARY_WEEK.value, node_id, properties)
+
+    return GraphNode(
+        id=node_id,
+        type=NodeType.RUN_SUMMARY_WEEK.value,
+        label=f"{repo} {key}",
+        properties=properties,
+    )
+
+
+# ── Pruning pass ────────────────────────────────────────────────────────────
+
+
+# Labels that are candidates for salience-based pruning. Kept as a
+# module-level constant so the "never delete Goal / Skill / Repo /
+# RunSummaryWeek" invariant is discoverable — if you add a label
+# here, update the safety doc in ``docs/memory-graph-plan.md`` §4.1.
+_PRUNABLE_LABELS: tuple[str, ...] = (
+    NodeType.RUN.value,
+    NodeType.AUDIT_EVENT.value,
+    NodeType.CAUSAL_EVENT.value,
+)
+
+
+async def prune_low_salience(
+    store: _SupportsCompaction,
+    repo: str,
+    *,
+    threshold: float = 0.25,
+    cutoff_days: int = 30,
+    now: datetime | None = None,
+) -> int:
+    """Delete low-salience tier-0 nodes older than ``cutoff_days``.
+
+    Walks ``:Run``, ``:AuditEvent``, and ``:CausalEvent`` scoped to
+    ``repo``; computes each node's salience via :func:`compute_salience`
+    and deletes it when:
+
+    1. ``run_at`` / ``observed_at`` is older than ``cutoff_days``; and
+    2. salience is strictly below ``threshold``; and
+    3. the node is not ``pinned: true``.
+
+    ``:Goal`` and ``:Skill`` nodes are **never** deleted — they are the
+    durable semantic / procedural tier and are protected at the label
+    level rather than via a per-node pin. Returns the total count of
+    nodes actually deleted.
+    """
+    reference = now or datetime.now(UTC)
+    cutoff = reference - timedelta(days=cutoff_days)
+    deleted_total = 0
+
+    for label in _PRUNABLE_LABELS:
+        rows = await store.list_nodes_with_properties(
+            label,
+            where="n.repo = $repo",
+            params={"repo": repo},
+        )
+        for row in rows:
+            # Safety gate 1: explicit pin. Stored as a boolean in Neo4j
+            # but may arrive as the string "true" from some older
+            # writers — normalise before the check.
+            if _is_pinned(row.get("pinned")):
+                continue
+
+            # Safety gate 2: age. The timestamp we read off the node
+            # depends on the label — runs use ``run_at``, audit and
+            # causal events use ``observed_at``. Fall back across both
+            # so a partially-stamped node doesn't slip through.
+            timestamp = _coerce_datetime(row.get("run_at") or row.get("observed_at"))
+            if timestamp is None:
+                # No timestamp means we can't reason about age — skip
+                # rather than risk deleting a load-bearing node.
+                continue
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.replace(tzinfo=UTC)
+            if timestamp > cutoff:
+                continue
+
+            salience = compute_salience(row, now=reference)
+            if salience >= threshold:
+                continue
+
+            node_id = row.get("id")
+            if not isinstance(node_id, str) or not node_id:
+                continue
+            try:
+                await store.delete_node(label, node_id)
+            except Exception:  # store errors are best-effort
+                logger.warning(
+                    "prune_low_salience: failed to delete %s %r", label, node_id, exc_info=True
+                )
+                continue
+            deleted_total += 1
+
+    return deleted_total
+
+
+def _is_pinned(value: Any) -> bool:
+    """Normalise the ``pinned`` property across bool / str / int shapes."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes"}
+    if isinstance(value, int):
+        return value != 0
+    return False
+
+
+# ── Nightly orchestrator entry point ─────────────────────────────────────────
+
+
+async def run_nightly(
+    store: _SupportsCompaction,
+    repo: str,
+    *,
+    week_of: date | None = None,
+    threshold: float = 0.25,
+    cutoff_days: int = 30,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """One-shot compaction job: tier-0 → tier-1 rollup, then prune.
+
+    Runs the ISO-week rollup for the week containing ``week_of``
+    (default: last week, i.e. ``today - 7d``) and then the
+    :func:`prune_low_salience` pass. Returns a counter dict:
+
+    * ``rolled_up_runs``: how many ``:Run`` rows fed the rollup.
+    * ``pruned``: how many tier-0 nodes were deleted.
+
+    Exceptions from either phase are logged and swallowed — compaction
+    is best-effort by design, per ``docs/memory-graph-plan.md`` §10.
+    """
+    reference = now or datetime.now(UTC)
+    target_week = week_of or (reference.date() - timedelta(days=7))
+
+    rolled_up_runs = 0
+    try:
+        week_node = await compact_tier0_to_tier1(store, repo, target_week)
+        run_count_raw = week_node.properties.get("run_count", 0)
+        if isinstance(run_count_raw, int):
+            rolled_up_runs = run_count_raw
+        elif isinstance(run_count_raw, (str, float)):
+            try:
+                rolled_up_runs = int(run_count_raw)
+            except (TypeError, ValueError):
+                rolled_up_runs = 0
+    except Exception:
+        logger.warning("compact_tier0_to_tier1 failed for %s", repo, exc_info=True)
+
+    pruned = 0
+    try:
+        pruned = await prune_low_salience(
+            store,
+            repo,
+            threshold=threshold,
+            cutoff_days=cutoff_days,
+            now=reference,
+        )
+    except Exception:
+        logger.warning("prune_low_salience failed for %s", repo, exc_info=True)
+
+    return {"rolled_up_runs": rolled_up_runs, "pruned": pruned}
+
+
+__all__ = [
+    "compact_tier0_to_tier1",
+    "compute_salience",
+    "prune_low_salience",
+    "run_nightly",
+]

--- a/src/caretaker/graph/models.py
+++ b/src/caretaker/graph/models.py
@@ -31,6 +31,14 @@ class NodeType(StrEnum):
     COMMENT = "Comment"
     CHECK_RUN = "CheckRun"
     EXECUTOR = "Executor"
+    # ── Added in M4 of the memory-graph plan ────────────────────────────
+    # Tier-1 rollup node emitted by the nightly compaction job. Each
+    # ``:RunSummaryWeek`` aggregates every ``:Run`` whose ``run_at``
+    # falls inside one ISO week for a given repo so raw tier-0 rows
+    # can be pruned after 30 days without losing weekly telemetry.
+    # Skills that are crystallised out of a weekly rollup link back
+    # via ``Skill-[:LEARNED_IN]->RunSummaryWeek`` provenance.
+    RUN_SUMMARY_WEEK = "RunSummaryWeek"
 
 
 class RelType(StrEnum):
@@ -59,6 +67,11 @@ class RelType(StrEnum):
     VALIDATED_BY = "VALIDATED_BY"  # Skill → CausalEvent
     AFFECTED = "AFFECTED"  # Run → Goal (with before/after score)
     HANDLED_BY = "HANDLED_BY"  # PR → Executor (copilot / foundry / claude_code)
+    # ── Added in M4 of the memory-graph plan ────────────────────────────
+    # Skill → RunSummaryWeek provenance: lets callers answer "which
+    # weekly rollup was this skill crystallised from?" once the
+    # tier-0 → tier-1 compaction pass learns a new skill.
+    LEARNED_IN = "LEARNED_IN"
 
 
 class GraphNode(BaseModel):

--- a/src/caretaker/graph/store.py
+++ b/src/caretaker/graph/store.py
@@ -51,6 +51,8 @@ class GraphStore:
             "CREATE CONSTRAINT IF NOT EXISTS FOR (c:Comment) REQUIRE c.id IS UNIQUE",
             "CREATE CONSTRAINT IF NOT EXISTS FOR (cr:CheckRun) REQUIRE cr.id IS UNIQUE",
             "CREATE CONSTRAINT IF NOT EXISTS FOR (e:Executor) REQUIRE e.id IS UNIQUE",
+            # M4: tier-1 weekly rollup node constraint.
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (w:RunSummaryWeek) REQUIRE w.id IS UNIQUE",
         ]
         async with self._driver.session(database=self._database) as session:
             for q in queries:
@@ -88,6 +90,47 @@ class GraphStore:
         async with self._driver.session(database=self._database) as session:
             await session.run("MATCH (n) DETACH DELETE n")
         logger.warning("Graph store cleared")
+
+    # ── Compaction primitives (M4) ────────────────────────────────────────
+    #
+    # These are the minimum store-level hooks the tiered compaction job
+    # needs so the raw cypher stays out of ``compaction.py`` and the fake
+    # stores used by unit tests can mirror them without speaking Neo4j.
+
+    async def list_nodes_with_properties(
+        self,
+        label: str,
+        *,
+        where: str | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return raw property dicts for every ``label`` node matching ``where``.
+
+        ``where`` is an optional cypher fragment that may reference the node
+        alias ``n`` (e.g. ``"n.repo = $repo"``). ``params`` are passed
+        through to the driver. The returned list preserves insertion order
+        from Neo4j and each entry is the plain ``dict(n)`` representation
+        — callers that need degree or relationships should go through
+        ``get_neighbors`` instead.
+        """
+        clause = f"WHERE {where} " if where else ""
+        query = f"MATCH (n:{label}) {clause}RETURN n"
+        rows: list[dict[str, Any]] = []
+        async with self._driver.session(database=self._database) as session:
+            result = await session.run(query, **(params or {}))
+            async for record in result:
+                rows.append(dict(record["n"]))
+        return rows
+
+    async def delete_node(self, label: str, node_id: str) -> None:
+        """Detach-delete a single node by ``id``.
+
+        Used by the tiered compaction prune pass (M4). Missing nodes are a
+        no-op — the query simply matches zero rows.
+        """
+        query = f"MATCH (n:{label} {{id: $id}}) DETACH DELETE n"
+        async with self._driver.session(database=self._database) as session:
+            await session.run(query, id=node_id)
 
     # ── Read operations ───────────────────────────────────────────────────
 

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -187,11 +187,18 @@ async def _lifespan(application: FastAPI):  # type: ignore[no-untyped-def]
             neo4j_url = os.environ.get("NEO4J_URL", "")
             if neo4j_url:
                 try:
+                    from caretaker.admin.graph_api import (
+                        admin_router as graph_admin_router,
+                    )
                     from caretaker.admin.graph_api import configure as configure_graph
                     from caretaker.admin.graph_api import router as graph_router
 
                     await configure_graph()
                     application.include_router(graph_router)
+                    # M4 compaction endpoint — lives on ``/api/admin``
+                    # but shares the same store handle as the graph
+                    # router so we mount it in the same branch.
+                    application.include_router(graph_admin_router)
                     logger.info("Graph API enabled (Neo4j at %s)", neo4j_url)
                 except Exception:
                     logger.warning("Failed to initialise graph API", exc_info=True)

--- a/tests/test_graph_compaction.py
+++ b/tests/test_graph_compaction.py
@@ -1,0 +1,388 @@
+"""Tests for M4 of the memory-graph plan — tiered compaction + salience.
+
+Mirrors the ``RecordingStore`` pattern from ``tests/test_graph_builder_m3.py``
+but extends it with a ``deleted`` list so :func:`prune_low_salience` can be
+exercised without a live Neo4j. The scoring tests stay pure-stdlib and
+exercise :func:`compute_salience` on synthetic :class:`RunSummary`
+instances.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from caretaker.graph import compaction
+from caretaker.graph.models import NodeType
+from caretaker.state.models import RunSummary
+
+
+class RecordingCompactionStore:
+    """Fake :class:`GraphStore` exposing the compaction-protocol surface.
+
+    Extends the M3 ``RecordingStore`` pattern with ``deleted`` + a
+    pre-seeded ``node_rows`` map so tests can stage tier-0 rows, run
+    the compaction routines, then assert on what was merged / deleted.
+    """
+
+    def __init__(self) -> None:
+        self.nodes: list[tuple[str, str, dict[str, Any]]] = []
+        self.deleted: list[tuple[str, str]] = []
+        # label → list of property dicts returned by ``list_nodes_*``.
+        # Tests populate this directly; the compaction code never
+        # mutates it.
+        self.node_rows: dict[str, list[dict[str, Any]]] = {}
+
+    async def ensure_indexes(self) -> None:
+        # Unused by compaction but kept for symmetry with the real
+        # store — avoids surprise attribute errors if a future caller
+        # routes through here.
+        return None
+
+    async def merge_node(self, label: str, node_id: str, props: dict[str, Any]) -> None:
+        self.nodes.append((label, node_id, props))
+
+    async def list_nodes_with_properties(
+        self,
+        label: str,
+        *,
+        where: str | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return seeded rows, filtered by the ``repo`` param + run_at window.
+
+        The real store pushes filtering into cypher, but the fake
+        reproduces the subset compaction actually uses: tenant scoping
+        via ``n.repo = $repo`` and run_at bounds for the rollup query.
+        """
+        rows = list(self.node_rows.get(label, []))
+        if params is None:
+            return rows
+        repo = params.get("repo")
+        if repo is not None:
+            rows = [r for r in rows if r.get("repo") == repo]
+        start = params.get("start")
+        end = params.get("end")
+        if start and end:
+            rows = [
+                r
+                for r in rows
+                if isinstance(r.get("run_at"), str) and r["run_at"] and start <= r["run_at"] < end
+            ]
+        return rows
+
+    async def delete_node(self, label: str, node_id: str) -> None:
+        self.deleted.append((label, node_id))
+
+
+# ── Salience scoring ────────────────────────────────────────────────────────
+
+
+def test_compute_salience_is_bounded_zero_to_one() -> None:
+    """The weighted sum must stay in ``[0, 1]`` for any plausible input."""
+    # Freshly-emitted run with no escalations, no errors, high connectivity:
+    # the weights sum to 1 so the bound is contract-level.
+    run = RunSummary(
+        run_at=datetime.now(UTC),
+        prs_escalated=100,
+        issues_escalated=100,
+        goal_escalation_count=50,
+        errors=["failure-a", "failure-b"],
+        escalation_rate=1.0,
+    )
+    value = compaction.compute_salience(run, connectivity=9999)
+    assert 0.0 <= value <= 1.0
+
+    # Ancient run, no signal at all — still bounded.
+    ancient = RunSummary(
+        run_at=datetime(2020, 1, 1, tzinfo=UTC),
+        prs_escalated=0,
+        errors=[],
+        escalation_rate=0.0,
+    )
+    value = compaction.compute_salience(ancient, connectivity=0)
+    assert 0.0 <= value <= 1.0
+
+
+def test_high_escalation_run_outranks_low_escalation_run() -> None:
+    """The escalation signal must dominate: same-age runs rank by escalations."""
+    now = datetime(2026, 4, 21, tzinfo=UTC)
+    run_at = now - timedelta(days=1)
+
+    low = RunSummary(
+        run_at=run_at,
+        prs_escalated=0,
+        issues_escalated=0,
+        errors=[],
+        escalation_rate=0.0,
+    )
+    high = RunSummary(
+        run_at=run_at,
+        prs_escalated=5,
+        issues_escalated=3,
+        goal_escalation_count=2,
+        errors=["ci failure"],
+        escalation_rate=0.8,
+    )
+    low_score = compaction.compute_salience(low, connectivity=0, now=now)
+    high_score = compaction.compute_salience(high, connectivity=0, now=now)
+    assert high_score > low_score
+
+
+def test_compute_salience_handles_missing_fields_gracefully() -> None:
+    """A bare dict with only ``run_at`` must not raise."""
+    now = datetime(2026, 4, 21, tzinfo=UTC)
+    value = compaction.compute_salience(
+        {"run_at": (now - timedelta(days=2)).isoformat()},
+        connectivity=None,
+        now=now,
+    )
+    assert 0.0 <= value <= 1.0
+
+
+def test_compute_salience_recency_decays_to_zero_for_very_old_runs() -> None:
+    """Runs from years ago contribute almost nothing to the recency term."""
+    now = datetime(2026, 4, 21, tzinfo=UTC)
+    ancient = RunSummary(run_at=datetime(2020, 1, 1, tzinfo=UTC))
+    # No escalations, no errors, default connectivity ⇒ only the recency
+    # term is non-zero, and it should be tiny after ≥ 6 years.
+    score = compaction.compute_salience(ancient, connectivity=0, now=now)
+    assert score < 0.05
+
+
+# ── Tier-0 → Tier-1 rollup ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_compact_tier0_to_tier1_aggregates_weekly_counters() -> None:
+    """Weekly rollup sums PRs + issues and means escalation_rate."""
+    store = RecordingCompactionStore()
+    # 2026-W16 is the week of Mon 2026-04-13. Seed three runs inside it
+    # for repo ``acme/widgets`` plus one for an unrelated repo that
+    # must be ignored.
+    week_start = datetime(2026, 4, 13, tzinfo=UTC)
+    store.node_rows[NodeType.RUN.value] = [
+        {
+            "id": f"run:{(week_start + timedelta(hours=h)).isoformat()}",
+            "repo": "acme/widgets",
+            "run_at": (week_start + timedelta(hours=h)).isoformat(),
+            "prs_merged": pm,
+            "issues_triaged": it,
+            "escalation_rate": er,
+        }
+        for h, pm, it, er in [(2, 3, 5, 0.1), (10, 0, 2, 0.2), (40, 2, 1, 0.3)]
+    ]
+    store.node_rows[NodeType.RUN.value].append(
+        {
+            "id": "run:2026-04-15T00:00:00+00:00",
+            "repo": "other/repo",
+            "run_at": "2026-04-15T00:00:00+00:00",
+            "prs_merged": 99,
+            "issues_triaged": 99,
+            "escalation_rate": 0.99,
+        }
+    )
+
+    node = await compaction.compact_tier0_to_tier1(store, "acme/widgets", date(2026, 4, 15))
+    assert node.type == NodeType.RUN_SUMMARY_WEEK.value
+    assert node.properties["repo"] == "acme/widgets"
+    assert node.properties["week_of"] == "2026-04-13"
+    assert node.properties["week_key"] == "2026-W16"
+    assert node.properties["run_count"] == 3
+    assert node.properties["prs_merged_total"] == 5  # 3 + 0 + 2
+    assert node.properties["issues_triaged_total"] == 8  # 5 + 2 + 1
+    assert node.properties["escalation_rate_mean"] == pytest.approx(0.2)
+    assert node.properties["top_skill_ids"] == []
+    assert "rolled_up_at" in node.properties
+
+    # Exactly one merged node — the rollup, under the expected label.
+    assert len(store.nodes) == 1
+    label, node_id, props = store.nodes[0]
+    assert label == NodeType.RUN_SUMMARY_WEEK.value
+    assert node_id == "runweek:acme/widgets:2026-W16"
+    assert props["run_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_compact_tier0_to_tier1_empty_week_produces_zero_counters() -> None:
+    """No matching runs → a rollup node with ``run_count=0`` and mean=0.0."""
+    store = RecordingCompactionStore()
+    store.node_rows[NodeType.RUN.value] = []
+    node = await compaction.compact_tier0_to_tier1(store, "acme/widgets", date(2026, 4, 15))
+    assert node.properties["run_count"] == 0
+    assert node.properties["prs_merged_total"] == 0
+    assert node.properties["escalation_rate_mean"] == 0.0
+
+
+# ── Pruning ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prune_low_salience_deletes_aged_low_score_nodes() -> None:
+    """Default 30-day / 0.25 gate evicts stale, low-signal runs."""
+    store = RecordingCompactionStore()
+    now = datetime(2026, 4, 21, tzinfo=UTC)
+    store.node_rows[NodeType.RUN.value] = [
+        {
+            # Ancient + zero signal — should be pruned.
+            "id": "run:ancient",
+            "repo": "acme/widgets",
+            "run_at": (now - timedelta(days=120)).isoformat(),
+            "prs_escalated": 0,
+            "errors": [],
+            "escalation_rate": 0.0,
+        },
+        {
+            # Recent — age gate alone spares it regardless of salience.
+            "id": "run:yesterday",
+            "repo": "acme/widgets",
+            "run_at": (now - timedelta(days=1)).isoformat(),
+            "prs_escalated": 0,
+            "errors": [],
+            "escalation_rate": 0.0,
+        },
+        {
+            # Ancient but high escalation count → high salience spares it.
+            "id": "run:ancient-hot",
+            "repo": "acme/widgets",
+            "run_at": (now - timedelta(days=120)).isoformat(),
+            "prs_escalated": 9,
+            "issues_escalated": 9,
+            "errors": ["hard-failure"],
+            "escalation_rate": 0.9,
+        },
+    ]
+
+    pruned = await compaction.prune_low_salience(store, "acme/widgets", now=now)
+    assert pruned == 1
+    assert store.deleted == [(NodeType.RUN.value, "run:ancient")]
+
+
+@pytest.mark.asyncio
+async def test_prune_low_salience_respects_pinned_flag() -> None:
+    """A pinned node is never deleted, even when stale and low-score."""
+    store = RecordingCompactionStore()
+    now = datetime(2026, 4, 21, tzinfo=UTC)
+    store.node_rows[NodeType.RUN.value] = [
+        {
+            "id": "run:pinned-bool",
+            "repo": "acme/widgets",
+            "run_at": (now - timedelta(days=400)).isoformat(),
+            "pinned": True,
+            "errors": [],
+            "escalation_rate": 0.0,
+        },
+        {
+            "id": "run:pinned-str",
+            "repo": "acme/widgets",
+            "run_at": (now - timedelta(days=400)).isoformat(),
+            # Some older writers persist ``pinned`` as a string — the
+            # prune pass must normalise both representations.
+            "pinned": "true",
+            "errors": [],
+            "escalation_rate": 0.0,
+        },
+    ]
+
+    pruned = await compaction.prune_low_salience(store, "acme/widgets", now=now)
+    assert pruned == 0
+    assert store.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_prune_low_salience_ignores_other_repos() -> None:
+    """The ``repo`` filter keeps tenant boundaries intact during pruning."""
+    store = RecordingCompactionStore()
+    now = datetime(2026, 4, 21, tzinfo=UTC)
+    store.node_rows[NodeType.RUN.value] = [
+        {
+            "id": "run:other-tenant-ancient",
+            "repo": "other/repo",
+            "run_at": (now - timedelta(days=400)).isoformat(),
+            "errors": [],
+            "escalation_rate": 0.0,
+        },
+    ]
+    pruned = await compaction.prune_low_salience(store, "acme/widgets", now=now)
+    assert pruned == 0
+    assert store.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_prune_low_salience_skips_goal_and_skill_labels() -> None:
+    """``:Goal`` / ``:Skill`` are never candidates — safety over completeness."""
+    store = RecordingCompactionStore()
+    now = datetime(2026, 4, 21, tzinfo=UTC)
+    # Seed a Goal that would look stale + low-signal if it were a Run.
+    store.node_rows[NodeType.GOAL.value] = [
+        {
+            "id": "goal:ci_health",
+            "repo": "acme/widgets",
+            "run_at": (now - timedelta(days=9999)).isoformat(),
+            "errors": [],
+            "escalation_rate": 0.0,
+        },
+    ]
+    store.node_rows[NodeType.SKILL.value] = [
+        {
+            "id": "skill:ci/unknown",
+            "repo": "acme/widgets",
+            "run_at": (now - timedelta(days=9999)).isoformat(),
+            "errors": [],
+            "escalation_rate": 0.0,
+        },
+    ]
+    # No runs present at all — prune should still return 0 and never
+    # have touched the ``Goal`` / ``Skill`` labels (the labels aren't
+    # in ``_PRUNABLE_LABELS``, so the fake store's rows for them
+    # should remain untouched).
+    pruned = await compaction.prune_low_salience(store, "acme/widgets", now=now)
+    assert pruned == 0
+    assert store.deleted == []
+    # And the Goal / Skill labels must not have been queried for
+    # deletion — cross-check by label presence in the deleted log.
+    assert not any(d[0] in {NodeType.GOAL.value, NodeType.SKILL.value} for d in store.deleted)
+
+
+# ── Nightly orchestrator ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_nightly_rolls_up_last_week_and_prunes() -> None:
+    """The one-shot entry point returns a counter dict with both stages."""
+    store = RecordingCompactionStore()
+    now = datetime(2026, 4, 21, tzinfo=UTC)
+
+    # Seed one run in last week (will roll up) and one ancient run
+    # (will prune).
+    last_week_ts = (now - timedelta(days=7)).isoformat()
+    store.node_rows[NodeType.RUN.value] = [
+        {
+            "id": f"run:{last_week_ts}",
+            "repo": "acme/widgets",
+            "run_at": last_week_ts,
+            "prs_merged": 2,
+            "issues_triaged": 1,
+            "escalation_rate": 0.1,
+            "errors": [],
+        },
+        {
+            "id": "run:ancient",
+            "repo": "acme/widgets",
+            "run_at": (now - timedelta(days=120)).isoformat(),
+            "prs_merged": 0,
+            "issues_triaged": 0,
+            "escalation_rate": 0.0,
+            "errors": [],
+        },
+    ]
+
+    counts = await compaction.run_nightly(store, "acme/widgets", now=now)
+    assert counts["rolled_up_runs"] == 1
+    assert counts["pruned"] == 1
+    # The rolled-up week node landed.
+    rollup_nodes = [n for n in store.nodes if n[0] == NodeType.RUN_SUMMARY_WEEK.value]
+    assert len(rollup_nodes) == 1
+    assert store.deleted == [(NodeType.RUN.value, "run:ancient")]


### PR DESCRIPTION
## Summary

Fourth milestone of the memory-graph plan (`docs/memory-graph-plan.md` §4.1 + §4.2). Nightly job rolls Run / CausalEvent / AuditEvent tier-0 rows into `:RunSummaryWeek` tier-1 nodes and prunes anything low-salience past 30 days.

## Changes

- **`NodeType.RUN_SUMMARY_WEEK`** + `RelType.LEARNED_IN` (Skill → RunSummaryWeek).
- **`src/caretaker/graph/compaction.py`** (new):
  - `compute_salience(run)` — weighted sum per plan §4.2 (0.3 escalation, 0.3 unexpected, 0.2 recency-decay e^(-age/30), 0.2 connectivity). Bounded [0, 1].
  - `compact_tier0_to_tier1(store, repo, week_of)` — merges one `:RunSummaryWeek` per ISO-week per repo with `run_count`, `prs_merged_total`, `issues_triaged_total`, `escalation_rate_mean`, `top_skill_ids`.
  - `prune_low_salience(store, repo, threshold=0.25, cutoff_days=30)` — deletes low-salience `:Run` / `:AuditEvent` / `:CausalEvent`. Pinned nodes + `:Goal` + `:Skill` always exempt.
  - `run_nightly(store, repo)` — rollup + prune in one call.
- **New admin endpoint** `POST /api/admin/graph/compact {repo}` behind the OIDC dependency.
- **`admin.state_loader`**: 24 h compaction heartbeat in the refresh closure. Monotonic timestamp so the interval survives clock skew. Errors swallowed — compaction is best-effort.
- **`GraphStore` primitives**: `list_nodes_with_properties`, `delete_node`, plus `:RunSummaryWeek` uniqueness constraint in `ensure_indexes`.
- **10 new tests** in `tests/test_graph_compaction.py` — salience math bounds + ordering, rollup payload, pruning honours salience floor, pinned nodes untouched.

## Rough edges

- Connectivity degree is currently read off an explicit arg / row property; computing causal-chain degree per row would cost extra cypher. Will land alongside M5 core-memory nodes.
- `pyproject.toml` mypy unused-override warnings (`neo4j.*`, `itsdangerous.*`) are pre-existing; not touched here.

## Test plan

- [x] `ruff check` + `ruff format --check` on M4 files — clean
- [x] `mypy src/caretaker/graph` — clean
- [x] `pytest tests/test_graph_compaction.py tests/test_graph_builder_m3.py -q` — 18 passed
- [x] Full suite: **960 passed, 1 skipped**, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)