### PR TITLE
fix(datetime): replace deprecated datetime.utcnow() with datetime.now(UTC)

### DIFF
--- a/src/caretaker/issue_agent/agent.py
+++ b/src/caretaker/issue_agent/agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from caretaker.issue_agent.classifier import IssueClassification, classify_issue
@@ -77,7 +77,7 @@ class IssueAgent:
                         tracking.state = IssueTrackingState.COMPLETED
                     else:
                         tracking.state = IssueTrackingState.CLOSED
-                    tracking.last_checked = datetime.utcnow()
+                    tracking.last_checked = datetime.now(UTC)
                     tracked_issues[issue.number] = tracking
                     continue
 
@@ -93,7 +93,7 @@ class IssueAgent:
                     IssueTrackingState.COMPLETED,
                     IssueTrackingState.CLOSED,
                 ):
-                    tracking.last_checked = datetime.utcnow()
+                    tracking.last_checked = datetime.now(UTC)
                     tracked_issues[issue.number] = tracking
                     continue
 
@@ -102,7 +102,7 @@ class IssueAgent:
                 report.triaged += 1
 
                 tracking = await self._process_issue(issue, classification, tracking, report)
-                tracking.last_checked = datetime.utcnow()
+                tracking.last_checked = datetime.now(UTC)
                 tracked_issues[issue.number] = tracking
 
             except Exception as e:

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -49,7 +49,15 @@ logger = logging.getLogger(__name__)
 
 
 def _as_utc(dt: datetime) -> datetime:
-    """Return a UTC-aware datetime, attaching UTC if the datetime is naive."""
+    """Return a UTC-aware datetime, attaching UTC if the datetime is naive.
+
+    All new producers in ``src/caretaker/`` now emit tz-aware UTC datetimes
+    (see the datetime.utcnow() sweep PR). This helper is retained purely to
+    normalize datetimes round-tripped from older serialized state that may
+    still contain naive ISO strings without a ``+00:00`` offset.  Once the
+    persisted state corpus has rolled over, the remaining call sites can be
+    dropped.
+    """
     if dt.tzinfo is None:
         return dt.replace(tzinfo=UTC)
     return dt
@@ -375,7 +383,7 @@ class Orchestrator:
 
         # Load persisted state
         state = OrchestratorState()
-        summary = RunSummary(mode=mode, run_at=datetime.utcnow())
+        summary = RunSummary(mode=mode, run_at=datetime.now(UTC))
         has_errors = False
 
         try:

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -175,7 +175,7 @@ class PRAgent:
             try:
                 tracking = tracked_prs.get(pr.number, TrackedPR(number=pr.number))
                 tracking = await self._process_pr(pr, tracking, report)
-                tracking.last_checked = datetime.utcnow()
+                tracking.last_checked = datetime.now(UTC)
                 tracked_prs[pr.number] = tracking
             except Exception as e:
                 logger.error("Error processing PR #%d: %s", pr.number, e)
@@ -220,7 +220,7 @@ class PRAgent:
     ) -> TrackedPR:
         """Process a single PR through the state machine."""
         if tracking.first_seen_at is None:
-            tracking.first_seen_at = datetime.utcnow()
+            tracking.first_seen_at = datetime.now(UTC)
 
         # Fetch CI status and reviews
         check_runs = await self._github.get_check_runs(self._owner, self._repo, pr.head_ref)
@@ -405,7 +405,7 @@ class PRAgent:
             if success:
                 logger.info("PR #%d merged via %s", pr.number, merge_decision.method)
                 tracking.state = PRTrackingState.MERGED
-                tracking.merged_at = datetime.utcnow()
+                tracking.merged_at = datetime.now(UTC)
                 report.merged.append(pr.number)
             else:
                 logger.warning("PR #%d merge failed", pr.number)
@@ -581,7 +581,7 @@ class PRAgent:
             tracking.copilot_attempts = attempt
             tracking.last_task_comment_id = result.comment_id
             tracking.state = PRTrackingState.FIX_REQUESTED
