### PR TITLE
feat(auth): OAuth2 client_credentials client with JWT caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.0] — 2026-04-22
+
+### Added
+
+- **OAuth2 `client_credentials` client** for service-to-service auth (`src/caretaker/auth/oauth_client.py`). `OAuth2ClientCredentials` posts to a token endpoint using `client_secret_basic`, caches the returned JWT in-process keyed by a 30-second skew buffer against the server-reported `expires_in`, and coalesces concurrent callers through an `asyncio.Lock` so a burst of requests triggers a single refresh. `build_client_from_env()` is the opt-in entry point — it returns `None` when the `OAUTH2_CLIENT_ID` / `OAUTH2_CLIENT_SECRET` / `OAUTH2_TOKEN_URL` trio is unset so callers fall through to their unauthenticated path with byte-identical behaviour.
+- **`OAuth2ClientConfig`** on `FleetRegistryConfig.oauth2` (`config.py`). Off by default. When enabled alongside the fleet emitter, the heartbeat POST is decorated with `Authorization: Bearer <jwt>` from the cached client; HMAC (`CARETAKER_FLEET_SECRET`) and OAuth2 can be used together, and the backend can require either or both.
+- **Module-level OAuth2 client cache in the fleet emitter**: the client is built once per process and reused across heartbeats, keyed on `(client_id, client_secret, token_url, scope_env, scope, timeout)` so a credential rotation invalidates the cache correctly without a process restart. A failed token fetch is logged at `WARNING` and swallowed — the emitter's fail-open contract is preserved so an auth-server outage never fails the run loop.
+
 ## [0.10.4] — 2026-04-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caretaker-github"
-version = "0.11.0"
+version = "0.12.0"
 description = "Autonomous GitHub repository maintenance powered by Copilot"
 readme = "README.md"
 license = "MIT"

--- a/src/caretaker/auth/__init__.py
+++ b/src/caretaker/auth/__init__.py
@@ -1,0 +1,19 @@
+"""OAuth2 client helpers for caretaker service-to-service auth.
+
+Separate from :mod:`caretaker.admin.auth`, which handles the interactive
+OIDC login flow for the admin dashboard. This package contains the
+service-side client used by caretaker when it calls out to OAuth2-protected
+backends (fleet registry, remote MCP servers, etc.) from CI runs.
+"""
+
+from caretaker.auth.oauth_client import (
+    OAuth2ClientCredentials,
+    OAuth2TokenError,
+    build_client_from_env,
+)
+
+__all__ = [
+    "OAuth2ClientCredentials",
+    "OAuth2TokenError",
+    "build_client_from_env",
+]

--- a/src/caretaker/auth/oauth_client.py
+++ b/src/caretaker/auth/oauth_client.py
@@ -121,9 +121,7 @@ class OAuth2ClientCredentials:
             ) from exc
 
         if resp.status_code != 200:
-            raise OAuth2TokenError(
-                f"token endpoint returned {resp.status_code}: {resp.text[:200]}"
-            )
+            raise OAuth2TokenError(f"token endpoint returned {resp.status_code}: {resp.text[:200]}")
 
         try:
             payload = resp.json()

