### PR TITLE
feat(llm): structured_complete[T] helper; migrate inline_reviewer as canary

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -215,6 +215,10 @@ class LLMConfig(StrictBaseModel):
     # Fallback model chain — only used when provider="litellm".  Each entry is
     # a LiteLLM-format model string tried in order if the primary call fails.
     fallback_models: list[str] = Field(default_factory=list)
+    # Number of retries for ``ClaudeClient.structured_complete`` when the model
+    # returns malformed JSON or a payload that fails pydantic validation.
+    # Set to 0 to disable the self-correcting retry loop.
+    structured_output_retries: int = 1
 
 
 class OrchestratorConfig(StrictBaseModel):

--- a/src/caretaker/llm/claude.py
+++ b/src/caretaker/llm/claude.py
@@ -12,8 +12,11 @@ The public method signatures are unchanged, so existing callers in
 
 from __future__ import annotations
 
+import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
+
+from pydantic import BaseModel, ValidationError
 
 from .provider import AnthropicProvider, LLMRequest, build_provider
 
@@ -23,6 +26,44 @@ if TYPE_CHECKING:
     from .provider import LLMProvider
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class StructuredCompleteError(Exception):
+    """Raised when ``ClaudeClient.structured_complete`` exhausts its retries.
+
+    Attributes:
+        raw_text: Last raw LLM response received, for diagnostic logging.
+        validation_error: The underlying :class:`pydantic.ValidationError` or
+            :class:`json.JSONDecodeError` that caused the final failure.
+    """
+
+    def __init__(
+        self,
+        raw_text: str,
+        validation_error: Exception,
+    ) -> None:
+        super().__init__(
+            f"LLM structured completion failed validation after retries: "
+            f"{type(validation_error).__name__}: {validation_error}"
+        )
+        self.raw_text = raw_text
+        self.validation_error = validation_error
+
+
+def _strip_code_fences(text: str) -> str:
+    """Strip optional ```json ... ``` fences some models emit despite instructions."""
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        # drop opening fence (possibly with language tag) and trailing fence
+        lines = stripped.splitlines()
+        if lines:
+            lines = lines[1:]
+            if lines and lines[-1].strip().startswith("```"):
+                lines = lines[:-1]
+            stripped = "\n".join(lines).strip()
+    return stripped
 
 
 # Default per-feature model/max-tokens fallback when LLMConfig is not supplied
