### PR TITLE
fix(foundry): remove mis-shaped tool_loop fallback for Anthropic models

### DIFF
--- a/src/caretaker/foundry/tool_loop.py
+++ b/src/caretaker/foundry/tool_loop.py
@@ -14,7 +14,6 @@ iteration.  Termination conditions:
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -99,30 +98,22 @@ async def run_tool_loop(
         if response.cost_usd is not None:
             total_cost = (total_cost or 0.0) + response.cost_usd
 
-        # Append the assistant turn.
-        if response.raw_message is not None:
-            messages.append(response.raw_message)
-        else:
-            # Defensive: build a minimal assistant message. Models that return
-            # only text are handled by the text-only branch below.
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": response.text or None,
-                    "tool_calls": [
-                        {
-                            "id": tc.id,
-                            "type": "function",
-                            "function": {
-                                "name": tc.name,
-                                "arguments": json.dumps(tc.arguments),
-                            },
-                        }
-                        for tc in response.tool_calls
-                    ]
-                    or None,
-                }
+        # Append the assistant turn verbatim. Providers that implement
+        # ``complete_with_tools`` MUST populate ``raw_message`` with a
+        # provider-native message dict (OpenAI function-calling shape for
+        # LiteLLM/OpenAI-compatible backends, Anthropic tool_use content-block
+        # shape for native Anthropic backends, etc.). Rebuilding the assistant
+        # turn here was previously hard-coded to OpenAI shape and would produce
+        # a 400 on the next request when the provider expected Anthropic
+        # tool_use blocks, so we now refuse to paper over a provider bug and
+        # surface the contract violation as a ToolLoopError instead.
+        if response.raw_message is None:
+            raise ToolLoopError(
+                f"provider {provider.name} returned a tool-use response with "
+                "raw_message=None; cannot safely round-trip the assistant turn "
+                "(provider must populate raw_message with its native message shape)"
             )
+        messages.append(response.raw_message)
 
         if not response.tool_calls:
             return ToolLoopResult(

--- a/tests/test_foundry/test_tool_loop.py
+++ b/tests/test_foundry/test_tool_loop.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from caretaker.foundry.tool_loop import ToolLoopError, run_tool_loop
 from caretaker.foundry.tools import ToolContext, build_tool_registry
-from caretaker.llm.provider import LLMToolCall
+from caretaker.llm.provider import LLMRequest, LLMResponse, LLMToolCall, LLMToolResponse
 
 from .conftest import FakeToolProvider, ScriptedTurn
 
@@ -134,3 +136,159 @@ class TestToolLoop:
                 model="azure_ai/fake",
                 max_iterations=3,
             )
