### PR TITLE
fix(pr_agent): four correctness fixes (shadowed var, merge-ready gate, triage survivor, comment order)

### DIFF
--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -147,11 +147,15 @@ class PRAgent:
                 PRTrackingState.CLOSED,
                 PRTrackingState.ESCALATED,
             }
-            for pr_number, tracked in list(tracked_prs.items()):
-                if pr_number not in open_pr_numbers and tracked.state not in _terminal:
+            # Use a distinct loop variable so we don't shadow the outer
+            # ``pr_number`` parameter. Even though the post-loop code below
+            # doesn't currently re-read it, shadowing a parameter is a latent
+            # bug magnet — keep the names separate.
+            for tracked_pr_number, tracked in list(tracked_prs.items()):
+                if tracked_pr_number not in open_pr_numbers and tracked.state not in _terminal:
                     try:
                         closed_pr = await self._github.get_pull_request(
-                            self._owner, self._repo, pr_number
+                            self._owner, self._repo, tracked_pr_number
                         )
                         if closed_pr is not None:
                             if closed_pr.merged:
@@ -161,15 +165,17 @@ class PRAgent:
                                 if tracked.merged_at is None:
                                     tracked.merged_at = closed_pr.merged_at
                                 logger.info(
-                                    "PR #%d: externally merged — updated tracked state", pr_number
+                                    "PR #%d: externally merged — updated tracked state",
+                                    tracked_pr_number,
                                 )
                             elif closed_pr.state == PRState.CLOSED:
                                 tracked.state = PRTrackingState.CLOSED
                                 logger.info(
-                                    "PR #%d: externally closed — updated tracked state", pr_number
+                                    "PR #%d: externally closed — updated tracked state",
+                                    tracked_pr_number,
                                 )
                     except Exception as exc:
-                        logger.debug("Could not sync state for PR #%d: %s", pr_number, exc)
+                        logger.debug("Could not sync state for PR #%d: %s", tracked_pr_number, exc)
 
         for pr in open_prs:
             try:
@@ -261,6 +267,7 @@ class PRAgent:
                 ignore_jobs=self._config.ci.ignore_jobs,
                 auto_approve_workflows=self._config.ci.auto_approve_workflows,
                 required_reviews=self._config.readiness.required_reviews,
+                auto_merge=self._config.auto_merge,
             )
             tracking = await self._handle_ownership(pr, tracking, evaluation, report)
             return tracking
@@ -274,6 +281,7 @@ class PRAgent:
             ignore_jobs=self._config.ci.ignore_jobs,
             auto_approve_workflows=self._config.ci.auto_approve_workflows,
             required_reviews=self._config.readiness.required_reviews,
