### PR TITLE
chore(release): 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.1] — 2026-04-22
+
+### Fixed
+
+- **`FleetOAuthClientCache`** (#472): the OAuth2 client cache shipped in 0.12.0 lived in a pair of module-level globals. Any multi-tenant path — admin backend, tests constructing two `MaintainerConfig`s — would silently let the second config reuse the first's cached client. Extracted onto a per-owner class; `Orchestrator` owns its own instance and threads it through `emit_heartbeat`. Module singleton kept only for the legacy single-owner call path.
+- **`datetime.utcnow()` sweep** (#471): replaced all call sites in `src/caretaker/` with `datetime.now(UTC)`. Python 3.12 deprecates `utcnow()`, and the resulting naive timestamps mixed unsafely with the tz-aware datetimes already used elsewhere. Added an AST-based regression test to prevent reintroductions.
+- **PR-agent correctness batch** (#474): four small independent fixes — shadowed `pr_number` loop variable, `MERGE_READY` reported for human PRs even when auto-merge was disabled, duplicate-PR survivor policy disagreeing with the duplicate-issue sibling, and `_has_pending_task_comment` relying on implicit comment ordering.
+- **Foundry tool-loop fallback** (#470): the `raw_message=None` defensive path built an OpenAI-shaped assistant message that would 400 on the next turn for Anthropic models. The path was papering over a provider-contract gap; dropped the fallback and require providers to populate `raw_message` on any tool-use turn.
+
+### Docs
+
+- **Plan of record** (#473): added `docs/plans/2026-Q2-agentic-migration.md` (master plan, 3 phases, 28 sub-agent tasks, parallelization map), `docs/plans/2026-04-22-fleet-audit.md` (operational audit of the five caretaker-topic consumer repos), and `docs/plans/2026-04-22-source-audit.md` (code-level bug list + agentic-migration candidates).
+
 ## [0.12.0] — 2026-04-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caretaker-github"
-version = "0.12.0"
+version = "0.12.1"
 description = "Autonomous GitHub repository maintenance powered by Copilot"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bug-fix release bundling the five PRs merged this afternoon.

### Fixed
- **#470** — `foundry/tool_loop.py` OpenAI-shape fallback removed; raises `ToolLoopError` on `raw_message=None` during tool-use turns.
- **#471** — `datetime.utcnow()` → `datetime.now(UTC)` across `src/caretaker/`; AST-based regression test added.
- **#472** — `FleetOAuthClientCache` extracted from module globals; orchestrator owns its own instance. Fixes a multi-tenant cache leak self-inflicted in 0.12.0.
- **#474** — pr_agent correctness batch: shadowed `pr_number` renamed, `MERGE_READY` gated on auto-merge config, duplicate-PR survivor policy aligned with issue-triage (oldest wins), `_has_pending_task_comment` sorts comments explicitly.

### Docs
- **#473** — persisted the 2026-Q2 agentic migration plan + fleet audit + source audit under `docs/plans/`.

## Test plan

- [x] All five upstream PRs had CI green on real gates (test/lint/build/Analyze) prior to merge.
- [ ] Tag `v0.12.1` and cut a GitHub release post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)