### PR TITLE
fix(release-sync): ensure trailing newline on every written consumer file

### DIFF
--- a/src/caretaker/foundry/tools.py
+++ b/src/caretaker/foundry/tools.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from pathlib import Path  # noqa: TC003 — used at runtime in ToolContext dataclass
 from typing import TYPE_CHECKING, Any
 
+from caretaker.util.text import ensure_trailing_newline
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -222,12 +224,17 @@ async def _tool_write_file(ctx: ToolContext, path: str, content: str) -> str:
     except PathViolation as exc:
         return _fence("error", str(exc))
     resolved.parent.mkdir(parents=True, exist_ok=True)
+    # Guarantee a trailing newline so downstream pre-commit end-of-file-fixer
+    # hooks don't fail on files the LLM forgot to terminate. Idempotent:
+    # content that already ends with ``\n`` (including multi-newline endings
+    # like JSON blobs with trailing blank lines) is returned unchanged.
+    normalised = ensure_trailing_newline(content)
     try:
-        resolved.write_text(content, encoding="utf-8")
+        resolved.write_text(normalised, encoding="utf-8")
     except OSError as exc:
         return _fence("error", f"write failed: {exc}")
-    ctx.record_mutation(f"write_file {path} ({len(content)} bytes)")
-    return _fence(f"write_file:{path}", f"OK ({len(content)} bytes written)")
+    ctx.record_mutation(f"write_file {path} ({len(normalised)} bytes)")
+    return _fence(f"write_file:{path}", f"OK ({len(normalised)} bytes written)")
 
 
 async def _tool_apply_patch(ctx: ToolContext, unified_diff: str) -> str:

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode
 import httpx
 
 from caretaker.tools.github import CopilotAgentAssignment
+from caretaker.util.text import ensure_trailing_newline
 
 if TYPE_CHECKING:
     from caretaker.tools.github import GitHubRepositoryTools
@@ -1113,12 +1114,21 @@ class GitHubClient:
         branch: str,
         sha: str | None = None,
     ) -> dict[str, Any]:
-        """Create or update a file via the contents API. *content* is raw UTF-8 text."""
+        """Create or update a file via the contents API. *content* is raw UTF-8 text.
+
+        The content is passed through :func:`ensure_trailing_newline` before
+        being base64-encoded so the resulting blob ends with a single ``\\n``.
+        This keeps consumer-side pre-commit ``end-of-file-fixer`` hooks happy
+        on files caretaker writes (CHANGELOG.md, workflow YAMLs, etc.) — see
+        PR python_dsa#42 / kubernetes-apply-vscode#17 for the failure mode
+        this prevents.
+        """
         import base64
 
+        normalised = ensure_trailing_newline(content)
         payload: dict[str, Any] = {
             "message": message,
-            "content": base64.b64encode(content.encode()).decode(),
+            "content": base64.b64encode(normalised.encode()).decode(),
             "branch": branch,
         }
         if sha:

--- a/src/caretaker/util/__init__.py
+++ b/src/caretaker/util/__init__.py
@@ -1,0 +1,5 @@
+"""Small, dependency-free helpers shared across caretaker subsystems."""
+
+from caretaker.util.text import ensure_trailing_newline
+
+__all__ = ["ensure_trailing_newline"]