-            tracking.last_state_change_at = datetime.utcnow()
+            tracking.last_state_change_at = datetime.now(UTC)
             tracking.last_copilot_attempt_at = datetime.now(UTC)
             report.fix_requested.append(pr.number)
             logger.info(

--- a/src/caretaker/review_agent/agent.py
+++ b/src/caretaker/review_agent/agent.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -108,7 +108,7 @@ class ReviewAgent(BaseAgent):
         history_len = len(state.run_history) if hasattr(state, "run_history") else 0
 
         return ReviewScorecard(
-            reviewed_at=datetime.utcnow(),
+            reviewed_at=datetime.now(UTC),
             target=target,
             window=WindowInfo(lookback_runs=cfg.lookback_runs, lookback_days=cfg.lookback_days),
             overall=OverallScore(score=score, grade=grade, confidence=0.8, status="mixed"),

--- a/src/caretaker/state/models.py
+++ b/src/caretaker/state/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 
 from pydantic import BaseModel, Field
@@ -96,7 +96,7 @@ class TrackedIssue(BaseModel):
 
 
 class RunSummary(BaseModel):
-    run_at: datetime = Field(default_factory=datetime.utcnow)
+    run_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     mode: str = "full"
     prs_monitored: int = 0
     prs_merged: int = 0

--- a/tests/test_evolution_state_machine.py
+++ b/tests/test_evolution_state_machine.py
@@ -291,7 +291,9 @@ class TestPlanModeCooldown:
         """Stored ISO strings may be naive — parser must normalize to UTC."""
         goal_id = "ci_health"
         state = OrchestratorState()
-        naive_recent = datetime.utcnow() - timedelta(hours=12)
+        # Intentionally construct a naive datetime (no tzinfo) to simulate
+        # legacy serialized cooldowns — the parser must still normalize it.
+        naive_recent = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=12)
         state.plan_cooldowns[goal_id] = naive_recent.isoformat()
 
         plan_mode = PlanMode(github_mock, "owner", "repo", claude_stub)

--- a/tests/test_no_utcnow.py
+++ b/tests/test_no_utcnow.py
@@ -1,0 +1,59 @@
+"""Regression guard: ``datetime.utcnow()`` must not return to ``src/caretaker``.
+
+``datetime.utcnow()`` is deprecated in Python 3.12 and produces naive
+datetimes that mix unsafely with the tz-aware datetimes used elsewhere in
+the codebase (``last_copilot_attempt_at``, fleet heartbeat timestamps,
+graph node ``write_ts``). The sweep PR replaced every call site with
+``datetime.now(UTC)``; this test stops it creeping back.
+
+The check walks the AST rather than doing a substring scan so references
+inside docstrings, comments, or string literals do not trigger false
+positives.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "caretaker"
+
+
+def _call_is_datetime_utcnow(node: ast.Call) -> bool:
+    """Return True if ``node`` is a call like ``datetime.utcnow()``.
+
+    Matches both ``datetime.utcnow()`` (module-level ``datetime`` type) and
+    ``datetime.datetime.utcnow()`` (when the module itself is imported as
+    ``datetime``). Does not match unrelated ``something.utcnow()`` helpers.
+    """
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr != "utcnow":
+        return False
+    value = func.value
+    # datetime.utcnow()
+    if isinstance(value, ast.Name) and value.id == "datetime":
+        return True
+    # datetime.datetime.utcnow()
+    return bool(
+        isinstance(value, ast.Attribute)
+        and value.attr == "datetime"
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "datetime"
+    )
+
+
+def test_no_datetime_utcnow_in_src() -> None:
+    """No source file under ``src/caretaker/`` may call ``datetime.utcnow()``."""
+    offenders: list[str] = []
+    for py_file in SRC_ROOT.rglob("*.py"):
+        source = py_file.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(py_file))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _call_is_datetime_utcnow(node):
+                rel = py_file.relative_to(SRC_ROOT.parent.parent)
+                offenders.append(f"{rel}:{node.lineno}")
+
+    assert not offenders, (
+        "datetime.utcnow() is deprecated and produces naive datetimes. "
+        "Use datetime.now(UTC) instead. Offending call sites:\n  " + "\n  ".join(offenders)
+    )

--- a/tests/test_review_agent/test_models.py
+++ b/tests/test_review_agent/test_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from caretaker.review_agent.models import (
     DimensionScore,
@@ -28,7 +28,7 @@ def test_target_info():
 
 def test_review_scorecard():
     scorecard = ReviewScorecard(
-        reviewed_at=datetime.utcnow(),
+        reviewed_at=datetime.now(UTC),
         target=TargetInfo(kind="run"),
         window=WindowInfo(lookback_runs=5, lookback_days=7),
         overall=OverallScore(score=95, grade="A", confidence=0.9, status="excellent"),


### PR DESCRIPTION
## Summary

Python 3.12 deprecates `datetime.utcnow()`, which also produced naive
datetimes that mixed unsafely with the tz-aware datetimes already in use
across the codebase (`last_copilot_attempt_at`, fleet heartbeat
timestamps, graph node `write_ts`, etc.). A prior fix (#300) had to
paper over one such mismatch with the `_as_utc` helper in
`orchestrator.py`; this PR is the systemic cleanup.

## Changes

- Replaced every `datetime.utcnow()` call in `src/caretaker/` with
  `datetime.now(UTC)`. Affected modules:
  - `src/caretaker/orchestrator.py`
  - `src/caretaker/state/models.py` (`RunSummary.run_at` default factory)
  - `src/caretaker/pr_agent/agent.py` (`last_checked`, `first_seen_at`,
    `merged_at`, `last_state_change_at`)
  - `src/caretaker/issue_agent/agent.py` (`last_checked` — three sites)
  - `src/caretaker/review_agent/agent.py` (`reviewed_at`)
- Updated the two test fixtures that called `datetime.utcnow()`:
  - `tests/test_review_agent/test_models.py` now uses `datetime.now(UTC)`.
  - `tests/test_evolution_state_machine.py::test_naive_datetime_stamp_treated_as_utc`
    still needs to construct a naive datetime on purpose (it verifies the
    legacy-state parser), so it now builds one explicitly via
    `datetime.now(UTC).replace(tzinfo=None)` with a comment explaining why.
- Retained the `_as_utc` helper in `orchestrator.py` (call sites at
  lines 673 and 692) because both wrap datetimes read out of persisted
  `OrchestratorState`, which may still contain legacy ISO strings without
  a `+00:00` offset from pre-migration runs. The docstring now explains
  that the helper is purely a legacy-state normalizer and can be dropped
  once the persisted corpus has rolled over.
- Added `tests/test_no_utcnow.py`: an AST-based regression guard that
  walks every `.py` file under `src/caretaker/` and fails the build if
  any `datetime.utcnow()` call site returns. AST walking avoids false
  positives from docstrings, comments, or string literals.

Serialized-state compatibility: `RunSummary` (and other pydantic models)
will now emit ISO strings with a `+00:00` offset. The deserializer
already handles both naive and aware values thanks to `_as_utc`, so old
tracking-issue state keeps loading cleanly.

## Test plan

- [x] `.venv/bin/pytest -q` — full suite green (1083 passed, 1 skipped).
- [x] `.venv/bin/ruff check src tests` + `.venv/bin/ruff format --check src tests` — both clean.
- [x] `.venv/bin/mypy src/caretaker` — no new errors (two pre-existing k8s stub errors on `launcher.py:244` are unrelated and present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)