### PR TITLE
chore(triage): pin dry_run in real maintainer config

### DIFF
--- a/.caretaker.yml
+++ b/.caretaker.yml
@@ -11,9 +11,3 @@ mongo:
   database_name: caretaker
   memory_collection: agent_memory
   audit_collection: audit_log
-
-# Triage subsystem (v0.11.0) — start in dry-run so the first live invocations
-# surface their plan in the run report without actually closing anything.
-# Flip dry_run to false once a scheduled run confirms the plan looks right.
-triage:
-  dry_run: true

--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -122,3 +122,10 @@ executor:
       - LINT_FAILURE
       - REVIEW_COMMENT
     route_same_repo_only: true
+
+# Triage subsystem (v0.11.0) — start in dry-run so the next scheduled run
+# emits the "[DRY RUN]" plan-summary log line without closing anything.
+# Flip dry_run to false (or remove the block to use defaults) once a run
+# confirms the planner's choices look correct.
+triage:
+  dry_run: true


### PR DESCRIPTION
## Summary
- Move the triage `dry_run: true` override from `.caretaker.yml` to `.github/maintainer/config.yml`, which is the path the workflow actually loads (`caretaker run --config .github/maintainer/config.yml`)
- Drop the stray triage block from `.caretaker.yml` — it was a no-op and would mislead future readers
- The 04:11 UTC run (#24759725094) invoked TriageAgent live, not in dry_run, because of this path mismatch. Plan was zero items so nothing got closed, but the smoke test was accidental rather than guarded. Pin dry_run in the real config before the next scheduled run

## Context
Smoke test history:
- f2eb09d put `triage.dry_run: true` in `.caretaker.yml` — never read
- Run #24759725094 ran triage live, logged `Triage agent: pr(empty=0 duplicate=0 conflicted=0) issue(empty=0 duplicate=0 stale=0 resolved=0) cascade(planned=0 applied=0 skipped=0)` — zero plan
- Real config path is `.github/maintainer/config.yml` per `.github/workflows/maintainer.yml` lines 283–287

## Test plan
- [x] `uv run caretaker validate-config --config .github/maintainer/config.yml` — ✅ valid
- [ ] Next scheduled Caretaker run on main shows `Triage agent [DRY RUN]: pr(…) issue(…) cascade(…)` in `caretaker-run.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)