### PR TITLE
fix(fleet): extract OAuth2 client cache onto a per-owner class

### DIFF
--- a/src/caretaker/fleet/__init__.py
+++ b/src/caretaker/fleet/__init__.py
@@ -4,6 +4,7 @@ from caretaker.fleet.abstraction import abstract_sop
 from caretaker.fleet.api import admin_router, public_router
 from caretaker.fleet.emitter import (
     FleetHeartbeat,
+    FleetOAuthClientCache,
     build_heartbeat,
     emit_heartbeat,
     sign_payload,
@@ -19,6 +20,7 @@ from caretaker.fleet.store import (
 __all__ = [
     "FleetClient",
     "FleetHeartbeat",
+    "FleetOAuthClientCache",
     "FleetRegistryStore",
     "abstract_sop",
     "admin_router",

--- a/src/caretaker/fleet/emitter.py
+++ b/src/caretaker/fleet/emitter.py
@@ -55,57 +55,79 @@ _COUNTERS = (
 )
 
 
-_oauth_client: OAuth2ClientCredentials | None = None
-_oauth_client_key: tuple[str, str, str, str, str, float] | None = None
+class FleetOAuthClientCache:
+    """Per-owner cache for the fleet heartbeat's OAuth2 client.
 
+    Caching the client across heartbeats is what lets the in-process JWT
+    cache inside :class:`OAuth2ClientCredentials` actually deliver value;
+    without it, every run would refetch a token. The cache key covers
+    every config + env var the client depends on, so a credential
+    rotation invalidates automatically.
 
-def _get_oauth_client(fleet: FleetRegistryConfig) -> OAuth2ClientCredentials | None:
-    """Return a cached OAuth2 client for the given config, rebuilding on change.
-
-    Caching the client instance across heartbeat calls is what lets the
-    in-memory JWT cache actually deliver value: without it, each run
-    would refetch a token. The cache key covers every config + env var
-    the client depends on, so a rotation invalidates correctly.
+    One instance is expected per logical owner — :class:`Orchestrator` in
+    production, or a test. A :data:`_default_cache` module singleton is
+    kept for the legacy free-function call path (``emit_heartbeat`` with
+    no ``oauth_cache=`` kwarg), but the singleton is no longer the only
+    place the state lives: multiple orchestrators or a multi-tenant admin
+    process each get their own instance and never cross-contaminate.
     """
-    global _oauth_client, _oauth_client_key
 
-    oauth_cfg = fleet.oauth2
-    if not oauth_cfg.enabled:
-        return None
+    __slots__ = ("_client", "_key")
 
-    scope = os.environ.get(oauth_cfg.scope_env, "").strip() or oauth_cfg.default_scope
-    key = (
-        os.environ.get(oauth_cfg.client_id_env, ""),
-        os.environ.get(oauth_cfg.client_secret_env, ""),
-        os.environ.get(oauth_cfg.token_url_env, ""),
-        oauth_cfg.scope_env,
-        scope,
-        oauth_cfg.timeout_seconds,
-    )
-    if _oauth_client_key == key and _oauth_client is not None:
-        return _oauth_client
+    _KeyT = tuple[str, str, str, str, str, float]
 
-    client = build_client_from_env(
-        client_id_env=oauth_cfg.client_id_env,
-        client_secret_env=oauth_cfg.client_secret_env,
-        token_url_env=oauth_cfg.token_url_env,
-        scope_env=oauth_cfg.scope_env,
-        timeout_seconds=oauth_cfg.timeout_seconds,
-    )
-    _oauth_client = client
-    _oauth_client_key = key if client is not None else None
-    return client
+    def __init__(self) -> None:
+        self._client: OAuth2ClientCredentials | None = None
+        self._key: FleetOAuthClientCache._KeyT | None = None
+
+    def get(self, fleet: FleetRegistryConfig) -> OAuth2ClientCredentials | None:
+        oauth_cfg = fleet.oauth2
+        if not oauth_cfg.enabled:
+            return None
+
+        scope = os.environ.get(oauth_cfg.scope_env, "").strip() or oauth_cfg.default_scope
+        key: FleetOAuthClientCache._KeyT = (
+            os.environ.get(oauth_cfg.client_id_env, ""),
+            os.environ.get(oauth_cfg.client_secret_env, ""),
+            os.environ.get(oauth_cfg.token_url_env, ""),
+            oauth_cfg.scope_env,
+            scope,
+            oauth_cfg.timeout_seconds,
+        )
+        if self._key == key and self._client is not None:
+            return self._client
+
+        client = build_client_from_env(
+            client_id_env=oauth_cfg.client_id_env,
+            client_secret_env=oauth_cfg.client_secret_env,
+            token_url_env=oauth_cfg.token_url_env,
+            scope_env=oauth_cfg.scope_env,
+            timeout_seconds=oauth_cfg.timeout_seconds,
+        )
+        self._client = client
+        self._key = key if client is not None else None
+        return client
+
+    def invalidate(self) -> None:
+        self._client = None
+        self._key = None
+
+
+_default_cache = FleetOAuthClientCache()
 
 
 async def _oauth_bearer_headers(
-    fleet: FleetRegistryConfig, *, client: httpx.AsyncClient
+    fleet: FleetRegistryConfig,
+    *,
+    client: httpx.AsyncClient,
+    cache: FleetOAuthClientCache,
 ) -> dict[str, str]:
     """Return ``Authorization: Bearer …`` if OAuth2 is configured, else ``{}``.
 
     Failures are logged at WARNING and swallowed: the fleet emitter is
     fail-open, so a flaky auth server never breaks the run loop.
     """
-    oauth = _get_oauth_client(fleet)
+    oauth = cache.get(fleet)
     if oauth is None:
         return {}
     try:
@@ -211,12 +233,18 @@ async def emit_heartbeat(
     summary: RunSummary,
     *,
     client: httpx.AsyncClient | None = None,
+    oauth_cache: FleetOAuthClientCache | None = None,
 ) -> bool:
     """POST a heartbeat to the configured fleet endpoint.
 
     Returns ``True`` on a 2xx response, ``False`` otherwise. Never raises:
     network or configuration problems are logged at ``WARNING`` and
     swallowed so a failure to register never fails the orchestrator run.
+
+    ``oauth_cache`` lets the caller own the OAuth2 client cache (needed
+    when multiple configs share a process, e.g. the admin backend or
+    tests). When omitted, the module-level :data:`_default_cache` is used
+    for the single-owner default case.
     """
     fleet: FleetRegistryConfig = config.fleet_registry
     if not fleet.enabled:
@@ -238,13 +266,14 @@ async def emit_heartbeat(
     if secret:
         headers["X-Caretaker-Signature"] = "sha256=" + sign_payload(body, secret)
 
+    cache = oauth_cache if oauth_cache is not None else _default_cache
     owns_client = client is None
     try:
         if owns_client:
             client = httpx.AsyncClient(timeout=fleet.timeout_seconds)
         assert client is not None  # narrow for type-checkers
         try:
-            oauth_headers = await _oauth_bearer_headers(fleet, client=client)
+            oauth_headers = await _oauth_bearer_headers(fleet, client=client, cache=cache)
             if oauth_headers:
                 headers.update(oauth_headers)
             resp = await client.post(endpoint, content=body, headers=headers)

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -178,6 +178,13 @@ class Orchestrator:
         if config.mcp.enabled:
             self._mcp_client = MCPClient(config.mcp)
 
+        # Per-orchestrator cache for the fleet heartbeat's OAuth2 client.
+        # Owned here so multi-tenant hosts (admin backend, tests) don't
+        # share a single cross-config client via a module global.
+        from caretaker.fleet import FleetOAuthClientCache
+
+        self._fleet_oauth_cache = FleetOAuthClientCache()
+
         # Evolution layer (InsightStore, ReflectionEngine, StrategyMutator, PlanMode)
         self._insight_store: InsightStore | None = None
         self._skill_crystallizer: SkillCrystallizer | None = None
@@ -555,7 +562,11 @@ class Orchestrator:
             try:
                 from caretaker.fleet import emit_heartbeat
 
-                await emit_heartbeat(self._config, summary)
+                await emit_heartbeat(
+                    self._config,
+                    summary,
+                    oauth_cache=self._fleet_oauth_cache,
+                )
             except Exception as e:
                 logger.warning("Fleet heartbeat failed: %s", e)
 

--- a/tests/test_fleet_registry.py
+++ b/tests/test_fleet_registry.py
@@ -24,6 +24,7 @@ from fastapi.testclient import TestClient
 from caretaker.config import FleetRegistryConfig, MaintainerConfig, OAuth2ClientConfig
 from caretaker.fleet import (
     FleetHeartbeat,
+    FleetOAuthClientCache,
     build_heartbeat,
     emit_heartbeat,
     get_store,
@@ -31,7 +32,6 @@ from caretaker.fleet import (
     reset_store_for_tests,
     sign_payload,
 )
-from caretaker.fleet import emitter as emitter_mod
 from caretaker.state.models import RunSummary
 
 # ── Config defaults ───────────────────────────────────────────────────────
@@ -144,9 +144,8 @@ async def test_emitter_attaches_oauth_bearer_and_caches_token(monkeypatch) -> No
     monkeypatch.setenv("OAUTH2_CLIENT_ID", "cid")
     monkeypatch.setenv("OAUTH2_CLIENT_SECRET", "csec")
     monkeypatch.setenv("OAUTH2_TOKEN_URL", "https://auth.test/oauth/token")
-    # Reset the module-level OAuth client cache so this test is hermetic.
-    emitter_mod._oauth_client = None
-    emitter_mod._oauth_client_key = None
+    # Per-test OAuth cache — avoids any cross-test leak from a module global.
+    oauth_cache = FleetOAuthClientCache()
 
     cfg = MaintainerConfig(
         fleet_registry=FleetRegistryConfig(
@@ -172,9 +171,15 @@ async def test_emitter_attaches_oauth_bearer_and_caches_token(monkeypatch) -> No
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as client:
-        assert await emit_heartbeat(cfg, _summary_fixture(), client=client) is True
+        assert (
+            await emit_heartbeat(cfg, _summary_fixture(), client=client, oauth_cache=oauth_cache)
+            is True
+        )
         # Second heartbeat in the same process reuses the cached token.
-        assert await emit_heartbeat(cfg, _summary_fixture(), client=client) is True
+        assert (
+            await emit_heartbeat(cfg, _summary_fixture(), client=client, oauth_cache=oauth_cache)
+            is True
+        )
 
     assert token_calls == 1  # JWT cache prevents a second token fetch
     assert heartbeat_calls == ["Bearer bearer-abc", "Bearer bearer-abc"]
@@ -186,8 +191,7 @@ async def test_emitter_oauth_token_failure_is_swallowed(monkeypatch) -> None:
     monkeypatch.setenv("OAUTH2_CLIENT_ID", "cid")
     monkeypatch.setenv("OAUTH2_CLIENT_SECRET", "csec")
     monkeypatch.setenv("OAUTH2_TOKEN_URL", "https://auth.test/oauth/token")
-    emitter_mod._oauth_client = None
-    emitter_mod._oauth_client_key = None
+    oauth_cache = FleetOAuthClientCache()
 
     cfg = MaintainerConfig(
         fleet_registry=FleetRegistryConfig(
@@ -206,7 +210,60 @@ async def test_emitter_oauth_token_failure_is_swallowed(monkeypatch) -> None:
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as client:
-        assert await emit_heartbeat(cfg, _summary_fixture(), client=client) is True
+        assert (
+            await emit_heartbeat(cfg, _summary_fixture(), client=client, oauth_cache=oauth_cache)
+            is True
+        )
+
+
+@pytest.mark.asyncio
+async def test_emitter_oauth_caches_are_per_instance(monkeypatch) -> None:
+    """Two caches in the same process must not share a client.
+
+    Regression test for the pre-0.12.1 module-global `_oauth_client` that
+    let a second MaintainerConfig's creds silently win over the first.
+    """
+    monkeypatch.setenv("GITHUB_REPOSITORY", "ianlintner/demo")
+    monkeypatch.setenv("OAUTH2_CLIENT_ID", "cid-A")
+    monkeypatch.setenv("OAUTH2_CLIENT_SECRET", "csec-A")
+    monkeypatch.setenv("OAUTH2_TOKEN_URL", "https://auth.test/oauth/token")
+
+    cache_a = FleetOAuthClientCache()
+    cache_b = FleetOAuthClientCache()
+    cfg = MaintainerConfig(
+        fleet_registry=FleetRegistryConfig(
+            enabled=True,
+            endpoint="https://fleet.example/heartbeat",
+            oauth2=OAuth2ClientConfig(enabled=True),
+        )
+    )
+
+    seen_basic_auths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "https://auth.test/oauth/token":
+            seen_basic_auths.append(request.headers.get("authorization", ""))
+            return httpx.Response(200, json={"access_token": "tok", "expires_in": 3600})
+        return httpx.Response(202, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        assert (
+            await emit_heartbeat(cfg, _summary_fixture(), client=client, oauth_cache=cache_a)
+            is True
+        )
+        # Rotate the secret mid-process — a real deploy during credential
+        # rotation. cache_b must see the new creds; it does not share state
+        # with cache_a.
+        monkeypatch.setenv("OAUTH2_CLIENT_ID", "cid-B")
+        monkeypatch.setenv("OAUTH2_CLIENT_SECRET", "csec-B")
+        assert (
+            await emit_heartbeat(cfg, _summary_fixture(), client=client, oauth_cache=cache_b)
+            is True
+        )
+
+    assert len(seen_basic_auths) == 2
+    assert seen_basic_auths[0] != seen_basic_auths[1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to the v0.12.0 OAuth2 work that just merged as #469. The emitter shipped with a pair of module-level globals (`_oauth_client`, `_oauth_client_key`) caching the fleet heartbeat's OAuth2 client. That works for one `MaintainerConfig` per process, but any multi-tenant path — the admin backend, a test that constructs two configs, a future "caretaker manages multiple fleets from one process" — silently lets the second config reuse the first's cached client. Self-inflicted bug, flagged in the staff-engineer audit as **S6** in `/tmp/caretaker-research/02-source-audit.md`.

## Change

- New `FleetOAuthClientCache` class on `caretaker.fleet.emitter`, exported through `caretaker.fleet`. Holds the cache state on an instance, not on the module.
- `emit_heartbeat` grows an optional `oauth_cache: FleetOAuthClientCache | None` kwarg. When `None`, falls back to a module `_default_cache` singleton so the free-function call path stays byte-identical.
- `Orchestrator` instantiates its own cache (`self._fleet_oauth_cache`) and threads it through to `emit_heartbeat`. Production heartbeats now never touch the module singleton.
- Tests that previously poked `emitter_mod._oauth_client = None` to reset the global now construct a per-test `FleetOAuthClientCache()`.
- New regression test `test_emitter_oauth_caches_are_per_instance` runs two caches through a mid-process credential rotation and asserts each cache saw its own creds.

The cache key is unchanged (`client_id`, `client_secret`, `token_url`, `scope_env`, `scope`, `timeout`), so credential-rotation invalidation still works as before.

## Test plan

- [x] `pytest tests/test_fleet_registry.py tests/test_oauth_client.py` — 32 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy src/caretaker/fleet src/caretaker/orchestrator.py` clean
- [ ] Let a real consumer-repo heartbeat fire post-merge and confirm the bearer-header round-trip still works (no shadow-mode for this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
