### PR TITLE
feat(llm): enable Anthropic prompt caching + emit cache-hit metrics

### DIFF
--- a/src/caretaker/llm/claude.py
+++ b/src/caretaker/llm/claude.py
@@ -152,7 +152,14 @@ class ClaudeClient:
                 max_tokens = override.max_tokens
         return model, max_tokens
 
-    async def _complete(self, feature: str, prompt: str, default_max_tokens: int) -> str:
+    async def _complete(
+        self,
+        feature: str,
+        prompt: str,
+        default_max_tokens: int,
+        *,
+        system: str | None = None,
+    ) -> str:
         if not self.available:
             return ""
         model, max_tokens = self._resolve_feature(feature, default_max_tokens)
@@ -160,7 +167,13 @@ class ClaudeClient:
         _log_prompt(feature, prompt)
         try:
             response = await self._provider.complete(
-                LLMRequest(feature=feature, prompt=prompt, model=model, max_tokens=max_tokens)
+                LLMRequest(
+                    feature=feature,
+                    prompt=prompt,
+                    model=model,
+                    max_tokens=max_tokens,
+                    system=system,
+                )
             )
         except Exception as exc:  # provider-level failures are non-fatal
             logger.warning("LLM call failed [%s]: %s", feature, exc)
@@ -179,13 +192,13 @@ class ClaudeClient:
     ) -> str:
         """General-purpose completion method.
 
-        Prepends an optional ``system`` instruction to the user prompt before
-        calling the underlying LLM.  Intended for callers (e.g. pr_reviewer)
+        Passes an optional ``system`` instruction through as a dedicated system
+        prompt on the underlying LLM request (enabling Anthropic prompt caching
+        on the stable system text). Intended for callers (e.g. pr_reviewer)
         that need a free-form system prompt rather than a domain-specific
         method from the public feature API below.
         """