--- a/src/caretaker/auth/oauth_client.py
+++ b/src/caretaker/auth/oauth_client.py
@@ -1,0 +1,187 @@
+"""OAuth2 ``client_credentials`` token client.
+
+Fetches and caches access tokens for service-to-service calls. Designed
+for CI use: caretaker consumer repos set ``OAUTH2_CLIENT_ID`` /
+``OAUTH2_CLIENT_SECRET`` as repo secrets plus ``OAUTH2_TOKEN_URL`` as a
+repo variable, and this module reads them via :func:`build_client_from_env`.
+
+Concurrency: a single :class:`OAuth2ClientCredentials` instance may be
+shared across tasks; access to the cached token is guarded by an
+``asyncio.Lock`` so concurrent callers coalesce on a single refresh.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# Refresh this many seconds before the server-reported expiry, so a token
+# in flight never expires mid-request under clock skew.
+_EXPIRY_SKEW_SECONDS = 30
+
+
+class OAuth2TokenError(RuntimeError):
+    """Raised when a token cannot be obtained from the authorization server."""
+
+
+@dataclass(slots=True)
+class _CachedToken:
+    access_token: str
+    expires_at_monotonic: float
+
+    def is_valid(self, skew: float = _EXPIRY_SKEW_SECONDS) -> bool:
+        return time.monotonic() + skew < self.expires_at_monotonic
+
+
+class OAuth2ClientCredentials:
+    """Async OAuth2 client-credentials token fetcher with in-process cache.
+
+    Parameters
+    ----------
+    client_id, client_secret:
+        Credentials issued by the authorization server at client registration.
+    token_url:
+        Full token endpoint (e.g. ``https://auth.example.com/oauth/token``).
+    scope:
+        Optional space-separated list of scopes requested. When empty, the
+        server's default scope set for the client is granted.
+    timeout_seconds:
+        Per-request HTTP timeout.
+    """
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        token_url: str,
+        scope: str = "",
+        timeout_seconds: float = 10.0,
+    ) -> None:
+        if not client_id or not client_secret or not token_url:
+            raise ValueError("client_id, client_secret, and token_url are required")
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._token_url = token_url
+        self._scope = scope.strip()
+        self._timeout = timeout_seconds
+        self._lock = asyncio.Lock()
+        self._cached: _CachedToken | None = None
+
+    async def get_token(self, *, client: httpx.AsyncClient | None = None) -> str:
+        """Return a valid access token, refreshing if cached one is stale."""
+        async with self._lock:
+            if self._cached is not None and self._cached.is_valid():
+                return self._cached.access_token
+            self._cached = await self._fetch_new(client=client)
+            return self._cached.access_token
+
+    async def authorization_header(
+        self, *, client: httpx.AsyncClient | None = None
+    ) -> dict[str, str]:
+        """Convenience: return ``{"Authorization": "Bearer <token>"}``."""
+        token = await self.get_token(client=client)
+        return {"Authorization": f"Bearer {token}"}
+
+    def invalidate(self) -> None:
+        """Drop the cached token; the next call will fetch fresh."""
+        self._cached = None
+
+    async def _fetch_new(self, *, client: httpx.AsyncClient | None) -> _CachedToken:
+        data = {"grant_type": "client_credentials"}
+        if self._scope:
+            data["scope"] = self._scope
+
+        owns_client = client is None
+        try:
+            if owns_client:
+                client = httpx.AsyncClient(timeout=self._timeout)
+            assert client is not None
+            try:
+                resp = await client.post(
+                    self._token_url,
+                    data=data,
+                    auth=(self._client_id, self._client_secret),
+                    headers={"Accept": "application/json"},
+                )
+            finally:
+                if owns_client:
+                    await client.aclose()
+        except httpx.HTTPError as exc:
+            raise OAuth2TokenError(
+                f"transport error fetching token from {self._token_url}: {exc}"
+            ) from exc
+
+        if resp.status_code != 200:
+            raise OAuth2TokenError(
+                f"token endpoint returned {resp.status_code}: {resp.text[:200]}"
+            )
+
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise OAuth2TokenError(
+                f"token endpoint returned non-JSON body: {resp.text[:200]}"
+            ) from exc
+
+        access_token = payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise OAuth2TokenError("token endpoint response missing access_token")
+
+        expires_in = payload.get("expires_in", 3600)
+        try:
+            expires_in_f = float(expires_in)
+        except (TypeError, ValueError):
+            expires_in_f = 3600.0
+        # Clamp to a sane minimum to avoid pathological tight-loop refreshes
+        # if the server returns 0 or a negative value.
+        expires_in_f = max(expires_in_f, 60.0)
+
+        return _CachedToken(
+            access_token=access_token,
+            expires_at_monotonic=time.monotonic() + expires_in_f,
+        )
+
+
+def build_client_from_env(
+    *,
+    client_id_env: str = "OAUTH2_CLIENT_ID",
+    client_secret_env: str = "OAUTH2_CLIENT_SECRET",
+    token_url_env: str = "OAUTH2_TOKEN_URL",
+    scope_env: str = "OAUTH2_SCOPE",
+    timeout_seconds: float = 10.0,
+) -> OAuth2ClientCredentials | None:
+    """Construct a client from process env vars, or ``None`` if unset.
+
+    Returns ``None`` when any of the three required env vars is missing or
+    empty — callers then fall back to their unauthenticated code path. This
+    keeps OAuth2 strictly opt-in and preserves byte-identical behavior for
+    consumers that haven't configured it yet.
+    """
+    client_id = os.environ.get(client_id_env, "").strip()
+    client_secret = os.environ.get(client_secret_env, "").strip()
+    token_url = os.environ.get(token_url_env, "").strip()
+    scope = os.environ.get(scope_env, "").strip()
+    if not (client_id and client_secret and token_url):
+        logger.debug(
+            "oauth2 client: skipping — one or more of %s/%s/%s is unset",
+            client_id_env,
+            client_secret_env,
+            token_url_env,
+        )
+        return None
+    return OAuth2ClientCredentials(
+        client_id=client_id,
+        client_secret=client_secret,
+        token_url=token_url,
+        scope=scope,
+        timeout_seconds=timeout_seconds,
+    )

--- a/src/caretaker/auth/oauth_client.py
+++ b/src/caretaker/auth/oauth_client.py
@@ -170,10 +170,7 @@ def build_client_from_env(
     scope = os.environ.get(scope_env, "").strip()
     if not (client_id and client_secret and token_url):
         logger.debug(
-            "oauth2 client: skipping — one or more of %s/%s/%s is unset",
-            client_id_env,
-            client_secret_env,
-            token_url_env,
+            "oauth2 client: skipping — required env vars for id/secret/token_url are unset"
         )
         return None
     return OAuth2ClientCredentials(

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -572,6 +572,31 @@ class TelemetryConfig(StrictBaseModel):
     application_insights_connection_string_env: str = "APPLICATIONINSIGHTS_CONNECTION_STRING"
 
 
+class OAuth2ClientConfig(StrictBaseModel):
+    """OAuth2 ``client_credentials`` settings for service-to-service auth.
+
+    Opt-in: when ``enabled`` is ``True`` AND all three env vars named by
+    ``client_id_env`` / ``client_secret_env`` / ``token_url_env`` are
+    populated, consumers like :class:`FleetRegistryConfig` will attach a
+    bearer token to outbound requests instead of (or alongside) HMAC.
+
+    The default names match the conventional ``OAUTH2_CLIENT_ID`` /
+    ``OAUTH2_CLIENT_SECRET`` / ``OAUTH2_TOKEN_URL`` triple that caretaker
+    writes into consumer repos when an operator provisions client
+    credentials against a shared authorization server.
+    """
+
+    enabled: bool = False
+    client_id_env: str = "OAUTH2_CLIENT_ID"
+    client_secret_env: str = "OAUTH2_CLIENT_SECRET"
+    token_url_env: str = "OAUTH2_TOKEN_URL"
+    scope_env: str = "OAUTH2_SCOPE"
+    # Requested scope if ``scope_env`` is not populated. Empty string means
+    # "use the server-side default scope set for this client".
+    default_scope: str = ""
+    timeout_seconds: float = 10.0
+
+
 class FleetRegistryConfig(StrictBaseModel):
     """Opt-in fleet registry.
 
@@ -590,6 +615,12 @@ class FleetRegistryConfig(StrictBaseModel):
     backend verifies before recording. When unset, heartbeats are
     delivered without authentication (suitable for private networks /
     trusted origins only).
+
+    ``oauth2`` is an alternative (or additional) auth mode: when its
+    ``enabled`` flag is True and its env vars are populated, the emitter
+    fetches a bearer token via the OAuth2 ``client_credentials`` grant
+    and sends it in the ``Authorization`` header. HMAC + OAuth2 may be
+    used together; the backend can require either or both.
     """
 
     enabled: bool = False
@@ -601,6 +632,7 @@ class FleetRegistryConfig(StrictBaseModel):
     # sent. Default False to minimise the risk of surfacing repo-private
     # details (error log snippets, etc.) through the central dashboard.
     include_full_summary: bool = False
+    oauth2: OAuth2ClientConfig = Field(default_factory=OAuth2ClientConfig)
 
 
 class FleetConfig(StrictBaseModel):

--- a/src/caretaker/fleet/emitter.py
+++ b/src/caretaker/fleet/emitter.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from pydantic import BaseModel, Field
 
+from caretaker.auth import OAuth2ClientCredentials, OAuth2TokenError, build_client_from_env
+
 if TYPE_CHECKING:
     from caretaker.config import FleetRegistryConfig, MaintainerConfig
     from caretaker.state.models import RunSummary
@@ -51,6 +53,66 @@ _COUNTERS = (
     "owned_prs",
     "authority_merges",
 )
+
+
+_oauth_client: OAuth2ClientCredentials | None = None
+_oauth_client_key: tuple[str, str, str, str, str, float] | None = None
+
+
+def _get_oauth_client(fleet: FleetRegistryConfig) -> OAuth2ClientCredentials | None:
+    """Return a cached OAuth2 client for the given config, rebuilding on change.
+
+    Caching the client instance across heartbeat calls is what lets the
+    in-memory JWT cache actually deliver value: without it, each run
+    would refetch a token. The cache key covers every config + env var
+    the client depends on, so a rotation invalidates correctly.
+    """
+    global _oauth_client, _oauth_client_key
+
+    oauth_cfg = fleet.oauth2
+    if not oauth_cfg.enabled:
+        return None
+
+    scope = os.environ.get(oauth_cfg.scope_env, "").strip() or oauth_cfg.default_scope
+    key = (
+        os.environ.get(oauth_cfg.client_id_env, ""),
+        os.environ.get(oauth_cfg.client_secret_env, ""),
+        os.environ.get(oauth_cfg.token_url_env, ""),
+        oauth_cfg.scope_env,
+        scope,
+        oauth_cfg.timeout_seconds,
+    )
+    if _oauth_client_key == key and _oauth_client is not None:
+        return _oauth_client
+
+    client = build_client_from_env(
+        client_id_env=oauth_cfg.client_id_env,
+        client_secret_env=oauth_cfg.client_secret_env,
+        token_url_env=oauth_cfg.token_url_env,
+        scope_env=oauth_cfg.scope_env,
+        timeout_seconds=oauth_cfg.timeout_seconds,
+    )
+    _oauth_client = client
+    _oauth_client_key = key if client is not None else None
+    return client
+
+
+async def _oauth_bearer_headers(
+    fleet: FleetRegistryConfig, *, client: httpx.AsyncClient
+) -> dict[str, str]:
+    """Return ``Authorization: Bearer …`` if OAuth2 is configured, else ``{}``.
+
+    Failures are logged at WARNING and swallowed: the fleet emitter is
+    fail-open, so a flaky auth server never breaks the run loop.
+    """
+    oauth = _get_oauth_client(fleet)
+    if oauth is None:
+        return {}
+    try:
+        return await oauth.authorization_header(client=client)
+    except OAuth2TokenError as exc:
+        logger.warning("fleet heartbeat: oauth2 token fetch failed: %s", exc)
+        return {}
 
 
 def _caretaker_version() -> str:
@@ -182,6 +244,9 @@ async def emit_heartbeat(
             client = httpx.AsyncClient(timeout=fleet.timeout_seconds)
         assert client is not None  # narrow for type-checkers
         try:
+            oauth_headers = await _oauth_bearer_headers(fleet, client=client)
+            if oauth_headers:
+                headers.update(oauth_headers)
             resp = await client.post(endpoint, content=body, headers=headers)
         finally:
             if owns_client:

--- a/tests/test_fleet_registry.py
+++ b/tests/test_fleet_registry.py
@@ -21,7 +21,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from caretaker.config import FleetRegistryConfig, MaintainerConfig
+from caretaker.config import FleetRegistryConfig, MaintainerConfig, OAuth2ClientConfig
 from caretaker.fleet import (
     FleetHeartbeat,
     build_heartbeat,
@@ -31,6 +31,7 @@ from caretaker.fleet import (
     reset_store_for_tests,
     sign_payload,
 )
+from caretaker.fleet import emitter as emitter_mod
 from caretaker.state.models import RunSummary
 
 # ── Config defaults ───────────────────────────────────────────────────────
@@ -135,6 +136,77 @@ async def test_emitter_fails_open_on_transport_error(monkeypatch) -> None:
     # Must return False, never raise.
     result = await emit_heartbeat(cfg, _summary_fixture())
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_emitter_attaches_oauth_bearer_and_caches_token(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "ianlintner/demo")
+    monkeypatch.setenv("OAUTH2_CLIENT_ID", "cid")
+    monkeypatch.setenv("OAUTH2_CLIENT_SECRET", "csec")
+    monkeypatch.setenv("OAUTH2_TOKEN_URL", "https://auth.test/oauth/token")
+    # Reset the module-level OAuth client cache so this test is hermetic.
+    emitter_mod._oauth_client = None
+    emitter_mod._oauth_client_key = None
+
+    cfg = MaintainerConfig(
+        fleet_registry=FleetRegistryConfig(
+            enabled=True,
+            endpoint="https://fleet.example/heartbeat",
+            oauth2=OAuth2ClientConfig(enabled=True),
+        )
+    )
+
+    token_calls = 0
+    heartbeat_calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal token_calls
+        if str(request.url) == "https://auth.test/oauth/token":
+            token_calls += 1
+            return httpx.Response(
+                200,
+                json={"access_token": "bearer-abc", "expires_in": 3600},
+            )
+        heartbeat_calls.append(request.headers.get("authorization", ""))
+        return httpx.Response(202, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        assert await emit_heartbeat(cfg, _summary_fixture(), client=client) is True
+        # Second heartbeat in the same process reuses the cached token.
+        assert await emit_heartbeat(cfg, _summary_fixture(), client=client) is True
+
+    assert token_calls == 1  # JWT cache prevents a second token fetch
+    assert heartbeat_calls == ["Bearer bearer-abc", "Bearer bearer-abc"]
+
+
+@pytest.mark.asyncio
+async def test_emitter_oauth_token_failure_is_swallowed(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "ianlintner/demo")
+    monkeypatch.setenv("OAUTH2_CLIENT_ID", "cid")
+    monkeypatch.setenv("OAUTH2_CLIENT_SECRET", "csec")
+    monkeypatch.setenv("OAUTH2_TOKEN_URL", "https://auth.test/oauth/token")
+    emitter_mod._oauth_client = None
+    emitter_mod._oauth_client_key = None
+
+    cfg = MaintainerConfig(
+        fleet_registry=FleetRegistryConfig(
+            enabled=True,
+            endpoint="https://fleet.example/heartbeat",
+            oauth2=OAuth2ClientConfig(enabled=True),
+        )
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "https://auth.test/oauth/token":
+            return httpx.Response(500, text="auth server down")
+        # Heartbeat should still go through, just without a bearer header.
+        assert "authorization" not in {k.lower() for k in request.headers}
+        return httpx.Response(202, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        assert await emit_heartbeat(cfg, _summary_fixture(), client=client) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_oauth_client.py
+++ b/tests/test_oauth_client.py
@@ -35,9 +35,7 @@ class _MockTransport(httpx.MockTransport):
             raise AssertionError("mock transport ran out of responses") from exc
 
 
-def _success_response(
-    access_token: str = "tok-xyz", expires_in: int = 3600
-) -> httpx.Response:
+def _success_response(access_token: str = "tok-xyz", expires_in: int = 3600) -> httpx.Response:
     return httpx.Response(
         200,
         json={
@@ -117,9 +115,7 @@ async def test_concurrent_callers_coalesce_on_single_refresh() -> None:
             client_secret="secret",
             token_url="https://auth.test/oauth/token",
         )
-        results = await asyncio.gather(
-            *(oauth.get_token(client=client) for _ in range(10))
-        )
+        results = await asyncio.gather(*(oauth.get_token(client=client) for _ in range(10)))
 
     assert results == ["once"] * 10
     assert len(transport.requests) == 1
@@ -127,9 +123,7 @@ async def test_concurrent_callers_coalesce_on_single_refresh() -> None:
 
 @pytest.mark.asyncio
 async def test_non_200_raises_token_error() -> None:
-    transport = _MockTransport(
-        [httpx.Response(401, json={"error": "invalid_client"})]
-    )
+    transport = _MockTransport([httpx.Response(401, json={"error": "invalid_client"})])
     async with httpx.AsyncClient(transport=transport) as client:
         oauth = OAuth2ClientCredentials(
             client_id="id",
@@ -211,9 +205,7 @@ def test_build_client_from_env_succeeds_when_set(
 
 @pytest.mark.asyncio
 async def test_expires_in_clamped_to_minimum(monkeypatch: pytest.MonkeyPatch) -> None:
-    transport = _MockTransport(
-        [httpx.Response(200, json={"access_token": "t", "expires_in": 0})]
-    )
+    transport = _MockTransport([httpx.Response(200, json={"access_token": "t", "expires_in": 0})])
     async with httpx.AsyncClient(transport=transport) as client:
         oauth = OAuth2ClientCredentials(
             client_id="id",

--- a/tests/test_oauth_client.py
+++ b/tests/test_oauth_client.py
@@ -1,0 +1,229 @@
+"""Tests for :mod:`caretaker.auth.oauth_client`."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from caretaker.auth import (
+    OAuth2ClientCredentials,
+    OAuth2TokenError,
+    build_client_from_env,
+)
+
+
+class _MockTransport(httpx.MockTransport):
+    """Mock transport that counts requests and serves scripted responses."""
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self.requests: list[httpx.Request] = []
+        self._iter: Iterator[httpx.Response] = iter(responses)
+        super().__init__(self._handle)
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise AssertionError("mock transport ran out of responses") from exc
+
+
+def _success_response(
+    access_token: str = "tok-xyz", expires_in: int = 3600
+) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": expires_in,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_token_fetches_once_and_caches() -> None:
+    transport = _MockTransport([_success_response("abc")])
+    async with httpx.AsyncClient(transport=transport) as client:
+        oauth = OAuth2ClientCredentials(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.test/oauth/token",
+            scope="read write",
+        )
+        first = await oauth.get_token(client=client)
+        second = await oauth.get_token(client=client)
+
+    assert first == "abc"
+    assert second == "abc"
+    assert len(transport.requests) == 1
+    req = transport.requests[0]
+    assert req.method == "POST"
+    assert b"grant_type=client_credentials" in req.content
+    assert b"scope=read+write" in req.content
+    # client_secret_basic auth — Basic <base64(id:secret)>
+    assert req.headers["authorization"].startswith("Basic ")
+
+
+@pytest.mark.asyncio
+async def test_scope_omitted_when_empty() -> None:
+    transport = _MockTransport([_success_response()])
+    async with httpx.AsyncClient(transport=transport) as client:
+        oauth = OAuth2ClientCredentials(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.test/oauth/token",
+        )
+        await oauth.get_token(client=client)
+
+    assert b"scope=" not in transport.requests[0].content
+
+
+@pytest.mark.asyncio
+async def test_refresh_when_token_expires() -> None:
+    # expires_in=60 is clamped to the minimum 60s; force expiry by invalidating.
+    transport = _MockTransport(
+        [
+            _success_response("first", expires_in=60),
+            _success_response("second", expires_in=3600),
+        ]
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        oauth = OAuth2ClientCredentials(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.test/oauth/token",
+        )
+        assert await oauth.get_token(client=client) == "first"
+        oauth.invalidate()
+        assert await oauth.get_token(client=client) == "second"
+
+    assert len(transport.requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_coalesce_on_single_refresh() -> None:
+    transport = _MockTransport([_success_response("once")])
+    async with httpx.AsyncClient(transport=transport) as client:
+        oauth = OAuth2ClientCredentials(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.test/oauth/token",
+        )
+        results = await asyncio.gather(
+            *(oauth.get_token(client=client) for _ in range(10))
+        )
+
+    assert results == ["once"] * 10
+    assert len(transport.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_200_raises_token_error() -> None:
+    transport = _MockTransport(
+        [httpx.Response(401, json={"error": "invalid_client"})]
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        oauth = OAuth2ClientCredentials(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.test/oauth/token",
+        )
+        with pytest.raises(OAuth2TokenError, match="401"):
+            await oauth.get_token(client=client)
+
+
+@pytest.mark.asyncio
+async def test_missing_access_token_field_raises() -> None:
+    transport = _MockTransport([httpx.Response(200, json={"token_type": "Bearer"})])
+    async with httpx.AsyncClient(transport=transport) as client:
+        oauth = OAuth2ClientCredentials(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.test/oauth/token",
+        )
+        with pytest.raises(OAuth2TokenError, match="access_token"):
+            await oauth.get_token(client=client)
+
+
+@pytest.mark.asyncio
+async def test_transport_error_raises_token_error() -> None:
+    def _raise(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_raise)) as client:
+        oauth = OAuth2ClientCredentials(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.test/oauth/token",
+        )
+        with pytest.raises(OAuth2TokenError, match="transport error"):
+            await oauth.get_token(client=client)
+
+
+@pytest.mark.asyncio
+async def test_authorization_header_shape() -> None:
+    transport = _MockTransport([_success_response("zzz")])
+    async with httpx.AsyncClient(transport=transport) as client:
+        oauth = OAuth2ClientCredentials(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.test/oauth/token",
+        )
+        headers = await oauth.authorization_header(client=client)
+    assert headers == {"Authorization": "Bearer zzz"}
+
+
+def test_constructor_rejects_empty_fields() -> None:
+    with pytest.raises(ValueError):
+        OAuth2ClientCredentials(
+            client_id="",
+            client_secret="s",
+            token_url="https://x",
+        )
+
+
+def test_build_client_from_env_returns_none_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in ("OAUTH2_CLIENT_ID", "OAUTH2_CLIENT_SECRET", "OAUTH2_TOKEN_URL"):
+        monkeypatch.delenv(var, raising=False)
+    assert build_client_from_env() is None
+
+
+def test_build_client_from_env_succeeds_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OAUTH2_CLIENT_ID", "cid")
+    monkeypatch.setenv("OAUTH2_CLIENT_SECRET", "csec")
+    monkeypatch.setenv("OAUTH2_TOKEN_URL", "https://auth.test/oauth/token")
+    monkeypatch.setenv("OAUTH2_SCOPE", "read")
+    client = build_client_from_env()
+    assert client is not None
+
+
+@pytest.mark.asyncio
+async def test_expires_in_clamped_to_minimum(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = _MockTransport(
+        [httpx.Response(200, json={"access_token": "t", "expires_in": 0})]
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        oauth = OAuth2ClientCredentials(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://auth.test/oauth/token",
+        )
+        await oauth.get_token(client=client)
+
+    # After the fetch, is_valid() at t+30s skew boundary should still hold
+    # because expires_in=0 was clamped up to 60s.
+    cached: Any = oauth._cached  # noqa: SLF001 — test-only access
+    assert cached is not None
+    assert cached.expires_at_monotonic > time.monotonic() + 20


### PR DESCRIPTION
## Summary

- Adds a small async OAuth2 `client_credentials` helper at `caretaker.auth.oauth_client` for service-to-service calls from consumer repos. Tokens are cached in-process keyed on a 30s skew against the server-reported `expires_in`, and concurrent callers are coalesced through an `asyncio.Lock` so a burst triggers a single refresh.
- Wires the client into the fleet-registry emitter under a new `FleetRegistryConfig.oauth2` block (opt-in, default off). When enabled the heartbeat POST is decorated with `Authorization: Bearer <jwt>`; the HMAC path is preserved and may be used alongside it. A module-level client cache keeps the JWT cache warm across heartbeats and invalidates automatically on rotation.
- Fail-open semantics of the fleet emitter are preserved: an auth-server outage logs a `WARNING` and the heartbeat still goes out (without a bearer header) rather than breaking the run loop.

## Consumer rollout

Five consumer repos (`caretaker`-topic) now carry per-repo `OAUTH2_CLIENT_ID` / `OAUTH2_CLIENT_SECRET` secrets plus `OAUTH2_TOKEN_URL` / `OAUTH2_ISSUER_URL` variables, issued from the `roauth2.cat-herding.net` authorization server under a `client_credentials` grant with `read write` scope. The feature is strictly opt-in on the caretaker side — existing installs remain byte-identical until they flip `fleet_registry.oauth2.enabled`.

## Test plan

- [x] `pytest tests/test_oauth_client.py tests/test_fleet_registry.py tests/test_config.py` — 40 passed
- [x] `ruff check` clean across new + touched files
- [x] `mypy` clean across `src/caretaker/auth`, `src/caretaker/fleet`, `src/caretaker/config.py`
- [ ] Run one real heartbeat against the dev fleet endpoint with `OAUTH2_*` populated and verify the bearer header is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)