### PR TITLE
docs(plans): 2026-Q2 agentic migration plan + fleet + source audits

### DIFF
--- a/docs/plans/2026-04-22-fleet-audit.md
+++ b/docs/plans/2026-04-22-fleet-audit.md
@@ -1,0 +1,128 @@
+# Caretaker Fleet Audit — Consumer-Repo Effectiveness (as of 2026-04-22)
+
+## Executive verdict
+
+Of five consumer repos, only **two** are meaningfully served by caretaker today: `Example-React-AI-Chat-App` (the most active dogfooding target) and `python_dsa` (the newest, still recovering from a CI-format storm). `kubernetes-apply-vscode` is marginal. `flashcards` and `audio_engineer` are effectively non-functional — `audio_engineer`'s `Caretaker` workflow has had **a 14% success rate over its last 50 runs** (7 success, 43 failure) and has not produced a healthy run on `main` since 2026-04-17.
+
+The fleet exposes the same handful of root causes repeatedly: the `maintain` job exits non-zero at the end of otherwise-productive runs (breaking every consumer that relies on `self-heal-on-failure` as a guardrail), the `GITHUB_TOKEN` used by caretaker lacks several of the permissions its agents assume (assignees on restricted repos, Dependabot/code-scanning alerts, PR creation), and caretaker's Copilot-driven upgrade path regularly orphans its own PRs in an "awaiting requirements" state.
+
+---
+
+## Per-repo scorecard
+
+### 1. `ianlintner/audio_engineer` — **mostly broken**
+
+- **50 runs / 7 success / 43 failure** (14% success). All 6 Dependabot PRs opened 2026-04-22 triggered `Caretaker` runs that failed; the most recent `schedule`-equivalent push run was 24762617294 (also failed).
+- Workflow is **stuck on a broken state**: every push to `main` for a week has failed the `Caretaker` workflow, yet there are **no caretaker-authored issues** under this workflow name beyond orchestrator state (`[Maintainer] Orchestrator State` #11) — the self-heal and escalation-digest paths are not firing here. This strongly suggests the failure is happening **before** the orchestrator runs (likely a secret-missing / install-step failure during the workflow bootstrap), so none of caretaker's own telemetry agents get a chance to run.
+- 22 Copilot PRs (21 merged, 1 closed-unmerged) and 44 Dependabot PRs (19 merged, 3 still open, ~22 closed-unmerged) — Copilot/Dependabot automation itself is working, but **caretaker isn't actually merging/shepherding them**; the human operator or classic GH auto-merge is.
+- No `caretaker:owned`, `caretaker:self-heal`, or `maintainer:escalation-digest` labels on any current issue — caretaker can't even signal its own failures on this repo.
+- Verdict: **mostly broken**. The workflow itself is red; every run is wasted CI minutes. Nothing user-visible about the repo improves because of caretaker.
+
+### 2. `ianlintner/python_dsa` — **partially working**
+
+- **81 runs / 48 success / 14 failure / 19 cancelled** (59% success; cancellation is mostly the concurrency-group pattern working as intended on burst check_suite events).
+- The orchestrator `[Maintainer] Orchestrator State` issue (#23) is actively being updated — **146 comments**, all `github-actions`, mostly `caretaker:run-history` and `caretaker:orchestrator-state` markers — and the dispatch-guard is correctly short-circuiting those.
+- Escalation is active but **crude**: issue #30 ("CI failure on main: maintain (unknown)") has been open since 2026-04-17; issue #31 (W16 digest) is stale; PRs #39, #42, #43 were all opened by Copilot on 2026-04-20 to fix the same trailing-newline problem and are still open ("caretaker:owned", `maintainer:escalated`, 60% readiness, "Reviews approved 0%"). On PR #42 all CI checks are now green (CLEAN state) and it **still sits unmerged** — caretaker's readiness gate blocks on human approval that will never come.
+- The v0.10.1 upgrade PR #45 is in the same state. Issue #44 ("Upgrade to v0.10.1") has Copilot assigned but the PR loops on the same readiness-score comment without the merge bot ever taking action.
+- Verdict: **partially working**. Instrumentation and CI self-healing fire; the "last mile" merge/approve step does not.
+
+### 3. `ianlintner/kubernetes-apply-vscode` — **partially working**
+
+- **15 runs / 11 success / 0 failure / 4 action_required**. Cleanest success rate on paper, but volume is low (mostly PR events).
+- Actively escalating: #16 ("Caretaker self-heal: Unknown caretaker failure: "), #10/#11 (CI-failure twins for `self-heal-on-failure` and `maintain`), #18 (`[Maintainer] Upgrade to v0.10.2`) all open with no assignees on the escalations despite `maintainer:assigned` labels being applied — classic label-applied-without-actual-assignee.
+- Copilot upgrade loop on display: PR #16 (v0.10.1) and PR #17 (EOF-newline fix) both sit at "Monitoring — awaiting requirements", `action_required`, readiness 20–40%. The "add trailing newline" Copilot PR chain is the exact same bug pattern as python_dsa and flashcards, suggesting the caretaker release-sync tool produces a config file without a trailing `\n` and every downstream pre-commit hook chokes on it.
+- Verdict: **partially working**. Caretaker correctly detects and files, but leaves the work undone.
+
+### 4. `ianlintner/flashcards` — **mostly broken**
+
+- **14 runs / 6 success / 8 failure** (43% success). Scheduled run on 2026-04-21 (ID 24712826996) failed at the final step despite the orchestrator logging a full run — the `upload-artifact` step then fails ("No files were found... .caretaker-memory-snapshot.json") and `Process completed with exit code 1`. That non-zero exit masks the fact that the orchestrator itself largely succeeded.
+- Inside that same log: `POST /issues/18/assignees → 403 Forbidden` (cannot assign Copilot/`ianlintner` on issue #18), `dependabot/alerts → 403`, `code-scanning/alerts → 403`, `secret-scanning/alerts → 403`, `POST /pulls → 403` on the docs changelog PR. Five separate integration-permission gaps, each silently swallowed by `caretaker.security_agent` / `caretaker.docs_agent`.
+- The orchestrator still manages to update escalation-digest #9 (W16) — **but W16 was 2 weeks stale**, listing self-heal issues #7 and #16 that the escalation agent itself created. Caretaker is digesting its own exhaust.
+- 1 Copilot upgrade PR merged recently (#5 v0.5.2, 2026-04-17); one PR merged via human; no Dependabot traffic.
+- Verdict: **mostly broken**. Every scheduled run fails its final step, every PR path is 403.
+
+### 5. `ianlintner/Example-React-AI-Chat-App` — **working well**
+
+- **100 runs / 71 success / 22 cancelled / 6 failure / 1 action_required** (71% success; cancellations are the concurrency-group pattern). 62 of 100 runs are `check_suite` (webhook-driven from dependent CI completions), which is exactly the reactive pattern caretaker claims.
+- The caretaker-owned Dependabot rollups (PR #195 "npm_and_yarn group across 4 directories", 19 updates; PR #192 across 3 dirs, 20 updates) carry the `caretaker:owned` label and are staying green — but **no merges** yet. UNSTABLE state indicates failing CI.
+- Self-heal loop is observable but controlled: issues #134, #178, #199 all "Unknown caretaker failure: Process completed with exit code 1." #134 and #178 closed (one by stale, one by digest); #199 created 6 hours ago. Self-heal is producing duplicate issues every time the orchestrator final-step fails — same artifact-upload non-zero-exit bug as flashcards.
+- Escalation digest #177 (W17) is well-formed.
+- Verdict: **working well** in absolute terms — but a large share of that "success" is caretaker doing nothing because the PRs it watches are working under their own steam.
+
+---
+
+## Patterns across the fleet
+
+**P1 — "Final-step false-failure" drives self-heal storms.** On at least `flashcards`, `Example-React-AI-Chat-App`, and intermittently `python_dsa` / `kubernetes-apply-vscode`, the orchestrator logs a clean run but exits 1 because `upload-artifact` cannot find `.caretaker-memory-snapshot.json`, or because `Run completed with 1 errors` is escalated to job failure. This fires `self-heal-on-failure`, which opens a `Caretaker self-heal: Unknown caretaker failure: Process completed with exit code 1.` issue with an empty error body (because the error was swallowed). The same issue gets re-opened each scheduled run until the weekly digest closes or escalates it. Evidence: `flashcards` run 24712826996; `Example-React` issues #134 / #178 / #199.
+
+**P2 — Permission-starved integration token.** caretaker's agents assume scopes the workflow `GITHUB_TOKEN` doesn't always have: `Dependabot alerts` (`flashcards` 403), `code-scanning/alerts` (403), `secret-scanning/alerts` (403), `POST /pulls` for docs changelog (403), `POST /assignees` for Copilot (403). Each agent logs a warning and moves on — no user-visible signal that half the surface area is dead. Evidence: `flashcards` run 24712826996 log.
+
+**P3 — Trailing-newline Copilot fan-out.** When caretaker asks Copilot to bump its own version, the templated `maintainer.yml` lands without a final `\n`, the consumer's `end-of-file-fixer` pre-commit hook fails, caretaker's devops agent files a CI-failure issue, assigns Copilot to produce another PR to add the newline, and that PR also doesn't merge itself. Three repos (`python_dsa`, `kubernetes-apply-vscode`, `flashcards`) show this exact chain within 48 hours of each other. Evidence: `python_dsa` PRs #39 / #42 / #43, `kubernetes-apply-vscode` PR #17, matching `maintainer:escalated` labels.
+
+**P4 — Readiness-gate dead end.** Caretaker's PR agent computes a readiness score (0/20/40/60/80%) and blocks on "Reviews approved = 0%" for its own PRs. On a single-maintainer repo with no reviewers, that gate can never clear. PRs on `python_dsa` #42 sit at `MERGEABLE / CLEAN` with all checks green and still do not merge. This is a policy mismatch, not a bug — but it means caretaker **cannot actually complete its headline job** (merging its own upgrade PRs) on any solo repo.
+
+**P5 — Escalation-digest is self-referential.** In `flashcards` #9, the digest lists the self-heal issues and CI-failure issues caretaker itself produced. There is no real human-actionable content — it's an internal audit log being re-surfaced as an actionable weekly report. Same on `kubernetes-apply-vscode` #19 (W17 digest).
+
+**P6 — Dispatch-guard works correctly.** On `audio_engineer`, `issue_comment` events from bots and caretaker-marker comments are short-circuited at the guard step (no `maintain` job runs). No evidence of webhook infinite loops. The guard regex is straightforward and I did not see it produce false positives or negatives in sampled events.
+
+**P7 — Scheduled vs. webhook run split.** `Example-React` runs are 62% `check_suite`, 30% `pull_request`, 1% `schedule` — genuine reactive maintenance. `audio_engineer` is 54% `push` (all failing) and 0% `schedule`/`check_suite`, indicating the `cron` and check_suite hooks aren't even landing on that repo. Likely caretaker workflow is disabled on schedule because the job fails so consistently that GitHub has auto-disabled it — worth confirming in repo settings.
+
+**P8 — `audio_engineer` is ghosted.** No successful `schedule` run on record, no `caretaker:*` labels on any issue, `Orchestrator State` issue not updated since setup. That repo isn't "partially working" — caretaker has been dark there for a week and nobody noticed because the digest never got written.
+
+---
+
+## Ranked issues (impact × frequency)
+
+| # | Issue | Repos | Evidence | Hypothesis |
+|---|---|---|---|---|
+| 1 | Orchestrator exits 1 on artifact-upload / residual errors, triggering duplicate self-heal issues on every schedule | flashcards, Example-React, kubernetes-apply-vscode | flashcards run 24712826996 (`No files were found with the provided path: .caretaker-memory-snapshot.json`); Ex-React issues #199/#178/#134 | Memory snapshot is conditionally written; absent file shouldn't be fatal — set `if-no-files-found: ignore` AND make orchestrator exit 0 when all agent errors are in known-failure buckets (403s etc.) |
+| 2 | Caretaker workflow fully red on `audio_engineer` for a week | audio_engineer | Runs 24754140054, 24762617294, etc.; no `caretaker:self-heal` issue opened (meta) | Failing before orchestrator bootstrap — probably missing `workflows: write` / missing `OPENAI_API_KEY`/OAuth2 secret, or release-install step 404. Telemetry silence confirms it's pre-orchestrator. |
+| 3 | Readiness gate requires human approval that never arrives on solo repos | python_dsa, kubernetes-apply-vscode, Example-React | python_dsa PR #42 (clean, 60% readiness, `maintainer:escalated`), #45; k-apply #16/#17 | Hardcoded `reviews_approved >= 1` in readiness heuristic; should be configurable or LLM-judged for self-owned PRs |
+| 4 | Copilot upgrade PRs produce `maintainer.yml` without trailing newline, cascading into secondary "add EOF newline" PRs | python_dsa, kubernetes-apply-vscode, flashcards | python_dsa #39/#42/#43, k-apply #17 | Template writer in caretaker doesn't round-trip YAML with `\n` at EOF; fix in the release-sync tool |
+| 5 | Token lacks several scopes the agents quietly assume | flashcards (confirmed), likely audio_engineer | flashcards log: `403 Forbidden` on `dependabot/alerts`, `code-scanning/alerts`, `secret-scanning/alerts`, `pulls`, `assignees` | Workflow `permissions:` block insufficient, or `security_events: read` / `actions: write` missing; agents need to be scope-gated up front and skip loudly, not quietly |
+| 6 | Escalation digest lists only caretaker-internal issues | flashcards #9, k-apply #19, Example-React #177 | See bodies (self-heal/CI-failure-of-caretaker) | Digest classifier should exclude issues whose author is `app/github-actions` unless they're user-facing (e.g., `dependencies:major-upgrade`) |
+| 7 | Self-heal storm: 7+ duplicate `CI failure on main: self-heal-on-failure (unknown)` issues in 2 minutes | audio_engineer | Issues #33/#36/#39/#43/#45/#46/#48 all opened 2026-04-15 02:53–02:55 | Claims to have a "self-heal storm cap (5/hour, 20/day)" in v0.10.0 release notes, but the cap key didn't apply here because repo was on pre-0.10.0. Still, it slipped through. |
+| 8 | Orchestrator-state tracking issue balloons comment history (146 on python_dsa #23) | python_dsa, others | 146 comments on a single issue | Two separate markers (`caretaker:orchestrator-state`, `caretaker:run-history`) each append instead of edit-in-place on some runs — the run-history text claims "edited in place on every run", but the pattern here is append-then-patch. Worth a dedupe. |
+| 9 | `maintainer:assigned` label applied without an actual GitHub assignee | flashcards #9, Example-React #177 | `assignees: []` with label present | Label-assign is decoupled from the `POST /assignees` call that 403s (see #5); label still lands. |
+| 10 | Dependabot PRs with `caretaker:owned` never merge despite green CI | Example-React #192, #195 | `mergeable: MERGEABLE UNSTABLE` — CI actually failing on the update bundle itself | Bundled 19-package dependabot groups break on the real build; caretaker labels them owned but has no path to split/fix individual breakages. Design gap: caretaker can't bisect a grouped Dependabot PR. |
+| 11 | Dry-run triage block added via `claude-code` PR on all 5 repos 2026-04-22 but unmerged | all 5 | PR bodies "enable fleet-registry heartbeat with OAuth2", `labels: [claude-code]` | New feature rollout in flight; will land once OAuth2 creds are accepted |
+| 12 | Concurrency cancellations account for 20–30% of `Example-React` run count | Example-React, python_dsa | 22/100 `cancelled` on Ex-React | Intentional (concurrency: caretaker cancel-in-progress), but skews success-rate metrics; dashboards should filter. |
+| 13 | `kubernetes-apply-vscode` shows `action_required` conclusion — missing approval for first-time workflow runs from bots | k-apply | 4/15 runs `action_required` | GH settings: "Require approval for first-time contributors" blocks dependabot/copilot workflow runs until manually approved. Config gap, not caretaker bug. |
+
+Roughly: 1–5 are genuine bugs, 6–10 are design questions, 11–13 are config gaps.
+
+---
+
+## Agentic-vs-bizlogic observations
+
+**Places where hand-written heuristics are doing LLM work (badly):**
+
+- **Readiness score is a hardcoded weighted sum** (`draft 0%, automated feedback 20%, reviews 0%, CI 40%` = 60%). This is a classifier job — an LLM with PR context ("is this my own upgrade PR on a solo repo?", "did the author already say 'LGTM'?") would give a much better answer than a linear formula that can never clear a "solo repo" PR.
+- **Self-heal issue classifier lumps everything non-matching into "Unknown caretaker failure"** with an empty error body. An LLM reading the last 200 log lines would correctly bucket this as "upload-artifact missing file — benign" vs. "actual orchestrator crash", dramatically shrinking the self-heal volume.
+- **Escalation-digest grouping is label-based**, so it pulls in caretaker-internal self-heal noise. An LLM summarizing "what actually needs human attention this week" would trivially omit the meta-noise.
+
+**Places where LLM is handling what should be deterministic:**
+
+- **Dispatch-guard should stay regex.** The marker check is correctly deterministic; delegating it to an LLM would reintroduce webhook loops under model flakiness. Current implementation is correct — keep it.
+- **Copilot-driven "add EOF newline" PRs are LLM work for a 1-line deterministic fix.** Asking Copilot to add a trailing newline to a file produces a 4-hour round-trip. A trivial bin/fix should run deterministically in caretaker itself and open a self-authored PR (no Copilot invocation).
+- **Version-pin bump.** Caretaker asks Copilot to "apply this upgrade" (issue #35 on python_dsa); the only file change is `.github/maintainer/.version`. Same as above — this is a `sed` job, not a Copilot task.
+- **Readiness-comment re-rendering.** Caretaker posts the same "Monitoring — awaiting requirements / 60% / Blockers" block on every run for every PR. Formatting is deterministic templating; the work done per render is negligible — but it's firing through an LLM path in some agents, wasting tokens.
+
+**Direction of travel:** move the `readiness`, `escalation-digest content`, and `self-heal classification` to LLM. Move the `version-bump`, `EOF-newline fix`, and `readiness-comment render` to deterministic code and out of Copilot.
+
+---
+
+## Data gaps
+
+Things I could NOT determine from GitHub alone:
+
+- **Secret / OAuth2 state per repo.** Cannot confirm which repos have `OPENAI_API_KEY`, `OAUTH2_CLIENT_ID`, `OAUTH2_CLIENT_SECRET`. `audio_engineer`'s silent bootstrap failure is most easily explained by missing secrets, but I can't prove it without admin access to repo settings or the Mongo audit log showing which run attempted an OAuth exchange.
+- **Mongo audit-log timing.** Run logs show that `state.audit_log` records "audit" events, but the actual event payload (the `caretaker:causal` chain) is not surfaced in GitHub comments — would need the caretaker admin dashboard or Mongo to reconstruct the decision graph.
+- **Neo4j relationship graph.** Whether caretaker currently believes the 5 repos are in one fleet (and is propagating state across them) is invisible from GitHub. The recent `fleet_registry.oauth2` PR fan-out suggests this is in progress and not yet wired up.
+- **Token scope at install time.** GitHub run logs don't echo the effective permissions of `GITHUB_TOKEN`; the 403s on `flashcards` could be scope gaps, org-level restrictions, or feature-disabled-on-repo (e.g., Dependabot alerts off on a public repo). Distinguishing those requires the repo settings API per repo, not the run log.
+- **Pre-orchestrator failure mode on audio_engineer.** Without `--log-failed` content (the logs return 404 — GH may have rolled them off) I can only infer from the run metadata. Would need to trigger a fresh run with debug logging on or pull from Actions' raw log storage.
+- **LLM call budget / cost per run.** The log shows `LLM not available — analysis features disabled` on `flashcards`, meaning that deployment is running **without any LLM integration at all**. Which features are degraded by that, and whether the other repos are in the same state, can't be told without per-repo config dump.
+
+---
+
+**Bottom line.** Caretaker has real signal on one repo (Example-React), mixed signal on two (python_dsa, kubernetes-apply-vscode), and effectively zero signal on two (flashcards, audio_engineer). The three dominant failure modes — spurious non-zero exit triggering self-heal, token-scope 403s, and a readiness gate that can never clear on solo repos — are all fixable in the caretaker codebase without any consumer-side changes, and would move the needle more than any new agent.

--- a/docs/plans/2026-04-22-source-audit.md
+++ b/docs/plans/2026-04-22-source-audit.md
@@ -1,0 +1,145 @@
+# Caretaker Source Audit — Engineering Plan of Record (2026-04-22)
+
+## 1. Top-line health read
+
+Caretaker is in the architecturally-ambitious-but-drifting bucket. Twelve minor versions in ~3 weeks, ~40 subsystems, a memory-graph milestone plan that shipped M1–M8 in a single week, a fleet-registry with OAuth2 and Neo4j projection, and at the same time PR #418, #462, #412, #413 show caretaker still failing its own CI on `main` and filing self-heal issues about "unknown" failures. The central anti-pattern is exactly what the user flagged: brittle keyword-and-regex judgement embedded in `pr_agent`, `issue_agent`, `pr_reviewer`, `ci_triage`, `review`, `evolution/crystallizer`, and the webhook dispatch guard — all places where a short LLM call with a structured schema would be far more robust and cheaper to maintain. The Anthropic SDK call path (`llm/provider.py:158`) does not use prompt caching despite caretaker's repeated large-context calls to the same system prompt, which is leaving real money on the table. The PR-agent main file (`pr_agent/agent.py`, 1022 LOC) is on the verge of "god module." There is a lot of sound engineering here — bitemporal graph edges, fail-open fleet emitter, rate-limit cooldowns, idempotent comment upsert, the dispatcher/executor split — but the decision layer that sits between GitHub state and those mechanisms is mostly if/elif ladders that should be model-synthesised.
+
+## 2. Critical bugs (fix now)
+
+1. `src/caretaker/pr_agent/agent.py:178, 223, 408, 584` and peers — ten call sites use `datetime.utcnow()` which is deprecated in 3.12 and, more importantly, produces naive datetimes that get mixed with tz-aware datetimes elsewhere (`last_copilot_attempt_at` uses `datetime.now(UTC)`). The `_as_utc` helper in `orchestrator.py:51` already exists to paper over this; prior PR #300 had to fix a similar bug. Fix: replace all `utcnow()` with `datetime.now(UTC)` and strip `_as_utc` defensive wraps.
+
+2. `src/caretaker/pr_agent/agent.py:110-132` — `pr_number` is used as the function parameter name and then reused as the loop variable on line 150 (`for pr_number, tracked in list(tracked_prs.items())`). The outer `pr_number` parameter is shadowed for the rest of the function body. This is benign today but a footgun for anyone editing the function. Rename the loop var to `tracked_pr_number`.
+
+3. `src/caretaker/pr_agent/states.py:367` — When reviews are `pending` (no reviewers at all) and CI is green, caretaker recommends `merge` unconditionally. `evaluate_merge` then separately checks `config.auto_merge.human_prs`, but the recommended_state is `MERGE_READY`, so a human PR with no reviewers and green CI will report `ready for merge` in the status comment even if auto-merge is disabled. Split `MERGE_READY` from `AWAITING_REVIEW` based on the same auto-merge config.
+
+4. `src/caretaker/pr_agent/pr_triage.py:150-167` — "duplicate of" selector picks `max(prs, key=created_at)` — the newest PR — and closes the older siblings. The docstring for `close_duplicate_issues` in the twin `issue_triage.py` says the opposite: "Survivor: oldest issue by created_at (preserves the canonical history)." Two close cousins with opposite rules is almost certainly a bug. Pick one, match docs.
+
+5. `src/caretaker/foundry/tool_loop.py:106-125` — the "defensive" fallback when `raw_message` is `None` builds an assistant message with `tool_calls` in OpenAI function-calling shape, but for Anthropic tool-use the required shape is different (`content` blocks with `type: tool_use`). If any LiteLLM path ever returns `raw_message=None` for an Anthropic model the next turn will 400. Fix: drop the fallback and require providers to always populate `raw_message`, or branch on provider family.
+
+6. `src/caretaker/fleet/emitter.py:58-97` — `_oauth_client` is a **module-level** mutable global. If two `MaintainerConfig`s with different OAuth creds run in the same process (tests, the admin backend's multi-tenant path) the second build silently mutates the first's cache. Fix: move the cache onto a thin `FleetOAuthClientCache` instance owned by the `Orchestrator`.
+
+7. `src/caretaker/pr_agent/agent.py:450-459` — `_has_pending_task_comment` iterates comments twice and implicitly assumes they're sorted by id ascending. `get_pr_comments` does not guarantee order; if the API ever returns them reversed, the "last task before any result" logic inverts. Sort by `(created_at, id)` explicitly.
+
+## 3. Existing-feature improvements (agentic migration candidates)
+
+1. **PR readiness scoring** (`src/caretaker/pr_agent/states.py:178-259`). Today a fixed-weight (10/20/30/40) additive rubric produces a score and blocker list. This is exactly the "is this PR ready?" judgement the user wants model-driven. Replace with an LLM call that sees the PR payload, check-run summaries, review bodies, labels, linked issues, and returns:
+
+   ```python
+   class Readiness(BaseModel):
+       verdict: Literal["ready", "blocked", "pending", "needs_human"]
+       confidence: float  # 0..1
+       blockers: list[Blocker]  # each with category + human_reason + suggested_action
+       summary: str  # <= 200 chars for the status comment
+   ```
+   Keep the imperative path as a fallback when `llm.available` is False. The caretaker/pr-readiness check-run body then comes from the model's `summary` + structured blocker list rather than concatenated blocker tokens.
+
+2. **Webhook dispatch guard — "is this caretaker's own echo?"** (`.github/workflows/maintainer.yml:104-140` JS block and mirrored actor set in `src/caretaker/pr_agent/_constants.py:7-15`). Two hand-maintained bot-login sets, one regex, one "explicit command" string match. The model is a natural fit. Move the logic inline into caretaker: on `issue_comment`, call an LLM with the comment body + actor + recent action history and get `{is_self_echo: bool, is_human_intent: bool, suggested_agent: str | null}`. Keep the YAML guard as a cheap "probably-self" prefilter for cost control.
+
+3. **CI failure triage** (`src/caretaker/pr_agent/ci_triage.py:38-128`). Keyword regex ladder across TEST/LINT/BUILD/TYPE/TIMEOUT/BACKLOG/UNKNOWN. The LLM is already invoked for log summarisation inside `analyze_ci_logs`, but classification is still regex. Ironically, classify_failure sees mostly `UNKNOWN` on the `main` CI failures (issues #412/#413/#462). Structured output:
+
+   ```python
+   class FailureTriage(BaseModel):
+       category: Literal["test", "lint", "build", "type", "timeout", "flaky", "backpressure", "infra", "unknown"]
+       confidence: float
+       is_transient: bool  # caller uses this to decide retry vs fix
+       root_cause_hypothesis: str
+       minimal_reproduction: str | None
+       suggested_fix: str
+       files_to_touch: list[str]
+   ```
+   `is_transient` replaces today's `NON_ACTIONABLE_CONCLUSIONS` frozenset and the `flaky_retries` integer counter.
+
+4. **Review-comment classification** (`src/caretaker/pr_agent/review.py:36-86`). The keyword list (`nit:`, `bug`, `must`, `?`) is embarrassing for a "principal-engineer-quality" review. The LLM path exists (`analyze_review_comment`) but falls back to heuristics and returns a free-text blob that isn't parsed. Require structured output, delete `classify_review_basic`:
+
+   ```python
+   class ReviewClassification(BaseModel):
+       kind: Literal["actionable", "nitpick", "question", "praise", "discussion"]
+       severity: Literal["blocker", "major", "minor", "trivial"]
+       summary_one_line: str
+       requires_code_change: bool
+       suggested_prompt_to_copilot: str | None
+   ```
+
+5. **Issue duplication + classification** (`src/caretaker/issue_agent/classifier.py:30-127` and `src/caretaker/issue_agent/issue_triage.py:48-61`). Title-hash + CVE regex for duplicate detection, plus a huge keyword ladder for BUG vs FEATURE vs QUESTION. Replace with a single issue-triage LLM call that sees the issue + embedding-similar recent issues and returns kind, suggested labels, duplicate-of candidate with confidence, and stalestate. Keep the CVE regex as a deterministic pre-filter (regex is genuinely right for structured CVE IDs).
+
+6. **Cascade close-linked-issues / redirection logic** (`src/caretaker/pr_agent/cascade.py:132-184`). "PR body <200 chars AND single linked issue → close PR" is the kind of heuristic that will mis-fire on a one-line diff with "Fixes #N". Let the model inspect the PR + the canonical issue and return `{action: "redirect"|"close"|"keep_open", justification: str}`.
+
+7. **"Is this comment from the bot?" detection** (repeated in `pr_agent/_constants.py`, `pr_agent/agent.py:214`, `foundry/executor.py`, `.github/workflows/maintainer.yml`). Five different places string-match `[bot]`, `copilot`, `the-care-taker[bot]`, etc. Push the check into one helper that asks an LLM once per unfamiliar login and caches the verdict in `memory/core.py` keyed on login; fall back to the current allowlist when caching is disabled.
+
+8. **Stuck-PR escalation** (`src/caretaker/pr_agent/agent.py:196-216, 230-253`). `stuck_age_hours` and `is_pr_stuck_by_age` are tight thresholds that don't reflect the actual state: a human-reviewed PR stuck at "waiting for release" for 3 days is not the same as a Copilot PR stuck in CI failure. Let the LLM judge:
+
+   ```python
+   class StuckVerdict(BaseModel):
+       is_stuck: bool
+       stuck_reason: Literal["abandoned", "awaiting_human_decision", "ci_deadlock", "merge_queue", "not_stuck"]
+       recommended_action: Literal["escalate", "nudge_reviewer", "request_fix", "wait", "close_stale"]
+       explanation: str
+   ```
+
+9. **Executor routing (size classifier + pre/post-flight)** (`src/caretaker/foundry/size_classifier.py`, `pr_reviewer/routing.py`). Both are fine-grained point systems (LOC + files + sensitive-path regex) that the user's guidance says are ambiguous on the happy path. Have the model return `{path: "inline" | "foundry" | "claude_code" | "copilot", reason: str, risk_tags: list[str]}`. The small cost is acceptable because routing happens once per PR.
+
+10. **Failure-crystallization category inference** (`src/caretaker/evolution/crystallizer.py:25-39`). Category-by-regex. Swap for the same triage call that classifies CI failures (item 3): you get a category for free and stop maintaining two regex tables.
+
+## 4. Enhancements (net-new but scoped)
+
+1. **Anthropic prompt caching across the system prompt prefix**. `llm/provider.py:158-178` sends the full `messages` list every call. Caretaker's `FoundryExecutor` in particular sends the ~1KB `_BASE_SYSTEM_PROMPT` + denylist + allowed_commands + task_guidance on every tool-loop iteration. Add `cache_control: {type: "ephemeral"}` on the system block and on stable user-side skills hints; measure cache-hit rate via the `usage.cache_read_input_tokens` / `cache_creation_input_tokens` fields. Acceptance: ≥50% cache-read ratio on tool-loop iterations 2..N; emitted as a `llm_cache_hit_ratio` Prometheus counter.
+
+2. **Cross-run memory retrieval for the PR agent**. `memory/core.py` publishes an `AgentCoreMemory` node on every dispatch but nothing reads it. On PR entry, retrieve the 3-5 most-similar past PR core-memory snapshots (cosine over embedded summary) and inject them into the readiness LLM call. Leverages data already captured. Shape: new `caretaker/memory/retriever.py` with `find_relevant(agent, pr_context) -> list[CoreMemoryHit]`.
+
+3. **Skill promotion loop wiring**. `fleet/graph.py` projects `:Skill` nodes into `:GlobalSkill` when signature appears in ≥ min_repos. There is no path from `:GlobalSkill` back into `build_prompt` / `_format_skills` — fleet promotion is write-only. Wire `InsightStore.get_relevant` to union local skills with GlobalSkill candidates (cheap Neo4j query) so a new client repo gets day-one benefit from the fleet.
+
+4. **Fleet admin dashboard: exceptions & alerts**. Fleet heartbeats have counters + `goal_health` but the admin UI only renders them. Add a thin alerting path: when a repo's `goal_health` falls below threshold for N consecutive heartbeats or `error_count` spikes, emit a `FleetAlert` node in the graph and surface in the Fleet tab. New file: `caretaker/fleet/alerts.py`; reuses `run_history` already in state.
+
+5. **Dry-run "shadow" mode for agentic migrations**. Before flipping any of §3's LLM handovers to authoritative, run the LLM in parallel with the existing heuristic, log disagreements into a new `:ShadowDecision` graph node with outcome, and expose a diff report in the admin UI. Makes the migration measurable instead of a leap of faith.
+
+6. **Structured-output validation wrapper**. `pr_reviewer/inline_reviewer.py:112-117` does a raw `json.loads` and degrades silently to `verdict=COMMENT` on any parse error. Introduce a `structured_complete[T: BaseModel](prompt, schema) -> T | None` helper on `ClaudeClient` that: prefixes the schema to the system prompt; attempts pydantic parse; on failure, re-asks the model once with the validation error included ("your previous response failed: <err>, return only valid JSON"). Foundational for every item in §3.
+
+## 5. Research spikes
+
+1. **GitHub App vs scheduled workflow as the primary runtime** (`github_app/` is scaffolded but the production mode is still the maintainer.yml schedule). Why it matters: the dispatch guard, cooldowns, and two-comment dedup all exist because scheduled invocations race. A webhook-driven App would remove that class. 2 days: prototype receiving `pull_request` + `check_run` + `issue_comment`, measure end-to-end latency and race windows vs current schedule.
+
+2. **Prompt-cache TTL and stickiness on Foundry's tool-loop**. Anthropic ephemeral cache is 5 min; tool-loop runs often exceed that. Investigation: measure mean loop duration, test if breaking work into shorter tool-bursts per iteration boost net cache hit rate. 1 day: instrument `tool_loop.py`, run synthetic 20-iteration tasks, graph cache-read tokens per iteration.
+
+3. **Persistence model for cross-repo skill promotion**. Today `:GlobalSkill` lives in Neo4j keyed on the raw signature string; skill *SOP text* is fed through `abstract_sop` in Python. The right long-term store could be a vector index (signature embedding → SOP) for semantic match, not string equality. 2 days: evaluate 3 stores (pgvector, Neo4j vector index, Qdrant) against a corpus of ~500 real caretaker skill rows; measure recall@5 on held-out paraphrased signatures.
+
+4. **Replace the PR state machine enum with a model-emitted state**. `PRTrackingState` has 9 values, `recommended_action` strings are matched in a `match/case` on `pr_agent/agent.py:301-317`. Does the model-first approach render the FSM obsolete entirely, or is the FSM still the audit artefact? 1 day: design doc + small prototype calling Claude with "here is the PR payload + current state, what's the next action" and compare trace quality vs current logs.
+
+5. **OTel GenAI span → CausalEvent → reflection prompt round-trip**. M8 shipped OTel spans and `CausalEvent` now carries `span_id`. Are the reflection prompts actually improved by this richer provenance? 1 day: run the reflection engine on last 30 stuck goals, with and without span-derived context, and ask the model which one produces more specific recommendations.
+
+## 6. Phased rollout plan
+
+**Phase 1 — Foundations (weeks 1–2).** Goal: unblock all later LLM-handover work behind a safe, measured migration path. Workstreams: (W1) fix §2 correctness bugs as separate small PRs; (W2) ship §4.1 prompt-caching on both `AnthropicProvider` and `LiteLLMProvider` with cache-hit metric; (W3) ship §4.6 `structured_complete[T]` helper and migrate `pr_reviewer/inline_reviewer.py` to it as the canary; (W4) ship §4.5 shadow-decision graph node. Exit criteria: all §2 PRs merged, cache-hit ratio visible in Prometheus, one endpoint (`pr_inline_review`) uses pydantic-validated structured output end-to-end. Risk: low; blast radius contained to one reviewer agent. Parallelism: W1/W2/W3/W4 fully independent.
+
+**Phase 2 — Decision migrations (weeks 3–5).** Goal: move the brittle judgement calls from §3 onto the LLM, shadow-first. Workstreams: (W5) PR readiness — §3.1; (W6) CI failure triage — §3.3 + §3.10 (single shared classifier); (W7) review-comment classification — §3.4; (W8) issue triage & dup detection — §3.5; (W9) cascade & stuck-PR judgement — §3.6 + §3.8; (W10) bot-identity consolidation — §3.7. Each lands behind a config flag (`agentic.<domain> = shadow | enforce`). Exit criteria: ≥1 week of shadow data per workstream, disagreement rate <5% before flipping to enforce. Risk: medium; the readiness and triage migrations touch hot paths, shadow mitigates.
+
+**Phase 3 — Leverage what's captured (week 6).** Goal: turn the memory-graph and fleet graph from write-only into read-and-decide. Workstreams: (W11) §4.2 cross-run memory retrieval wired into readiness LLM calls; (W12) §4.3 fleet skill promotion → prompt injection; (W13) §4.4 fleet alerts surface in admin UI; (W14) §3.2 dispatch-guard migration (depends on W10). Exit criteria: at least one merged PR attributable to a retrieved past-skill hint; fleet alert demoable. Risk: low-medium; read-path only for W11/W12.
+
+Research spikes §5.1, §5.2, §5.3 run alongside Phase 1–2 as 1–2-day timeboxes; §5.4 and §5.5 are Phase 3 inputs.
+
+## 7. Parallelization map
+
+| Item | Workstream | Preconditions | Sub-agent prompt seed |
+|---|---|---|---|
+| §2.1 utcnow | W1 | none | "Replace every `datetime.utcnow()` in `src/caretaker/` with `datetime.now(UTC)` and remove now-redundant `_as_utc` wraps; preserve serialized tz-naive compatibility in pydantic state models." |
+| §2.2 pr_number shadowing | W1 | none | "Rename the loop variable in `pr_agent/agent.py` `_terminal` block so the outer `pr_number` parameter stays bound." |
+| §2.3 MERGE_READY split | W1 | W1.1 done | "Split PR states so `MERGE_READY` only fires when auto-merge config permits; status comment must never claim 'ready for merge' for a disabled auto-merge profile." |
+| §2.4 triage survivor | W1 | none | "Align `pr_triage.close_duplicate_fix_prs` survivor selection with `issue_triage.close_duplicate_issues` (oldest wins); update tests." |
+| §2.5 tool_loop fallback | W1 | none | "Remove the OpenAI-shaped fallback in `foundry/tool_loop.py`; require providers to always populate `raw_message` and add a unit test." |
+| §2.6 fleet cache | W1 | none | "Replace the module-global OAuth client cache in `fleet/emitter.py` with an instance on `Orchestrator` and thread it through `emit_heartbeat`." |
+| §2.7 comment ordering | W1 | none | "Sort comments by `(created_at, id)` inside `_has_pending_task_comment` and add a regression test for reverse-order input." |
+| §3.1 readiness LLM | W5 | W3 helper | "Introduce `Readiness` pydantic model, route PR readiness through `structured_complete`, gate behind `agentic.readiness` flag with shadow logging." |
+| §3.2 dispatch self-echo | W14 | W10 | "Move the marker+actor loop guard from `maintainer.yml` into an LLM-backed `is_self_echo` detector with a 2-second timeout fallback to the regex." |
+| §3.3 CI triage | W6 | W3 | "Rewrite `ci_triage.classify_failure` as a structured LLM call returning `FailureTriage`; delete `_PATTERNS` regexes and `NON_ACTIONABLE_CONCLUSIONS` once shadow data confirms parity." |
+| §3.4 review comments | W7 | W3 | "Swap `classify_review_basic` for a `ReviewClassification` structured LLM call; update `analyze_reviews` to propagate severity downstream." |
+| §3.5 issue triage | W8 | W3 | "Replace `classify_issue` keyword ladder with a structured LLM call; keep the CVE regex as a pre-filter and add embedding-similarity for dup detection." |
+| §3.6 cascade | W9 | W3 | "Route `on_issue_closed_as_duplicate` decisions through the model; preserve deterministic `parse_linked_issues` for the edge lookup." |
+| §3.7 bot detection | W10 | none | "Consolidate all `[bot]`/`copilot` string checks behind `caretaker.identity.is_automated(login)`; back it with a memoized LLM lookup when login is unfamiliar." |
+| §3.8 stuck-PR | W9 | W3, §3.1 | "Replace `_is_pr_stuck_by_age` threshold with a `StuckVerdict` LLM call; keep `stuck_age_hours` as minimum-age prefilter." |
+| §3.9 executor routing | W6/W7 | W3 | "Replace `pr_reviewer/routing.py` + `foundry/size_classifier.py` point systems with a structured routing LLM call." |
+| §3.10 crystallizer category | W6 | §3.3 | "Call the shared triage classifier inside `crystallizer._infer_category` and remove `_CATEGORY_PATTERNS`." |
+| §4.1 prompt caching | W2 | none | "Add `cache_control: ephemeral` to the system block in both `AnthropicProvider.complete` and `LiteLLMProvider.complete_with_tools`; emit `llm_cache_hit_ratio`." |
+| §4.2 memory retrieval | W11 | W5 | "Build `memory/retriever.py`; wire retrieved core-memory snapshots into the readiness prompt under a ≤500-token budget." |
+| §4.3 skill promotion | W12 | none | "Union local Skills with :GlobalSkill candidates inside `InsightStore.get_relevant`; add test coverage for cross-repo promotion." |
+| §4.4 fleet alerts | W13 | none | "Add `caretaker/fleet/alerts.py` emitting `:FleetAlert` nodes; render in the admin Fleet tab." |
+| §4.5 shadow mode | W4 | none | "Add `:ShadowDecision` graph node + a decorator that runs the new LLM path alongside the old heuristic and logs disagreement." |
+| §4.6 structured_complete | W3 | none | "Ship `ClaudeClient.structured_complete[T]` with one automatic re-ask on pydantic validation failure; migrate `pr_inline_review` as the canary." |

--- a/docs/plans/2026-Q2-agentic-migration.md
+++ b/docs/plans/2026-Q2-agentic-migration.md
@@ -1,0 +1,171 @@
+# Caretaker Master Plan of Record (2026-04-22)
+
+Two parallel audits (fleet-operational + source-engineering) ran this morning. Their raw reports live in `01-fleet-audit.md` and `02-source-audit.md`. This document unifies them into an action plan the next wave of sub-agents can pick up in parallel.
+
+## TL;DR
+
+- **Fleet today.** Five consumer repos; only one (Example-React-AI-Chat-App) is clearly working, two are partially working, two are effectively dark. The three dominant failure modes — spurious non-zero exits triggering self-heal storms, `GITHUB_TOKEN` scope gaps swallowed silently, and a readiness gate that can never clear on solo repos — are all fixable in caretaker itself, not in consumers.
+- **Source today.** Architecturally ambitious but drifting. ~40 subsystems added over 3 weeks. The decision layer between GitHub state and caretaker's mechanisms is a stack of if/elif ladders and keyword regexes that should be LLM-synthesised with structured output, exactly as the user flagged. Anthropic prompt caching is not wired up anywhere in the provider layer, costing money on every tool-loop turn.
+- **Central thesis.** Stop hand-coding judgement calls. Introduce a `structured_complete[T]` helper + a shadow-mode decorator, move the readiness gate, CI-failure triage, review-comment classification, issue triage, cascade decisions, stuck-PR detection, and executor routing onto the model behind feature flags, and leverage the memory-graph and fleet-graph that are already being written but nothing reads from. Everything else falls out of that.
+
+## Issue inventory (de-duplicated + cross-referenced)
+
+This is the joined list. Fleet-audit findings (F#) are operational; source-audit findings (S#) are code-level.
+
+| ID | Description | Severity | Surface | Cross-ref |
+|----|-------------|----------|---------|-----------|
+| M1 | Orchestrator exits non-zero on benign tail (missing artifact, stray agent warning) → triggers duplicate self-heal issues every run | blocker | src/caretaker/orchestrator.py + `.github/workflows/maintainer.yml` upload-artifact step | F#1, S#§2.3-adjacent |
+| M2 | Caretaker workflow has been red on audio_engineer for a week; pre-orchestrator bootstrap failure leaves no telemetry | blocker | maintainer.yml install step + secret presence checks | F#2, F#8 |
+| M3 | Readiness gate requires human approval that never arrives on solo repos; caretaker can't merge its own upgrade PRs | blocker | src/caretaker/pr_agent/states.py:178-259 | F#3, S#§3.1 |
+| M4 | `maintainer.yml` template ships without trailing newline → pre-commit `end-of-file-fixer` fails → Copilot fan-out PRs | major | release-sync tool + tests | F#4 |
+| M5 | Agents silently swallow 403s on dependabot/code-scanning/secret-scanning/assignees/pulls APIs | major | src/caretaker/security_agent/, docs_agent/, github_client/ | F#5 |
+| M6 | Escalation digest is self-referential: lists caretaker-internal self-heal + CI-failure issues caretaker itself created | major | src/caretaker/escalation/ digest builder | F#6 |
+| M7 | Self-heal storm: 7+ duplicate issues within 2 minutes on audio_engineer despite a cap claimed in v0.10.0 notes | major | src/caretaker/self_heal_agent/ cap check | F#7 |
+| M8 | Orchestrator-state issue balloons to 146 comments; `run-history` + `orchestrator-state` markers append instead of edit-in-place in some paths | minor | src/caretaker/orchestrator.py comment upsert | F#8 |
+| M9 | `maintainer:assigned` label applied without actual GitHub assignee (label-assign decoupled from failing POST /assignees) | minor | src/caretaker/pr_agent/agent.py assignee flow | F#9 |
+| M10 | Bundled Dependabot PRs (19-package groups) never bisected when one updates breaks CI | major | new dependency_agent capability | F#10 |
+| S1 | 10× `datetime.utcnow()` uses produce naive timestamps mixing with tz-aware ones elsewhere | major | src/caretaker/pr_agent/agent.py:178,223,408,584 + peers | S#§2.1 |
+| S2 | `pr_number` parameter shadowed by loop variable in `_terminal` block | minor | pr_agent/agent.py:110-150 | S#§2.2 |
+| S3 | `MERGE_READY` can be reported for human PRs even when auto-merge disabled | major | pr_agent/states.py:367 | S#§2.3 |
+| S4 | `close_duplicate_fix_prs` keeps newest; `close_duplicate_issues` keeps oldest → opposite policies | minor | pr_agent/pr_triage.py:150-167 vs issue_agent/issue_triage.py | S#§2.4 |
+| S5 | `tool_loop` fallback builds OpenAI-shape assistant message for Anthropic models → 400s on some provider paths | major | src/caretaker/foundry/tool_loop.py:106-125 | S#§2.5 |
+| S6 | Fleet OAuth client cache is a module-level global — cross-tenant leak in multi-config processes | major | src/caretaker/fleet/emitter.py:58-97 (code **I shipped** in v0.12.0 — self-inflicted) | S#§2.6 |
+| S7 | `_has_pending_task_comment` assumes comment ordering from the API | minor | pr_agent/agent.py:450-459 | S#§2.7 |
+| E1 | No Anthropic prompt caching anywhere — every tool-loop turn resends the full system prompt | major | src/caretaker/llm/provider.py:158-178 | S#§4.1 |
+| E2 | `AgentCoreMemory` graph node is written every run but nothing reads it back on the next run | major | src/caretaker/memory/core.py + new retriever.py | S#§4.2 |
+| E3 | `:GlobalSkill` fleet promotion is write-only — promoted skills never flow back into prompts | major | src/caretaker/fleet/graph.py + llm prompt builders | S#§4.3 |
+| E4 | Fleet dashboard renders heartbeats but does not alert on goal_health regression | minor | new src/caretaker/fleet/alerts.py + frontend Fleet tab | S#§4.4 |
+| D1 | No shadow-mode infrastructure — every LLM handover is a leap of faith | blocker for migrations | new :ShadowDecision graph node + decorator | S#§4.5 |
+| D2 | `pr_reviewer/inline_reviewer.py` raw json.loads with silent downgrade on parse error | major | need `structured_complete[T]` helper | S#§4.6 |
+
+## Agentic migration targets (from source §3)
+
+Each of these hand-rolled heuristics is an LLM decision with a structured-output schema in waiting. The schemas below are the contract; the sub-agent prompts in §Parallelization map implement them.
+
+| Tag | Current code | Schema |
+|-----|--------------|--------|
+| A1 | `pr_agent/states.py` readiness rubric | `Readiness(verdict, confidence, blockers[], summary)` |
+| A2 | `.github/workflows/maintainer.yml` + `pr_agent/_constants.py` dispatch-guard actors/markers | `DispatchVerdict(is_self_echo, is_human_intent, suggested_agent?)` |
+| A3 | `pr_agent/ci_triage.py` keyword ladder | `FailureTriage(category, confidence, is_transient, root_cause_hypothesis, minimal_reproduction, suggested_fix, files_to_touch[])` |
+| A4 | `pr_agent/review.py` `classify_review_basic` | `ReviewClassification(kind, severity, summary_one_line, requires_code_change, suggested_prompt_to_copilot?)` |
+| A5 | `issue_agent/classifier.py` + `issue_triage.py` keyword+hash | `IssueTriage(kind, labels[], duplicate_of?, staleness, confidence)` |
+| A6 | `pr_agent/cascade.py:132-184` cascade heuristic | `CascadeAction(action: redirect\|close\|keep_open, justification)` |
+| A7 | Five places string-matching bot logins | `BotIdentity(is_automated, family?)` memoized |
+| A8 | `pr_agent/agent.py:196-216` stuck-PR age threshold | `StuckVerdict(is_stuck, stuck_reason, recommended_action, explanation)` |
+| A9 | `pr_reviewer/routing.py` + `foundry/size_classifier.py` point systems | `ExecutorRoute(path, reason, risk_tags[])` |
+| A10 | `evolution/crystallizer.py` category regex | reuse A3 |
+
+## Places where LLM is doing deterministic work (from fleet §Agentic-vs-bizlogic)
+
+These go the other direction: pull them **out** of the LLM path and back into deterministic Python.
+
+- Trailing-newline fix on `maintainer.yml` (→ one-line Python, no Copilot round-trip). Ties to M4.
+- `.github/maintainer/.version` bump to apply an upgrade (→ `sed -i`, no Copilot issue). Ties to upgrade_agent.
+- Readiness-comment templating (→ pure string rendering, delete the LLM fallback path for this).
+- Comment marker insertion (→ already deterministic, keep it).
+
+## Phased rollout
+
+### Phase 1 — Foundations + fleet triage (weeks 1–2)
+
+Goal: unblock everything downstream with the migration scaffolding, fix the bleeding on live consumer repos, land all correctness bugs.
+
+Parallel workstreams:
+
+- **W1 — Correctness bugs.** Ship S1–S7 and M8 as small independent PRs. Author: one sub-agent, serialized commits, parallel PR review. Exit: all seven merged and released as `0.12.1`.
+- **W2 — Prompt caching + cache-hit metric (E1).** Add `cache_control: ephemeral` to Anthropic and LiteLLM provider call paths, emit `caretaker_llm_cache_hit_ratio` Prometheus metric, back it with `usage.cache_read_input_tokens`. Exit: ≥50% cache-hit ratio on a synthetic 20-iteration FoundryExecutor loop.
+- **W3 — `structured_complete[T: BaseModel]` helper (D2).** One automatic pydantic-validation re-ask; canary migrate `pr_reviewer/inline_reviewer.py`. Exit: inline reviewer ships, raw json.loads gone.
+- **W4 — Shadow-mode infra (D1).** `ShadowDecision` Neo4j node + `@shadow_decision(name)` decorator that runs old + new side-by-side, logs disagreement. Admin UI tab. Exit: one feature (inline reviewer) has shadow data flowing.
+- **W5 — Fleet bleeding fixes (M1, M2, M5, M7).** Make `orchestrator` return exit 0 when all agent errors are in a known-transient bucket; make artifact upload `if-no-files-found: ignore`; add an explicit `caretaker doctor` pre-run check that fails loudly on missing secrets + missing scopes; plug the self-heal storm cap by keying on `(repo, error_signature)` instead of just `error_signature`. Exit: audio_engineer green on schedule; no more "Unknown caretaker failure" self-heal storms fleet-wide.
+
+Phase 1 is the only phase where bleeding-edge migrations (Phase 2) are blocked on predecessor work (W3+W4). Everything else is independent — five sub-agents in parallel.
+
+### Phase 2 — Decision migrations (weeks 3–5)
+
+Goal: move A1–A10 onto the model, each gated `agentic.<domain> = off | shadow | enforce`, with ≥1 week of shadow data before flipping to enforce.
+
+Parallel workstreams:
+
+- **W6 — Readiness (A1, M3).** `Readiness` model + flag; solves "solo repo can't merge" by design because the model sees the repo shape.
+- **W7 — Failure triage (A3, A10).** One shared classifier for CI failures and crystallizer categories.
+- **W8 — Review-comment classification (A4).**
+- **W9 — Issue triage + dup detection (A5).** Keep CVE regex as deterministic pre-filter.
+- **W10 — Cascade + stuck-PR (A6, A8).** Share context with readiness (W6) for solo-repo awareness.
+- **W11 — Bot-identity consolidation (A7).** Prerequisite for W14.
+- **W12 — Escalation-digest rewrite (M6).** Model-authored weekly digest that filters out caretaker's own exhaust.
+
+Phase 2 can be parallelized at the workstream level. W10 depends on W6 for the solo-repo context model.
+
+### Phase 3 — Read-side leverage + dispatch migration (week 6)
+
+Goal: unlock the data caretaker is already writing.
+
+- **W13 — Cross-run memory retrieval (E2).** `memory/retriever.py`; injected into W6's readiness call under a 500-token budget. Exit: one merged PR attributable to a retrieved past-skill hint.
+- **W14 — Skill promotion round-trip (E3).** Union `:Skill` ∪ `:GlobalSkill` in `InsightStore.get_relevant`. Exit: a skill promoted on one repo appears in another repo's next prompt.
+- **W15 — Fleet alerts (E4).** `:FleetAlert` node + admin UI. Exit: goal_health regression triggers an alert on a staged repo.
+- **W16 — Dispatch-guard LLM migration (A2).** Depends on W11.
+- **W17 — Dependabot bisector (M10).** Split-fix for broken grouped Dependabot PRs; can be its own agent.
+
+### Research spikes (timeboxed, can run anytime in Phase 1–2)
+
+- R1 — GitHub App as primary runtime vs scheduled workflow (2 days). Remove races that motivate half the current safeguards.
+- R2 — Prompt-cache TTL vs tool-loop length (1 day). Measure; may motivate loop-chunking.
+- R3 — Vector store for skill promotion (2 days). pgvector vs Neo4j vector vs Qdrant; recall@5 on 500 rows.
+- R4 — Is PRTrackingState enum still load-bearing once A1+A8 ship? (1 day).
+- R5 — OTel span provenance effect on reflection prompt quality (1 day).
+
+## Parallelization map (for sub-agent fan-out)
+
+Every row is one sub-agent's job. Columns: id, workstream, preconditions (workstream IDs), seed prompt fragment. Sub-agents are expected to produce a PR + tests + CHANGELOG entry + passing CI.
+
+| ID | WS | Preconditions | Seed |
+|----|----|---------------|------|
+| T-S1 | W1 | — | Replace every `datetime.utcnow()` in `src/caretaker/` with `datetime.now(UTC)`; remove now-redundant `_as_utc` wraps; preserve serialized tz-naive compat where pydantic state models round-trip from YAML. |
+| T-S2 | W1 | — | Rename the shadowed loop variable in `pr_agent/agent.py`'s `_terminal` block so the outer `pr_number` parameter stays bound. |
+| T-S3 | W1 | T-S1 | Split PR states so `MERGE_READY` only fires when `auto_merge.<profile>` permits; status comment must never claim "ready for merge" under a disabled profile. |
+| T-S4 | W1 | — | Align `pr_triage.close_duplicate_fix_prs` survivor selection with `issue_triage.close_duplicate_issues` (oldest wins); update tests + docstring cross-reference. |
+| T-S5 | W1 | — | Remove the OpenAI-shaped fallback in `foundry/tool_loop.py`; require providers to always populate `raw_message`; add a regression test. |
+| T-S6 | W1 | — | Replace the module-global OAuth client cache in `fleet/emitter.py` with an instance on `Orchestrator`; thread through `emit_heartbeat`; add multi-tenant regression test. |
+| T-S7 | W1 | — | Sort comments by `(created_at, id)` inside `_has_pending_task_comment`; regression test with reversed-order input. |
+| T-M1 | W5 | — | Make orchestrator exit 0 when all agent errors are in a known-transient bucket (403s, empty-artifact, upstream 5xx); emit `orchestrator_soft_fail_total` counter so the signal stays visible. |
+| T-M2 | W5 | T-M1 | Add a `caretaker doctor` preflight run inside maintainer.yml that fails loudly on missing secrets + missing scopes before any agent boots; produce a structured "required scopes" report. |
+| T-M4 | W5 | — | Ensure every file written by the release-sync tool ends with `\n`; add a golden-file test on `maintainer.yml`; close the Copilot-EOF-newline fan-out root cause. |
+| T-M5 | W5 | — | Surface 403s from `dependabot/alerts`, `code-scanning/alerts`, `secret-scanning/alerts`, `POST /pulls`, `POST /assignees` as a single "scope gap" issue per run instead of five silent warnings. |
+| T-M7 | W5 | — | Change self-heal cap key from `error_signature` to `(repo, error_signature, hour_window)`; add a storm-replay test. |
+| T-M8 | W1 | — | Fix orchestrator-state issue comment upsert so `run-history` + `orchestrator-state` markers always edit-in-place; test by driving 20 runs and asserting comment count ≤ 2. |
+| T-E1 | W2 | — | Add `cache_control: {type: "ephemeral"}` to the system block in both `AnthropicProvider.complete` and `LiteLLMProvider.complete_with_tools`; emit `caretaker_llm_cache_hit_ratio`. |
+| T-D2 | W3 | T-E1 | Ship `ClaudeClient.structured_complete[T: BaseModel]` with one auto-re-ask on pydantic validation failure; migrate `pr_reviewer/inline_reviewer.py` as canary. |
+| T-D1 | W4 | — | Add `:ShadowDecision` graph node + `@shadow_decision(name)` decorator; render diff report in admin UI Fleet/Shadow tab. |
+| T-A1 | W6 | T-D2, T-D1 | Readiness migration: pydantic model + `agentic.readiness` flag + shadow; ship behind `off` default. |
+| T-A3 | W7 | T-D2 | CI failure triage migration with `FailureTriage`; delete keyword-ladder when shadow disagreement <5%. |
+| T-A4 | W8 | T-D2 | Review-comment classification with `ReviewClassification`; propagate severity downstream. |
+| T-A5 | W9 | T-D2 | Issue triage + dup with `IssueTriage`; keep CVE regex as deterministic pre-filter; wire embedding-similarity for dup candidates. |
+| T-A6 | W10 | T-D2 | Cascade migration (`close_linked_issues`/`redirect`) with `CascadeAction`; preserve deterministic linked-issue parser. |
+| T-A8 | W10 | T-D2, T-A1 | Stuck-PR judgement with `StuckVerdict`; `stuck_age_hours` stays as min-age pre-filter. |
+| T-A7 | W11 | — | Consolidate all `[bot]`/`copilot` login checks behind `caretaker.identity.is_automated(login)`; memoize per-login; used by W14. |
+| T-M6 | W12 | T-A5 | Rewrite weekly escalation digest as model-authored summary that explicitly excludes caretaker-authored self-heal + CI-failure issues unless they contain novel signal. |
+| T-E2 | W13 | T-A1 | `memory/retriever.py` cosine-over-embedded-summary; inject top-3 past snapshots into readiness prompt ≤500 tokens. |
+| T-E3 | W14 | — | Union `:Skill` ∪ `:GlobalSkill` in `InsightStore.get_relevant`; cross-repo test. |
+| T-E4 | W15 | — | `caretaker/fleet/alerts.py` + admin Fleet tab; goal_health regression threshold. |
+| T-A2 | W16 | T-A7 | Move dispatch-guard from workflow YAML into caretaker; regex stays as cheap prefilter, LLM for ambiguous cases; timeout fallback to old behaviour. |
+| T-M10 | W17 | — | Dependabot bisector: on a `MERGEABLE UNSTABLE` grouped PR, split by sub-package, retry CI per subset, propose a surgical merge plan. |
+| T-R1..T-R5 | spikes | — | One-pager design docs as described in §Research spikes. |
+
+## Supervisor loop
+
+A thin supervisor runs the fan-out:
+
+1. Claim the next unblocked task (lowest ID) from the parallelization map.
+2. Dispatch a sub-agent with the seed prompt + a reference to `00-master-plan.md`, `01-fleet-audit.md`, `02-source-audit.md`, and the relevant file paths.
+3. The sub-agent returns a PR URL + a short note on whether it hit a precondition the map didn't capture.
+4. CI green → merge; CI red → re-dispatch with the failure context.
+5. Each merged task triggers a quick release (`0.12.x` during Phase 1, `0.13.x` in Phase 2, `0.14.0` at Phase 3 exit).
+
+The supervisor itself is a reasonable candidate for its own sub-agent in a follow-on iteration.
+
+## Open risks
+
+- **Readiness-gate migration (T-A1) is the hottest path.** If the model under-blocks, caretaker starts merging work that shouldn't merge. Shadow data gating is mandatory; enforce-mode flip gated on human review.
+- **Prompt-cache TTL (R2).** Tool loops regularly exceed 5 min; cache wins may be smaller than expected on long-running Foundry runs. Measure before claiming savings.
+- **M4 + M5 are simple code fixes but each unblocks large fleet-wide silences.** Do not save them for Phase 2.
+- **S6 is self-inflicted** — shipped in v0.12.0 this morning. Patch in Phase 1 W1 or mark the v0.12.0 docs.


### PR DESCRIPTION
## Summary

Persists the plan of record that came out of a full-fleet audit this morning. Three files under `docs/plans/`:

- **`2026-Q2-agentic-migration.md`** — master plan. Three phases over ~6 weeks, 28 sub-agent tasks in a parallelization map, cross-referenced issue inventory (operational `M*` items + source-level `S*` / `E*` / `D*` items).
- **`2026-04-22-fleet-audit.md`** — raw operational audit of the five `caretaker`-topic consumer repos: run success rates, PR / issue lifecycle evidence, dominant failure modes (self-heal storms from benign non-zero exits, silent 403s from token scope gaps, readiness gate that can never clear on solo repos).
- **`2026-04-22-source-audit.md`** — code-level bug list plus the agentic-migration candidates, grouped by current heuristic (PR readiness, CI-failure triage, review-comment classification, issue triage, cascade, stuck-PR, dispatch-guard, executor routing).

The plan's thesis: let an LLM synthesise the ambiguous PR / issue judgement calls behind a structured-output contract and a shadow-mode gate, but leave deterministic work deterministic (marker regexes, version bumps, EOF-newline fixes).

PRs already in flight that pick up Phase 1 work:
- #470 — tool_loop provider fallback (S5)
- #471 — `datetime.utcnow()` sweep (S1)
- #472 — fleet OAuth cache extracted from module globals (S6, self-inflicted in #469)

## Test plan

- [x] Docs-only change. Verified by `gh pr diff` — no source files touched.
- [ ] Circulate the plan for review; update based on feedback before spawning Phase 1 sub-agents at scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
