### PR TITLE
chore(triage): log plan summary so dry-run invocations are visible

### DIFF
--- a/src/caretaker/pr_agent/triage_adapter.py
+++ b/src/caretaker/pr_agent/triage_adapter.py
@@ -7,6 +7,7 @@ toggle alone enables or disables triage without code changes.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from caretaker.agent_protocol import AgentResult, BaseAgent
@@ -21,6 +22,8 @@ from caretaker.pr_agent.pr_triage import run_pr_triage
 if TYPE_CHECKING:
     from caretaker.github_client.models import PullRequest
     from caretaker.state.models import OrchestratorState, RunSummary
+
+logger = logging.getLogger(__name__)
 
 
 class TriageAgentAdapter(BaseAgent):
@@ -69,6 +72,23 @@ class TriageAgentAdapter(BaseAgent):
             cascade_actions,
             state.tracked_issues,
             dry_run=cfg.dry_run,
+        )
+
+        logger.info(
+            "Triage agent%s: pr(empty=%d duplicate=%d conflicted=%d) "
+            "issue(empty=%d duplicate=%d stale=%d resolved=%d) "
+            "cascade(planned=%d applied=%d skipped=%d)",
+            " [DRY RUN]" if cfg.dry_run else "",
+            len(pr_report.closed_empty),
+            len(pr_report.closed_duplicate),
+            len(pr_report.closed_conflicted),
+            len(issue_report.closed_empty),
+            len(issue_report.closed_duplicate),
+            len(issue_report.closed_stale),
+            len(issue_report.closed_resolved),
+            len(cascade_actions),
+            len(cascade_report.applied),
+            len(cascade_report.skipped),
         )
 
         errors = [*pr_report.errors, *issue_report.errors, *cascade_report.errors]


### PR DESCRIPTION
## Summary
- Add a single INFO log line to `TriageAgentAdapter.execute()` summarizing plan counts across PR triage, issue triage, and cascade
- Prefix with `[DRY RUN]` when `triage.dry_run` is set so the log at a glance distinguishes a planned-only pass from a destructive one
- Motivated by the first scheduled v0.11.0 Caretaker run on main: the triage agent executed silently (no log line at all) while every other agent emits a per-dispatch summary. With `.caretaker.yml` set to `triage.dry_run: true`, there was no way to see what the planner was about to do

## Test plan
- [x] `uv run ruff format src/caretaker/pr_agent/triage_adapter.py` — clean
- [x] `uv run ruff check src/caretaker/pr_agent/triage_adapter.py` — clean
- [x] `uv run mypy src/caretaker/pr_agent/triage_adapter.py` — clean
- [x] `uv run pytest tests/test_pr_agent/test_cascade.py tests/test_pr_agent/test_pr_triage.py tests/test_issue_agent/test_issue_triage.py` — 34 passed
- [ ] Next scheduled Caretaker run on main shows a `Triage agent [DRY RUN]: pr(…) issue(…) cascade(…)` line in `caretaker-run.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)