### PR TITLE
feat(flux): GitOps reconcile caretaker on bigboy AKS

### DIFF
--- a/k8s/apps/caretaker-ingress/kustomization.yaml
+++ b/k8s/apps/caretaker-ingress/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Istio ingress for caretaker. Lives in the `default` namespace
+# because the `aks-istio-ingress/cat-herding-gateway` Gateway is
+# shared across tenants. Split from the `caretaker` app bundle so
+# Flux reconciles it separately and a blast-radius issue in the
+# main bundle doesn't take the routing manifest with it.
+
+namespace: default
+
+resources:
+  - ../../../infra/k8s/caretaker-virtualservice.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: caretaker
+      app.kubernetes.io/managed-by: flux

--- a/k8s/apps/caretaker/kustomization.yaml
+++ b/k8s/apps/caretaker/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Caretaker application bundle.
+# Reconciled by the Flux Kustomization CR at
+# `k8s/flux/clusters/bigboy/caretaker.yaml`.
+# The underlying resource definitions remain in `infra/k8s/` so
+# that hand-apply and GitOps read from the same source of truth.
+
+namespace: caretaker
+
+resources:
+  - namespace.yaml
+  - ../../../infra/k8s/redis-statefulset.yaml
+  - ../../../infra/k8s/neo4j-statefulset.yaml
+  - ../../../infra/k8s/caretaker-agent-worker.yaml
+  - ../../../infra/k8s/caretaker-mcp-serviceaccount.yaml
+  - ../../../infra/k8s/caretaker-mcp-deployment.yaml
+  - ../../../infra/k8s/caretaker-mcp-service.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: caretaker
+      app.kubernetes.io/managed-by: flux

--- a/k8s/apps/caretaker/namespace.yaml
+++ b/k8s/apps/caretaker/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: caretaker
+  labels:
+    app.kubernetes.io/part-of: caretaker
+    istio-injection: enabled

--- a/k8s/flux/README.md
+++ b/k8s/flux/README.md
@@ -1,0 +1,86 @@
+# Flux GitOps for caretaker
+
+Mirrors the pattern used by `Example-React-AI-Chat-App`. Flux reconciles
+the manifests under `k8s/apps/<name>/` into the target cluster on every
+`main` commit; the reconciliation is driven by the Flux `Kustomization`
+CRs declared under `k8s/flux/clusters/<cluster>/`.
+
+## Layout
+
+```
+k8s/
+├── apps/
+│   ├── caretaker/                 — main bundle (Redis, Neo4j, MCP, agent-worker)
+│   │   ├── kustomization.yaml
+│   │   └── namespace.yaml
+│   └── caretaker-ingress/         — Istio VirtualService (default ns)
+│       └── kustomization.yaml
+└── flux/
+    ├── README.md                  — this file
+    └── clusters/
+        └── bigboy/
+            └── caretaker.yaml     — two Kustomization CRs (app + ingress)
+```
+
+The underlying resource YAML stays in `infra/k8s/`. The `k8s/apps/*/kustomization.yaml` files reference those paths so a hand-apply (`kubectl apply -f infra/k8s/`) and Flux GitOps agree on a single source of truth.
+
+## Target
+
+| Cluster | Context | Namespace | Domain |
+|---------|---------|-----------|--------|
+| `bigboy` | `bigboy` | `caretaker` (app) / `default` (ingress) | `caretaker.cat-herding.net` |
+
+## One-time bootstrap
+
+The cluster already runs the Azure-managed Flux extension (`fluxconfig-agent` + `fluxconfig-controller`). Onboard the caretaker repo with `az k8s-configuration flux create` (or apply a `FluxConfig` CR directly — see the existing `chat-app` FluxConfig for the template):
+
+```sh
+az k8s-configuration flux create \
+  --name caretaker \
+  --namespace flux-system \
+  --cluster-name <aks-name> \
+  --resource-group <rg> \
+  --cluster-type managedClusters \
+  --scope cluster \
+  --url https://github.com/ianlintner/caretaker.git \
+  --branch main \
+  --interval 1m \
+  --kustomization \
+    name=caretaker \
+    path=k8s/flux/clusters/bigboy \
+    prune=true \
+    sync_interval=1m \
+    timeout=10m
+```
+
+That `FluxConfig` provisions a `GitRepository` source named `caretaker` in the `flux-system` namespace. The `Kustomization` CRs in `k8s/flux/clusters/bigboy/caretaker.yaml` reference that source and reconcile the app bundles.
+
+Caretaker is a public repo, so no auth secret is needed. If you later make it private, pass `--https-user`, `--https-key` (PAT), or `--ssh-private-key` to `az k8s-configuration flux create`.
+
+## Verify after bootstrap
+
+```sh
+flux get sources git -n flux-system caretaker
+flux get kustomizations -n flux-system caretaker caretaker-ingress
+kubectl get pods -n caretaker
+kubectl get virtualservice -n default caretaker-virtualservice
+```
+
+Expect both Kustomizations `Ready=True`, all pods `Running`, VirtualService advertised on `caretaker.cat-herding.net`.
+
+## Roll back
+
+GitOps roll back: revert the offending commit on `main`; Flux reconciles to the prior state on the next 1-minute sync. For an emergency stop:
+
+```sh
+flux suspend kustomization -n flux-system caretaker
+```
+
+Resume with `flux resume kustomization -n flux-system caretaker`.
+
+## Adding a new cluster
+
+1. Add `k8s/flux/clusters/<cluster>/caretaker.yaml` mirroring `bigboy/caretaker.yaml`.
+2. Apply a new `FluxConfig` against the new cluster's context with `path=k8s/flux/clusters/<cluster>`.
+
+Keep per-cluster deltas out of `k8s/apps/` — prefer per-cluster kustomize overlays under `k8s/apps/caretaker/overlays/<cluster>/` and point the new cluster's `Kustomization` at the overlay.