@@ -145,6 +186,128 @@ class ClaudeClient:
         """
         full_prompt = f"{system}\n\n{prompt}" if system else prompt
         return await self._complete(feature, full_prompt, max_tokens)
+
+    async def structured_complete(
+        self,
+        prompt: str,
+        *,
+        schema: type[T],
+        feature: str = "structured_complete",
+        system: str | None = None,
+        max_retries: int | None = None,
+        max_tokens: int = 2000,
+        model: str | None = None,
+    ) -> T:
+        """Call the LLM and parse its response into ``schema``.
+
+        The request's system prompt (or user prompt if no system is supplied)
+        is prefixed with a terse instruction telling the model to emit a single
+        JSON object matching ``schema.model_json_schema()``. The response is
+        JSON-decoded and passed through ``schema.model_validate``. On
+        :class:`json.JSONDecodeError` or :class:`pydantic.ValidationError`,
+        the helper re-invokes the model once (by default) with the previous
+        raw output and the validation error appended, asking it to self-correct.
+
+        Args:
+            prompt: The user-turn prompt.
+            schema: The :class:`pydantic.BaseModel` subclass to validate against.
+            feature: Feature key used for model resolution and logging.
+                Defaults to ``"structured_complete"``.
+            system: Optional system instruction; the schema prefix is prepended
+                to it (or to ``prompt`` if ``system`` is ``None``).
+            max_retries: Number of retries on parse/validation failure.
+                Defaults to ``LLMConfig.structured_output_retries`` (1).
+            max_tokens: Hard cap on output length.
+            model: Optional explicit model string. When set, overrides
+                the resolved per-feature model.
+
+        Returns:
+            An instance of ``schema``.
+
+        Raises:
+            StructuredCompleteError: When all attempts fail validation.
+        """
+        if max_retries is None:
+            max_retries = self._config.structured_output_retries if self._config is not None else 1
+
+        schema_json = json.dumps(schema.model_json_schema(), separators=(",", ":"))
+        prefix = f"Respond with only a single JSON object matching this schema: {schema_json}"
+        effective_system = f"{prefix}\n\n{system}" if system else prefix
+
+        # Resolve model and max_tokens like ``complete`` does; allow override.
+        resolved_model, resolved_max_tokens = self._resolve_feature(feature, max_tokens)
+        if model is not None:
+            resolved_model = model
+
+        attempt_prompt = prompt
+        last_text = ""
+        last_error: Exception | None = None
+
+        attempts = max_retries + 1
+        for attempt in range(attempts):
+            if not self.available:
+                # No provider — surface as a validation failure so callers
+                # don't get silently downgraded to an empty T.
+                raise StructuredCompleteError(
+                    raw_text="",
+                    validation_error=RuntimeError("LLM provider unavailable"),
+                )
+
+            full_prompt = f"{effective_system}\n\n{attempt_prompt}"
+            _log_prompt(feature, full_prompt)
+            try:
+                response = await self._provider.complete(
+                    LLMRequest(
+                        feature=feature,
+                        prompt=full_prompt,
+                        model=resolved_model,
+                        max_tokens=resolved_max_tokens,
+                    )
+                )
+            except Exception as exc:
+                # Provider-level failure: surface to caller rather than swallowing.
+                raise StructuredCompleteError(raw_text="", validation_error=exc) from exc
+
+            _log_response(feature, response.text, response)
+            last_text = response.text or ""
+            cleaned = _strip_code_fences(last_text)
+
+            try:
+                parsed = json.loads(cleaned)
+            except json.JSONDecodeError as exc:
+                last_error = exc
+                logger.warning(
+                    "structured_complete[%s] attempt %d: JSON decode failed: %s",
+                    feature,
+                    attempt + 1,
+                    exc,
+                )
+                attempt_prompt = (
+                    f"{prompt}\n\n"
+                    f"Your previous response failed to parse: {exc}. "
+                    "Return only valid JSON matching the schema above."
+                )
+                continue
+
+            try:
+                return schema.model_validate(parsed)
+            except ValidationError as exc:
+                last_error = exc
+                logger.warning(
+                    "structured_complete[%s] attempt %d: schema validation failed: %s",
+                    feature,
+                    attempt + 1,
+                    exc,
+                )
+                attempt_prompt = (
+                    f"{prompt}\n\n"
+                    f"Your previous response failed to parse: {exc}. "
+                    "Return only valid JSON matching the schema above."
+                )
+                continue
+
+        assert last_error is not None  # loop always sets it on failure
+        raise StructuredCompleteError(raw_text=last_text, validation_error=last_error)
 
     # ── Public feature API ──────────────────────────────────────────────────
 

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -172,47 +172,61 @@ class PRReviewerAgent(BaseAgent):
                 )
                 decision = decision  # fall through to claude-code below
             else:
-                result = await inline_reviewer.review(
-                    github=self._ctx.github,
-                    owner=owner,
-                    repo=repo,
-                    pr_number=pr_number,
-                    pr_title=str(pr.get("title", "")),
-                    pr_body=str(pr.get("body") or ""),
-                    llm=self._ctx.llm_router,
-                    max_diff_lines=cfg.max_diff_lines,
-                )
-                commit_sha = (pr.get("head") or {}).get("sha", "")
-                if not commit_sha:
-                    logger.warning("pr-reviewer: no head SHA for #%d", pr_number)
-                    report.skipped.append(pr_number)
-                    return
+                from caretaker.llm.claude import StructuredCompleteError
 
-                await post_review(
-                    github=self._ctx.github,
-                    owner=owner,
-                    repo=repo,
-                    pr_number=pr_number,
-                    commit_sha=commit_sha,
-                    result=result,
-                    post_inline_comments=cfg.post_inline_comments,
-                    force_event=cfg.review_event if cfg.review_event != "AUTO" else None,
-                )
-                # Mark as reviewed
                 try:
-                    reviewed_label = "caretaker:reviewed"
-                    await self._ctx.github.ensure_label(
-                        owner,
-                        repo,
-                        reviewed_label,
-                        color="0075ca",
-                        description="Reviewed by caretaker",
+                    result = await inline_reviewer.review(
+                        github=self._ctx.github,
+                        owner=owner,
+                        repo=repo,
+                        pr_number=pr_number,
+                        pr_title=str(pr.get("title", "")),
+                        pr_body=str(pr.get("body") or ""),
+                        llm=self._ctx.llm_router,
+                        max_diff_lines=cfg.max_diff_lines,
                     )
-                    await self._ctx.github.add_labels(owner, repo, pr_number, [reviewed_label])
-                except Exception:
-                    pass
-                report.reviewed.append(pr_number)
-                return
+                except StructuredCompleteError as exc:
+                    # LLM returned malformed output after retries — fall through
+                    # to the claude-code hand-off path rather than silently
+                    # posting an empty COMMENT review (the old behavior).
+                    logger.warning(
+                        "pr-reviewer: inline review validation failed for #%d: %s — "
+                        "falling back to claude-code dispatch",
+                        pr_number,
+                        exc.validation_error,
+                    )
+                else:
+                    commit_sha = (pr.get("head") or {}).get("sha", "")
+                    if not commit_sha:
+                        logger.warning("pr-reviewer: no head SHA for #%d", pr_number)
+                        report.skipped.append(pr_number)
+                        return
+
+                    await post_review(
+                        github=self._ctx.github,
+                        owner=owner,
+                        repo=repo,
+                        pr_number=pr_number,
+                        commit_sha=commit_sha,
+                        result=result,
+                        post_inline_comments=cfg.post_inline_comments,
+                        force_event=cfg.review_event if cfg.review_event != "AUTO" else None,
+                    )
+                    # Mark as reviewed
+                    try:
+                        reviewed_label = "caretaker:reviewed"
+                        await self._ctx.github.ensure_label(
+                            owner,
+                            repo,
+                            reviewed_label,
+                            color="0075ca",
+                            description="Reviewed by caretaker",
+                        )
+                        await self._ctx.github.add_labels(owner, repo, pr_number, [reviewed_label])
+                    except Exception:
+                        pass
+                    report.reviewed.append(pr_number)
+                    return
 
         # Claude-code hand-off path
         success = await claude_code_reviewer.dispatch(

--- a/src/caretaker/pr_reviewer/inline_reviewer.py
+++ b/src/caretaker/pr_reviewer/inline_reviewer.py
@@ -6,10 +6,13 @@ Returns a ``ReviewResult`` that ``github_review.post_review()`` can post directl
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+from caretaker.llm.claude import StructuredCompleteError
 
 if TYPE_CHECKING:
     from caretaker.github_client.api import GitHubClient
@@ -20,22 +23,6 @@ logger = logging.getLogger(__name__)
 _REVIEW_SYSTEM = """\
 You are an expert code reviewer. Review the pull request diff below and produce
 a concise, actionable review. Focus on correctness, security, and maintainability.