+
+    @pytest.mark.asyncio
+    async def test_missing_raw_message_raises_tool_loop_error(self, tool_ctx: ToolContext) -> None:
+        """Providers must populate ``raw_message`` on tool-use responses.
+
+        The loop used to silently rebuild the assistant message in OpenAI
+        function-calling shape, which 400s on the next turn for Anthropic
+        tool_use. Ensure we now fail loudly with :class:`ToolLoopError`.
+        """
+
+        class RawMessageMissingProvider:
+            name = "raw-missing"
+            available = True
+
+            async def complete(self, request: LLMRequest) -> LLMResponse:
+                return LLMResponse(text="", model=request.model, provider=self.name)
+
+            async def complete_with_tools(
+                self, request: LLMRequest, tools: list[dict[str, Any]]
+            ) -> LLMToolResponse:
+                return LLMToolResponse(
+                    text="",
+                    tool_calls=[LLMToolCall(id="call_1", name="git_status", arguments={})],
+                    model=request.model,
+                    provider=self.name,
+                    raw_message=None,
+                )
+
+        with pytest.raises(ToolLoopError, match="raw_message=None"):
+            await run_tool_loop(
+                provider=RawMessageMissingProvider(),
+                system_prompt="sys",
+                user_prompt="usr",
+                tools=build_tool_registry(),
+                tool_ctx=tool_ctx,
+                model="azure_ai/fake",
+                max_iterations=3,
+            )
+
+    @pytest.mark.asyncio
+    async def test_anthropic_shape_raw_message_is_round_tripped(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """Anthropic-style ``tool_use`` content blocks must flow through unchanged.
+
+        Previously the loop would have papered over a None ``raw_message`` by
+        rebuilding the assistant turn in OpenAI shape, which Anthropic rejects.
+        The loop now appends whatever the provider returns verbatim; this test
+        asserts we round-trip the native Anthropic shape into the next request.
+        """
+
+        anthropic_assistant_message: dict[str, Any] = {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "git_status",
+                    "input": {},
+                },
+            ],
+        }
+
+        class AnthropicShapeProvider:
+            name = "anthropic-shape"
+            available = True
+
+            def __init__(self) -> None:
+                # Snapshots of ``messages`` at each call, since the loop mutates
+                # the same list in place between turns.
+                self.message_snapshots: list[list[dict[str, Any]]] = []
+                self._turn = 0
+
+            async def complete(self, request: LLMRequest) -> LLMResponse:
+                return LLMResponse(text="", model=request.model, provider=self.name)
+
+            async def complete_with_tools(
+                self, request: LLMRequest, tools: list[dict[str, Any]]
+            ) -> LLMToolResponse:
+                assert request.messages is not None
+                self.message_snapshots.append([dict(m) for m in request.messages])
+                self._turn += 1
+                if self._turn == 1:
+                    return LLMToolResponse(
+                        text="",
+                        tool_calls=[LLMToolCall(id="toolu_1", name="git_status", arguments={})],
+                        model=request.model,
+                        provider=self.name,
+                        raw_message=anthropic_assistant_message,
+                    )
+                return LLMToolResponse(
+                    text="done",
+                    tool_calls=[],
+                    model=request.model,
+                    provider=self.name,
+                    raw_message={"role": "assistant", "content": "done"},
+                )
+
+        provider = AnthropicShapeProvider()
+        result = await run_tool_loop(
+            provider=provider,
+            system_prompt="sys",
+            user_prompt="usr",
+            tools=build_tool_registry(),
+            tool_ctx=tool_ctx,
+            model="claude-sonnet-4",
+            max_iterations=5,
+        )
+        assert result.stopped_reason == "completed"
+        assert result.iterations == 2
+        assert result.tool_calls_made == 1
+        # Second request must have the verbatim Anthropic-shape assistant turn
+        # appended — not an OpenAI-rebuilt ``tool_calls`` list.
+        second_messages = provider.message_snapshots[1]
+        assistant_turns = [m for m in second_messages if m.get("role") == "assistant"]
+        assert assistant_turns == [anthropic_assistant_message]
+
+    @pytest.mark.asyncio
+    async def test_openai_shape_raw_message_is_round_tripped(self, tool_ctx: ToolContext) -> None:
+        """OpenAI function-calling shape round-trips too (LiteLLM happy path).
+
+        This is the shape the FakeToolProvider in conftest emits; the other
+        tests already cover it implicitly, but assert it explicitly so the
+        provider-specific behaviour doesn't silently regress.
+        """
+        provider = FakeToolProvider(
+            [
+                ScriptedTurn(
+                    tool_calls=[LLMToolCall(id="call_1", name="git_status", arguments={})]
+                ),
+                ScriptedTurn(text="done"),
+            ]
+        )
+        result = await run_tool_loop(
+            provider=provider,
+            system_prompt="sys",
+            user_prompt="usr",
+            tools=build_tool_registry(),
+            tool_ctx=tool_ctx,
+            model="azure_ai/fake",
+            max_iterations=5,
+        )
+        assert result.stopped_reason == "completed"
+        # The loop mutates ``request.messages`` in place, so inspect whatever
+        # state the list is in at the end of the run — it should contain the
+        # first assistant turn carrying OpenAI-shape ``tool_calls``.
+        second_messages = provider.calls[1].messages
+        assert second_messages is not None
+        assistant_turns_with_calls = [
+            m for m in second_messages if m.get("role") == "assistant" and m.get("tool_calls")
+        ]
+        assert len(assistant_turns_with_calls) == 1
+        tool_calls = assistant_turns_with_calls[0]["tool_calls"]
+        assert isinstance(tool_calls, list)
+        assert tool_calls[0]["type"] == "function"
+        assert tool_calls[0]["function"]["name"] == "git_status"


### PR DESCRIPTION
## Summary

- Delete the defensive fallback in `run_tool_loop` that rebuilt the assistant turn in OpenAI function-calling shape (`{"role": "assistant", "tool_calls": [...]}`) when the provider returned `raw_message=None`. That shape is wrong for Anthropic tool-use (which expects content blocks with `type: "tool_use"`), so any Anthropic path that hit the fallback would 400 on the next turn.
- Raise `ToolLoopError` instead when `raw_message is None` so provider contract violations surface immediately rather than silently corrupting the next request.
- Cover the new behaviour with unit tests: missing `raw_message` → `ToolLoopError`, Anthropic-shape content-block message round-trips verbatim, OpenAI-shape `tool_calls` message still round-trips.

## Why path (a)?

Only `LiteLLMProvider` implements `complete_with_tools`, and it always populates `raw_message` (either `message.model_dump()` or a manual dict build). `AnthropicProvider` and `NullProvider` raise `NotImplementedError` and never return a tool-use response. There is no legitimate code path today that produces `raw_message=None`, so the fallback was only masking a provider bug. Path (b) (branching on provider family inside the loop) would add surface area without closing the contract gap.

## Test plan

- [x] `.venv/bin/pytest -q tests/test_foundry/ tests/test_llm.py` — 94 passed
- [x] `.venv/bin/ruff check src/caretaker/foundry/ src/caretaker/llm/ tests/test_foundry/ tests/test_llm.py` — clean
- [x] `.venv/bin/ruff format --check src/caretaker/foundry/ src/caretaker/llm/ tests/test_foundry/ tests/test_llm.py` — clean
- [x] `.venv/bin/mypy src/caretaker/foundry src/caretaker/llm` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)