--- a/src/caretaker/util/text.py
+++ b/src/caretaker/util/text.py
@@ -1,0 +1,48 @@
+"""Text-munging helpers shared by writers that land files in consumer repos.
+
+The helpers here are intentionally narrow and dependency-free so they can be
+called from any file-writing path (Foundry tool registry, GitHub contents
+API wrapper, local release-sync templater, etc.) without pulling in agent
+scaffolding.
+"""
+
+from __future__ import annotations
+
+
+def ensure_trailing_newline(content: str) -> str:
+    """Return ``content`` with exactly one trailing ``\\n`` appended, if missing.
+
+    Why this exists:
+        Consumer repos commonly wire the pre-commit ``end-of-file-fixer`` hook,
+        which refuses to merge a file that lacks a single trailing newline.
+        When caretaker writes templated files (e.g. ``.github/workflows/
+        maintainer.yml``) into a consumer repo on version upgrade, a missing
+        EOF newline causes the hook to fail, the devops agent then opens a
+        CI-failure issue, Copilot is assigned to add the newline, and those
+        secondary "add EOF newline" PRs pile up unmerged. Three consumer
+        repos hit this exact chain within 48 hours (python_dsa #39/#42/#43,
+        kubernetes-apply-vscode #17, flashcards).
+
+    Semantics:
+        - If ``content`` ends with ``\\n``, it is returned unchanged — even
+          if it already ends with multiple newlines. Over-normalising would
+          corrupt Markdown fixtures or JSON payloads where the author
+          deliberately left blank trailing lines.
+        - If ``content`` is the empty string, the empty string is returned
+          unchanged. Callers that want an empty-file-with-newline should
+          pass ``"\\n"`` explicitly; we refuse to invent content for them.
+        - Otherwise a single ``\\n`` is appended.
+
+    Args:
+        content: The text about to be written to disk or sent to the
+            GitHub contents API.
+
+    Returns:
+        ``content`` with a guaranteed single trailing newline (or the
+        original string if it already ended with one, or was empty).
+    """
+    if not content:
+        return content
+    if content.endswith("\n"):
+        return content
+    return content + "\n"

--- a/tests/test_foundry/test_tools.py
+++ b/tests/test_foundry/test_tools.py
@@ -76,8 +76,29 @@ class TestMutationTools:
         reg = build_tool_registry()
         result = await reg["write_file"].handler(tool_ctx, "new.txt", "hi there")
         assert "OK" in result
-        assert (tool_ctx.workspace_root / "new.txt").read_text() == "hi there"
+        # Trailing newline is guaranteed — see T-M4 / python_dsa#42 cascade.
+        assert (tool_ctx.workspace_root / "new.txt").read_text() == "hi there\n"
         assert any("write_file new.txt" in m for m in tool_ctx.mutations)
+
+    @pytest.mark.asyncio
+    async def test_write_file_preserves_existing_trailing_newline(
+        self, tool_ctx: ToolContext
+    ) -> None:
+        """If the LLM already appended ``\\n``, don't double it. Regression
+        guard for the T-M4 release-sync EOF-newline fix.
+        """
+        reg = build_tool_registry()
+        await reg["write_file"].handler(tool_ctx, "pinned.txt", "0.12.1\n")
+        assert (tool_ctx.workspace_root / "pinned.txt").read_text() == "0.12.1\n"
+
+    @pytest.mark.asyncio
+    async def test_write_file_preserves_multi_newline_endings(self, tool_ctx: ToolContext) -> None:
+        """Don't over-normalise: a file that intentionally ends with a blank
+        line is left alone. The contract is 'at least one', not 'exactly one'.
+        """
+        reg = build_tool_registry()
+        await reg["write_file"].handler(tool_ctx, "doc.md", "# Title\n\n")
+        assert (tool_ctx.workspace_root / "doc.md").read_text() == "# Title\n\n"
 
     @pytest.mark.asyncio
     async def test_write_file_denylist_rejects(self, tool_ctx: ToolContext) -> None:

