### PR TITLE
feat(cli): caretaker doctor preflight

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -231,9 +231,68 @@ jobs:
           echo "should_run=${{ steps.guard.outputs.should_run }}"
           echo "reason=${{ steps.guard.outputs.reason }}"
 
-  maintain:
+  # Pre-flight: fail loudly on missing secrets / missing required GitHub
+  # token scopes / unreachable external services *before* any agent boots.
+  # See src/caretaker/doctor.py for the check list. Non-strict by default
+  # so unreachable external services downgrade to WARN rather than FAIL
+  # and block the whole run.
+  doctor:
     needs: dispatch-guard
     if: ${{ needs.dispatch-guard.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      status: ${{ steps.doctor.outputs.status }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install caretaker (dogfood)
+        run: pip install .
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CARETAKER_APP_ID }}
+          private-key: ${{ secrets.CARETAKER_APP_PRIVATE_KEY }}
+      - name: Preflight
+        id: doctor
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set +e
+          caretaker doctor --config .github/maintainer/config.yml --json \
+            >doctor.json 2>doctor.stderr
+          code=$?
+          # Human-readable report always gets echoed to the run log…
+          cat doctor.stderr
+          # …and the JSON payload is uploaded as a step summary.
+          {
+            echo "## caretaker doctor preflight"
+            echo
+            echo '```'
+            cat doctor.stderr
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"
+          # Emit a job-level status so downstream jobs can skip when
+          # preflight itself crashed (exit 2) while still running when
+          # preflight passed (exit 0). A doctor FAIL (exit 1) also blocks.
+          if [ "$code" = "0" ]; then
+            echo "status=pass" >>"$GITHUB_OUTPUT"
+          elif [ "$code" = "1" ]; then
+            echo "status=fail" >>"$GITHUB_OUTPUT"
+          else
+            echo "status=error" >>"$GITHUB_OUTPUT"
+          fi
+          exit $code
+
+  maintain:
+    needs: [dispatch-guard, doctor]
+    if: ${{ needs.dispatch-guard.outputs.should_run == 'true' && needs.doctor.outputs.status == 'pass' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -316,11 +375,15 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
-  # When the caretaker run itself fails, trigger the self-heal agent
+  # When the caretaker run itself fails, trigger the self-heal agent.
+  # We intentionally require ``maintain.result == 'failure'`` (not a bare
+  # ``failure()`` call) so a ``doctor`` FAIL — which is a config problem,
+  # not a runtime bug — doesn't fan out into a second caretaker run that
+  # would hit the same missing secret or scope.
   self-heal-on-failure:
     runs-on: ubuntu-latest
-    needs: [dispatch-guard, maintain]
-    if: ${{ needs.dispatch-guard.outputs.should_run == 'true' && failure() }}
+    needs: [dispatch-guard, doctor, maintain]
+    if: ${{ needs.dispatch-guard.outputs.should_run == 'true' && needs.maintain.result == 'failure' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/caretaker/cli.py
+++ b/src/caretaker/cli.py
@@ -152,5 +152,77 @@ def validate_config(config: str) -> None:
     )
 
 
+DEFAULT_DOCTOR_CONFIG = ".github/maintainer/config.yml"
+
+
+@main.command("doctor")
+@click.option(
+    "--config",
+    default=DEFAULT_DOCTOR_CONFIG,
+    show_default=True,
+    type=click.Path(),
+    help="Path to config.yml. Defaults to .github/maintainer/config.yml.",
+)
+@click.option(
+    "--json",
+    "emit_json",
+    is_flag=True,
+    default=False,
+    help="Emit a machine-readable JSON summary on stdout (human table still goes to stderr).",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Treat unreachable external services as FAIL instead of WARN.",
+)
+@click.option(
+    "--skip-github",
+    is_flag=True,
+    default=False,
+    help="Skip GitHub token probes (used in tests / offline environments).",
+)
+def doctor(config: str, emit_json: bool, strict: bool, skip_github: bool) -> None:
+    """Preflight every required secret, scope, and external service.
+
+    Exit code matrix:
+
+    * 0 — no FAILs
+    * 1 — at least one FAIL
+    * 2 — internal error (preflight itself crashed)
+    """
+    # Imports are deferred so ``caretaker --help`` stays fast and test
+    # fixtures that stub the CLI entrypoint don't pay for httpx + pydantic.
+    import traceback
+
+    from caretaker.doctor import Severity, render_table, run_doctor_sync
+
+    try:
+        loaded = MaintainerConfig.from_yaml(config)
+    except FileNotFoundError as exc:
+        click.echo(f"doctor: config file not found: {exc}", err=True)
+        raise SystemExit(2) from exc
+    except Exception as exc:
+        click.echo(f"doctor: failed to load config: {exc}", err=True)
+        raise SystemExit(2) from exc
+
+    try:
+        report = run_doctor_sync(loaded, strict=strict, skip_github=skip_github)
+    except Exception as exc:  # pragma: no cover - surfaced to CLI user
+        click.echo(f"doctor: internal error during preflight: {exc}", err=True)
+        click.echo(traceback.format_exc(), err=True)
+        raise SystemExit(2) from exc
+
+    # Human-readable table → stderr so the optional JSON payload on
+    # stdout stays cleanly parseable for CI consumers.
+    click.echo(render_table(report), err=True)
+
+    if emit_json:
+        click.echo(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+
+    if any(r.severity is Severity.FAIL for r in report.results):
+        raise SystemExit(1)
+
+
 if __name__ == "__main__":
     main()

--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -1,0 +1,917 @@
+"""Preflight ``caretaker doctor`` checks.
+
+``caretaker doctor`` catches configuration gaps *before* any agent boots,
+so we never again spend a whole run silently swallowing 403s for half
+the product surface. The scope-gap tracker in
+:mod:`caretaker.github_client.scope_gap` is the after-the-fact safety
+net; this module is the pre-flight equivalent.
+
+The three classes of check today:
+
+* **Secrets present** — every ``*_env`` name the loaded
+  :class:`~caretaker.config.MaintainerConfig` references is looked up in
+  ``os.environ``. The severity is ``FAIL`` when the owning config block
+  is ``enabled=True`` and ``WARN`` otherwise (forward-compat: an
+  operator may be staging env vars before flipping the switch).
+
+* **GitHub token scopes** — we ask GitHub directly. First we inspect
+  ``GET /user`` for an ``X-OAuth-Scopes`` response header (PATs have
+  it; workflow ``GITHUB_TOKEN``s don't). When the header is absent we
+  probe the handful of endpoint templates each enabled agent relies
+  on and treat a ``403 Resource not accessible by integration`` as a
+  missing scope. The required-scope map piggybacks on
+  :data:`caretaker.github_client.scope_gap._ENDPOINT_SCOPE_MAP` so the
+  after-the-fact tracker and the preflight agree on the vocabulary.
+
+* **External services reachable** — for every ``*.enabled = true``
+  block that points at a network dependency (Mongo, Redis, Neo4j,
+  fleet registry, OIDC issuer) we resolve the host and, where it's
+  cheap, open a TCP connection on a short timeout. Unreachable is
+  reported as ``WARN`` by default, upgraded to ``FAIL`` in strict
+  mode.
+
+The checks deliberately return structured :class:`CheckResult`
+objects so the CLI can render a human table *and* a machine-readable
+JSON summary from a single source of truth.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from caretaker.github_client.scope_gap import is_scope_gap_message
+
+if TYPE_CHECKING:
+    from caretaker.config import MaintainerConfig
+    from caretaker.github_client.api import GitHubClient
+
+logger = logging.getLogger(__name__)
+
+
+# ── Result primitives ──────────────────────────────────────────────────
+
+
+class Severity(StrEnum):
+    """Check severities rendered in the doctor report."""
+
+    OK = "OK"
+    WARN = "WARN"
+    FAIL = "FAIL"
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single preflight check.
+
+    ``category`` groups checks in the rendered table; ``name`` is the
+    human-readable row title; ``detail`` is the short "why" that ships
+    next to the severity so operators can act without re-reading the
+    config.
+    """
+
+    category: str
+    name: str
+    severity: Severity
+    detail: str
+    # Optional hint surfaced only in the JSON payload (e.g. the scope
+    # string GitHub expects, or the host:port we couldn't connect to).
+    hint: str | None = None
+
+    def to_dict(self) -> dict[str, str | None]:
+        data = asdict(self)
+        data["severity"] = self.severity.value
+        return data
+
+
+@dataclass
+class DoctorReport:
+    """Aggregated preflight report.
+
+    Callers inspect :attr:`has_failures` to decide the process exit
+    code. :meth:`to_dict` produces the JSON payload written to stdout
+    when ``--json`` is passed.
+    """
+
+    results: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def has_failures(self) -> bool:
+        return any(r.severity is Severity.FAIL for r in self.results)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(r.severity is Severity.WARN for r in self.results)
+
+    def add(self, result: CheckResult) -> None:
+        self.results.append(result)
+
+    def summary_counts(self) -> dict[str, int]:
+        counts = {sev.value: 0 for sev in Severity}
+        for r in self.results:
+            counts[r.severity.value] += 1
+        return counts
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": "fail" if self.has_failures else ("warn" if self.has_warnings else "ok"),
+            "counts": self.summary_counts(),
+            "checks": [r.to_dict() for r in self.results],
+        }
+
+
+# ── Config → env-var references ────────────────────────────────────────
+
+
+@dataclass
+class EnvReference:
+    """One env-var reference extracted from the effective config.
+
+    ``owner_enabled`` tells the secrets check whether to escalate a
+    missing value to ``FAIL`` (enabled block) or ``WARN`` (disabled
+    block; future-proofing for operators staging rollouts).
+    """
+
+    env_name: str
+    config_path: str
+    owner_enabled: bool
+    # Free-form description surfaced in the detail column.
+    purpose: str
+
+
+def collect_env_references(config: MaintainerConfig) -> list[EnvReference]:
+    """Return every env-var reference the config transitively makes.
+
+    The list is ordered by the order in which blocks are declared on
+    :class:`~caretaker.config.MaintainerConfig` so the rendered table
+    groups related checks together.
+    """
+    refs: list[EnvReference] = []
+
+    # MongoDB durable state (memory store + audit log + evolution).
+    refs.append(
+        EnvReference(
+            env_name=config.mongo.mongodb_url_env,
+            config_path="mongo.mongodb_url_env",
+            owner_enabled=config.mongo.enabled,
+            purpose="MongoDB / Cosmos DB connection string",
+        )
+    )
+
+    # Redis cache / dedupe.
+    refs.append(
+        EnvReference(
+            env_name=config.redis.redis_url_env,
+            config_path="redis.redis_url_env",
+            owner_enabled=config.redis.enabled,
+            purpose="Redis connection string",
+        )
+    )
+
+    # Fleet registry HMAC secret (used by the outbound heartbeat emitter).
+    refs.append(
+        EnvReference(
+            env_name=config.fleet_registry.secret_env,
+            config_path="fleet_registry.secret_env",
+            owner_enabled=config.fleet_registry.enabled,
+            purpose="Fleet registry HMAC shared secret",
+        )
+    )
+
+    # Fleet registry optional OAuth2 client creds.
+    fleet_oauth = config.fleet_registry.oauth2
+    fleet_oauth_enabled = config.fleet_registry.enabled and fleet_oauth.enabled
+    for env_name, sub in (
+        (fleet_oauth.client_id_env, "client_id_env"),
+        (fleet_oauth.client_secret_env, "client_secret_env"),
+        (fleet_oauth.token_url_env, "token_url_env"),
+    ):
+        refs.append(
+            EnvReference(
+                env_name=env_name,
+                config_path=f"fleet_registry.oauth2.{sub}",
+                owner_enabled=fleet_oauth_enabled,
+                purpose="Fleet registry OAuth2 client credential",
+            )
+        )
+
+    # GitHub App — private key, webhook secret, optional OAuth client.
+    gha = config.github_app
+    refs.append(
+        EnvReference(
+            env_name=gha.private_key_env,
+            config_path="github_app.private_key_env",
+            owner_enabled=gha.enabled,
+            purpose="GitHub App PEM-encoded private key",
+        )
+    )
+    refs.append(
+        EnvReference(
+            env_name=gha.webhook_secret_env,
+            config_path="github_app.webhook_secret_env",
+            owner_enabled=gha.enabled,
+            purpose="GitHub App webhook shared secret",
+        )
+    )
+    for env_name, sub in (
+        (gha.oauth_client_id_env, "oauth_client_id_env"),
+        (gha.oauth_client_secret_env, "oauth_client_secret_env"),
+    ):
+        refs.append(
+            EnvReference(
+                env_name=env_name,
+                config_path=f"github_app.{sub}",
+                owner_enabled=gha.enabled,
+                purpose="GitHub App OAuth client credential",
+            )
+        )
+
+    # Admin dashboard — OIDC + session secret.
+    admin = config.admin_dashboard
+    for env_name, sub, purpose in (
+        (admin.oidc_client_id_env, "oidc_client_id_env", "Admin OIDC client id"),
+        (
+            admin.oidc_client_secret_env,
+            "oidc_client_secret_env",
+            "Admin OIDC client secret",
+        ),
+        (admin.session_secret_env, "session_secret_env", "Admin session signing key"),
+    ):
+        refs.append(
+            EnvReference(
+                env_name=env_name,
+                config_path=f"admin_dashboard.{sub}",
+                owner_enabled=admin.enabled,
+                purpose=purpose,
+            )
+        )
+
+    # Graph store — Neo4j URL + auth.
+    graph = config.graph_store
+    for env_name, sub, purpose in (
+        (graph.neo4j_url_env, "neo4j_url_env", "Neo4j Bolt URL"),
+        (graph.neo4j_auth_env, "neo4j_auth_env", "Neo4j auth pair"),
+    ):
+        refs.append(
+            EnvReference(
+                env_name=env_name,
+                config_path=f"graph_store.{sub}",
+                owner_enabled=graph.enabled,
+                purpose=purpose,
+            )
+        )
+
+    # Telemetry — App Insights connection string (only referenced when enabled).
+    refs.append(
+        EnvReference(
+            env_name=config.telemetry.application_insights_connection_string_env,
+            config_path="telemetry.application_insights_connection_string_env",
+            owner_enabled=config.telemetry.enabled,
+            purpose="Application Insights connection string",
+        )
+    )
+
+    return refs
+
+
+def _llm_env_requirement(config: MaintainerConfig) -> EnvReference | None:
+    """Return the LLM API key env reference implied by the config.
+
+    The LLMConfig does not name the env var (the SDK layer reads
+    ``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` directly), so we infer
+    the name from the configured provider. Returns ``None`` when we
+    can't make a confident mapping.
+    """
+    provider = config.llm.provider
+    # The primary "is LLM enabled" signal — features list non-empty
+    # and provider selected. We don't try to override ``claude_enabled
+    # = "auto"`` here because the preflight is intentionally noisier
+    # than the runtime fallback path.
+    if provider == "anthropic":
+        return EnvReference(
+            env_name="ANTHROPIC_API_KEY",
+            config_path="llm.provider=anthropic",
+            owner_enabled=True,
+            purpose="Anthropic SDK API key",
+        )
+    # LiteLLM chooses its own env var per-model; we can't pin one name.
+    return None
+
+
+# ── Check runners ──────────────────────────────────────────────────────
+
+
+def check_env_secrets(config: MaintainerConfig, env: dict[str, str]) -> list[CheckResult]:
+    """Return one :class:`CheckResult` per env-var reference in ``config``.
+
+    ``env`` is injected so tests can pass a fixture without touching
+    the real process environment.
+    """
+    refs = collect_env_references(config)
+    llm_ref = _llm_env_requirement(config)
+    if llm_ref is not None:
+        refs.append(llm_ref)
+
+    # GITHUB_TOKEN / COPILOT_PAT are not declared in the config model
+    # but the orchestrator refuses to start without at least one of
+    # them (see ``EnvCredentialsProvider.__init__``). Check them here
+    # so ``caretaker doctor`` surfaces the same failure mode.
+    results: list[CheckResult] = []
+    if not env.get("GITHUB_TOKEN") and not env.get("COPILOT_PAT"):
+        results.append(
+            CheckResult(
+                category="secrets",
+                name="GITHUB_TOKEN",
+                severity=Severity.FAIL,
+                detail=(
+                    "Neither GITHUB_TOKEN nor COPILOT_PAT is set; the GitHub "
+                    "client will refuse to start."
+                ),
+                hint="GITHUB_TOKEN or COPILOT_PAT",
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                category="secrets",
+                name="GITHUB_TOKEN",
+                severity=Severity.OK,
+                detail="GitHub token present",
+            )
+        )
+
+    for ref in refs:
+        present = bool(env.get(ref.env_name))
+        if present:
+            severity = Severity.OK
+            detail = f"{ref.purpose} present"
+        elif ref.owner_enabled:
+            severity = Severity.FAIL
+            detail = f"{ref.purpose} missing ({ref.config_path} is enabled)"
+        else:
+            severity = Severity.WARN
+            detail = f"{ref.purpose} missing ({ref.config_path} is disabled; forward-compat)"
+        results.append(
+            CheckResult(
+                category="secrets",
+                name=ref.env_name,
+                severity=severity,
+                detail=detail,
+                hint=ref.config_path,
+            )
+        )
+    return results
+
+
+# ── GitHub token probes ────────────────────────────────────────────────
+
+
+# (endpoint template, HTTP method, required scope hint, enabled?-predicate hint)
+# The predicate is a dotted path whose truthiness we read off the config.
+# Kept as a string so the map is pure data and can be introspected by tests.
+@dataclass(frozen=True)
+class _ScopeProbe:
+    method: str
+    path: str
+    scope: str
+    needed_when: str  # human description of which agents need it
+
+
+def _required_probes(config: MaintainerConfig, owner: str, repo: str) -> list[_ScopeProbe]:
+    """Build the list of probe endpoints the enabled agents require.
+
+    We only probe surface that's actually enabled so the preflight
+    report doesn't drown operators in warnings for features they
+    haven't switched on.
+    """
+    probes: list[_ScopeProbe] = []
+
+    # Always: the bare ``GET /repos/{owner}/{repo}`` works under any
+    # read scope and proves the token can see the repo at all.
+    probes.append(
+        _ScopeProbe(
+            method="GET",
+            path=f"/repos/{owner}/{repo}",
+            scope="metadata: read",
+            needed_when="baseline repo access",
+        )
+    )
+
+    if config.issue_agent.enabled or config.charlie_agent.enabled:
+        probes.append(
+            _ScopeProbe(
+                method="GET",
+                path=f"/repos/{owner}/{repo}/issues",
+                scope="issues: read",
+                needed_when="issue_agent / charlie_agent",
+            )
+        )
+
+    if config.pr_agent.enabled or config.pr_reviewer.enabled:
+        probes.append(
+            _ScopeProbe(
+                method="GET",
+                path=f"/repos/{owner}/{repo}/pulls",
+                scope="pull_requests: read",
+                needed_when="pr_agent / pr_reviewer",
+            )
+        )
+
+    if config.devops_agent.enabled or config.self_heal_agent.enabled:
+        probes.append(
+            _ScopeProbe(
+                method="GET",
+                path=f"/repos/{owner}/{repo}/actions/runs",
+                scope="actions: read",
+                needed_when="devops_agent / self_heal_agent",
+            )
+        )
+
+    if config.security_agent.enabled:
+        if config.security_agent.include_dependabot:
+            probes.append(
+                _ScopeProbe(
+                    method="GET",
+                    path=f"/repos/{owner}/{repo}/dependabot/alerts",
+                    scope="security_events: read",
+                    needed_when="security_agent (dependabot)",
+                )
+            )
+        if config.security_agent.include_code_scanning:
+            probes.append(
+                _ScopeProbe(
+                    method="GET",
+                    path=f"/repos/{owner}/{repo}/code-scanning/alerts",
+                    scope="security_events: read",
+                    needed_when="security_agent (code scanning)",
+                )
+            )
+        if config.security_agent.include_secret_scanning:
+            probes.append(
+                _ScopeProbe(
+                    method="GET",
+                    path=f"/repos/{owner}/{repo}/secret-scanning/alerts",
+                    scope="security_events: read",
+                    needed_when="security_agent (secret scanning)",
+                )
+            )
+
+    return probes
+
+
+def _parse_repo_slug(slug: str) -> tuple[str, str] | None:
+    """Parse ``owner/repo`` out of a ``GITHUB_REPOSITORY`` style string."""
+    if not slug or "/" not in slug:
+        return None
+    owner, _, repo = slug.partition("/")
+    owner, repo = owner.strip(), repo.strip()
+    if not owner or not repo:
+        return None
+    return owner, repo
+
+
+async def check_github_scopes(
+    config: MaintainerConfig,
+    github: GitHubClient,
+    env: dict[str, str],
+) -> list[CheckResult]:
+    """Probe the token for each scope the enabled agents need.
+
+    The check sequence:
+
+    1. ``GET /user`` — parses ``X-OAuth-Scopes`` when present (PATs).
+    2. ``GET /repos/{owner}/{repo}`` plus one probe per enabled agent
+       surface. A 403 with a scope-gap body → ``FAIL`` row. A
+       non-403 error (network, auth, 404 on a missing repo) is
+       reported as ``WARN`` so the preflight doesn't hard-fail on
+       transient issues.
+
+    We intentionally make no *write* calls during preflight; the
+    scope-gap tracker still catches write-scope gaps at runtime and
+    emits its own issue.
+    """
+    results: list[CheckResult] = []
+
+    slug = env.get("GITHUB_REPOSITORY", "")
+    parsed = _parse_repo_slug(slug)
+    if parsed is None:
+        results.append(
+            CheckResult(
+                category="github",
+                name="GITHUB_REPOSITORY",
+                severity=Severity.WARN,
+                detail=(
+                    "GITHUB_REPOSITORY not set; preflight cannot probe repo-scoped "
+                    "endpoints. Set it to 'owner/repo' in the workflow env."
+                ),
+            )
+        )
+        return results
+    owner, repo = parsed
+
+    # 1) Read declared scopes when the token advertises them (PATs do;
+    #    installation tokens do not — GitHub issues them with
+    #    permissions instead of OAuth scopes).
+    try:
+        resp = await _raw_get_with_headers(github, "/user")
+    except Exception as exc:  # noqa: BLE001 — preflight is tolerant
+        results.append(
+            CheckResult(
+                category="github",
+                name="GET /user",
+                severity=Severity.FAIL,
+                detail=f"token rejected by GitHub: {exc}",
+            )
+        )
+        # No point probing further with a bad token.
+        return results
+    else:
+        declared = resp.get("x-oauth-scopes", "")
+        if declared:
+            results.append(
+                CheckResult(
+                    category="github",
+                    name="declared scopes",
+                    severity=Severity.OK,
+                    detail=f"OAuth scopes: {declared}",
+                    hint=declared,
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    category="github",
+                    name="declared scopes",
+                    severity=Severity.OK,
+                    detail=(
+                        "no X-OAuth-Scopes header (installation or fine-grained "
+                        "token); falling back to endpoint probes."
+                    ),
+                )
+            )
+
+    # 2) Probe each enabled-surface endpoint.
+    for probe in _required_probes(config, owner, repo):
+        probe_result = await _probe_endpoint(github, probe)
+        results.append(probe_result)
+
+    return results
+
+
+async def _raw_get_with_headers(github: GitHubClient, path: str) -> dict[str, str]:
+    """Perform ``GET path`` and return response headers (lowercased).
+
+    Reaches into :class:`GitHubClient`'s httpx client directly so we
+    can observe the ``X-OAuth-Scopes`` response header, which the
+    normal ``_request`` helper discards. Raises on non-2xx so the
+    caller can flag the token.
+    """
+    # Deferred import keeps the circular boundary clean at module
+    # import time: the CLI imports doctor; doctor references the
+    # github_client type only lazily.
+    creds = github._creds
+    token = await creds.default_token()
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await github._client.request("GET", path, headers=headers)
+    if resp.status_code >= 400:
+        try:
+            body = resp.json()
+            message = body.get("message", resp.text)
+        except Exception:
+            message = resp.text
+        raise RuntimeError(f"{resp.status_code}: {message}")
+    return {k.lower(): v for k, v in resp.headers.items()}
+
+
+async def _probe_endpoint(github: GitHubClient, probe: _ScopeProbe) -> CheckResult:
+    """Issue a single HEAD/GET probe and map the outcome to a row."""
+    creds = github._creds
+    try:
+        token = await creds.default_token()
+    except Exception as exc:
+        return CheckResult(
+            category="github",
+            name=f"{probe.method} {probe.path}",
+            severity=Severity.FAIL,
+            detail=f"no GitHub token available: {exc}",
+            hint=probe.scope,
+        )
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        resp = await github._client.request(probe.method, probe.path, headers=headers)
+    except Exception as exc:  # noqa: BLE001 — network errors → WARN
+        return CheckResult(
+            category="github",
+            name=f"{probe.method} {probe.path}",
+            severity=Severity.WARN,
+            detail=f"request failed: {exc}",
+            hint=probe.scope,
+        )
+    status = resp.status_code
+    if status < 400:
+        return CheckResult(
+            category="github",
+            name=f"{probe.method} {probe.path}",
+            severity=Severity.OK,
+            detail=f"ok ({probe.needed_when})",
+            hint=probe.scope,
+        )
+    # 403 + scope-gap body → FAIL with the exact scope needed.
+    if status == 403:
+        try:
+            body = resp.json()
+            message = body.get("message", resp.text)
+        except Exception:
+            message = resp.text
+        if is_scope_gap_message(message):
+            return CheckResult(
+                category="github",
+                name=f"{probe.method} {probe.path}",
+                severity=Severity.FAIL,
+                detail=f"403 scope-gap: needs {probe.scope} ({probe.needed_when})",
+                hint=probe.scope,
+            )
+        return CheckResult(
+            category="github",
+            name=f"{probe.method} {probe.path}",
+            severity=Severity.FAIL,
+            detail=f"403: {message}",
+            hint=probe.scope,
+        )
+    # 404 is not a scope failure — the resource just doesn't exist.
+    # Report as WARN so operators see it but we don't block the run.
+    if status == 404:
+        return CheckResult(
+            category="github",
+            name=f"{probe.method} {probe.path}",
+            severity=Severity.WARN,
+            detail=f"404 (endpoint absent; {probe.needed_when})",
+            hint=probe.scope,
+        )
+    return CheckResult(
+        category="github",
+        name=f"{probe.method} {probe.path}",
+        severity=Severity.WARN,
+        detail=f"HTTP {status} ({probe.needed_when})",
+        hint=probe.scope,
+    )
+
+
+# ── External-service reachability ──────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _ServiceProbe:
+    name: str
+    config_path: str
+    url: str
+
+
+def _collect_service_probes(config: MaintainerConfig, env: dict[str, str]) -> list[_ServiceProbe]:
+    probes: list[_ServiceProbe] = []
+    if config.mongo.enabled:
+        url = env.get(config.mongo.mongodb_url_env, "")
+        if url:
+            probes.append(_ServiceProbe(name="mongo", config_path="mongo.mongodb_url_env", url=url))
+    if config.redis.enabled:
+        url = env.get(config.redis.redis_url_env, "")
+        if url:
+            probes.append(_ServiceProbe(name="redis", config_path="redis.redis_url_env", url=url))
+    if config.graph_store.enabled:
+        url = env.get(config.graph_store.neo4j_url_env, "")
+        if url:
+            probes.append(
+                _ServiceProbe(
+                    name="neo4j",
+                    config_path="graph_store.neo4j_url_env",
+                    url=url,
+                )
+            )
+    if config.fleet_registry.enabled and config.fleet_registry.endpoint:
+        probes.append(
+            _ServiceProbe(
+                name="fleet_registry",
+                config_path="fleet_registry.endpoint",
+                url=config.fleet_registry.endpoint,
+            )
+        )
+    if config.admin_dashboard.enabled and config.admin_dashboard.oidc_issuer_url:
+        probes.append(
+            _ServiceProbe(
+                name="oidc_issuer",
+                config_path="admin_dashboard.oidc_issuer_url",
+                url=config.admin_dashboard.oidc_issuer_url,
+            )
+        )
+    return probes
+
+
+def _extract_host_port(url: str) -> tuple[str, int] | None:
+    """Best-effort ``(host, port)`` extraction for probing.
+
+    Handles ``mongodb+srv://``, ``rediss://``, ``bolt://``, ``https://``
+    etc. without taking a dependency on each provider's driver.
+    Returns ``None`` when the URL is unparseable or carries no host.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+    host = parsed.hostname
+    if not host:
+        return None
+    if parsed.port:
+        return host, parsed.port
+    # Default ports for known schemes — deliberately a tiny table, we
+    # only need it to produce *some* signal.
+    default_ports = {
+        "http": 80,
+        "https": 443,
+        "redis": 6379,
+        "rediss": 6379,
+        "mongodb": 27017,
+        "mongodb+srv": 27017,
+        "bolt": 7687,
+        "neo4j": 7687,
+        "neo4j+s": 7687,
+    }
+    port = default_ports.get(parsed.scheme, 0)
+    if port == 0:
+        return None
+    return host, port
+
+
+def _check_tcp_reachable(host: str, port: int, *, timeout: float = 2.0) -> tuple[bool, str]:
+    """Return ``(reachable, detail)`` for a short-timeout TCP probe."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True, f"{host}:{port} reachable"
+    except OSError as exc:
+        return False, f"{host}:{port} unreachable: {exc}"
+
+
+def check_external_services(
+    config: MaintainerConfig,
+    env: dict[str, str],
+    *,
+    strict: bool,
+) -> list[CheckResult]:
+    """Return reachability checks for every enabled external service."""
+    results: list[CheckResult] = []
+    probes = _collect_service_probes(config, env)
+    for probe in probes:
+        host_port = _extract_host_port(probe.url)
+        if host_port is None:
+            results.append(
+                CheckResult(
+                    category="services",
+                    name=probe.name,
+                    severity=Severity.WARN,
+                    detail=f"cannot parse host/port from {probe.config_path}",
+                    hint=probe.config_path,
+                )
+            )
+            continue
+        host, port = host_port
+        ok, detail = _check_tcp_reachable(host, port)
+        if ok:
+            results.append(
+                CheckResult(
+                    category="services",
+                    name=probe.name,
+                    severity=Severity.OK,
+                    detail=detail,
+                    hint=probe.config_path,
+                )
+            )
+        else:
+            sev = Severity.FAIL if strict else Severity.WARN
+            results.append(
+                CheckResult(
+                    category="services",
+                    name=probe.name,
+                    severity=sev,
+                    detail=detail,
+                    hint=probe.config_path,
+                )
+            )
+    return results
+
+
+# ── Orchestration ──────────────────────────────────────────────────────
+
+
+async def run_doctor(
+    config: MaintainerConfig,
+    *,
+    env: dict[str, str] | None = None,
+    github: GitHubClient | None = None,
+    strict: bool = False,
+    skip_github: bool = False,
+) -> DoctorReport:
+    """Run every preflight check and return the aggregated report.
+
+    ``github`` is accepted so tests can inject a mocked client; when
+    omitted we construct one lazily from the environment (only if
+    ``skip_github`` is False).
+    """
+    env = env if env is not None else dict(os.environ)
+    report = DoctorReport()
+
+    for result in check_env_secrets(config, env):
+        report.add(result)
+
+    if not skip_github:
+        close_after = False
+        if github is None:
+            try:
+                from caretaker.github_client.api import GitHubClient as _GitHubClient
+
+                github = _GitHubClient()
+                close_after = True
+            except Exception as exc:  # noqa: BLE001 — token absent → FAIL row
+                report.add(
+                    CheckResult(
+                        category="github",
+                        name="client",
+                        severity=Severity.FAIL,
+                        detail=f"cannot construct GitHubClient: {exc}",
+                    )
+                )
+                github = None
+        if github is not None:
+            try:
+                for result in await check_github_scopes(config, github, env):
+                    report.add(result)
+            finally:
+                if close_after:
+                    await github.close()
+
+    for result in check_external_services(config, env, strict=strict):
+        report.add(result)
+
+    return report
+
+
+def run_doctor_sync(
+    config: MaintainerConfig,
+    *,
+    env: dict[str, str] | None = None,
+    strict: bool = False,
+    skip_github: bool = False,
+) -> DoctorReport:
+    """Blocking convenience wrapper for the CLI entrypoint."""
+    return asyncio.run(run_doctor(config, env=env, strict=strict, skip_github=skip_github))
+
+
+# ── Rendering ──────────────────────────────────────────────────────────
+
+
+def render_table(report: DoctorReport) -> str:
+    """Render the report as a plain-text table suitable for stderr.
+
+    We deliberately avoid external dependencies (rich, tabulate) so
+    the preflight runs in the smallest possible environment.
+    """
+    if not report.results:
+        return "(no checks ran)"
+    header = ("CATEGORY", "NAME", "SEVERITY", "DETAIL")
+    rows = [header]
+    for r in report.results:
+        rows.append((r.category, r.name, r.severity.value, r.detail))
+    widths = [max(len(row[i]) for row in rows) for i in range(len(header))]
+    sep = "  "
+    lines = []
+    for i, row in enumerate(rows):
+        lines.append(sep.join(cell.ljust(widths[j]) for j, cell in enumerate(row)))
+        if i == 0:
+            lines.append(sep.join("-" * widths[j] for j in range(len(header))))
+    counts = report.summary_counts()
+    lines.append("")
+    lines.append(
+        "summary: OK={ok} WARN={warn} FAIL={fail}".format(
+            ok=counts["OK"], warn=counts["WARN"], fail=counts["FAIL"]
+        )
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "CheckResult",
+    "DoctorReport",
+    "EnvReference",
+    "Severity",
+    "check_env_secrets",
+    "check_external_services",
+    "check_github_scopes",
+    "collect_env_references",
+    "render_table",
+    "run_doctor",
+    "run_doctor_sync",
+]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -382,13 +382,29 @@ class TestDoctorCLI:
         cfg = _write_config(tmp_path / "config.yml")
         monkeypatch.setenv("GITHUB_TOKEN", "ghs_fake")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
-        runner = CliRunner()
+        # CliRunner constructor changed between click 8.1 (mix_stderr kwarg)
+        # and 8.2 (streams always separate). Construct without the kwarg and
+        # parse the JSON block out of combined output — cheaper than a
+        # version probe and works on both.
+        try:
+            runner = CliRunner(mix_stderr=False)  # type: ignore[call-arg]
+        except TypeError:
+            runner = CliRunner()
         result = runner.invoke(
             cli_main,
             ["doctor", "--config", str(cfg), "--skip-github", "--json"],
         )
         assert result.exit_code == 0
-        data = json.loads(result.stdout)
+        # The human table is emitted first (to stderr on 8.1 with
+        # mix_stderr=False; to combined output on 8.2). The JSON payload
+        # is the last contiguous JSON object in ``result.output``.
+        combined = result.output
+        first_brace = combined.find("\n{")
+        if first_brace == -1 and combined.startswith("{"):
+            first_brace = 0
+        else:
+            first_brace += 1  # skip the leading newline
+        data = json.loads(combined[first_brace:])
         assert data["status"] in {"ok", "warn"}
         assert "checks" in data
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,421 @@
+"""Tests for the ``caretaker doctor`` preflight subcommand."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from click.testing import CliRunner
+
+from caretaker.cli import main as cli_main
+from caretaker.config import MaintainerConfig
+from caretaker.doctor import (
+    CheckResult,
+    DoctorReport,
+    Severity,
+    check_env_secrets,
+    check_external_services,
+    check_github_scopes,
+    collect_env_references,
+    render_table,
+    run_doctor,
+)
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Iterator
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+def _write_config(path: pathlib.Path, overrides: dict[str, Any] | None = None) -> pathlib.Path:
+    """Write a minimal valid YAML config with optional block overrides."""
+    import yaml
+
+    data: dict[str, Any] = {"version": "v1"}
+    if overrides:
+        data.update(overrides)
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+def _load_config(overrides: dict[str, Any] | None = None) -> MaintainerConfig:
+    data: dict[str, Any] = {"version": "v1"}
+    if overrides:
+        data.update(overrides)
+    return MaintainerConfig.model_validate(data)
+
+
+@pytest.fixture(autouse=True)
+def _no_process_env_leak(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Scrub env vars the doctor inspects so tests are hermetic."""
+    for name in (
+        "GITHUB_TOKEN",
+        "COPILOT_PAT",
+        "GITHUB_REPOSITORY",
+        "ANTHROPIC_API_KEY",
+        "MONGODB_URL",
+        "REDIS_URL",
+        "NEO4J_URL",
+        "NEO4J_AUTH",
+        "CARETAKER_FLEET_SECRET",
+        "CARETAKER_ADMIN_OIDC_CLIENT_ID",
+        "CARETAKER_ADMIN_OIDC_CLIENT_SECRET",
+        "CARETAKER_ADMIN_SESSION_SECRET",
+        "CARETAKER_GITHUB_APP_PRIVATE_KEY",
+        "CARETAKER_GITHUB_APP_WEBHOOK_SECRET",
+        "CARETAKER_GITHUB_APP_CLIENT_ID",
+        "CARETAKER_GITHUB_APP_CLIENT_SECRET",
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "OAUTH2_CLIENT_ID",
+        "OAUTH2_CLIENT_SECRET",
+        "OAUTH2_TOKEN_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+# ── collect_env_references ────────────────────────────────────────────
+
+
+class TestCollectEnvReferences:
+    def test_includes_all_known_env_names_by_default(self) -> None:
+        config = _load_config()
+        refs = collect_env_references(config)
+        names = {r.env_name for r in refs}
+        assert "MONGODB_URL" in names
+        assert "REDIS_URL" in names
+        assert "CARETAKER_FLEET_SECRET" in names
+        assert "CARETAKER_GITHUB_APP_PRIVATE_KEY" in names
+        assert "CARETAKER_ADMIN_OIDC_CLIENT_ID" in names
+        assert "NEO4J_URL" in names
+        assert "NEO4J_AUTH" in names
+
+    def test_owner_enabled_tracks_block_state(self) -> None:
+        config = _load_config({"mongo": {"enabled": True}})
+        refs = collect_env_references(config)
+        mongo = next(r for r in refs if r.env_name == "MONGODB_URL")
+        assert mongo.owner_enabled is True
+
+        config2 = _load_config({"mongo": {"enabled": False}})
+        refs2 = collect_env_references(config2)
+        mongo2 = next(r for r in refs2 if r.env_name == "MONGODB_URL")
+        assert mongo2.owner_enabled is False
+
+
+# ── check_env_secrets ─────────────────────────────────────────────────
+
+
+class TestCheckEnvSecrets:
+    def test_missing_on_enabled_block_is_fail(self) -> None:
+        config = _load_config({"mongo": {"enabled": True}})
+        env = {"GITHUB_TOKEN": "ghs_fake"}
+        rows = check_env_secrets(config, env)
+        mongo_row = next(r for r in rows if r.name == "MONGODB_URL")
+        assert mongo_row.severity is Severity.FAIL
+
+    def test_missing_on_disabled_block_is_warn(self) -> None:
+        config = _load_config()  # mongo defaults to enabled=False
+        env = {"GITHUB_TOKEN": "ghs_fake"}
+        rows = check_env_secrets(config, env)
+        mongo_row = next(r for r in rows if r.name == "MONGODB_URL")
+        assert mongo_row.severity is Severity.WARN
+
+    def test_present_env_is_ok(self) -> None:
+        config = _load_config({"mongo": {"enabled": True}})
+        env = {"GITHUB_TOKEN": "ghs_fake", "MONGODB_URL": "mongodb://localhost:27017"}
+        rows = check_env_secrets(config, env)
+        mongo_row = next(r for r in rows if r.name == "MONGODB_URL")
+        assert mongo_row.severity is Severity.OK
+
+    def test_missing_github_token_fails(self) -> None:
+        config = _load_config()
+        rows = check_env_secrets(config, {})
+        token_row = next(r for r in rows if r.name == "GITHUB_TOKEN")
+        assert token_row.severity is Severity.FAIL
+
+    def test_copilot_pat_alone_satisfies_github_token(self) -> None:
+        config = _load_config()
+        rows = check_env_secrets(config, {"COPILOT_PAT": "ghp_fake"})
+        token_row = next(r for r in rows if r.name == "GITHUB_TOKEN")
+        assert token_row.severity is Severity.OK
+
+    def test_anthropic_key_expected_when_provider_is_anthropic(self) -> None:
+        config = _load_config()  # provider default = anthropic
+        rows = check_env_secrets(config, {"GITHUB_TOKEN": "ghs_fake"})
+        ant_row = next(r for r in rows if r.name == "ANTHROPIC_API_KEY")
+        assert ant_row.severity is Severity.FAIL
+
+
+# ── check_github_scopes ───────────────────────────────────────────────
+
+
+def _make_mock_github() -> tuple[Any, list[tuple[str, str]]]:
+    """Return a fake GitHubClient + the list of recorded requests."""
+    calls: list[tuple[str, str]] = []
+
+    class _FakeResponse:
+        def __init__(
+            self,
+            status_code: int,
+            body: dict[str, Any] | None = None,
+            headers: dict[str, str] | None = None,
+        ) -> None:
+            self.status_code = status_code
+            self._body = body or {}
+            self.headers = headers or {}
+            self.text = json.dumps(self._body)
+
+        def json(self) -> dict[str, Any]:
+            return self._body
+
+    class _FakeClient:
+        async def request(self, method: str, path: str, **_kw: Any) -> _FakeResponse:
+            calls.append((method, path))
+            if path == "/user":
+                return _FakeResponse(
+                    200, {"login": "octocat"}, headers={"X-OAuth-Scopes": "repo, read:org"}
+                )
+            if path.endswith("/dependabot/alerts"):
+                return _FakeResponse(403, {"message": "Resource not accessible by integration"})
+            if path.endswith("/code-scanning/alerts"):
+                return _FakeResponse(200, [])
+            if "/issues" in path:
+                return _FakeResponse(200, [])
+            if "/pulls" in path:
+                return _FakeResponse(200, [])
+            if "/actions/runs" in path:
+                return _FakeResponse(200, [])
+            return _FakeResponse(200, {"owner": {"login": "o"}, "name": "r"})
+
+    class _FakeCreds:
+        async def default_token(self, *, installation_id: int | None = None) -> str:  # noqa: ARG002
+            return "tok"
+
+        async def copilot_token(self, *, installation_id: int | None = None) -> str:  # noqa: ARG002
+            return "tok"
+
+    class _FakeGithub:
+        def __init__(self) -> None:
+            self._creds = _FakeCreds()
+            self._client = _FakeClient()
+
+        async def close(self) -> None:
+            return None
+
+    return _FakeGithub(), calls
+
+
+class TestCheckGithubScopes:
+    @pytest.mark.asyncio
+    async def test_requires_github_repository_env(self) -> None:
+        config = _load_config()
+        github, _calls = _make_mock_github()
+        rows = await check_github_scopes(config, github, env={})
+        assert any(r.name == "GITHUB_REPOSITORY" and r.severity is Severity.WARN for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_declared_scopes_reported(self) -> None:
+        config = _load_config()
+        github, _calls = _make_mock_github()
+        rows = await check_github_scopes(config, github, env={"GITHUB_REPOSITORY": "o/r"})
+        declared = next(r for r in rows if r.name == "declared scopes")
+        assert "repo" in (declared.detail or "")
+
+    @pytest.mark.asyncio
+    async def test_403_scope_gap_is_fail(self) -> None:
+        config = _load_config(
+            {
+                "security_agent": {
+                    "enabled": True,
+                    "include_dependabot": True,
+                    "include_code_scanning": False,
+                    "include_secret_scanning": False,
+                }
+            }
+        )
+        github, calls = _make_mock_github()
+        rows = await check_github_scopes(config, github, env={"GITHUB_REPOSITORY": "o/r"})
+        depa = next(r for r in rows if "dependabot/alerts" in r.name)
+        assert depa.severity is Severity.FAIL
+        assert any(path.endswith("/dependabot/alerts") for _m, path in calls)
+
+    @pytest.mark.asyncio
+    async def test_disabled_security_agent_skips_probes(self) -> None:
+        config = _load_config({"security_agent": {"enabled": False}})
+        github, calls = _make_mock_github()
+        await check_github_scopes(config, github, env={"GITHUB_REPOSITORY": "o/r"})
+        probed = {path for _m, path in calls}
+        assert not any("/dependabot/alerts" in p for p in probed)
+
+
+# ── check_external_services ───────────────────────────────────────────
+
+
+class TestCheckExternalServices:
+    def test_skips_disabled_blocks(self) -> None:
+        config = _load_config()
+        rows = check_external_services(config, env={}, strict=False)
+        assert rows == []
+
+    def test_strict_upgrades_warn_to_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = _load_config({"mongo": {"enabled": True}})
+        env = {"MONGODB_URL": "mongodb://unreachable.invalid:27017"}
+
+        def _boom(_host: str, _port: int, *, timeout: float = 2.0) -> tuple[bool, str]:
+            return False, "unreachable: test"
+
+        monkeypatch.setattr("caretaker.doctor._check_tcp_reachable", _boom)
+
+        warn_rows = check_external_services(config, env=env, strict=False)
+        assert any(r.severity is Severity.WARN for r in warn_rows)
+        fail_rows = check_external_services(config, env=env, strict=True)
+        assert any(r.severity is Severity.FAIL for r in fail_rows)
+
+    def test_reachable_service_reports_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = _load_config({"mongo": {"enabled": True}})
+        env = {"MONGODB_URL": "mongodb://localhost:27017"}
+
+        def _ok(_host: str, _port: int, *, timeout: float = 2.0) -> tuple[bool, str]:
+            return True, "localhost:27017 reachable"
+
+        monkeypatch.setattr("caretaker.doctor._check_tcp_reachable", _ok)
+        rows = check_external_services(config, env=env, strict=False)
+        assert rows and rows[0].severity is Severity.OK
+
+
+# ── Report + rendering ────────────────────────────────────────────────
+
+
+class TestDoctorReport:
+    def test_has_failures_and_counts(self) -> None:
+        report = DoctorReport(
+            results=[
+                CheckResult("secrets", "A", Severity.OK, "ok"),
+                CheckResult("secrets", "B", Severity.WARN, "meh"),
+                CheckResult("secrets", "C", Severity.FAIL, "nope"),
+            ]
+        )
+        assert report.has_failures is True
+        assert report.has_warnings is True
+        assert report.summary_counts() == {"OK": 1, "WARN": 1, "FAIL": 1}
+
+    def test_to_dict_shape(self) -> None:
+        report = DoctorReport(results=[CheckResult("s", "x", Severity.OK, "ok")])
+        data = report.to_dict()
+        assert data["status"] == "ok"
+        assert isinstance(data["checks"], list)
+        assert data["counts"] == {"OK": 1, "WARN": 0, "FAIL": 0}
+
+    def test_render_table_contains_header(self) -> None:
+        report = DoctorReport(results=[CheckResult("s", "x", Severity.OK, "ok")])
+        table = render_table(report)
+        assert "CATEGORY" in table
+        assert "OK=1" in table
+
+
+# ── run_doctor orchestration ──────────────────────────────────────────
+
+
+class TestRunDoctor:
+    @pytest.mark.asyncio
+    async def test_skip_github_skips_scope_checks(self) -> None:
+        config = _load_config()
+        report = await run_doctor(
+            config,
+            env={"GITHUB_TOKEN": "ghs_fake"},
+            skip_github=True,
+        )
+        assert not any(r.category == "github" for r in report.results)
+
+    @pytest.mark.asyncio
+    async def test_github_probes_invoked(self) -> None:
+        config = _load_config()
+        github, calls = _make_mock_github()
+        env = {"GITHUB_TOKEN": "ghs_fake", "GITHUB_REPOSITORY": "o/r"}
+        report = await run_doctor(config, env=env, github=github, skip_github=False)
+        assert any(r.category == "github" for r in report.results)
+        assert any(path == "/user" for _m, path in calls)
+
+
+# ── CLI integration ───────────────────────────────────────────────────
+
+
+class TestDoctorCLI:
+    def test_missing_config_exits_2(self, tmp_path: pathlib.Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["doctor", "--config", str(tmp_path / "nonexistent.yml"), "--skip-github"],
+        )
+        assert result.exit_code == 2
+
+    def test_ok_run_exits_0(self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = _write_config(tmp_path / "config.yml")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghs_fake")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["doctor", "--config", str(cfg), "--skip-github"],
+        )
+        assert result.exit_code == 0
+
+    def test_fail_on_missing_secret_exits_1(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _write_config(tmp_path / "config.yml", {"mongo": {"enabled": True}})
+        monkeypatch.setenv("GITHUB_TOKEN", "ghs_fake")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["doctor", "--config", str(cfg), "--skip-github"],
+        )
+        assert result.exit_code == 1
+
+    def test_json_output_on_stdout(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _write_config(tmp_path / "config.yml")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghs_fake")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            cli_main,
+            ["doctor", "--config", str(cfg), "--skip-github", "--json"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["status"] in {"ok", "warn"}
+        assert "checks" in data
+
+    def test_strict_flag_is_propagated(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--strict upgrades WARN to FAIL for unreachable external services."""
+        cfg = _write_config(tmp_path / "config.yml", {"mongo": {"enabled": True}})
+        monkeypatch.setenv("GITHUB_TOKEN", "ghs_fake")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
+        monkeypatch.setenv("MONGODB_URL", "mongodb://unreachable.invalid:27017")
+
+        def _boom(_host: str, _port: int, *, timeout: float = 2.0) -> tuple[bool, str]:
+            return False, "unreachable: test"
+
+        monkeypatch.setattr("caretaker.doctor._check_tcp_reachable", _boom)
+
+        runner = CliRunner()
+        # Without --strict, mongo being unreachable is WARN → exit 0.
+        result_warn = runner.invoke(
+            cli_main,
+            ["doctor", "--config", str(cfg), "--skip-github"],
+        )
+        assert result_warn.exit_code == 0
+        # With --strict, mongo being unreachable is FAIL → exit 1.
+        result_strict = runner.invoke(
+            cli_main,
+            ["doctor", "--config", str(cfg), "--skip-github", "--strict"],
+        )
+        assert result_strict.exit_code == 1

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -382,7 +382,7 @@ class TestDoctorCLI:
         cfg = _write_config(tmp_path / "config.yml")
         monkeypatch.setenv("GITHUB_TOKEN", "ghs_fake")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake")
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
         result = runner.invoke(
             cli_main,
             ["doctor", "--config", str(cfg), "--skip-github", "--json"],


### PR DESCRIPTION
## Summary

Adds a `caretaker doctor` subcommand that catches configuration gaps *before* any agent boots, and wires a matching `doctor` job into `.github/workflows/maintainer.yml` that gates the main `maintain` job. This is the pre-flight counterpart to the post-hoc scope-gap tracker from #480 — where the tracker collects silent 403s after the fact, `doctor` refuses to run when the token / secrets / services can't support the enabled agent surface.

Motivation: `docs/plans/2026-04-22-fleet-audit.md` P2/M5 flagged fleet runs where entire agents (security, dependabot alerts, etc.) silently swallowed 403s for a whole cycle because nobody checked the workflow token permissions before dispatch.

## Checks

- **Secrets present** — every `*_env` name the effective `MaintainerConfig` references (`mongo.mongodb_url_env`, `redis.redis_url_env`, `fleet_registry.secret_env`, `github_app.private_key_env`, `admin_dashboard.oidc_*`, `graph_store.neo4j_*`, `telemetry.*`, fleet registry OAuth2 triple, plus `ANTHROPIC_API_KEY` when `llm.provider=anthropic`) is looked up in the environment. `FAIL` when the owning block is enabled; `WARN` when disabled (forward-compat for operators staging rollouts). `GITHUB_TOKEN`/`COPILOT_PAT` also checked because `EnvCredentialsProvider` refuses to start without one.
- **GitHub token scopes** — `GET /user` surfaces `X-OAuth-Scopes` for PATs; for installation / fine-grained tokens we probe the handful of endpoints each enabled agent needs (issues, pulls, actions/runs, dependabot/code-scanning/secret-scanning alerts) and treat a `403 Resource not accessible by integration` as a scope miss. Required-scope vocabulary is shared with `caretaker.github_client.scope_gap` so preflight and post-hoc tracker agree.
- **External services reachable** — `mongo` / `redis` / `graph_store` / `fleet_registry` / `admin_dashboard.oidc_issuer_url` each get a short-timeout TCP probe. Unreachable → `WARN` by default, `FAIL` under `--strict`.

## Exit code matrix

| Exit | Meaning                                                     |
|------|-------------------------------------------------------------|
| 0    | No `FAIL` rows. `WARN` rows may still appear.               |
| 1    | At least one `FAIL` — run should be blocked.                |
| 2    | Preflight itself crashed (missing/invalid config, etc.).    |

## Workflow wiring

- New `doctor` job runs after `dispatch-guard` (so we don't spend preflight budget on skipped events), on a 3-minute timeout.
- `maintain` now `needs: [dispatch-guard, doctor]` and only runs when `needs.doctor.outputs.status == 'pass'`.
- `self-heal-on-failure` now gates on `needs.maintain.result == 'failure'` explicitly (not a bare `failure()`) so a `doctor` FAIL — a config problem, not a runtime bug — doesn't fan out into a second caretaker run that would hit the same missing secret.
- The human-readable table is echoed into `$GITHUB_STEP_SUMMARY`; the JSON payload goes to `doctor.json` in the workspace.

## Rollout note

Existing consumer repos won't pick up the workflow change until their `.github/maintainer/.version` pin advances to a release that includes this commit. The CLI change is backward compatible — older consumer workflows continue to call `caretaker run` directly; `doctor` is additive.

## Test plan

- [x] `PYTHONPATH="$PWD/src" pytest -q` — 1211 passed, 1 skipped
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src/caretaker` — only pre-existing `k8s_worker/launcher.py` errors remain
- [x] New `tests/test_doctor.py` covers: env-var reference collection, severity escalation on enabled vs disabled blocks, scope-gap 403 detection, `--strict` promotion, `--json` stdout payload, CLI exit codes, `GITHUB_REPOSITORY` missing warning
- [ ] Staging check — run `caretaker doctor --config .github/maintainer/config.yml` against a real workflow token on a PR branch and confirm the table matches expectation
- [ ] Verify the `doctor` job is visible as a separate step in the maintainer workflow run UI once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)