--- a/k8s/flux/clusters/bigboy/caretaker.yaml
+++ b/k8s/flux/clusters/bigboy/caretaker.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: caretaker
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./k8s/apps/caretaker
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    # Azure-managed FluxConfig provisions the GitRepository with the
+    # same name as the FluxConfig resource, so the source we reconcile
+    # against is `caretaker`.
+    name: caretaker
+  targetNamespace: caretaker
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: caretaker-ingress
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  path: ./k8s/apps/caretaker-ingress
+  prune: true
+  wait: true
+  timeout: 2m0s
+  sourceRef:
+    kind: GitRepository
+    name: caretaker
+  targetNamespace: default
+  dependsOn:
+    - name: caretaker


### PR DESCRIPTION
## Summary

Stands caretaker up on the existing Azure-managed Flux extension on the `bigboy` AKS cluster. Mirrors the GitOps pattern already in production for `Example-React-AI-Chat-App`.

### Files added

```
k8s/
├── apps/
│   ├── caretaker/
│   │   ├── kustomization.yaml
│   │   └── namespace.yaml
│   └── caretaker-ingress/
│       └── kustomization.yaml
└── flux/
    ├── README.md
    └── clusters/bigboy/
        └── caretaker.yaml
```

### How it works

Two Flux `Kustomization` CRs (both in `flux-system`), declared in `k8s/flux/clusters/bigboy/caretaker.yaml`:

- **`caretaker`** (`targetNamespace: caretaker`) — Redis + Neo4j StatefulSets, MCP Deployment + Service + ServiceAccount, agent-worker SA + Role + RoleBinding. `prune: true`, `wait: true`, `interval: 1m0s`.
- **`caretaker-ingress`** (`targetNamespace: default`) — Istio VirtualService for `caretaker.cat-herding.net`. `dependsOn: caretaker` so the app namespace exists first. Split so routing doesn't ride on the main bundle's health.

Resource files stay in `infra/k8s/` and are consumed by `k8s/apps/*/kustomization.yaml` via relative paths. Flux's kustomize-controller uses `LoadRestrictionsNone` so the cross-dir references work; local validation requires `kustomize build --load-restrictor LoadRestrictionsNone k8s/apps/caretaker/`.

### One-time onboarding (post-merge)

Out-of-band, against the cluster:

```
az k8s-configuration flux create \
  --name caretaker \
  --namespace flux-system \
  --cluster-name <aks-name> \
  --resource-group <rg> \
  --cluster-type managedClusters \
  --scope cluster \
  --url https://github.com/ianlintner/caretaker.git \
  --branch main \
  --interval 1m \
  --kustomization \
    name=caretaker \
    path=k8s/flux/clusters/bigboy \
    prune=true \
    sync_interval=1m \
    timeout=10m
```

Public repo → no auth secret needed.

### Test plan

- [x] `kustomize build --load-restrictor LoadRestrictionsNone k8s/apps/caretaker/` — produces expected Namespace + SAs + Role/RoleBinding + Services + StatefulSets + Deployment.
- [x] `kustomize build --load-restrictor LoadRestrictionsNone k8s/apps/caretaker-ingress/` — produces the VirtualService in `default`.
- [ ] After merge: run the `az k8s-configuration flux create` command above; watch `flux get kustomizations -n flux-system` transition to Ready=True; confirm `caretaker.cat-herding.net` still answers on 443.
- [ ] Rollback rehearsal: `flux suspend kustomization -n flux-system caretaker` → re-run verifies suspend works; `flux resume` → back to reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