-Respond ONLY with a JSON object matching the schema described in the user message.
-Do NOT wrap with markdown code fences. Output raw JSON only.
-"""
-
-_REVIEW_SCHEMA = """\
-{
-  "summary": "<1-3 sentence overall assessment>",
-  "verdict": "APPROVE" | "COMMENT" | "REQUEST_CHANGES",
-  "comments": [
-    {
-      "path": "<file path>",
-      "line": <line number, integer>,
-      "body": "<review comment text>"
-    }
-  ]
-}
 
 Rules:
 - verdict = APPROVE   when the diff looks correct and ready to merge
@@ -45,6 +32,27 @@ Rules:
 - limit comments to at most 8 items; omit trivial nits
 - keep each comment body under 300 characters
 """
+
+
+class InlineReviewCommentModel(BaseModel):
+    """Pydantic model for a single inline review comment."""
+
+    path: str = Field(..., description="Path of the file being commented on.")
+    line: int = Field(..., description="Line number in the new file (right side of diff).")
+    body: str = Field(..., description="Review comment body, under 300 characters.")
+
+
+class InlineReviewResult(BaseModel):
+    """Structured LLM review payload — validated schema for ``structured_complete``."""
+
+    summary: str = Field(..., description="1-3 sentence overall assessment.")
+    verdict: Literal["APPROVE", "COMMENT", "REQUEST_CHANGES"] = Field(
+        ..., description="Review verdict."
+    )
+    comments: list[InlineReviewCommentModel] = Field(
+        default_factory=list,
+        description="At most 8 line-scoped comments.",
+    )
 
 
 @dataclass
@@ -89,18 +97,29 @@ async def review(
         f"PR #{pr_number}: {pr_title}\n\n"
         f"{pr_body.strip()[:500] if pr_body else '(no description)'}\n\n"
         "---\n"
-        f"```diff\n{diff}\n```\n\n"
-        "Respond with a JSON object matching this schema:\n"
-        f"{_REVIEW_SCHEMA}"
+        f"```diff\n{diff}\n```"
     )
 
     try:
-        raw = await llm.claude.complete(
+        payload = await llm.claude.structured_complete(
+            prompt,
+            schema=InlineReviewResult,
             feature="pr_inline_review",
             system=_REVIEW_SYSTEM,
-            prompt=prompt,
             max_tokens=2000,
         )
+    except StructuredCompleteError:
+        # Surface parse/validation failures to the caller so they can be logged
+        # loudly. The pr-reviewer agent is expected to catch and fall back to
+        # a skip / claude-code dispatch — it must not silently issue an empty
+        # COMMENT review as the old ``json.loads`` fallback did.
+        logger.exception(
+            "inline review for %s/%s#%d failed validation after retries",
+            owner,
+            repo,
+            pr_number,
+        )
+        raise
     except Exception as exc:
         logger.warning("Inline LLM review failed for %s/%s#%d: %s", owner, repo, pr_number, exc)
         return ReviewResult(
@@ -108,26 +127,15 @@ async def review(
             verdict="COMMENT",
         )
 
-    raw_text = raw.strip()
-    try:
-        data = json.loads(raw_text)
-    except json.JSONDecodeError:
-        logger.warning("LLM response not valid JSON for %s/%s#%d", owner, repo, pr_number)
-        return ReviewResult(summary=raw_text[:500], verdict="COMMENT", raw_response=raw_text)
-
     comments = [
-        InlineReviewComment(
-            path=c.get("path", ""),
-            line=int(c.get("line", 1)),
-            body=c.get("body", ""),
-        )
-        for c in data.get("comments", [])
-        if c.get("path") and c.get("body")
+        InlineReviewComment(path=c.path, line=int(c.line), body=c.body)
+        for c in payload.comments
+        if c.path and c.body
     ]
 
     return ReviewResult(
-        summary=data.get("summary", ""),
-        verdict=data.get("verdict", "COMMENT").upper(),
+        summary=payload.summary,
+        verdict=payload.verdict,
         comments=comments,
-        raw_response=raw_text,
+        raw_response=payload.model_dump_json(),
     )

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import pytest
+from pydantic import BaseModel
+
 from caretaker.config import FeatureModelConfig, LLMConfig
-from caretaker.llm.claude import ClaudeClient
+from caretaker.llm.claude import ClaudeClient, StructuredCompleteError
 from caretaker.llm.provider import (
     AnthropicProvider,
     LiteLLMProvider,
@@ -18,9 +20,6 @@ from caretaker.llm.provider import (
     build_provider,
 )
 from caretaker.llm.router import LLMRouter
-
-if TYPE_CHECKING:
-    import pytest
 
 
 class FakeProvider:
@@ -277,3 +276,160 @@ class TestLLMRouter:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "x"}, clear=True):
             router = LLMRouter(LLMConfig(claude_enabled="auto", provider="anthropic"))
             assert router.available is True
+
+
+# ── structured_complete ──────────────────────────────────────────────────────
+
+
+class _SampleSchema(BaseModel):
+    verdict: str
+    score: int
+
+
+class ScriptedProvider:
+    """Provider that returns a scripted sequence of responses, one per call."""
+
+    name = "scripted"
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+        self.calls: list[LLMRequest] = []
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    async def complete(self, request: LLMRequest) -> LLMResponse:
+        self.calls.append(request)
+        text = self._responses.pop(0) if self._responses else ""
+        return LLMResponse(text=text, model=request.model, provider=self.name)
+
+
+class TestStructuredComplete:
+    async def test_happy_path_returns_parsed_model(self) -> None:
+        provider = ScriptedProvider(['{"verdict": "APPROVE", "score": 42}'])
+        client = ClaudeClient(provider=provider)
+
+        result = await client.structured_complete("do a review", schema=_SampleSchema)
+
+        assert isinstance(result, _SampleSchema)
+        assert result.verdict == "APPROVE"
+        assert result.score == 42
+        assert len(provider.calls) == 1
+
+    async def test_retry_recovers_from_malformed_first_attempt(self) -> None:
+        provider = ScriptedProvider(
+            [
+                "not valid json at all",
+                '{"verdict": "COMMENT", "score": 7}',
+            ]
+        )
+        client = ClaudeClient(provider=provider)
+
+        result = await client.structured_complete(
+            "review this", schema=_SampleSchema, max_retries=1
+        )
+
+        assert result.verdict == "COMMENT"
+        assert result.score == 7
+        assert len(provider.calls) == 2
+        # Second attempt prompt should include the previous-failure cue.
+        assert "previous response failed to parse" in provider.calls[1].prompt
+
+    async def test_exhausted_retries_raise_structured_complete_error(self) -> None:
+        provider = ScriptedProvider(
+            ["still not json", 'also {"incomplete": '],
+        )
+        client = ClaudeClient(provider=provider)
+
+        with pytest.raises(StructuredCompleteError) as excinfo:
+            await client.structured_complete("review", schema=_SampleSchema, max_retries=1)
+
+        assert "failed validation" in str(excinfo.value)
+        # Raw text from the last attempt must be preserved on the exception.
+        assert excinfo.value.raw_text.startswith("also ")
+        assert len(provider.calls) == 2
+
+    async def test_schema_prefix_included_in_outgoing_prompt(self) -> None:
+        provider = ScriptedProvider(['{"verdict": "APPROVE", "score": 1}'])
+        client = ClaudeClient(provider=provider)
+
+        await client.structured_complete(
+            "user prompt here",
+            schema=_SampleSchema,
+            system="You are a reviewer.",
+        )
+
+        sent = provider.calls[0].prompt
+        assert "Respond with only a single JSON object matching this schema" in sent
+        # Schema must actually be embedded (contains the field names).
+        assert "verdict" in sent and "score" in sent
+        # The system prompt survives.
+        assert "You are a reviewer." in sent
+        # The user prompt is also in the payload.
+        assert "user prompt here" in sent
+
+    async def test_max_retries_zero_fails_immediately(self) -> None:
+        provider = ScriptedProvider(["garbage"])
+        client = ClaudeClient(provider=provider)
+
+        with pytest.raises(StructuredCompleteError):
+            await client.structured_complete("prompt", schema=_SampleSchema, max_retries=0)
+
+        assert len(provider.calls) == 1
+
+    async def test_retry_recovers_from_validation_error(self) -> None:
+        # First response is valid JSON but missing ``score`` — pydantic validation fails.
+        provider = ScriptedProvider(
+            [
+                '{"verdict": "APPROVE"}',
+                '{"verdict": "APPROVE", "score": 99}',
+            ]
+        )
+        client = ClaudeClient(provider=provider)
+
+        result = await client.structured_complete("x", schema=_SampleSchema, max_retries=1)
+
+        assert result.score == 99
+        assert len(provider.calls) == 2
+
+    async def test_strips_code_fences(self) -> None:
+        """Models sometimes wrap JSON in ```json fences despite instructions."""
+        provider = ScriptedProvider(
+            ['```json\n{"verdict": "APPROVE", "score": 3}\n```'],
+        )
+        client = ClaudeClient(provider=provider)
+
+        result = await client.structured_complete("x", schema=_SampleSchema)
+
+        assert result.verdict == "APPROVE"
+        assert result.score == 3
+
+    async def test_retries_respects_llmconfig_default(self) -> None:
+        """``max_retries`` defaults to LLMConfig.structured_output_retries."""
+        provider = ScriptedProvider(["nope"])
+        client = ClaudeClient(
+            config=LLMConfig(structured_output_retries=0),
+            provider=provider,
+        )
+
+        with pytest.raises(StructuredCompleteError):
+            await client.structured_complete("prompt", schema=_SampleSchema)
+
+        assert len(provider.calls) == 1
+
+    async def test_unavailable_provider_raises_rather_than_returns_empty(self) -> None:
+        """Unlike ``complete``, the structured helper must never hand back an
+        unparseable empty value masquerading as valid output."""
+        provider = ScriptedProvider([])
+
+        class UnavailableProvider(ScriptedProvider):
+            @property
+            def available(self) -> bool:
+                return False
+
+        client = ClaudeClient(provider=UnavailableProvider([]))
+        with pytest.raises(StructuredCompleteError):
+            await client.structured_complete("prompt", schema=_SampleSchema)
+
+        assert provider.calls == []

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -122,20 +122,20 @@ def test_routing_score_capped_at_100() -> None:
 
 @pytest.mark.asyncio
 async def test_inline_review_success() -> None:
-    import json
+    from caretaker.pr_reviewer.inline_reviewer import InlineReviewResult
 
-    mock_response = json.dumps(
-        {
-            "summary": "Looks good overall.",
-            "verdict": "APPROVE",
-            "comments": [{"path": "src/foo.py", "line": 10, "body": "Consider a docstring here."}],
-        }
+    payload = InlineReviewResult(
+        summary="Looks good overall.",
+        verdict="APPROVE",
+        comments=[
+            {"path": "src/foo.py", "line": 10, "body": "Consider a docstring here."},  # type: ignore[list-item]
+        ],
     )
 
     mock_llm = MagicMock()
     mock_llm.available = True
     mock_llm.claude = MagicMock()
-    mock_llm.claude.complete = AsyncMock(return_value=mock_response)
+    mock_llm.claude.structured_complete = AsyncMock(return_value=payload)
 
     mock_github = MagicMock()
     diff = "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-x\n+y"
@@ -157,6 +157,10 @@ async def test_inline_review_success() -> None:
     assert "Looks good" in result.summary
     assert len(result.comments) == 1
     assert result.comments[0].path == "src/foo.py"
+    # Sanity-check that structured_complete was passed the schema and feature key.
+    call = mock_llm.claude.structured_complete.call_args
+    assert call.kwargs["schema"].__name__ == "InlineReviewResult"
+    assert call.kwargs["feature"] == "pr_inline_review"
 
 
 @pytest.mark.asyncio
@@ -184,7 +188,7 @@ async def test_inline_review_empty_diff() -> None:
 async def test_inline_review_llm_failure() -> None:
     mock_llm = MagicMock()
     mock_llm.claude = MagicMock()
-    mock_llm.claude.complete = AsyncMock(side_effect=RuntimeError("timeout"))
+    mock_llm.claude.structured_complete = AsyncMock(side_effect=RuntimeError("timeout"))
 
     mock_github = MagicMock()
     mock_github.get_pull_diff = AsyncMock(return_value="diff content")
@@ -202,6 +206,36 @@ async def test_inline_review_llm_failure() -> None:
     )
     assert result.verdict == "COMMENT"
     assert "failed" in result.summary.lower()
+
+
+@pytest.mark.asyncio
+async def test_inline_review_malformed_response_raises_loudly() -> None:
+    """StructuredCompleteError must bubble up — no silent verdict=COMMENT downgrade."""
+    from caretaker.llm.claude import StructuredCompleteError
+    from caretaker.pr_reviewer.inline_reviewer import review
+
+    mock_llm = MagicMock()
+    mock_llm.claude = MagicMock()
+    mock_llm.claude.structured_complete = AsyncMock(
+        side_effect=StructuredCompleteError(
+            raw_text='{"summary": "ok"}',  # missing required `verdict`
+            validation_error=ValueError("field required"),
+        )
+    )
+
+    mock_github = MagicMock()
+    mock_github.get_pull_diff = AsyncMock(return_value="diff")
+
+    with pytest.raises(StructuredCompleteError):
+        await review(
+            github=mock_github,
+            owner="org",
+            repo="repo",
+            pr_number=3,
+            pr_title="Foo",
+            pr_body="",
+            llm=mock_llm,
+        )
 
 
 # ── claude-code hand-off tests ─────────────────────────────────────────────


### PR DESCRIPTION
## Motivation

Every Phase 2 agentic migration in `docs/plans/2026-Q2-agentic-migration.md` §3
needs the same "LLM returns structured output, validated by pydantic, retry-once
with validation error on parse failure" behavior. Today
`src/caretaker/pr_reviewer/inline_reviewer.py` hand-rolls this with a raw
`json.loads` that silently downgrades to `verdict=COMMENT` on any parse error —
broken and un-debuggable. Ship the helper first, migrate inline_reviewer as a
canary, then unblock the rest of the migration.

## API shape

```python
from typing import TypeVar
from pydantic import BaseModel