--- a/tests/test_github_client_api.py
+++ b/tests/test_github_client_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 from datetime import UTC
 from datetime import datetime as _dt
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -843,3 +844,70 @@ async def test_update_issue_copilot_assignment_404_is_non_fatal() -> None:
         issue = await client.update_issue("o", "r", 55, assignees=["copilot"])
 
     assert issue.number == 55
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_file_appends_trailing_newline() -> None:
+    """Content missing a final ``\\n`` gets one appended before base64
+    encoding — keeps the consumer's ``end-of-file-fixer`` pre-commit hook
+    from failing on files caretaker writes via the contents API.
+
+    Regression guard for python_dsa#42 / kubernetes-apply-vscode#17.
+    """
+    client = GitHubClient(
+        credentials_provider=StaticCredentialsProvider(default_token="x"),
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_put(path: str, **kwargs: object) -> dict[str, object]:
+        captured["path"] = path
+        captured["json"] = kwargs.get("json")
+        return {"content": {"sha": "deadbeef"}}
+
+    with patch.object(client, "_put", side_effect=fake_put):
+        await client.create_or_update_file(
+            owner="o",
+            repo="r",
+            path=".github/workflows/maintainer.yml",
+            message="chore: sync maintainer workflow",
+            content="name: Maintainer\non: schedule",  # no trailing newline
+            branch="caretaker/sync",
+        )
+
+    payload = captured["json"]
+    assert isinstance(payload, dict)
+    decoded = base64.b64decode(payload["content"]).decode()
+    assert decoded == "name: Maintainer\non: schedule\n"
+    assert decoded.endswith("\n")
+    assert not decoded.endswith("\n\n")
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_file_preserves_existing_newline() -> None:
+    """Content that already ends with ``\\n`` is passed through unchanged —
+    don't double-terminate.
+    """
+    client = GitHubClient(
+        credentials_provider=StaticCredentialsProvider(default_token="x"),
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_put(path: str, **kwargs: object) -> dict[str, object]:
+        captured["json"] = kwargs.get("json")
+        return {"content": {"sha": "abc"}}
+
+    original = "# CHANGELOG\n\n## [2026-W17] — 2026-04-21\n- hello (#1)\n"
+    with patch.object(client, "_put", side_effect=fake_put):
+        await client.create_or_update_file(
+            owner="o",
+            repo="r",
+            path="CHANGELOG.md",
+            message="docs: update changelog",
+            content=original,
+            branch="docs/changelog-2026-W17",
+        )
+
+    payload = captured["json"]
+    assert isinstance(payload, dict)
+    decoded = base64.b64decode(payload["content"]).decode()
+    assert decoded == original

--- a/tests/test_util_text.py
+++ b/tests/test_util_text.py
@@ -1,0 +1,88 @@
+"""Tests for :mod:`caretaker.util.text`.
+
+Golden-file regression for the release-sync EOF-newline fix.
+
+Context:
+    Consumer repos run the ``end-of-file-fixer`` pre-commit hook. When
+    caretaker wrote templated files (``maintainer.yml``, agent markdown,
+    config YAML, etc.) without a trailing newline, the hook failed and
+    triggered a cascade: devops_agent filed a CI-failure issue → Copilot
+    opened a "add EOF newline" PR → that PR sat unmerged. Seen in
+    python_dsa PRs #39/#42/#43, kubernetes-apply-vscode #17, flashcards.
+
+These tests lock the helper's contract so that regression can't recur:
+    * missing newline → exactly one is appended
+    * single trailing newline → unchanged
+    * triple (or more) trailing newlines → unchanged (do not over-normalise)
+    * empty string → unchanged (no invented content)
+    * idempotency — helper is safe to call twice
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from caretaker.util.text import ensure_trailing_newline
+
+
+class TestEnsureTrailingNewline:
+    def test_appends_newline_when_missing(self) -> None:
+        result = ensure_trailing_newline("on: push\njobs: {}")
+        assert result == "on: push\njobs: {}\n"
+        assert result.endswith("\n")
+        # Exactly one trailing newline — not two.
+        assert not result.endswith("\n\n")
+
+    def test_leaves_single_trailing_newline_alone(self) -> None:
+        content = "on: push\njobs: {}\n"
+        assert ensure_trailing_newline(content) == content
+
+    def test_preserves_multiple_trailing_newlines(self) -> None:
+        """If the caller deliberately left extra blank lines (e.g. a JSON
+        payload or a markdown block with a trailing blank), the helper must
+        not over-normalise to a single newline. That would corrupt fixtures.
+        """
+        content = "hello\n\n\n"
+        assert ensure_trailing_newline(content) == content
+
+    def test_empty_string_is_unchanged(self) -> None:
+        """We refuse to invent content: empty in, empty out. Callers that
+        want an empty-file-with-newline must pass ``"\\n"`` themselves.
+        """
+        assert ensure_trailing_newline("") == ""
+
+    def test_single_newline_is_unchanged(self) -> None:
+        assert ensure_trailing_newline("\n") == "\n"
+
+    def test_is_idempotent(self) -> None:
+        """Helper must be safe to call multiple times along a pipeline."""
+        once = ensure_trailing_newline("content without newline")
+        twice = ensure_trailing_newline(once)
+        assert once == twice == "content without newline\n"
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # Golden fixtures mirroring the real consumer files that regressed.
+            ("name: Maintainer\non: schedule", "name: Maintainer\non: schedule\n"),
+            ("0.12.1", "0.12.1\n"),  # .github/maintainer/.version
+            ("# CHANGELOG\n\n## [2026-W17]\n- x", "# CHANGELOG\n\n## [2026-W17]\n- x\n"),
+            ("caretaker:\n  enabled: true\n", "caretaker:\n  enabled: true\n"),
+        ],
+    )
+    def test_golden_fixtures(self, raw: str, expected: str) -> None:
+        assert ensure_trailing_newline(raw) == expected
+        # Every golden fixture must end with exactly one ``\n`` after the
+        # round-trip — this is the invariant the consumer's
+        # ``end-of-file-fixer`` hook checks.
+        out = ensure_trailing_newline(raw)
+        assert out.endswith("\n")
+        assert not out.endswith("\n\n")
+
+    def test_trailing_whitespace_without_newline_still_gets_newline(self) -> None:
+        """Trailing spaces are not a newline. A ``.version`` file like
+        ``"0.12.1  "`` still needs a ``\\n`` appended — we do not strip the
+        spaces (that's a separate linter's job) but we do terminate the line.
+        """
+        result = ensure_trailing_newline("0.12.1  ")
+        assert result == "0.12.1  \n"


### PR DESCRIPTION
## Symptom

Consumer repos ran the pre-commit `end-of-file-fixer` hook. When caretaker wrote a templated file (for example `.github/workflows/maintainer.yml` on an upgrade, or `CHANGELOG.md` on the weekly docs reconciliation), the content was sent through without a terminating `\n`. The hook then failed on the resulting PR and triggered a cascade that devops_agent cannot self-heal:

1. Templated file lands in the consumer repo with no trailing newline.
2. `end-of-file-fixer` fails the first CI run.
3. `devops_agent` opens a "CI failing" issue and assigns Copilot.
4. Copilot opens a secondary "add EOF newline" PR — which itself sits unmerged.

Real examples observed within a single 48-hour window:

- python_dsa [#39](https://github.com/ianlintner/python_dsa/pull/39), [#42](https://github.com/ianlintner/python_dsa/pull/42), [#43](https://github.com/ianlintner/python_dsa/pull/43)
- kubernetes-apply-vscode [#17](https://github.com/ianlintner/kubernetes-apply-vscode/pull/17)
- flashcards (same cascade)

See `docs/plans/2026-04-22-fleet-audit.md` patterns P3 and M4.

## Root cause

Both of caretaker's consumer-repo write paths — `foundry.tools._tool_write_file` (the LLM-callable workspace writer) and `github_client.GitHubClient.create_or_update_file` (the direct contents API wrapper used by the docs agent) — shipped content verbatim. Any template, string join, or LLM-generated body that happened to finish on a non-newline character slipped straight through and tripped the consumer's pre-commit hook. We audited for `.strip()` calls that were hand-stripping newlines before writing; none were found — the bug was the absence of a normalising pass, not an over-eager strip.

## Change

- Add `caretaker.util.text.ensure_trailing_newline(content: str) -> str` — idempotent helper that appends exactly one `\n` if the content lacks one, preserves multi-newline endings, and leaves an empty string alone.
- Thread the helper through `foundry.tools._tool_write_file`, so every file the coding executor lands in a worktree is newline-terminated.
- Thread the helper through `GitHubClient.create_or_update_file`, so every direct contents-API write (CHANGELOG, future config, anything that bypasses the worktree) is newline-terminated before base64 encoding.

## Test plan

- [x] New `tests/test_util_text.py` golden-file regression covers: missing newline appended, single trailing newline unchanged, triple-newline content preserved (no over-normalisation), empty string unchanged, idempotency, and realistic fixtures (`maintainer.yml`, `.github/maintainer/.version`, `CHANGELOG.md`, `config.yml`).
- [x] New assertions in `tests/test_foundry/test_tools.py` verify `write_file` now emits `\n`-terminated content and leaves pre-terminated/multi-newline content alone.
- [x] New assertions in `tests/test_github_client_api.py` verify `create_or_update_file` base64-encodes a `\n`-terminated payload and preserves already-terminated content.
- [x] Full suite — `PYTHONPATH=src pytest -q` — 1110 passed, 1 skipped.
- [x] `ruff check src tests` clean.
- [x] `ruff format --check src tests` clean.
- [x] `mypy src/caretaker` — no new errors (the two pre-existing k8s_worker warnings are unchanged from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)