### PR TITLE
feat(pr-reviewer): dual-path automated PR code reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS — auto-request reviewers on pull requests.
+#
+# Caretaker bot is listed as a reviewer for all files so it appears in the
+# "Reviewers" picker and can be requested by contributors. The bot uses its
+# own PR reviewer agent (pr_reviewer/) to post automated code reviews.
+#
+# See docs on CODEOWNERS:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global fallback — caretaker reviews everything
+* @the-care-taker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **PR Reviewer Agent** — dual-path automated code reviewer that activates when `pr_reviewer.enabled = true`:
+  - **Routing engine** (`pr_reviewer/routing.py`): scores each PR 0–100 from LOC, file count, sensitive-file patterns (workflows, auth, migrations, infra), cross-package breadth, and label signals. Score ≥ threshold (default 40) → complex path; score < threshold → fast path.
+  - **Inline LLM reviewer** (`pr_reviewer/inline_reviewer.py`): fetches the unified diff, calls the configured LLM, returns a structured `ReviewResult` (summary + verdict + per-line inline comments); posts directly as a GitHub pull-request review event (APPROVE / COMMENT / REQUEST_CHANGES).
+  - **Claude Code hand-off** (`pr_reviewer/claude_code_reviewer.py`): for complex PRs applies the `claude-code` trigger label and posts a structured `@claude` mention comment; the `anthropics/claude-code-action` workflow handles the full review asynchronously.
+  - New `PRReviewerConfig` in `config.py` (opt-in, `enabled = false` default): `routing_threshold`, `max_diff_lines`, `post_inline_comments`, `skip_draft`, `skip_labels`, `review_event`, `claude_code_label`/`claude_code_mention`.
+  - New GitHub API methods: `get_pull_diff()` (vnd.github.diff accept header), `create_review()` (POST pulls/{n}/reviews with inline comments), `request_reviewers()` (POST pulls/{n}/requested_reviewers).
+  - `PRReviewerAgent` registered in the agent registry under mode `pr-reviewer`; `pull_request` events in both `github_app/events.py` and `agents/_registry_data.py` now route to it.
+  - `.github/CODEOWNERS` — `* @the-care-taker` so the bot appears in the PR reviewer picker.
+
 - **M7 — Graph UI v2**: Five-tab admin graph page replacing the single explorer view.
   - **Explorer** tab: existing 2D/3D subgraph view with extended node-type filter list covering all M3–M6 node types (Repo, Comment, CheckRun, Executor, RunSummaryWeek, GlobalSkill, AgentCoreMemory).
   - **Timeline** tab: recharts run-history sparkline + scrollable run list on the left; click any run to load its N-hop Neo4j neighbourhood on the right. Depth selector (1–3).

--- a/src/caretaker/agents/__init__.py
+++ b/src/caretaker/agents/__init__.py
@@ -21,6 +21,7 @@ from caretaker.issue_agent.adapter import IssueAgentAdapter
 from caretaker.migration_agent.agent import MigrationAgent
 from caretaker.perf_agent.agent import PerformanceAgent
 from caretaker.pr_agent.adapter import PRAgentAdapter
+from caretaker.pr_reviewer.agent import PRReviewerAgent
 from caretaker.principal_agent.agent import PrincipalAgent
 from caretaker.refactor_agent.agent import RefactorAgent
 from caretaker.review_agent.agent import ReviewAgent
@@ -52,4 +53,5 @@ __all__ = [
     "RefactorAgent",
     "PerformanceAgent",
     "MigrationAgent",
+    "PRReviewerAgent",
 ]

--- a/src/caretaker/agents/_registry_data.py
+++ b/src/caretaker/agents/_registry_data.py
@@ -13,6 +13,7 @@ from caretaker.issue_agent.adapter import IssueAgentAdapter
 from caretaker.migration_agent.agent import MigrationAgent
 from caretaker.perf_agent.agent import PerformanceAgent
 from caretaker.pr_agent.adapter import PRAgentAdapter
+from caretaker.pr_reviewer.agent import PRReviewerAgent
 from caretaker.principal_agent.agent import PrincipalAgent
 from caretaker.refactor_agent.agent import RefactorAgent
 from caretaker.review_agent.agent import ReviewAgent
@@ -44,6 +45,7 @@ ALL_ADAPTERS: list[type[BaseAgent]] = [
     RefactorAgent,
     PerformanceAgent,
     MigrationAgent,
+    PRReviewerAgent,
 ]
 
 # Maps agent name -> set of run modes that include it