-        full_prompt = f"{system}\n\n{prompt}" if system else prompt
-        return await self._complete(feature, full_prompt, max_tokens)
+        return await self._complete(feature, prompt, max_tokens, system=system)
 
     async def structured_complete(
         self,

--- a/src/caretaker/llm/provider.py
+++ b/src/caretaker/llm/provider.py
@@ -32,7 +32,28 @@ import os
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
+from caretaker.observability.metrics import record_llm_cache_usage
+
 logger = logging.getLogger(__name__)
+
+
+# Models that support Anthropic prompt caching via the ``cache_control`` content-
+# block annotation.  We key off substring matches because both the Anthropic
+# native SDK (``claude-*``) and LiteLLM-routed variants (``anthropic/claude-*``,
+# ``vertex_ai/claude-*``, ``bedrock/anthropic.claude-*``) carry ``claude`` in
+# the model id.
+_CACHE_CAPABLE_MODEL_MARKERS: tuple[str, ...] = ("claude",)
+
+
+def _supports_prompt_cache(model: str) -> bool:
+    """Return True when ``model`` accepts Anthropic ``cache_control`` markers.
+
+    Fail-open: unknown models return False so we never poison a request that
+    the target provider would reject.  Keep the check cheap and substring-
+    based — LiteLLM routes Claude through many namespaces.
+    """
+    lowered = model.lower()
+    return any(marker in lowered for marker in _CACHE_CAPABLE_MODEL_MARKERS)
 
 
 @dataclass
@@ -54,6 +75,11 @@ class LLMRequest:
     # uses it verbatim instead of constructing a message from ``prompt``.
     # Ignored by :meth:`complete`.
     messages: list[dict[str, Any]] | None = None
+    # Optional system prompt.  Used by :meth:`complete` to send a real
+    # ``system`` parameter (enabling Anthropic prompt caching); ignored by
+    # :meth:`complete_with_tools` which expects the system turn to already
+    # live at the head of ``messages``.
+    system: str | None = None
 
 
 @dataclass
@@ -64,6 +90,11 @@ class LLMResponse:
     input_tokens: int = 0
     output_tokens: int = 0
     cost_usd: float | None = None
+    # Anthropic prompt-cache token counts (0 when the provider/model does not
+    # surface them). ``cache_read_input_tokens`` is a cache *hit*;
+    # ``cache_creation_input_tokens`` is the one-time write on a miss.
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
 
 
 @dataclass
@@ -98,6 +129,9 @@ class LLMToolResponse:
     # Raw assistant message as returned by the provider, suitable for
     # appending to the next request's ``messages`` list verbatim.
     raw_message: dict[str, Any] | None = None
+    # Anthropic prompt-cache token counts — see :class:`LLMResponse`.
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
 
 
 @runtime_checkable
@@ -161,20 +195,46 @@ class AnthropicProvider:
         self._ensure_client()
         assert self._client is not None
 
-        response = await self._client.messages.create(
-            model=request.model,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            messages=[{"role": "user", "content": request.prompt}],
-        )
+        kwargs: dict[str, Any] = {
+            "model": request.model,
+            "max_tokens": request.max_tokens,
+            "temperature": request.temperature,
+            "messages": [{"role": "user", "content": request.prompt}],
+        }
+        # Send the system prompt as a structured text block carrying a
+        # ``cache_control: ephemeral`` breakpoint. Anthropic caches the
+        # tools → system → messages prefix up to the annotated block, so the
+        # shared system prompt is hot on every subsequent call within the
+        # 5-minute TTL. See ``shared/prompt-caching.md`` from the claude-api
+        # skill for placement rationale.
+        if request.system:
+            kwargs["system"] = [
+                {
+                    "type": "text",
+                    "text": request.system,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ]
+
+        response = await self._client.messages.create(**kwargs)
         text = response.content[0].text if response.content else ""
         usage = getattr(response, "usage", None)
+        cache_read = int(getattr(usage, "cache_read_input_tokens", 0) or 0)
+        cache_creation = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
+        record_llm_cache_usage(
+            provider=self.name,
+            model=request.model,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        )
         return LLMResponse(
             text=text,
             model=request.model,
             provider=self.name,
-            input_tokens=getattr(usage, "input_tokens", 0) or 0,
-            output_tokens=getattr(usage, "output_tokens", 0) or 0,
+            input_tokens=int(getattr(usage, "input_tokens", 0) or 0),
+            output_tokens=int(getattr(usage, "output_tokens", 0) or 0),
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
         )
 
     async def complete_with_tools(
@@ -252,9 +312,19 @@ class LiteLLMProvider:
         if not self.available or self._acompletion is None:
             return LLMResponse(text="", model=request.model, provider=self.name)
 
+        messages: list[dict[str, Any]] = []
+        if request.system:
+            messages.append(
+                _make_system_message(
+                    request.system,
+                    cache=_supports_prompt_cache(request.model),
+                )
+            )
+        messages.append({"role": "user", "content": request.prompt})
+
         kwargs: dict[str, Any] = {
             "model": request.model,
-            "messages": [{"role": "user", "content": request.prompt}],
+            "messages": messages,
             "max_tokens": request.max_tokens,
             "temperature": request.temperature,
             "timeout": self._timeout,
@@ -276,13 +346,23 @@ class LiteLLMProvider:
         except Exception:
             cost = None
 
+        cache_read, cache_creation = _extract_litellm_cache_tokens(usage)
+        record_llm_cache_usage(
+            provider=self.name,
+            model=actual_model,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        )
+
         return LLMResponse(
             text=text,
             model=actual_model,
             provider=self.name,
-            input_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-            output_tokens=getattr(usage, "completion_tokens", 0) or 0,
+            input_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+            output_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
             cost_usd=cost,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
         )
 
     async def complete_with_tools(
@@ -303,6 +383,8 @@ class LiteLLMProvider:
             if request.messages is not None
             else [{"role": "user", "content": request.prompt}]
         )
+        if _supports_prompt_cache(request.model):
+            messages = _annotate_system_cache_control(messages)
 
         kwargs: dict[str, Any] = {
             "model": request.model,
@@ -377,17 +459,114 @@ class LiteLLMProvider:
         except Exception:
             cost = None
 
+        cache_read, cache_creation = _extract_litellm_cache_tokens(usage)
+        record_llm_cache_usage(
+            provider=self.name,
+            model=actual_model,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        )
+
         return LLMToolResponse(
             text=text,
             tool_calls=tool_calls,
             model=actual_model,
             provider=self.name,
-            input_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-            output_tokens=getattr(usage, "completion_tokens", 0) or 0,
+            input_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+            output_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
             cost_usd=cost,
             stop_reason=finish_reason,
             raw_message=raw_message,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
         )
+
+
+# ── Prompt-cache helpers ──────────────────────────────────────────────────────
+
+
+def _make_system_message(system_text: str, *, cache: bool) -> dict[str, Any]:
+    """Build a ``role: system`` message, optionally with an ephemeral cache marker.
+
+    When ``cache`` is True, the content is rendered as a single ``text`` block
+    carrying ``cache_control: {"type": "ephemeral"}``.  LiteLLM passes this
+    through to Anthropic-family providers verbatim; OpenAI-family providers
+    ignore the marker, so this is safe to send unconditionally as long as the
+    model is cache-capable (see :func:`_supports_prompt_cache`).
+    """
+    if not cache:
+        return {"role": "system", "content": system_text}
+    return {
+        "role": "system",
+        "content": [
+            {
+                "type": "text",
+                "text": system_text,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+    }
+
+
+def _annotate_system_cache_control(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return ``messages`` with the leading system turn annotated for caching.
+
+    The Foundry tool loop constructs a stable system prompt that is identical
+    across every iteration of the loop — an ideal candidate for the Anthropic
+    prompt cache's 5-minute ephemeral TTL.  We rewrite the *first* ``system``
+    message in place so the rest of the ``messages`` list (tool results, user
+    turns, assistant turns) is untouched.
+
+    If ``messages`` is empty, has no leading system turn, or the system turn
+    is already using a list-of-blocks content shape (assumed to be caller-
+    configured), we return the list unchanged.
+    """
+    if not messages:
+        return messages
+    head = messages[0]
+    if head.get("role") != "system":
+        return messages
+    content = head.get("content")
+    if not isinstance(content, str) or not content:
+        # Already structured (or empty) — leave it alone.
+        return messages
+    annotated: list[dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": content,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        *messages[1:],
+    ]
+    return annotated
+
+
+def _extract_litellm_cache_tokens(usage: Any) -> tuple[int, int]:
+    """Pull Anthropic prompt-cache token counts from a LiteLLM ``usage`` object.
+
+    LiteLLM surfaces cache telemetry under a few shapes depending on version
+    and provider:
+
+    - ``usage.cache_read_input_tokens`` / ``usage.cache_creation_input_tokens``
+      (the Anthropic native keys, mirrored verbatim).
+    - ``usage.prompt_tokens_details.cached_tokens`` (OpenAI-compatible
+      aggregate, used as a fallback for read counts).
+
+    Any missing/None attribute defaults to 0.  Returned as ``(read, creation)``.
+    """
+    if usage is None:
+        return (0, 0)
+    read = getattr(usage, "cache_read_input_tokens", None)
+    if read is None:
+        details = getattr(usage, "prompt_tokens_details", None)
+        read = getattr(details, "cached_tokens", None) if details is not None else None
+    creation = getattr(usage, "cache_creation_input_tokens", None)
+    return (int(read or 0), int(creation or 0))
 
 
 # ── NullProvider ──────────────────────────────────────────────────────────────

--- a/src/caretaker/observability/metrics.py
+++ b/src/caretaker/observability/metrics.py
@@ -216,6 +216,33 @@ GITHUB_SCOPE_GAP_TOTAL = Counter(
     registry=REGISTRY,
 )
 
+# ── LLM prompt-cache telemetry ───────────────────────────────────────
+#
+# Emitted by :mod:`caretaker.llm.provider` on every completion.  Together
+# they let Grafana compute an Anthropic prompt-cache hit ratio:
+#
+#     sum(rate(caretaker_llm_cache_read_tokens_total[5m]))
+#       / sum(rate(caretaker_llm_cache_read_tokens_total[5m])
+#             + rate(caretaker_llm_cache_creation_tokens_total[5m]))
+#
+# Labelled by ``provider`` (``anthropic`` / ``litellm``) and ``model`` so
+# we can attribute hits per-provider and per-model.  Cardinality stays low:
+# a handful of providers × tens of model ids.
+
+LLM_CACHE_READ_TOKENS_TOTAL = Counter(
+    "caretaker_llm_cache_read_tokens_total",
+    "Input tokens served from Anthropic prompt cache (cache hits).",
+    ["provider", "model"],
+    registry=REGISTRY,
+)
+
+LLM_CACHE_CREATION_TOKENS_TOTAL = Counter(
+    "caretaker_llm_cache_creation_tokens_total",
+    "Input tokens written into the Anthropic prompt cache (cache misses).",
+    ["provider", "model"],
+    registry=REGISTRY,
+)
+
 # ── Build / version metadata ─────────────────────────────────────────
 
 APP_INFO = Gauge(
@@ -559,6 +586,32 @@ def record_github_scope_gap(scope: str) -> None:
     GITHUB_SCOPE_GAP_TOTAL.labels(service=_SERVICE_LABEL, scope=scope).inc()
 
 
+def record_llm_cache_usage(
+    *,
+    provider: str,
+    model: str,
+    cache_read_input_tokens: int,
+    cache_creation_input_tokens: int,
+) -> None:
+    """Record Anthropic prompt-cache token counts from a response's ``usage``.
+
+    Both inputs are **cumulative token counts** for a single completion, as
+    surfaced in ``usage.cache_read_input_tokens`` and
+    ``usage.cache_creation_input_tokens`` (Anthropic) or the LiteLLM-proxied
+    equivalents.  Non-positive values are silently ignored so providers that
+    don't support caching (or requests that skipped the cache) don't pollute
+    the counters with zero-valued increments.
+    """
+    if cache_read_input_tokens > 0:
+        LLM_CACHE_READ_TOKENS_TOTAL.labels(provider=provider, model=model).inc(
+            float(cache_read_input_tokens)
+        )
+    if cache_creation_input_tokens > 0:
+        LLM_CACHE_CREATION_TOKENS_TOTAL.labels(provider=provider, model=model).inc(
+            float(cache_creation_input_tokens)
+        )
+
+
 __all__ = [
     "APP_INFO",
     "CARETAKER_ERRORS_TOTAL",
@@ -571,6 +624,8 @@ __all__ = [
     "HTTP_SERVER_REQUESTS_TOTAL",
     "HTTP_SERVER_REQUEST_DURATION_SECONDS",
     "LATENCY_BUCKETS",
+    "LLM_CACHE_CREATION_TOKENS_TOTAL",
+    "LLM_CACHE_READ_TOKENS_TOTAL",
     "RATE_LIMIT_COOLDOWN_SECONDS",
     "RATE_LIMIT_REMAINING",
     "REGISTRY",
@@ -583,6 +638,7 @@ __all__ = [
     "record_error",
     "record_github_scope_gap",
     "record_http_client",
+    "record_llm_cache_usage",
     "record_orchestrator_soft_fail",
     "record_worker_job",
     "set_rate_limit_cooldown",

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
-from unittest.mock import patch
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -20,6 +22,7 @@ from caretaker.llm.provider import (
     build_provider,
 )
 from caretaker.llm.router import LLMRouter
+from caretaker.observability import metrics as metrics_mod
 
 
 class FakeProvider:
@@ -433,3 +436,317 @@ class TestStructuredComplete:
             await client.structured_complete("prompt", schema=_SampleSchema)
 
         assert provider.calls == []
+
+
+# ── Prompt caching + cache-hit metrics ───────────────────────────────────────
+
+
+def _read_counter(counter: Any, *, provider: str, model: str) -> float:
+    """Read the current value of a labelled Counter, 0 if uninitialised."""
+    # prometheus_client stores label values keyed by the label tuple.
+    metric = counter.labels(provider=provider, model=model)
+    return metric._value.get()  # type: ignore[attr-defined]
+
+
+class TestAnthropicPromptCaching:
+    """AnthropicProvider.complete annotates system + increments cache counters."""
+
+    async def test_system_prompt_sends_cache_control_ephemeral(self) -> None:
+        """Outgoing request body must contain cache_control on the system block."""
+        provider = AnthropicProvider(api_key="fake-key")
+
+        captured: dict[str, Any] = {}
+
+        async def fake_create(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            # Mimic Anthropic response shape with usage telemetry.
+            return SimpleNamespace(
+                content=[SimpleNamespace(text="ok", type="text")],
+                usage=SimpleNamespace(
+                    input_tokens=10,
+                    output_tokens=5,
+                    cache_read_input_tokens=123,
+                    cache_creation_input_tokens=456,
+                ),
+            )
+
+        fake_client = MagicMock()
+        fake_client.messages.create = AsyncMock(side_effect=fake_create)
+        provider._client = fake_client  # type: ignore[assignment]
+
+        response = await provider.complete(
+            LLMRequest(
+                feature="test",
+                prompt="hello",
+                model="claude-sonnet-4-5",
+                max_tokens=128,
+                system="You are a cached system prompt.",
+            )
+        )
+
+        # 1. Request body carries structured system list with cache_control.
+        system = captured["system"]
+        assert isinstance(system, list)
+        assert system[0]["type"] == "text"
+        assert system[0]["text"] == "You are a cached system prompt."
+        assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+        # 2. Response propagates the cache token counts verbatim.
+        assert response.cache_read_input_tokens == 123
+        assert response.cache_creation_input_tokens == 456
+        assert response.input_tokens == 10
+        assert response.output_tokens == 5
+
+    async def test_no_system_prompt_still_caches_nothing(self) -> None:
+        """When no system prompt is given, no ``system`` kwarg is sent."""
+        provider = AnthropicProvider(api_key="fake-key")
+
+        captured: dict[str, Any] = {}
+
+        async def fake_create(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[SimpleNamespace(text="ok", type="text")],
+                usage=SimpleNamespace(
+                    input_tokens=1,
+                    output_tokens=1,
+                    cache_read_input_tokens=0,
+                    cache_creation_input_tokens=0,
+                ),
+            )
+
+        fake_client = MagicMock()
+        fake_client.messages.create = AsyncMock(side_effect=fake_create)
+        provider._client = fake_client  # type: ignore[assignment]
+
+        await provider.complete(
+            LLMRequest(
+                feature="test",
+                prompt="hi",
+                model="claude-sonnet-4-5",
+                max_tokens=10,
+            )
+        )
+
+        assert "system" not in captured
+
+    async def test_cache_counters_increment_from_usage(self) -> None:
+        """Both counters step by the exact token counts reported in ``usage``."""
+        provider = AnthropicProvider(api_key="fake-key")
+
+        # Snapshot pre-test counter values so the assertion is order-safe
+        # against other tests that may have incremented the same labels.
+        pre_read = _read_counter(
+            metrics_mod.LLM_CACHE_READ_TOKENS_TOTAL,
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+        )
+        pre_creation = _read_counter(
+            metrics_mod.LLM_CACHE_CREATION_TOKENS_TOTAL,
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+        )
+
+        async def fake_create(**_: Any) -> Any:
+            return SimpleNamespace(
+                content=[SimpleNamespace(text="ok", type="text")],
+                usage=SimpleNamespace(
+                    input_tokens=0,
+                    output_tokens=0,
+                    cache_read_input_tokens=777,
+                    cache_creation_input_tokens=1111,
+                ),
+            )
+
+        fake_client = MagicMock()
+        fake_client.messages.create = AsyncMock(side_effect=fake_create)
+        provider._client = fake_client  # type: ignore[assignment]
+
+        await provider.complete(
+            LLMRequest(
+                feature="test",
+                prompt="hi",
+                model="claude-sonnet-4-5",
+                max_tokens=10,
+                system="cached system",
+            )
+        )
+
+        post_read = _read_counter(
+            metrics_mod.LLM_CACHE_READ_TOKENS_TOTAL,
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+        )
+        post_creation = _read_counter(
+            metrics_mod.LLM_CACHE_CREATION_TOKENS_TOTAL,
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+        )
+
+        assert post_read - pre_read == 777
+        assert post_creation - pre_creation == 1111
+
+    async def test_zero_usage_does_not_emit_counter_samples(self) -> None:
+        """A response with zero cache tokens must not pollute the counters.
+
+        The helper silently drops non-positive increments so the Grafana
+        hit-ratio calculation isn't skewed by providers that don't surface
+        cache telemetry at all.
+        """
+        provider = AnthropicProvider(api_key="fake-key")
+
+        pre_read = _read_counter(
+            metrics_mod.LLM_CACHE_READ_TOKENS_TOTAL,
+            provider="anthropic",
+            model="claude-haiku-4-5",
+        )
+        pre_creation = _read_counter(
+            metrics_mod.LLM_CACHE_CREATION_TOKENS_TOTAL,
+            provider="anthropic",
+            model="claude-haiku-4-5",
+        )
+
+        async def fake_create(**_: Any) -> Any:
+            return SimpleNamespace(
+                content=[SimpleNamespace(text="ok", type="text")],
+                usage=SimpleNamespace(
+                    input_tokens=0,
+                    output_tokens=0,
+                    cache_read_input_tokens=0,
+                    cache_creation_input_tokens=0,
+                ),
+            )
+
+        fake_client = MagicMock()
+        fake_client.messages.create = AsyncMock(side_effect=fake_create)
+        provider._client = fake_client  # type: ignore[assignment]
+
+        await provider.complete(
+            LLMRequest(
+                feature="test",
+                prompt="hi",
+                model="claude-haiku-4-5",
+                max_tokens=10,
+            )
+        )
+
+        assert (
+            _read_counter(
+                metrics_mod.LLM_CACHE_READ_TOKENS_TOTAL,
+                provider="anthropic",
+                model="claude-haiku-4-5",
+            )
+            == pre_read
+        )
+        assert (
+            _read_counter(
+                metrics_mod.LLM_CACHE_CREATION_TOKENS_TOTAL,
+                provider="anthropic",
+                model="claude-haiku-4-5",
+            )
+            == pre_creation
+        )
+
+
+class TestLiteLLMSystemCacheAnnotation:
+    """LiteLLM tool-use path annotates the leading system turn on Claude models."""
+
+    def test_annotates_claude_model_system_block(self) -> None:
+        from caretaker.llm.provider import (
+            _annotate_system_cache_control,
+            _supports_prompt_cache,
+        )
+
+        assert _supports_prompt_cache("anthropic/claude-sonnet-4-5") is True
+        assert _supports_prompt_cache("claude-sonnet-4-5") is True
+        assert _supports_prompt_cache("azure_ai/gpt-4o") is False
+
+        messages = [
+            {"role": "system", "content": "stable prefix"},
+            {"role": "user", "content": "hi"},
+        ]
+        result = _annotate_system_cache_control(messages)
+        assert result is not messages  # new list, not mutated in place
+        head = result[0]
+        assert head["role"] == "system"
+        assert isinstance(head["content"], list)
+        assert head["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert head["content"][0]["text"] == "stable prefix"
+        # Non-system turns are copied through unchanged.
+        assert result[1] == {"role": "user", "content": "hi"}
+
+    def test_skips_when_no_leading_system_turn(self) -> None:
+        from caretaker.llm.provider import _annotate_system_cache_control
+
+        messages = [{"role": "user", "content": "hi"}]
+        assert _annotate_system_cache_control(messages) == messages
+
+    def test_skips_when_content_already_structured(self) -> None:
+        from caretaker.llm.provider import _annotate_system_cache_control
+
+        pre_structured = [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "x"},
+                ],
+            }
+        ]
+        # Already structured → caller owns the shape, we don't touch it.
+        assert _annotate_system_cache_control(pre_structured) is pre_structured
+
+
+class TestLiteLLMCacheUsageExtraction:
+    """_extract_litellm_cache_tokens tolerates several ``usage`` shapes."""
+
+    def test_native_anthropic_keys(self) -> None:
+        from caretaker.llm.provider import _extract_litellm_cache_tokens
+
+        usage = SimpleNamespace(
+            cache_read_input_tokens=42,
+            cache_creation_input_tokens=7,
+        )
+        assert _extract_litellm_cache_tokens(usage) == (42, 7)
+
+    def test_openai_cached_tokens_fallback_for_reads(self) -> None:
+        from caretaker.llm.provider import _extract_litellm_cache_tokens
+
+        usage = SimpleNamespace(
+            prompt_tokens_details=SimpleNamespace(cached_tokens=13),
+        )
+        assert _extract_litellm_cache_tokens(usage) == (13, 0)
+
+    def test_missing_usage_returns_zeros(self) -> None:
+        from caretaker.llm.provider import _extract_litellm_cache_tokens
+
+        assert _extract_litellm_cache_tokens(None) == (0, 0)
+
+
+class TestPromptCacheFailOpen:
+    """Non-Claude models must not receive cache_control annotations."""
+
+    def test_non_claude_models_skip_annotation(self) -> None:
+        from caretaker.llm.provider import (
+            _annotate_system_cache_control,
+            _supports_prompt_cache,
+        )
+
+        assert _supports_prompt_cache("openai/gpt-4o-mini") is False
+        assert _supports_prompt_cache("azure_ai/gpt-4o") is False
+        # The provider only calls _annotate_system_cache_control when the model
+        # supports caching — assert the gate keeps non-Claude payloads untouched
+        # by exercising it directly.
+        messages = [
+            {"role": "system", "content": "x"},
+            {"role": "user", "content": "y"},
+        ]
+        # Must remain string-content when the upstream guard is off.
+        if not _supports_prompt_cache("openai/gpt-4o-mini"):
+            # Simulate the provider NOT calling the annotator.
+            assert messages[0]["content"] == "x"
+        else:  # pragma: no cover
+            raise AssertionError("unexpected: openai model should not be cache-capable")
+        # Sanity: calling the annotator directly still annotates — the fail-
+        # open behaviour is the absence of the call at the provider level.
+        annotated = _annotate_system_cache_control(messages)
+        assert isinstance(annotated[0]["content"], list)


### PR DESCRIPTION
## Summary

Turn on Anthropic's ephemeral prompt cache on every Claude-family
completion going through `AnthropicProvider.complete` and
`LiteLLMProvider.complete_with_tools`, and expose two Prometheus
counters so we can attribute cache hits per provider and model.

## Cost rationale

`FoundryExecutor` sends ~1 KB of stable system prefix (`_BASE_SYSTEM_PROMPT`
+ `write_denylist` + `allowed_commands` + task guidance) on every
iteration of the tool loop. Without `cache_control`, every turn pays
full input-token cost on that prefix. With `cache_control: ephemeral`
on the system block, the second and subsequent calls within the
5-minute TTL read the cached prefix at ~0.1x input price.

The break-even is two requests with the same prefix within 5 minutes,
so any multi-turn tool loop, any back-to-back analysis call on the
same codebase context, and any batch of triage calls that reuse the
same system text win.

## Which content blocks carry `cache_control`

- **`AnthropicProvider.complete`** — when `LLMRequest.system` is set,
  sends `system=[{"type": "text", "text": ..., "cache_control": {"type": "ephemeral"}}]`.
  `ClaudeClient.complete(..., system=...)` now routes through this
  field instead of concatenating system+prompt, so the existing
  `pr_reviewer/inline_reviewer.py` caller picks caching up for free.
- **`LiteLLMProvider.complete_with_tools`** — rewrites the leading
  `role: system` turn of the `messages` list into a single-block
  list-of-text-blocks shape with `cache_control: ephemeral`. This is
  how LiteLLM surfaces Anthropic cache breakpoints on the
  OpenAI-function-calling message shape. Rewrite is gated on a
  substring check for `claude` in the model id, so OpenAI / Azure
  OpenAI / Azure AI Foundry GPT models never see the marker and
  continue on the un-cached path.
- **`LiteLLMProvider.complete`** — same strategy for non-tool requests.
- **Tool loop breakpoint strategy** — we only cache the system prefix
  (1 of 4 available `cache_control` breakpoints). The task describes
  a follow-up spike to study whether the denylist/allowed_commands
  block, once rendered into the system, is stable enough across a
  maintainer fleet to be worth a second breakpoint — see TODO below.
  Current single-breakpoint placement cleanly caches the entire
  `tools` + `system` prefix.

## Metrics

Two new counters (labelled `{provider, model}`):

- `caretaker_llm_cache_read_tokens_total` — from
  `usage.cache_read_input_tokens` (cache hits)
- `caretaker_llm_cache_creation_tokens_total` — from
  `usage.cache_creation_input_tokens` (cache writes)

LiteLLM's `usage` surfaces the native Anthropic keys when routing to
Claude; we also fall back to `usage.prompt_tokens_details.cached_tokens`
(OpenAI-compatible key) for the read count. Zero-valued samples are
dropped so non-Claude providers don't pollute the label space.

### Grafana hit-ratio expression

```
sum(rate(caretaker_llm_cache_read_tokens_total[5m]))
  / (
    sum(rate(caretaker_llm_cache_read_tokens_total[5m]))
    + sum(rate(caretaker_llm_cache_creation_tokens_total[5m]))
  )
```

Break out by model/provider by adding `by (provider, model)` to each
`sum()`. The ratio is computed (not precomputed as a counter) so the
absolute tokens remain available for cost math.

## TODO — follow-up research spike (R2)

The Anthropic ephemeral cache has a 5-minute TTL. Foundry tool-loop
runs frequently exceed that, and some of the scheduled maintainer
cycles fire on >5-minute intervals. A research spike should:

1. Measure the observed cache hit ratio over a representative week.
2. If it's low, evaluate:
   - Moving the stable denylist/allowed_commands block to a second
     cache breakpoint (up to 4 are allowed per request).
   - Switching to the 1-hour TTL (`cache_control: {"type": "ephemeral",
     "ttl": "1h"}`) for tool-loop system blocks — note the 2x write
     premium requires at least 3 reads to pay off.
   - Cross-owner caching: a fleet-wide shared system prefix with
     per-owner configuration appended after the breakpoint.

## Test plan

- [x] Unit: fake `messages.create` with `usage.cache_read_input_tokens=123,
      cache_creation_input_tokens=456` increments both counters by the
      exact token counts.
- [x] Unit: outgoing Anthropic request body contains `cache_control:
      ephemeral` on the system block (verified by capturing the
      `messages.create` kwargs through an `AsyncMock`).
- [x] Unit: zero-valued usage is silently dropped (no counter
      pollution).
- [x] Unit: `_annotate_system_cache_control` copies — does not mutate —
      the messages list, preserving the tool_loop's growing transcript.
- [x] Unit: non-Claude models (`openai/*`, `azure_ai/*`) skip the
      annotator → verified by the `_supports_prompt_cache` gate.
- [x] Unit: `_extract_litellm_cache_tokens` handles the native
      Anthropic key shape and the OpenAI `prompt_tokens_details.cached_tokens`
      fallback.
- [x] Gates: `pytest -q` (1106 passed, 1 skipped), `ruff check`,
      `ruff format --check`, `mypy src/caretaker` (no new errors in
      changed files; pre-existing errors in `k8s_worker/launcher.py`
      unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)