T = TypeVar("T", bound=BaseModel)

async def structured_complete(
    self,
    prompt: str,
    *,
    schema: type[T],
    feature: str = "structured_complete",
    system: str | None = None,
    max_retries: int | None = None,
    max_tokens: int = 2000,
    model: str | None = None,
) -> T: ...
```

Behavior:

1. Prepends `"Respond with only a single JSON object matching this schema: <schema_json>"` to the system prompt (or to the user prompt if no system is given), using `schema.model_json_schema()`.
2. Calls the underlying provider; strips `` ```json `` fences if present.
3. `json.loads` + `schema.model_validate`.
4. On `JSONDecodeError` or `pydantic.ValidationError`, retries once by default, appending `"Your previous response failed to parse: <err>. Return only valid JSON matching the schema above."` to the user prompt.
5. If retries are exhausted, raises `StructuredCompleteError(raw_text, validation_error)` so the caller can log the raw LLM output and fall back rather than silently returning broken output.

`max_retries` defaults to the new `LLMConfig.structured_output_retries` knob (default `1`).

## inline_reviewer before/after

**Before** — raw `json.loads` with a silent downgrade fallback:

```python
raw_text = raw.strip()
try:
    data = json.loads(raw_text)
except json.JSONDecodeError:
    logger.warning("LLM response not valid JSON for ...")
    return ReviewResult(summary=raw_text[:500], verdict="COMMENT", raw_response=raw_text)
```