+            auto_merge=self._config.auto_merge,
         )
 
         logger.info(
@@ -447,8 +455,15 @@ class PRAgent:
         already outstanding and we should not spam another one.
         """
         comments = await self._github.get_pr_comments(self._owner, self._repo, pr_number)
+
+        # ``get_pr_comments`` does not guarantee any ordering. Sort explicitly
+        # by (created_at, id) so the "last task before any result" logic is
+        # stable regardless of how the API returned the page. ``created_at`` is
+        # required on Comment; ``id`` tie-breaks same-timestamp entries.
+        ordered = sorted(comments, key=lambda c: (c.created_at, c.id))
+
         last_task_idx: int | None = None
-        for i, comment in enumerate(comments):
+        for i, comment in enumerate(ordered):
             if comment.is_maintainer_task:
                 last_task_idx = i
 
@@ -456,7 +471,7 @@ class PRAgent:
             return False
 
         # Check if any result comment exists after the last task
-        return all(not comment.is_maintainer_result for comment in comments[last_task_idx + 1 :])
+        return all(not comment.is_maintainer_result for comment in ordered[last_task_idx + 1 :])
 
     async def _handle_ci_fix(
         self,

--- a/src/caretaker/pr_agent/pr_triage.py
+++ b/src/caretaker/pr_agent/pr_triage.py
@@ -125,10 +125,12 @@ async def close_duplicate_fix_prs(
 ) -> list[int]:
     """Group security/fix PRs by CVE or bumped package; close the stragglers.
 
-    Survivor selection: newest PR wins by ``created_at``. This is a simple
-    proxy for "likely to carry the highest pin"; the ci_triage layer already
-    filters for passing checks before merge, so a false pick here just means
-    the survivor won't auto-merge until it's green.
+    Survivor selection: oldest PR wins by ``created_at`` (lowest PR number as
+    tie-break). The canonical review history — inline comments, CI diagnoses,
+    reviewer discussion — lives on the first PR opened against a given fix;
+    closing the older twin would discard that context. Aligned with the
+    sibling policy in
+    :func:`caretaker.issue_agent.issue_triage.close_duplicate_issues`.
     """
     closed: list[int] = []
 
@@ -143,12 +145,17 @@ async def close_duplicate_fix_prs(
         if len(prs) < 2:
             continue
 
-        # Survivor: newest by created_at, falling back to highest PR number.
+        # Survivor: oldest by created_at, falling back to lowest PR number.
+        # PRs with an unknown created_at sort last (never chosen as survivor
+        # over a PR with a real timestamp).
         def _sort_key(p: PullRequest) -> tuple[float, int]:
-            created = p.created_at.timestamp() if p.created_at else 0.0
+            created = p.created_at.timestamp() if p.created_at else float("inf")
             return (created, p.number)
 
-        survivor = max(prs, key=_sort_key)
+        # why oldest wins: mirrors close_duplicate_issues in
+        # issue_agent/issue_triage.py — canonical history lives on the first
+        # PR opened for a given fix.
+        survivor = min(prs, key=_sort_key)
         for pr in prs:
             if pr.number == survivor.number:
                 continue

--- a/src/caretaker/pr_agent/states.py
+++ b/src/caretaker/pr_agent/states.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 from caretaker.github_client.models import (
     CheckConclusion,
@@ -16,6 +17,9 @@ from caretaker.github_client.models import (
 )
 from caretaker.pr_agent._constants import is_automated_reviewer
 from caretaker.state.models import PRTrackingState
+
+if TYPE_CHECKING:
+    from caretaker.config import AutoMergeConfig
 
 logger = logging.getLogger(__name__)
 
@@ -259,6 +263,25 @@ def evaluate_readiness(
     )
 
 
+def _auto_merge_allows(pr: PullRequest, auto_merge: AutoMergeConfig | None) -> bool:
+    """Return True when the configured auto-merge policy allows this PR family.
+
+    Used to gate the ``MERGE_READY`` recommendation: if caretaker wouldn't
+    actually merge this PR under ``config.auto_merge``, then the state
+    machine should not surface it as "ready for merge" in status comments —
+    that's user-confusing ("ready" but nothing happens). When ``auto_merge``
+    is ``None`` (caller didn't thread the config in), the gate is disabled
+    for backwards compatibility.
+    """
+    if auto_merge is None:
+        return True
+    if pr.is_copilot_pr:
+        return auto_merge.copilot_prs
+    if pr.is_dependabot_pr:
+        return auto_merge.dependabot_prs
+    return auto_merge.human_prs
+
+
 def evaluate_pr(
     pr: PullRequest,
     check_runs: list[CheckRun],
@@ -267,8 +290,16 @@ def evaluate_pr(
     ignore_jobs: list[str] | None = None,
     auto_approve_workflows: bool = False,
     required_reviews: int = 1,
+    auto_merge: AutoMergeConfig | None = None,
 ) -> PRStateEvaluation:
-    """Full PR evaluation — determines next state and action."""
+    """Full PR evaluation — determines next state and action.
+
+    ``auto_merge`` (optional): when supplied, the ``MERGE_READY`` recommendation
+    is suppressed for PR families that the configured auto-merge policy would
+    reject (e.g. ``human_prs=false``). The PR falls back to ``CI_PASSING`` with
+    ``await_review``, which correctly renders as "awaiting review" in the
+    status comment instead of the misleading "ready for merge".
+    """
     ci = evaluate_ci(check_runs, ignore_jobs)
     review_eval = evaluate_reviews(reviews)
     readiness = evaluate_readiness(pr, ci, review_eval, current_state, required_reviews)
@@ -364,7 +395,16 @@ def evaluate_pr(
                 recommended_action="request_review_fix",
             )
 
-    if ci.status == CIStatus.PASSING and (review_eval.approved or review_eval.pending):
+    # Cap MERGE_READY when auto-merge is disabled for this PR family —
+    # otherwise the status comment says "ready for merge" even though
+    # caretaker will refuse to merge (see merge.evaluate_merge). Fall through
+    # to CI_PASSING / await_review so the status comment correctly renders
+    # the awaiting-review state.
+    if (
+        ci.status == CIStatus.PASSING
+        and (review_eval.approved or review_eval.pending)
+        and _auto_merge_allows(pr, auto_merge)
+    ):
         return PRStateEvaluation(
             pr=pr,
             ci=ci,

--- a/tests/test_pr_agent/test_agent.py
+++ b/tests/test_pr_agent/test_agent.py
@@ -420,6 +420,52 @@ class TestTrackedPRExternalSync:
         github.get_pull_request.assert_not_awaited()
         assert tracked_prs[202].state == PRTrackingState.CI_PENDING
 
+    async def test_sync_loop_does_not_shadow_pr_number_parameter(self) -> None:
+        """Regression for T-S2: the closed-PR sync loop previously reused
+        ``pr_number`` as its loop variable, shadowing the outer parameter.
+
+        With multiple closed PRs in tracked_prs, each one must be fetched by
+        its own number (not the last-iterated loop variable) and updated
+        independently. This exercises the renamed loop variable.
+        """
+        from caretaker.pr_agent.agent import PRAgent
+        from tests.conftest import make_pr as make_test_pr
+
+        github = AsyncMock()
+        github.list_pull_requests.return_value = []  # empty scan
+
+        merged_at_a = datetime(2024, 2, 1, tzinfo=UTC)
+        merged_at_b = datetime(2024, 2, 2, tzinfo=UTC)
+        pr_a = make_test_pr(number=11, state=PRState.CLOSED, merged=True)
+        pr_a.merged_at = merged_at_a
+        pr_b = make_test_pr(number=22, state=PRState.CLOSED, merged=True)
+        pr_b.merged_at = merged_at_b
+
+        # get_pull_request must be answered per PR number — if the sync
+        # loop confused the outer parameter with its loop variable it could
+        # request the same number twice.
+        async def _get_pr(owner: str, repo: str, number: int):
+            return {11: pr_a, 22: pr_b}[number]
+
+        github.get_pull_request.side_effect = _get_pr
+
+        tracked_prs = {
+            11: TrackedPR(number=11, state=PRTrackingState.CI_PENDING),
+            22: TrackedPR(number=22, state=PRTrackingState.CI_PENDING),
+        }
+
+        agent = PRAgent(github=github, owner="o", repo="r", config=make_config())
+        _, updated_tracked = await agent.run(tracked_prs)
+
+        assert updated_tracked[11].state == PRTrackingState.MERGED
+        assert updated_tracked[11].merged_at == merged_at_a
+        assert updated_tracked[22].state == PRTrackingState.MERGED
+        assert updated_tracked[22].merged_at == merged_at_b
+        # Both numbers were requested — proves the loop iterated each entry
+        # by its own key.
+        called_numbers = sorted(call.args[2] for call in github.get_pull_request.await_args_list)
+        assert called_numbers == [11, 22]
+
 
 # ── is_copilot_pr recognition ────────────────────────────────────────
 
@@ -1018,6 +1064,77 @@ class TestCommentDeduplication:
         agent._copilot_bridge.request_ci_fix.assert_awaited_once()
         assert updated.copilot_attempts == 1
         assert 102 in report.fix_requested
+
+    async def test_reversed_order_still_returns_correct_pending_verdict(self) -> None:
+        """Regression for T-S7: get_pr_comments does not guarantee ordering.
+
+        When the API returns comments in reverse chronological order, the
+        previous implementation's "last task before any result" logic could
+        invert. The function must sort explicitly by (created_at, id) so the
+        verdict is stable regardless of input order.
+        """
+        from caretaker.github_client.models import Comment, User
+        from caretaker.pr_agent.agent import PRAgent
+
+        user = User(login="caretaker[bot]", id=99, type="Bot")
+        # Task first (older), then result (newer): the correct verdict is
+        # NOT pending — the task has been answered.
+        task = Comment(
+            id=1,
+            user=user,
+            body="<!-- caretaker:task -->Fix CI failure",
+            created_at=datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+        )
+        result = Comment(
+            id=2,
+            user=user,
+            body="<!-- caretaker:result -->FIXED",
+            created_at=datetime(2024, 1, 1, 13, 0, tzinfo=UTC),
+        )
+
+        github = AsyncMock()
+        # API returns them in reverse chronological order.
+        github.get_pr_comments.return_value = [result, task]
+        config = make_config()
+        agent = PRAgent(github=github, owner="o", repo="r", config=config)
+
+        assert await agent._has_pending_task_comment(1) is False
+
+    async def test_reversed_order_detects_unanswered_task(self) -> None:
+        """When the API returns an unanswered task among older comments in
+        reverse order, the verdict must be *pending* (True)."""
+        from caretaker.github_client.models import Comment, User
+        from caretaker.pr_agent.agent import PRAgent
+
+        user = User(login="caretaker[bot]", id=99, type="Bot")
+        # First task, then result, then second task (most recent). Correct
+        # verdict: pending (second task has no subsequent result).
+        first_task = Comment(
+            id=1,
+            user=user,
+            body="<!-- caretaker:task -->First task",
+            created_at=datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+        )
+        result = Comment(
+            id=2,
+            user=user,
+            body="<!-- caretaker:result -->FIXED",
+            created_at=datetime(2024, 1, 1, 13, 0, tzinfo=UTC),
+        )
+        second_task = Comment(
+            id=3,
+            user=user,
+            body="<!-- caretaker:task -->Second task",
+            created_at=datetime(2024, 1, 1, 14, 0, tzinfo=UTC),
+        )
+
+        github = AsyncMock()
+        # Reverse chronological order.
+        github.get_pr_comments.return_value = [second_task, result, first_task]
+        config = make_config()
+        agent = PRAgent(github=github, owner="o", repo="r", config=config)
+
+        assert await agent._has_pending_task_comment(1) is True
 
 
 # ── PR-number single-PR fast path ─────────────────────────────────────────────

--- a/tests/test_pr_agent/test_pr_triage.py
+++ b/tests/test_pr_agent/test_pr_triage.py
@@ -69,26 +69,51 @@ async def test_close_empty_prs_dry_run_does_not_close() -> None:
 
 @pytest.mark.asyncio
 async def test_close_duplicate_fix_prs_by_cve() -> None:
+    # Survivor policy: oldest wins (canonical review history lives on the
+    # first PR). Mirrors close_duplicate_issues in issue_agent/issue_triage.py.
     older = make_pr(number=10, created_at=datetime(2026, 1, 1, tzinfo=UTC))
     older.title = "Bump aiohttp for CVE-2026-34516"
     newer = make_pr(number=11, created_at=datetime(2026, 2, 1, tzinfo=UTC))
     newer.title = "Fix CVE-2026-34516 in aiohttp (proper pin)"
     gh = _FakeGH()
     closed = await close_duplicate_fix_prs(gh, "o", "r", [older, newer])
-    assert closed == [10]
-    # Close comment references the survivor.
-    assert any("#11" in body for (_, body) in gh.comments)
+    assert closed == [11]
+    # Close comment references the survivor (the older PR).
+    assert any("#10" in body for (_, body) in gh.comments)
 
 
 @pytest.mark.asyncio
 async def test_close_duplicate_fix_prs_package_bump() -> None:
+    # Survivor policy: oldest wins.
     a = make_pr(number=20, created_at=datetime(2026, 1, 1, tzinfo=UTC))
     a.title = "Bump pytest from 8 to 9.0.2"
     b = make_pr(number=21, created_at=datetime(2026, 1, 2, tzinfo=UTC))
     b.title = "Bump pytest from 8 to 9.0.3"
     gh = _FakeGH()
     closed = await close_duplicate_fix_prs(gh, "o", "r", [a, b])
-    assert closed == [20]
+    assert closed == [21]
+
+
+@pytest.mark.asyncio
+async def test_close_duplicate_fix_prs_survivor_matches_issue_triage_policy() -> None:
+    """Regression for T-S4: pr_triage survivor must match issue_triage (oldest wins).
+
+    Reversing the list order must not change the survivor — this catches any
+    regression to "newest wins" that would be hidden by input ordering.
+    """
+    first = make_pr(number=50, created_at=datetime(2026, 3, 1, tzinfo=UTC))
+    first.title = "Bump requests for CVE-2026-99999"
+    second = make_pr(number=51, created_at=datetime(2026, 3, 10, tzinfo=UTC))
+    second.title = "CVE-2026-99999 requests pin"
+    third = make_pr(number=52, created_at=datetime(2026, 3, 15, tzinfo=UTC))
+    third.title = "Fix CVE-2026-99999 in requests"
+
+    gh = _FakeGH()
+    closed = await close_duplicate_fix_prs(gh, "o", "r", [third, first, second])
+    # Oldest (#50) wins regardless of input order; #51 and #52 close.
+    assert sorted(closed) == [51, 52]
+    # All close comments reference #50 as the superseding PR.
+    assert all("#50" in body for (_, body) in gh.comments)
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr_agent/test_states.py
+++ b/tests/test_pr_agent/test_states.py
@@ -478,3 +478,75 @@ class TestReadinessRequiredReviews:
         assert result.readiness is not None
         assert "required_review_missing" in result.readiness.blockers
         assert result.readiness.score < 1.0
+
+
+class TestEvaluatePRAutoMergeGate:
+    """Regression for T-S3: MERGE_READY must respect auto_merge policy.
+
+    ``merge.evaluate_merge`` already refuses to merge PR families with
+    ``auto_merge.<profile>=false``, but the state machine upstream still
+    returned ``MERGE_READY`` — which made the status comment say "ready for
+    merge" while caretaker silently refused to act. Thread the policy into
+    ``evaluate_pr`` and cap the recommendation at ``CI_PASSING / await_review``.
+    """
+
+    def test_human_pr_auto_merge_disabled_does_not_return_merge_ready(self) -> None:
+        from caretaker.config import AutoMergeConfig
+        from caretaker.github_client.models import User
+
+        human = User(login="human-dev", id=7, type="User")
+        pr = make_pr(user=human)
+        checks = [make_check_run(name="test")]  # passing
+        auto_merge = AutoMergeConfig(human_prs=False)
+        result = evaluate_pr(
+            pr,
+            checks,
+            [],  # no reviewers assigned → reviews.pending=True
+            PRTrackingState.CI_PASSING,
+            auto_merge=auto_merge,
+        )
+        assert result.recommended_state != PRTrackingState.MERGE_READY
+        assert result.recommended_state == PRTrackingState.CI_PASSING
+        assert result.recommended_action == "await_review"
+
+    def test_human_pr_auto_merge_enabled_returns_merge_ready(self) -> None:
+        from caretaker.config import AutoMergeConfig
+        from caretaker.github_client.models import User
+
+        human = User(login="human-dev", id=7, type="User")
+        pr = make_pr(user=human)
+        checks = [make_check_run(name="test")]
+        auto_merge = AutoMergeConfig(human_prs=True)
+        result = evaluate_pr(
+            pr,
+            checks,
+            [],
+            PRTrackingState.CI_PASSING,
+            auto_merge=auto_merge,
+        )
+        assert result.recommended_state == PRTrackingState.MERGE_READY
+        assert result.recommended_action == "merge"
+
+    def test_copilot_pr_auto_merge_disabled_caps_at_ci_passing(self) -> None:
+        from caretaker.config import AutoMergeConfig
+        from caretaker.github_client.models import User
+
+        copilot = User(login="copilot[bot]", id=8, type="Bot")
+        pr = make_pr(user=copilot)
+        checks = [make_check_run(name="test")]
+        auto_merge = AutoMergeConfig(copilot_prs=False)
+        result = evaluate_pr(
+            pr,
+            checks,
+            [],
+            PRTrackingState.CI_PASSING,
+            auto_merge=auto_merge,
+        )
+        assert result.recommended_state != PRTrackingState.MERGE_READY
+
+    def test_no_auto_merge_config_preserves_legacy_behavior(self) -> None:
+        """When auto_merge is None, the gate is disabled — MERGE_READY returns."""
+        pr = make_pr()
+        checks = [make_check_run(name="test")]
+        result = evaluate_pr(pr, checks, [], PRTrackingState.CI_PASSING)
+        assert result.recommended_state == PRTrackingState.MERGE_READY


### PR DESCRIPTION
Batch of four independent correctness fixes in the PR agent. Each is small; batching because review overhead dominates the size of the change.

### T-S2 — shadowed `pr_number` variable

**Symptom:** In `PRAgent.run`, the closed-PR sync loop iterated with `for pr_number, tracked in list(tracked_prs.items())`, silently shadowing the outer `pr_number: int | None` parameter for the remainder of the function. The post-loop code happens not to re-read `pr_number`, so no live misbehavior — but any future edit that does will silently observe the last loop value.

**Evidence:** `src/caretaker/pr_agent/agent.py` line 150 (pre-fix).

**Fix:** Renamed the loop variable to `tracked_pr_number`; updated every reference inside the loop body. Added a regression test (`test_sync_loop_does_not_shadow_pr_number_parameter`) that exercises the loop with multiple closed PRs and verifies each is fetched by its own number.

### T-S3 — `MERGE_READY` reported even when auto-merge is disabled

**Symptom:** On a CI-green PR with no reviewer assigned, the state machine returned `recommended_state=MERGE_READY` unconditionally. `merge.evaluate_merge` correctly refused to merge when `config.auto_merge.human_prs=false`, but the status comment — driven upstream of that check — still rendered as "ready for merge", creating a user-confusing "caretaker says ready, nothing happens" loop.

**Evidence:** `src/caretaker/pr_agent/states.py` line 367 (pre-fix) versus `src/caretaker/pr_agent/merge.py` which already gated on `auto_merge.<profile>`.

**Fix:** Threaded `AutoMergeConfig` into `evaluate_pr` via a new optional `auto_merge` kwarg. When the configured policy would reject this PR family (Copilot / Dependabot / human), the recommendation caps at `CI_PASSING / await_review` instead of `MERGE_READY`. Default `auto_merge=None` preserves legacy behavior for existing callers. Added `TestEvaluatePRAutoMergeGate` covering the three PR profiles plus the backwards-compat case.

### T-S4 — duplicate-PR survivor policy disagreed with sibling

**Symptom:** `pr_triage.close_duplicate_fix_prs` selected the **newest** PR as the survivor; the sibling `issue_triage.close_duplicate_issues` kept the **oldest** ("preserves the canonical history"). The two functions were near-identical, so the divergent policy was almost certainly a bug rather than a deliberate split — closing the older twin discards the accumulated review discussion and CI history.

**Evidence:** `src/caretaker/pr_agent/pr_triage.py` line 151 (`max(prs, …)`, pre-fix) versus `src/caretaker/issue_agent/issue_triage.py` line 134 (`min(issues, …)`).

**Fix:** Flipped pr_triage to `min(prs, …)` with `created_at` ascending and lowest PR number as tie-break. Added a `# why oldest wins` comment pointing to the issue_triage twin. Updated the existing two tests that asserted newest-wins and added a regression test that reverses the input list order to catch any future "newest wins" regression hidden by input ordering.

### T-S7 — `_has_pending_task_comment` assumed comment ordering

**Symptom:** `_has_pending_task_comment` iterated the comment list twice and implicitly assumed it was sorted by id (i.e. by creation time). `GitHubClient.get_pr_comments` gives no ordering guarantee, so if the API page ever arrived in reverse, the "last task before any result" logic would invert — concluding no pending task when one actually existed.

**Evidence:** `src/caretaker/pr_agent/agent.py` line 450 (pre-fix).

**Fix:** Sort explicitly by `(created_at, id)` at the top of the function; both fields are always populated on `Comment`. Added two regression tests in `TestCommentDeduplication` that supply comments in reverse chronological order and assert the correct pending/not-pending verdict.

## Verification

- `PYTHONPATH=./src .venv/bin/pytest -q tests/test_pr_agent/ tests/test_issue_agent/` — 251 passed, no skips.
- `.venv/bin/pytest -q` (full suite) — 1090 passed, 1 skipped.
- `.venv/bin/ruff check src tests` — clean.
- `.venv/bin/ruff format --check src tests` — clean.
- `.venv/bin/mypy src/` — no new errors; two preexisting errors in `k8s_worker/launcher.py` are unrelated to this change and present on `main`.

## Test plan

- [x] Target tests green locally (`tests/test_pr_agent/`, `tests/test_issue_agent/`).
- [x] Full suite green locally.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy src/` shows no new errors relative to `main`.
- [ ] CI green on the PR.
- [ ] No regressions in real maintainer triage cycle (pick up on next dry-run invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)