@@ -65,11 +67,12 @@ AGENT_MODES: dict[str, set[str]] = {
     "refactor": {"full", "refactor"},
     "perf": {"full", "perf"},
     "migration": {"full", "migration"},
+    "pr-reviewer": {"full", "pr-only", "pr-reviewer"},
 }
 
 # Maps GitHub event types -> list of agent names to run
 EVENT_AGENT_MAP: dict[str, list[str]] = {
-    "pull_request": ["pr", "principal", "test", "perf"],
+    "pull_request": ["pr", "pr-reviewer", "principal", "test", "perf"],
     "pull_request_review": ["pr"],
     "check_run": ["pr"],
     "check_suite": ["pr"],

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -370,6 +370,34 @@ class ReviewAgentConfig(StrictBaseModel):
     use_llm_for_retro: bool = True
 
 
+class PRReviewerConfig(StrictBaseModel):
+    """Configuration for the dual-path PR code reviewer.
+
+    When ``enabled`` is ``True``, caretaker reviews opened/updated PRs:
+    - Low-complexity PRs (score < ``routing_threshold``) get an inline
+      LLM review posted as a GitHub pull-request review.
+    - High-complexity PRs get handed off to the ``claude-code-action``
+      workflow via a trigger label + structured ``@claude`` comment.
+    """
+
+    enabled: bool = False
+    # Score threshold: score >= threshold → claude-code hand-off; else inline LLM.
+    routing_threshold: int = 40
+    # Label/mention used for the claude-code-action hand-off.
+    claude_code_label: str = "claude-code"
+    claude_code_mention: str = "@claude"
+    # Maximum diff lines fetched for inline review (excess is truncated).
+    max_diff_lines: int = 2000
+    # Whether to post per-file inline comments (in addition to the review body).
+    post_inline_comments: bool = True
+    # Skip PRs marked as draft.
+    skip_draft: bool = True
+    # Skip PRs that already carry any of these labels (prevents re-review).
+    skip_labels: list[str] = Field(default_factory=lambda: ["caretaker:reviewed"])
+    # Review event forced on all inline reviews — "AUTO" lets the LLM decide.
+    review_event: Literal["AUTO", "COMMENT", "APPROVE", "REQUEST_CHANGES"] = "AUTO"
+
+
 class MemoryStoreConfig(StrictBaseModel):
     """Configuration for the disk-backed agent memory store."""
 
@@ -753,6 +781,7 @@ class MaintainerConfig(StrictBaseModel):
     llm: LLMConfig = Field(default_factory=LLMConfig)
     goal_engine: GoalEngineConfig = Field(default_factory=GoalEngineConfig)
     review_agent: ReviewAgentConfig = Field(default_factory=ReviewAgentConfig)
+    pr_reviewer: PRReviewerConfig = Field(default_factory=PRReviewerConfig)
     principal_agent: PrincipalAgentConfig = Field(default_factory=PrincipalAgentConfig)
     test_agent: TestAgentConfig = Field(default_factory=TestAgentConfig)
     refactor_agent: RefactorAgentConfig = Field(default_factory=RefactorAgentConfig)

--- a/src/caretaker/github_app/events.py
+++ b/src/caretaker/github_app/events.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 # values in ``caretaker.agents.AGENT_MODES``).
 EVENT_AGENT_MAP: dict[str, list[str]] = {
     # PR lifecycle
-    "pull_request": ["pr"],
+    "pull_request": ["pr", "pr-reviewer"],
     "pull_request_review": ["pr"],
     "pull_request_review_comment": ["pr"],
     # Check runs / CI

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -421,6 +421,67 @@ class GitHubClient:
         data = await self._get(f"/repos/{owner}/{repo}/issues/{number}/comments")
         return [self._parse_comment(c) for c in (data or [])]
 
+    async def get_pull_diff(self, owner: str, repo: str, number: int) -> str:
+        """Return the unified diff for a pull request as a string."""
+        token = await self._creds.default_token()
+        resp = await self._client.get(
+            f"/repos/{owner}/{repo}/pulls/{number}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github.diff",
+            },
+        )
+        if resp.status_code == 404:
+            return ""
+        if resp.status_code >= 400:
+            raise GitHubAPIError(resp.status_code, resp.text)
+        return resp.text
+
+    async def create_review(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        commit_sha: str,
+        body: str,
+        event: str = "COMMENT",
+        comments: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Submit a pull request review.
+
+        Args:
+            event: One of ``APPROVE``, ``REQUEST_CHANGES``, ``COMMENT``.
+            comments: Optional list of inline comments — each dict should
+                carry ``path``, ``line``, ``body`` and optionally ``side``.
+        """
+        payload: dict[str, Any] = {
+            "commit_id": commit_sha,
+            "body": body,
+            "event": event,
+        }
+        if comments:
+            payload["comments"] = comments
+        data = await self._post(f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews", json=payload)
+        return data if data else {}
+
+    async def request_reviewers(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        reviewers: list[str],
+        team_reviewers: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Request specific reviewers for a pull request."""
+        payload: dict[str, Any] = {"reviewers": reviewers}
+        if team_reviewers:
+            payload["team_reviewers"] = team_reviewers
+        data = await self._post(
+            f"/repos/{owner}/{repo}/pulls/{pr_number}/requested_reviewers",
+            json=payload,
+        )
+        return data if data else {}
+
     # ── Check Runs (CI) ────────────────────────────────────────
 
     async def get_check_runs(self, owner: str, repo: str, ref: str) -> list[CheckRun]:

--- a/src/caretaker/llm/claude.py
+++ b/src/caretaker/llm/claude.py
@@ -128,6 +128,24 @@ class ClaudeClient:
         _log_response(feature, response.text, response)
         return response.text
 
+    async def complete(
+        self,
+        feature: str,
+        prompt: str,
+        max_tokens: int = 2000,
+        *,
+        system: str | None = None,
+    ) -> str:
+        """General-purpose completion method.
+
+        Prepends an optional ``system`` instruction to the user prompt before
+        calling the underlying LLM.  Intended for callers (e.g. pr_reviewer)
+        that need a free-form system prompt rather than a domain-specific
+        method from the public feature API below.
+        """
+        full_prompt = f"{system}\n\n{prompt}" if system else prompt
+        return await self._complete(feature, full_prompt, max_tokens)
+
     # ── Public feature API ──────────────────────────────────────────────────
 
     async def analyze_ci_logs(self, logs: str, context: str = "") -> str:

--- a/src/caretaker/pr_reviewer/__init__.py
+++ b/src/caretaker/pr_reviewer/__init__.py
@@ -1,0 +1,1 @@
+"""PR reviewer agent — inline LLM review or claude-code-action hand-off."""

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -126,8 +126,10 @@ class PRReviewerAgent(BaseAgent):
             return
 
         # Skip if already reviewed by caretaker this cycle
-        pr_labels = [lbl.get("name", "") if isinstance(lbl, dict) else str(lbl)
-                     for lbl in pr.get("labels", [])]
+        pr_labels = [
+            lbl.get("name", "") if isinstance(lbl, dict) else str(lbl)
+            for lbl in pr.get("labels", [])
+        ]
         if any(lbl in cfg.skip_labels for lbl in pr_labels):
             report.skipped.append(pr_number)
             return
@@ -191,8 +193,11 @@ class PRReviewerAgent(BaseAgent):
                 try:
                     reviewed_label = "caretaker:reviewed"
                     await self._ctx.github.ensure_label(
-                        owner, repo, reviewed_label,
-                        color="0075ca", description="Reviewed by caretaker",
+                        owner,
+                        repo,
+                        reviewed_label,
+                        color="0075ca",
+                        description="Reviewed by caretaker",
                     )
                     await self._ctx.github.add_labels(owner, repo, pr_number, [reviewed_label])
                 except Exception:

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -1,0 +1,218 @@
+"""PRReviewerAgent — dual-path PR code reviewer.
+
+Subscribes to ``pull_request`` opened/synchronize events.  For each new or
+updated PR it:
+
+1. Scores the PR using :mod:`routing` (LOC, file count, sensitive patterns, labels).
+2. Routes to the inline LLM reviewer  (score < threshold) or
+   the ``claude-code-action`` hand-off (score >= threshold).
+3. Posts the review via the GitHub Reviews API (inline path) or
+   applies a trigger label + hand-off comment (claude-code path).
+
+The agent is opt-in: ``pr_reviewer.enabled = false`` (default) keeps
+existing behavior byte-identical.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from caretaker.agent_protocol import AgentResult, BaseAgent
+from caretaker.pr_reviewer import claude_code_reviewer, inline_reviewer
+from caretaker.pr_reviewer.github_review import post_review
+from caretaker.pr_reviewer.routing import decide
+
+if TYPE_CHECKING:
+    from caretaker.state.models import OrchestratorState
+
+logger = logging.getLogger(__name__)
+
+_HANDLED_ACTIONS = frozenset({"opened", "synchronize", "reopened"})
+
+
+@dataclass
+class _PRReviewReport:
+    reviewed: list[int] = field(default_factory=list)
+    dispatched: list[int] = field(default_factory=list)
+    skipped: list[int] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+class PRReviewerAgent(BaseAgent):
+    """Dual-path PR code reviewer."""
+
+    @property
+    def name(self) -> str:
+        return "pr-reviewer"
+
+    def enabled(self) -> bool:
+        return self._ctx.config.pr_reviewer.enabled
+
+    async def execute(
+        self,
+        state: OrchestratorState,
+        event_payload: dict[str, Any] | None = None,
+    ) -> AgentResult:
+        report = _PRReviewReport()
+
+        action = (event_payload or {}).get("action", "")
+        if action and action not in _HANDLED_ACTIONS:
+            return AgentResult(processed=0)
+
+        pr_data = (event_payload or {}).get("pull_request") if event_payload else None
+
+        if pr_data:
+            prs = [pr_data]
+        else:
+            # Polling fallback: review open PRs that have not been reviewed yet
+            try:
+                prs = await self._ctx.github.list_pull_requests(
+                    self._ctx.owner, self._ctx.repo, state="open"
+                )
+                # Convert to plain dicts so the handler doesn't need branching
+                prs = [
+                    {
+                        "number": pr.number,
+                        "title": pr.title,
+                        "body": pr.body,
+                        "draft": pr.draft,
+                        "head": {"sha": pr.head_sha},
+                        "labels": [{"name": lbl.name} for lbl in pr.labels],
+                    }
+                    for pr in prs
+                ]
+            except Exception as exc:
+                err = f"pr-reviewer: failed to list PRs: {exc}"
+                logger.error(err)
+                report.errors.append(err)
+                return AgentResult(errors=report.errors)
+
+        for pr in prs:
+            pr_number = int(pr.get("number", 0))
+            if not pr_number:
+                continue
+            try:
+                await self._handle_pr(pr, report)
+            except Exception as exc:
+                err = f"pr-reviewer: unhandled error on #{pr_number}: {exc}"
+                logger.exception(err)
+                report.errors.append(err)
+
+        return AgentResult(
+            processed=len(report.reviewed) + len(report.dispatched),
+            errors=report.errors,
+            extra={
+                "reviewed": report.reviewed,
+                "dispatched": report.dispatched,
+                "skipped": report.skipped,
+            },
+        )
+
+    async def _handle_pr(
+        self,
+        pr: dict[str, Any],
+        report: _PRReviewReport,
+    ) -> None:
+        cfg = self._ctx.config.pr_reviewer
+        pr_number = int(pr.get("number", 0))
+        owner = self._ctx.owner
+        repo = self._ctx.repo
+
+        # Skip drafts
+        if cfg.skip_draft and pr.get("draft", False):
+            report.skipped.append(pr_number)
+            return
+
+        # Skip if already reviewed by caretaker this cycle
+        pr_labels = [lbl.get("name", "") if isinstance(lbl, dict) else str(lbl)
+                     for lbl in pr.get("labels", [])]
+        if any(lbl in cfg.skip_labels for lbl in pr_labels):
+            report.skipped.append(pr_number)
+            return
+
+        # Fetch file metadata for routing
+        try:
+            files = await self._ctx.github.list_pull_request_files(owner, repo, pr_number)
+        except Exception as exc:
+            logger.warning("pr-reviewer: cannot fetch files for #%d: %s", pr_number, exc)
+            files = []
+
+        additions = sum(int(f.get("additions", 0)) for f in files)
+        deletions = sum(int(f.get("deletions", 0)) for f in files)
+        file_paths = [f.get("path", "") for f in files]
+
+        decision = decide(
+            additions=additions,
+            deletions=deletions,
+            file_count=len(files),
+            file_paths=file_paths,
+            pr_labels=pr_labels,
+            threshold=cfg.routing_threshold,
+        )
+        logger.info("pr-reviewer: #%d routing — %s", pr_number, decision.reason)
+
+        if decision.use_inline:
+            if self._ctx.llm_router is None or not self._ctx.llm_router.available:
+                logger.warning(
+                    "pr-reviewer: LLM unavailable for inline review of #%d, falling back",
+                    pr_number,
+                )
+                decision = decision  # fall through to claude-code below
+            else:
+                result = await inline_reviewer.review(
+                    github=self._ctx.github,
+                    owner=owner,
+                    repo=repo,
+                    pr_number=pr_number,
+                    pr_title=str(pr.get("title", "")),
+                    pr_body=str(pr.get("body") or ""),
+                    llm=self._ctx.llm_router,
+                    max_diff_lines=cfg.max_diff_lines,
+                )
+                commit_sha = (pr.get("head") or {}).get("sha", "")
+                if not commit_sha:
+                    logger.warning("pr-reviewer: no head SHA for #%d", pr_number)
+                    report.skipped.append(pr_number)
+                    return
+
+                await post_review(
+                    github=self._ctx.github,
+                    owner=owner,
+                    repo=repo,
+                    pr_number=pr_number,
+                    commit_sha=commit_sha,
+                    result=result,
+                    post_inline_comments=cfg.post_inline_comments,
+                    force_event=cfg.review_event if cfg.review_event != "AUTO" else None,
+                )
+                # Mark as reviewed
+                try:
+                    reviewed_label = "caretaker:reviewed"
+                    await self._ctx.github.ensure_label(
+                        owner, repo, reviewed_label,
+                        color="0075ca", description="Reviewed by caretaker",
+                    )
+                    await self._ctx.github.add_labels(owner, repo, pr_number, [reviewed_label])
+                except Exception:
+                    pass
+                report.reviewed.append(pr_number)
+                return
+
+        # Claude-code hand-off path
+        success = await claude_code_reviewer.dispatch(
+            github=self._ctx.github,
+            owner=owner,
+            repo=repo,
+            pr_number=pr_number,
+            config=cfg,
+            routing_reason=decision.reason,
+        )
+        if success:
+            report.dispatched.append(pr_number)
+        else:
+            report.errors.append(f"claude-code dispatch failed for #{pr_number}")
+
+    def apply_summary(self, result: AgentResult, summary: Any) -> None:  # type: ignore[override]
+        pass

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -25,7 +25,7 @@ from caretaker.pr_reviewer.github_review import post_review
 from caretaker.pr_reviewer.routing import decide
 
 if TYPE_CHECKING:
-    from caretaker.state.models import OrchestratorState
+    from caretaker.state.models import OrchestratorState, RunSummary
 
 logger = logging.getLogger(__name__)
 
@@ -219,5 +219,5 @@ class PRReviewerAgent(BaseAgent):
         else:
             report.errors.append(f"claude-code dispatch failed for #{pr_number}")
 
-    def apply_summary(self, result: AgentResult, summary: Any) -> None:  # type: ignore[override]
+    def apply_summary(self, result: AgentResult, summary: RunSummary) -> None:
         pass

--- a/src/caretaker/pr_reviewer/claude_code_reviewer.py
+++ b/src/caretaker/pr_reviewer/claude_code_reviewer.py
@@ -1,0 +1,115 @@
+"""Claude Code reviewer — slow path for complex PRs.
+
+Instead of running a review inline, this applies the configured trigger label
+and posts a structured ``@claude`` hand-off comment requesting a full code review.
+The ``anthropics/claude-code-action`` workflow picks that up asynchronously.
+
+This is intentionally thin: we delegate the hard work to the action so caretaker
+doesn't need to manage execution context or tool-loop budget for large diffs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from caretaker.config import PRReviewerConfig
+    from caretaker.github_client.api import GitHubClient
+
+logger = logging.getLogger(__name__)
+
+_HANDOFF_MARKER = "<!-- caretaker:pr-reviewer-handoff -->"
+
+
+def _build_handoff_comment(
+    *,
+    mention: str,
+    pr_number: int,
+    owner: str,
+    repo: str,
+    routing_reason: str,
+) -> str:
+    lines = [
+        _HANDOFF_MARKER,
+        f"{mention} caretaker is requesting a full code review for this PR.",
+        "",
+        f"**Repo:** `{owner}/{repo}` · **PR:** #{pr_number}",
+        f"**Routing reason:** {routing_reason}",
+        "",
+        "Please review this pull request for:",
+        "- Correctness and logic errors",
+        "- Security vulnerabilities or unsafe patterns",
+        "- API contract and backward-compatibility concerns",
+        "- Test coverage gaps",
+        "- Any blocking issues before merge",
+        "",
+        "Post a review comment summary and inline comments where applicable.",
+        "",
+        "_Delegated by caretaker's PRReviewerAgent via ClaudeCodeExecutor hand-off._",
+    ]
+    return "\n".join(lines)
+
+
+async def dispatch(
+    *,
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    config: PRReviewerConfig,
+    routing_reason: str,
+) -> bool:
+    """Apply trigger label + post hand-off comment. Returns True on success."""
+    label = config.claude_code_label
+    mention = config.claude_code_mention
+
+    try:
+        await github.ensure_label(
+            owner, repo, label, color="7057ff", description="claude-code-action trigger"
+        )
+        await github.add_labels(owner, repo, pr_number, [label])
+    except Exception as exc:
+        logger.warning(
+            "pr-reviewer: failed to apply trigger label %r to %s/%s#%d: %s",
+            label,
+            owner,
+            repo,
+            pr_number,
+            exc,
+        )
+        return False
+
+    comment_body = _build_handoff_comment(
+        mention=mention,
+        pr_number=pr_number,
+        owner=owner,
+        repo=repo,
+        routing_reason=routing_reason,
+    )
+    try:
+        await github.upsert_issue_comment(
+            owner,
+            repo,
+            pr_number,
+            marker=_HANDOFF_MARKER,
+            body=comment_body,
+        )
+    except Exception as exc:
+        logger.warning(
+            "pr-reviewer: failed to post hand-off comment on %s/%s#%d: %s",
+            owner,
+            repo,
+            pr_number,
+            exc,
+        )
+        return False
+
+    logger.info(
+        "pr-reviewer: claude-code hand-off dispatched for %s/%s#%d (%s)",
+        owner,
+        repo,
+        pr_number,
+        routing_reason,
+    )
+    return True

--- a/src/caretaker/pr_reviewer/github_review.py
+++ b/src/caretaker/pr_reviewer/github_review.py
@@ -1,0 +1,99 @@
+"""GitHub review posting helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from caretaker.pr_reviewer.inline_reviewer import ReviewResult  # noqa: TC001 (runtime-used)
+
+if TYPE_CHECKING:
+    from caretaker.github_client.api import GitHubClient
+
+logger = logging.getLogger(__name__)
+
+_REVIEW_MARKER = "<!-- caretaker:pr-reviewer -->"
+
+_VERDICT_TO_EVENT = {
+    "APPROVE": "APPROVE",
+    "REQUEST_CHANGES": "REQUEST_CHANGES",
+    "COMMENT": "COMMENT",
+}
+
+
+async def post_review(
+    *,
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    commit_sha: str,
+    result: ReviewResult,
+    post_inline_comments: bool = True,
+    force_event: str | None = None,
+) -> None:
+    """Submit a pull request review via the GitHub Reviews API."""
+    event = force_event or _VERDICT_TO_EVENT.get(result.verdict, "COMMENT")
+
+    body = f"{_REVIEW_MARKER}\n{result.summary}"
+
+    inline_comments: list[dict[str, object]] = []
+    if post_inline_comments and result.comments:
+        for c in result.comments:
+            if not c.path or not c.body:
+                continue
+            inline_comments.append(
+                {
+                    "path": c.path,
+                    "line": c.line,
+                    "body": c.body,
+                    "side": "RIGHT",
+                }
+            )
+
+    try:
+        await github.create_review(
+            owner=owner,
+            repo=repo,
+            pr_number=pr_number,
+            commit_sha=commit_sha,
+            body=body,
+            event=event,
+            comments=inline_comments if inline_comments else None,
+        )
+        logger.info(
+            "pr-reviewer: posted %s review on %s/%s#%d (%d inline comments)",
+            event,
+            owner,
+            repo,
+            pr_number,
+            len(inline_comments),
+        )
+    except Exception as exc:
+        logger.warning(
+            "pr-reviewer: failed to post review on %s/%s#%d: %s",
+            owner,
+            repo,
+            pr_number,
+            exc,
+        )
+        # Fallback: post as plain comment so the review is not lost
+        fallback_body = (
+            f"{_REVIEW_MARKER}\n**PR Review ({result.verdict})**\n\n{result.summary}"
+        )
+        if result.comments:
+            fallback_body += "\n\n**Comments:**\n"
+            for c in result.comments[:8]:
+                fallback_body += f"\n- `{c.path}:{c.line}` — {c.body}"
+        try:
+            await github.upsert_issue_comment(
+                owner, repo, pr_number, marker=_REVIEW_MARKER, body=fallback_body
+            )
+        except Exception as fallback_exc:
+            logger.error(
+                "pr-reviewer: fallback comment also failed for %s/%s#%d: %s",
+                owner,
+                repo,
+                pr_number,
+                fallback_exc,
+            )

--- a/src/caretaker/pr_reviewer/github_review.py
+++ b/src/caretaker/pr_reviewer/github_review.py
@@ -78,9 +78,7 @@ async def post_review(
             exc,
         )
         # Fallback: post as plain comment so the review is not lost
-        fallback_body = (
-            f"{_REVIEW_MARKER}\n**PR Review ({result.verdict})**\n\n{result.summary}"
-        )
+        fallback_body = f"{_REVIEW_MARKER}\n**PR Review ({result.verdict})**\n\n{result.summary}"
         if result.comments:
             fallback_body += "\n\n**Comments:**\n"
             for c in result.comments[:8]:

--- a/src/caretaker/pr_reviewer/inline_reviewer.py
+++ b/src/caretaker/pr_reviewer/inline_reviewer.py
@@ -1,0 +1,133 @@
+"""Inline LLM reviewer — fast path for small/simple PRs.
+
+Fetches the unified diff and asks the configured LLM for a structured review.
+Returns a ``ReviewResult`` that ``github_review.post_review()`` can post directly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from caretaker.github_client.api import GitHubClient
+    from caretaker.llm.router import LLMRouter
+
+logger = logging.getLogger(__name__)
+
+_REVIEW_SYSTEM = """\
+You are an expert code reviewer. Review the pull request diff below and produce
+a concise, actionable review. Focus on correctness, security, and maintainability.
+Respond ONLY with a JSON object matching the schema described in the user message.
+Do NOT wrap with markdown code fences. Output raw JSON only.
+"""
+
+_REVIEW_SCHEMA = """\
+{
+  "summary": "<1-3 sentence overall assessment>",
+  "verdict": "APPROVE" | "COMMENT" | "REQUEST_CHANGES",
+  "comments": [
+    {
+      "path": "<file path>",
+      "line": <line number, integer>,
+      "body": "<review comment text>"
+    }
+  ]
+}
+
+Rules:
+- verdict = APPROVE   when the diff looks correct and ready to merge
+- verdict = COMMENT   when you have observations but no blockers
+- verdict = REQUEST_CHANGES when there are correctness/security issues
+- comments must reference the new file line (right side of the diff)
+- limit comments to at most 8 items; omit trivial nits
+- keep each comment body under 300 characters
+"""
+
+
+@dataclass
+class InlineReviewComment:
+    path: str
+    line: int
+    body: str
+
+
+@dataclass
+class ReviewResult:
+    summary: str
+    verdict: str  # APPROVE | COMMENT | REQUEST_CHANGES
+    comments: list[InlineReviewComment] = field(default_factory=list)
+    raw_response: str = ""
+
+
+async def review(
+    *,
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    pr_title: str,
+    pr_body: str,
+    llm: LLMRouter,
+    max_diff_lines: int = 2000,
+) -> ReviewResult:
+    """Fetch the PR diff and call the LLM for a review."""
+    diff = await github.get_pull_diff(owner, repo, pr_number)
+    if not diff:
+        return ReviewResult(
+            summary="Could not fetch diff — skipping inline review.",
+            verdict="COMMENT",
+        )
+
+    diff_lines = diff.splitlines()
+    if len(diff_lines) > max_diff_lines:
+        diff = "\n".join(diff_lines[:max_diff_lines]) + "\n…(diff truncated)"
+
+    prompt = (
+        f"PR #{pr_number}: {pr_title}\n\n"
+        f"{pr_body.strip()[:500] if pr_body else '(no description)'}\n\n"
+        "---\n"
+        f"```diff\n{diff}\n```\n\n"
+        "Respond with a JSON object matching this schema:\n"
+        f"{_REVIEW_SCHEMA}"
+    )
+
+    try:
+        raw = await llm.claude.complete(
+            feature="pr_inline_review",
+            system=_REVIEW_SYSTEM,
+            prompt=prompt,
+            max_tokens=2000,
+        )
+    except Exception as exc:
+        logger.warning("Inline LLM review failed for %s/%s#%d: %s", owner, repo, pr_number, exc)
+        return ReviewResult(
+            summary=f"Inline review failed: {exc}",
+            verdict="COMMENT",
+        )
+
+    raw_text = raw.strip()
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError:
+        logger.warning("LLM response not valid JSON for %s/%s#%d", owner, repo, pr_number)
+        return ReviewResult(summary=raw_text[:500], verdict="COMMENT", raw_response=raw_text)
+
+    comments = [
+        InlineReviewComment(
+            path=c.get("path", ""),
+            line=int(c.get("line", 1)),
+            body=c.get("body", ""),
+        )
+        for c in data.get("comments", [])
+        if c.get("path") and c.get("body")
+    ]
+
+    return ReviewResult(
+        summary=data.get("summary", ""),
+        verdict=data.get("verdict", "COMMENT").upper(),
+        comments=comments,
+        raw_response=raw_text,
+    )

--- a/src/caretaker/pr_reviewer/routing.py
+++ b/src/caretaker/pr_reviewer/routing.py
@@ -1,0 +1,130 @@
+"""Routing decider — score-based selection between inline LLM and claude-code hand-off.
+
+Score breakdown (0-100):
+  - LOC bucket:        0-30 pts  (additions + deletions)
+  - File count:        0-20 pts
+  - Sensitive files:   0-25 pts  (workflows, secrets, infra, auth, migrations)
+  - Architecture:      0-15 pts  (config changes, many packages touched)
+  - Label signals:     0-10 pts  (operator-applied labels)
+
+Score >= threshold (default 40) → ClaudeCode hand-off (complex review).
+Score <  threshold              → inline LLM review  (fast path).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# File patterns that add to the sensitivity score.
+_SENSITIVE_PATTERNS: list[tuple[re.Pattern[str], int]] = [
+    (re.compile(r"\.github/workflows/", re.I), 15),
+    (re.compile(r"\.github/", re.I), 8),
+    (re.compile(r"(secret|credential|auth|token|password|key)", re.I), 10),
+    (re.compile(r"(migration|schema|alembic)", re.I), 8),
+    (re.compile(r"(infra|terraform|k8s|helm|deploy)", re.I), 8),
+    (re.compile(r"(security|audit)", re.I), 8),
+    (re.compile(r"pyproject\.toml|setup\.py|Cargo\.toml|go\.mod|package\.json", re.I), 5),
+]
+
+# PR labels that signal complexity.
+_COMPLEX_LABELS: frozenset[str] = frozenset(
+    {"architecture", "needs-prd", "breaking-change", "refactor", "migration"}
+)
+# PR labels that signal simplicity.
+_SIMPLE_LABELS: frozenset[str] = frozenset({"good-first-issue", "chore", "docs", "typo"})
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    score: int
+    use_inline: bool
+    reason: str
+
+
+def decide(
+    *,
+    additions: int,
+    deletions: int,
+    file_count: int,
+    file_paths: list[str],
+    pr_labels: list[str],
+    threshold: int = 40,
+) -> RoutingDecision:
+    """Return a routing decision for a PR."""
+    score = 0
+    reasons: list[str] = []
+
+    # LOC (0-30)
+    loc = additions + deletions
+    if loc > 800:
+        loc_pts = 30
+    elif loc > 400:
+        loc_pts = 20
+    elif loc > 150:
+        loc_pts = 12
+    elif loc > 50:
+        loc_pts = 6
+    else:
+        loc_pts = 0
+    score += loc_pts
+    if loc_pts:
+        reasons.append(f"loc={loc}(+{loc_pts})")
+
+    # File count (0-20)
+    if file_count > 20:
+        fc_pts = 20
+    elif file_count > 10:
+        fc_pts = 12
+    elif file_count > 5:
+        fc_pts = 6
+    else:
+        fc_pts = 0
+    score += fc_pts
+    if fc_pts:
+        reasons.append(f"files={file_count}(+{fc_pts})")
+
+    # Sensitive file patterns (capped at 25)
+    sensitive_pts = 0
+    matched: set[str] = set()
+    for path in file_paths:
+        for pattern, pts in _SENSITIVE_PATTERNS:
+            key = pattern.pattern
+            if key not in matched and pattern.search(path):
+                sensitive_pts = min(25, sensitive_pts + pts)
+                matched.add(key)
+    score += sensitive_pts
+    if sensitive_pts:
+        reasons.append(f"sensitive_files(+{sensitive_pts})")
+
+    # Architecture signals — many different packages/dirs (0-15)
+    top_dirs: set[str] = set()
+    for p in file_paths:
+        top_dirs.add(p.split("/")[0] if "/" in p else "")
+    if len(top_dirs) > 6:
+        arch_pts = 15
+    elif len(top_dirs) > 3:
+        arch_pts = 8
+    else:
+        arch_pts = 0
+    score += arch_pts
+    if arch_pts:
+        reasons.append(f"dirs={len(top_dirs)}(+{arch_pts})")
+
+    # Label signals (0-10)
+    label_set = {lbl.lower() for lbl in pr_labels}
+    if label_set & _COMPLEX_LABELS:
+        score += 10
+        reasons.append("complex_label(+10)")
+    elif label_set & _SIMPLE_LABELS:
+        score = max(0, score - 10)
+        reasons.append("simple_label(-10)")
+
+    score = min(100, max(0, score))
+    use_inline = score < threshold
+    path_str = ", ".join(reasons) if reasons else "low-complexity"
+    return RoutingDecision(
+        score=score,
+        use_inline=use_inline,
+        reason=f"score={score} [{path_str}] → {'inline' if use_inline else 'claude-code'}",
+    )

--- a/tests/test_github_app/test_events.py
+++ b/tests/test_github_app/test_events.py
@@ -10,7 +10,9 @@ from caretaker.github_app.events import (
 
 
 def test_pull_request_routes_to_pr_agent() -> None:
-    assert agents_for_event("pull_request") == ["pr"]
+    agents = agents_for_event("pull_request")
+    assert "pr" in agents
+    assert "pr-reviewer" in agents
 
 
 def test_workflow_run_routes_to_devops_self_heal_and_pr() -> None:
@@ -43,14 +45,15 @@ def test_unknown_event_returns_empty_list() -> None:
 
 
 def test_event_names_are_normalized() -> None:
-    assert agents_for_event("  Pull_Request ") == ["pr"]
+    assert "pr" in agents_for_event("  Pull_Request ")
     assert normalize_event_name("  PUSH\n") == "push"
 
 
 def test_mapping_is_not_aliased_across_calls() -> None:
     first = agents_for_event("pull_request")
+    original_len = len(first)
     first.append("mutated")
-    assert agents_for_event("pull_request") == ["pr"]
+    assert len(agents_for_event("pull_request")) == original_len
 
 
 def test_map_is_well_formed() -> None:

--- a/tests/test_github_client_api.py
+++ b/tests/test_github_client_api.py
@@ -779,7 +779,6 @@ async def test_add_issue_comment_cap_does_not_apply_to_non_caretaker_body() -> N
 
 @pytest.mark.asyncio
 async def test_add_issue_comment_cap_zero_disables_check() -> None:
-
     client = GitHubClient(
         credentials_provider=StaticCredentialsProvider(default_token="x"),
         comment_cap_per_issue=0,  # disabled

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -128,9 +128,7 @@ async def test_inline_review_success() -> None:
         {
             "summary": "Looks good overall.",
             "verdict": "APPROVE",
-            "comments": [
-                {"path": "src/foo.py", "line": 10, "body": "Consider a docstring here."}
-            ],
+            "comments": [{"path": "src/foo.py", "line": 10, "body": "Consider a docstring here."}],
         }
     )
 

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from caretaker.config import PRReviewerConfig
 from caretaker.pr_reviewer.inline_reviewer import InlineReviewComment, ReviewResult
-from caretaker.pr_reviewer.routing import RoutingDecision, decide
-
+from caretaker.pr_reviewer.routing import decide
 
 # ── routing tests ──────────────────────────────────────────────────────────
 
@@ -141,7 +140,8 @@ async def test_inline_review_success() -> None:
     mock_llm.claude.complete = AsyncMock(return_value=mock_response)
 
     mock_github = MagicMock()
-    mock_github.get_pull_diff = AsyncMock(return_value="--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-x\n+y")
+    diff = "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-x\n+y"
+    mock_github.get_pull_diff = AsyncMock(return_value=diff)
 
     from caretaker.pr_reviewer.inline_reviewer import review
 

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -1,0 +1,344 @@
+"""Tests for the PR reviewer agent — routing, inline review, and claude-code hand-off."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from caretaker.config import PRReviewerConfig
+from caretaker.pr_reviewer.inline_reviewer import InlineReviewComment, ReviewResult
+from caretaker.pr_reviewer.routing import RoutingDecision, decide
+
+
+# ── routing tests ──────────────────────────────────────────────────────────
+
+
+def test_routing_low_complexity() -> None:
+    d = decide(
+        additions=20,
+        deletions=10,
+        file_count=2,
+        file_paths=["src/foo.py", "tests/test_foo.py"],
+        pr_labels=[],
+        threshold=40,
+    )
+    assert d.use_inline is True
+    assert d.score < 40
+
+
+def test_routing_high_loc_forces_claude_code() -> None:
+    # High LOC (30pts) + many files (20pts) pushes score above threshold
+    d = decide(
+        additions=900,
+        deletions=200,
+        file_count=25,
+        file_paths=[f"src/module{i}.py" for i in range(25)],
+        pr_labels=[],
+        threshold=40,
+    )
+    assert d.use_inline is False
+    assert d.score >= 40
+
+
+def test_routing_sensitive_file_bumps_score() -> None:
+    d = decide(
+        additions=10,
+        deletions=5,
+        file_count=1,
+        file_paths=[".github/workflows/ci.yml"],
+        pr_labels=[],
+        threshold=40,
+    )
+    assert d.score >= 15
+
+
+def test_routing_complex_label_bumps_score() -> None:
+    baseline = decide(
+        additions=10,
+        deletions=5,
+        file_count=1,
+        file_paths=["src/foo.py"],
+        pr_labels=[],
+        threshold=40,
+    )
+    labeled = decide(
+        additions=10,
+        deletions=5,
+        file_count=1,
+        file_paths=["src/foo.py"],
+        pr_labels=["architecture"],
+        threshold=40,
+    )
+    assert labeled.score > baseline.score
+
+
+def test_routing_simple_label_reduces_score() -> None:
+    baseline = decide(
+        additions=60,
+        deletions=10,
+        file_count=2,
+        file_paths=["README.md"],
+        pr_labels=[],
+        threshold=40,
+    )
+    labeled = decide(
+        additions=60,
+        deletions=10,
+        file_count=2,
+        file_paths=["README.md"],
+        pr_labels=["docs"],
+        threshold=40,
+    )
+    assert labeled.score <= baseline.score
+
+
+def test_routing_many_dirs_architecture_signal() -> None:
+    paths = [f"pkg{i}/module.py" for i in range(8)]
+    d = decide(
+        additions=30,
+        deletions=10,
+        file_count=8,
+        file_paths=paths,
+        pr_labels=[],
+        threshold=40,
+    )
+    assert d.score >= 15  # arch signal contributed
+
+
+def test_routing_score_capped_at_100() -> None:
+    d = decide(
+        additions=2000,
+        deletions=1000,
+        file_count=50,
+        file_paths=[f".github/workflows/job{i}.yml" for i in range(10)],
+        pr_labels=["architecture", "migration"],
+        threshold=40,
+    )
+    assert d.score <= 100
+
+
+# ── inline reviewer tests ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inline_review_success() -> None:
+    import json
+
+    mock_response = json.dumps(
+        {
+            "summary": "Looks good overall.",
+            "verdict": "APPROVE",
+            "comments": [
+                {"path": "src/foo.py", "line": 10, "body": "Consider a docstring here."}
+            ],
+        }
+    )
+
+    mock_llm = MagicMock()
+    mock_llm.available = True
+    mock_llm.claude = MagicMock()
+    mock_llm.claude.complete = AsyncMock(return_value=mock_response)
+
+    mock_github = MagicMock()
+    mock_github.get_pull_diff = AsyncMock(return_value="--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-x\n+y")
+
+    from caretaker.pr_reviewer.inline_reviewer import review
+
+    result = await review(
+        github=mock_github,
+        owner="org",
+        repo="repo",
+        pr_number=42,
+        pr_title="Fix foo",
+        pr_body="Fixes the foo bug",
+        llm=mock_llm,
+    )
+
+    assert result.verdict == "APPROVE"
+    assert "Looks good" in result.summary
+    assert len(result.comments) == 1
+    assert result.comments[0].path == "src/foo.py"
+
+
+@pytest.mark.asyncio
+async def test_inline_review_empty_diff() -> None:
+    mock_llm = MagicMock()
+    mock_github = MagicMock()
+    mock_github.get_pull_diff = AsyncMock(return_value="")
+
+    from caretaker.pr_reviewer.inline_reviewer import review
+
+    result = await review(
+        github=mock_github,
+        owner="org",
+        repo="repo",
+        pr_number=1,
+        pr_title="Empty",
+        pr_body="",
+        llm=mock_llm,
+    )
+    assert result.verdict == "COMMENT"
+    assert "Could not fetch diff" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_inline_review_llm_failure() -> None:
+    mock_llm = MagicMock()
+    mock_llm.claude = MagicMock()
+    mock_llm.claude.complete = AsyncMock(side_effect=RuntimeError("timeout"))
+
+    mock_github = MagicMock()
+    mock_github.get_pull_diff = AsyncMock(return_value="diff content")
+
+    from caretaker.pr_reviewer.inline_reviewer import review
+
+    result = await review(
+        github=mock_github,
+        owner="org",
+        repo="repo",
+        pr_number=2,
+        pr_title="Foo",
+        pr_body="",
+        llm=mock_llm,
+    )
+    assert result.verdict == "COMMENT"
+    assert "failed" in result.summary.lower()
+
+
+# ── claude-code hand-off tests ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_claude_code_dispatch_success() -> None:
+    mock_github = MagicMock()
+    mock_github.ensure_label = AsyncMock()
+    mock_github.add_labels = AsyncMock(return_value=[])
+    mock_github.upsert_issue_comment = AsyncMock()
+
+    cfg = PRReviewerConfig(enabled=True)
+
+    from caretaker.pr_reviewer.claude_code_reviewer import dispatch
+
+    ok = await dispatch(
+        github=mock_github,
+        owner="org",
+        repo="repo",
+        pr_number=5,
+        config=cfg,
+        routing_reason="score=55 [loc=400]",
+    )
+    assert ok is True
+    mock_github.add_labels.assert_awaited_once()
+    mock_github.upsert_issue_comment.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_claude_code_dispatch_label_failure() -> None:
+    mock_github = MagicMock()
+    mock_github.ensure_label = AsyncMock()
+    mock_github.add_labels = AsyncMock(side_effect=RuntimeError("403"))
+
+    cfg = PRReviewerConfig(enabled=True)
+
+    from caretaker.pr_reviewer.claude_code_reviewer import dispatch
+
+    ok = await dispatch(
+        github=mock_github,
+        owner="org",
+        repo="repo",
+        pr_number=6,
+        config=cfg,
+        routing_reason="score=60",
+    )
+    assert ok is False
+
+
+# ── github_review tests ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_review_success() -> None:
+    mock_github = MagicMock()
+    mock_github.create_review = AsyncMock(return_value={"id": 1})
+
+    result = ReviewResult(
+        summary="LGTM",
+        verdict="APPROVE",
+        comments=[InlineReviewComment(path="foo.py", line=1, body="Nice")],
+    )
+
+    from caretaker.pr_reviewer.github_review import post_review
+
+    await post_review(
+        github=mock_github,
+        owner="org",
+        repo="repo",
+        pr_number=10,
+        commit_sha="abc123",
+        result=result,
+    )
+    mock_github.create_review.assert_awaited_once()
+    call_kwargs = mock_github.create_review.call_args.kwargs
+    assert call_kwargs["event"] == "APPROVE"
+    assert len(call_kwargs["comments"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_review_falls_back_on_error() -> None:
+    mock_github = MagicMock()
+    mock_github.create_review = AsyncMock(side_effect=RuntimeError("fail"))
+    mock_github.upsert_issue_comment = AsyncMock()
+
+    result = ReviewResult(summary="Something", verdict="COMMENT")
+
+    from caretaker.pr_reviewer.github_review import post_review
+
+    await post_review(
+        github=mock_github,
+        owner="org",
+        repo="repo",
+        pr_number=11,
+        commit_sha="def456",
+        result=result,
+    )
+    mock_github.upsert_issue_comment.assert_awaited_once()
+
+
+# ── config defaults ────────────────────────────────────────────────────────
+
+
+def test_pr_reviewer_config_defaults() -> None:
+    cfg = PRReviewerConfig()
+    assert cfg.enabled is False
+    assert cfg.routing_threshold == 40
+    assert cfg.skip_draft is True
+    assert "caretaker:reviewed" in cfg.skip_labels
+    assert cfg.review_event == "AUTO"
+
+
+def test_maintainer_config_includes_pr_reviewer() -> None:
+    from caretaker.config import MaintainerConfig
+
+    mc = MaintainerConfig()
+    assert hasattr(mc, "pr_reviewer")
+    assert isinstance(mc.pr_reviewer, PRReviewerConfig)
+    assert mc.pr_reviewer.enabled is False
+
+
+# ── event routing ──────────────────────────────────────────────────────────
+
+
+def test_events_route_pr_reviewer() -> None:
+    from caretaker.github_app.events import agents_for_event
+
+    agents = agents_for_event("pull_request")
+    assert "pr-reviewer" in agents
+
+
+def test_registry_includes_pr_reviewer() -> None:
+    from caretaker.agents._registry_data import AGENT_MODES, ALL_ADAPTERS
+    from caretaker.pr_reviewer.agent import PRReviewerAgent
+
+    assert PRReviewerAgent in ALL_ADAPTERS
+    assert "pr-reviewer" in AGENT_MODES

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "caretaker-github"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Adds `PRReviewerAgent` — an opt-in automated code reviewer triggered on `pull_request` opened/synchronize events.
- **Score-based routing** (0–100) splits PRs into a fast inline LLM path (score < 40) and a `claude-code-action` hand-off path (score ≥ 40). Score inputs: LOC, file count, sensitive-file patterns (workflows, auth, migrations, infra), cross-package breadth, PR labels.
- **Inline path**: fetches unified diff → LLM returns structured JSON (summary + verdict + per-line comments) → posts as a GitHub pull-request review event (APPROVE / COMMENT / REQUEST_CHANGES).
- **Claude Code path**: applies `claude-code` trigger label + posts structured `@claude` hand-off comment; `anthropics/claude-code-action` workflow handles the full review asynchronously.
- `.github/CODEOWNERS` with `* @the-care-taker` so the bot appears in the PR reviewer picker.

## New files

| File | Purpose |
|------|---------|
| `src/caretaker/pr_reviewer/routing.py` | Scoring engine |
| `src/caretaker/pr_reviewer/inline_reviewer.py` | Fast LLM review |
| `src/caretaker/pr_reviewer/claude_code_reviewer.py` | Claude Code hand-off |
| `src/caretaker/pr_reviewer/github_review.py` | GitHub Reviews API wrapper |
| `src/caretaker/pr_reviewer/agent.py` | `PRReviewerAgent(BaseAgent)` |
| `.github/CODEOWNERS` | Reviewer picker visibility |
| `tests/test_pr_reviewer.py` | 18 unit tests |

## Config

```yaml
pr_reviewer:
  enabled: true               # opt-in (default false)
  routing_threshold: 40       # score >= 40 → claude-code hand-off
  max_diff_lines: 2000
  post_inline_comments: true
  skip_draft: true
  review_event: AUTO          # let LLM decide; or force COMMENT/APPROVE/REQUEST_CHANGES
  claude_code_label: claude-code
  claude_code_mention: "@claude"
```

## Test plan

- [x] `uv run pytest tests/test_pr_reviewer.py` — 18/18 pass
- [x] `ruff check` — clean on all changed files
- [ ] Deploy and open a small PR in a test repo with `pr_reviewer.enabled = true` to confirm inline review posts correctly
- [ ] Open a large PR (>800 LOC) to confirm claude-code label + hand-off comment are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)