**After** — pydantic-validated `InlineReviewResult` via `structured_complete`:

```python
class InlineReviewResult(BaseModel):
    summary: str
    verdict: Literal["APPROVE", "COMMENT", "REQUEST_CHANGES"]
    comments: list[InlineReviewCommentModel] = Field(default_factory=list)

try:
    payload = await llm.claude.structured_complete(
        prompt, schema=InlineReviewResult,
        feature="pr_inline_review", system=_REVIEW_SYSTEM, max_tokens=2000,
    )
except StructuredCompleteError:
    logger.exception("inline review ... failed validation after retries")
    raise
```

`PRReviewerAgent._handle_pr` now catches `StructuredCompleteError` and falls
through to the claude-code dispatch path rather than posting an empty review
with `verdict=COMMENT`.

## Feature flag

New `LLMConfig.structured_output_retries: int = 1`. Users can set this to `0`
from `caretaker.yml` to disable the self-correcting retry loop.

## Test plan

- [x] Happy path: valid JSON → parsed `T` returned, one provider call
- [x] Retry path: malformed first response, valid second → second-attempt prompt contains the failure cue; parsed `T` returned after two calls
- [x] Failure path: both attempts malformed → `StructuredCompleteError` with last `raw_text` preserved
- [x] Schema prefix assembly: outgoing system prompt contains the schema JSON and the schema's field names
- [x] `max_retries=0` raises immediately after the first failure — no second call
- [x] ValidationError (valid JSON, missing required field) also triggers the retry loop
- [x] Strips ```` ```json ... ``` ```` code fences some models emit
- [x] Defaults to `LLMConfig.structured_output_retries` when `max_retries` omitted
- [x] Unavailable provider raises instead of silently returning an empty `T`
- [x] `inline_reviewer.review` success path uses `structured_complete` and passes `schema=InlineReviewResult` + `feature="pr_inline_review"`
- [x] `inline_reviewer.review` now raises `StructuredCompleteError` on malformed model output (no silent `verdict=COMMENT` downgrade)
- [x] Full suite: `pytest -q` → 1105 passed, 1 skipped
- [x] `ruff check src tests` clean
- [x] `ruff format --check src tests` clean

Blocks every Phase 2 agentic migration — prioritizing landing over gold-plating.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>