### PR TITLE
feat(evolution): @shadow_decision decorator + AgenticConfig flags + admin endpoint

### DIFF
--- a/src/caretaker/admin/shadow_api.py
+++ b/src/caretaker/admin/shadow_api.py
@@ -1,0 +1,225 @@
+"""Admin API surface for shadow-mode decisions.
+
+Exposes ``GET /api/admin/shadow/decisions`` so Phase 2 migrations can
+start shipping disagreement data without blocking on the UI PR that
+wires the frontend tab. Reads live Neo4j data when
+:class:`~caretaker.config.GraphStoreConfig` is enabled; otherwise falls
+back to the process-local ring buffer in
+:mod:`caretaker.evolution.shadow` so the endpoint still returns
+something in dev/test.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+
+from caretaker.admin.auth import UserInfo, require_session
+from caretaker.evolution.shadow import ShadowDecisionRecord, recent_records
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin/shadow", tags=["shadow"])
+
+
+# ── Module-level wiring (configured at startup) ──────────────────────────
+#
+# ``_graph_store`` is the live Neo4j ``GraphStore`` when the graph
+# backend is enabled; ``None`` means we are running in dev fallback
+# mode and the ring-buffer path should be used.
+
+_graph_store: Any | None = None
+
+
+def configure(graph_store: Any | None) -> None:
+    """Install the graph store used for live Neo4j reads.
+
+    Pass ``None`` to clear (tests / graph-disabled deployments). The
+    parameter type is ``Any`` so unit tests can pass a minimal fake
+    without importing :mod:`caretaker.graph.store`.
+    """
+    global _graph_store  # noqa: PLW0603 — process singleton.
+    _graph_store = graph_store
+
+
+# ── Response schema ──────────────────────────────────────────────────────
+
+
+class ShadowDecisionRow(BaseModel):
+    """One row of the ``/shadow/decisions`` response.
+
+    Mirrors :class:`ShadowDecisionRecord` but normalises
+    ``candidate_verdict_json`` so the empty-string Neo4j encoding maps
+    back to ``None`` — clients should never have to special-case the
+    backend storage layer.
+    """
+
+    id: str
+    name: str
+    repo_slug: str
+    run_at: datetime
+    outcome: str
+    mode: str
+    legacy_verdict_json: str
+    candidate_verdict_json: str | None
+    disagreement_reason: str | None
+    context_json: str
+
+    @classmethod
+    def from_record(cls, rec: ShadowDecisionRecord) -> ShadowDecisionRow:
+        return cls(
+            id=rec.id,
+            name=rec.name,
+            repo_slug=rec.repo_slug,
+            run_at=rec.run_at,
+            outcome=rec.outcome,
+            mode=rec.mode,
+            legacy_verdict_json=rec.legacy_verdict_json,
+            candidate_verdict_json=rec.candidate_verdict_json,
+            disagreement_reason=rec.disagreement_reason,
+            context_json=rec.context_json,
+        )
+
+
+class ShadowDecisionsResponse(BaseModel):
+    """Payload returned by ``GET /api/admin/shadow/decisions``."""
+
+    items: list[ShadowDecisionRow] = Field(default_factory=list)
+    agreement_rate: float = Field(
+        default=1.0,
+        description=(
+            "Fraction of returned items where the two paths agreed. "
+            "Defined as agree / (agree + disagree); ``candidate_error`` "
+            "rows are excluded. When the denominator is zero (nothing to "
+            "compare), the rate is 1.0 by convention."
+        ),
+    )
+    source: str = Field(
+        description="Which backend produced the data: ``neo4j`` or ``ring_buffer``.",
+    )
+
+
+# ── Cypher read path ─────────────────────────────────────────────────────
+
+
+_CYPHER_LIST = (
+    "MATCH (s:ShadowDecision) "
+    "WHERE ($name IS NULL OR s.name = $name) "
+    "  AND ($since IS NULL OR s.run_at >= $since) "
+    "RETURN s "
+    "ORDER BY s.run_at DESC "
+    "LIMIT $limit"
+)
+
+
+async def _read_from_neo4j(
+    *, name: str | None, since: str | None, limit: int
+) -> list[ShadowDecisionRow]:
+    """Query Neo4j for the most recent ``:ShadowDecision`` nodes.
+
+    ``since`` is passed through as an ISO-8601 string so Neo4j can do
+    lexicographic comparisons against the ``run_at`` property without
+    requiring a datetime type coercion on both ends.
+    """
+    assert _graph_store is not None  # caller guarantees
+    # Use the same ``session`` pattern as :class:`GraphStore`.
+    async with _graph_store._driver.session(database=_graph_store._database) as session:
+        result = await session.run(_CYPHER_LIST, name=name, since=since, limit=limit)
+        rows: list[ShadowDecisionRow] = []
+        async for record in result:
+            node = record["s"]
+            props = dict(node)
+            try:
+                run_at = datetime.fromisoformat(props["run_at"])
+            except (KeyError, ValueError):
+                # Skip malformed nodes rather than 500 the whole request.
+                continue
+            candidate = props.get("candidate_verdict_json") or None
+            reason = props.get("disagreement_reason") or None
+            rows.append(
+                ShadowDecisionRow(
+                    id=str(props.get("id", "")),
+                    name=str(props.get("name", "")),
+                    repo_slug=str(props.get("repo_slug", "")),
+                    run_at=run_at,
+                    outcome=str(props.get("outcome", "")),
+                    mode=str(props.get("mode", "")),
+                    legacy_verdict_json=str(props.get("legacy_verdict_json", "")),
+                    candidate_verdict_json=candidate,
+                    disagreement_reason=reason,
+                    context_json=str(props.get("context_json", "{}")),
+                )
+            )
+        return rows
+
+
+# ── Public endpoint ──────────────────────────────────────────────────────
+
+
+def _compute_agreement_rate(rows: list[ShadowDecisionRow]) -> float:
+    agree = sum(1 for r in rows if r.outcome == "agree")
+    disagree = sum(1 for r in rows if r.outcome == "disagree")
+    denom = agree + disagree
+    if denom == 0:
+        return 1.0
+    return agree / denom
+
+
+@router.get("/decisions", response_model=ShadowDecisionsResponse)
+async def list_shadow_decisions(
+    name: str | None = Query(
+        default=None,
+        description="Optional decision-site filter (e.g. ``readiness``).",
+    ),
+    since: datetime | None = Query(
+        default=None,
+        description="ISO-8601 lower bound on ``run_at`` (tz-aware).",
+    ),
+    limit: int = Query(default=100, ge=1, le=1000),
+    _user: UserInfo = Depends(require_session),
+) -> ShadowDecisionsResponse:
+    """Return the most-recent shadow-mode decisions.
+
+    Reads Neo4j when the graph backend is wired, otherwise falls back
+    to the process-local ring buffer so the UI has something to render
+    in dev.
+    """
+    # Normalise tz — Neo4j comparisons are string-level, so we want
+    # ISO-8601 UTC on the way in.
+    if since is not None and since.tzinfo is None:
+        since = since.replace(tzinfo=UTC)
+
+    if _graph_store is not None:
+        since_str = since.isoformat() if since is not None else None
+        try:
+            rows = await _read_from_neo4j(name=name, since=since_str, limit=limit)
+            return ShadowDecisionsResponse(
+                items=rows,
+                agreement_rate=_compute_agreement_rate(rows),
+                source="neo4j",
+            )
+        except Exception as exc:  # noqa: BLE001 — never 500 the admin UI
+            logger.warning(
+                "Neo4j read failed for shadow decisions, falling back to ring buffer: %s",
+                exc,
+            )
+
+    records = recent_records(name=name, since=since, limit=limit)
+    rows = [ShadowDecisionRow.from_record(r) for r in records]
+    return ShadowDecisionsResponse(
+        items=rows,
+        agreement_rate=_compute_agreement_rate(rows),
+        source="ring_buffer",
+    )
+
+
+__all__ = [
+    "ShadowDecisionRow",
+    "ShadowDecisionsResponse",
+    "configure",
+    "router",
+]

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -825,6 +825,47 @@ class ExecutorConfig(StrictBaseModel):
     k8s_worker: K8sAgentWorkerConfig = Field(default_factory=K8sAgentWorkerConfig)
 
 
+class AgenticDomainConfig(StrictBaseModel):
+    """Per-decision-site knobs for the Phase 2 agentic migration.
+
+    The ``mode`` field is the three-way switch consumed by
+    :func:`caretaker.evolution.shadow.shadow_decision`:
+
+    * ``off`` — classic heuristic is authoritative; LLM path never runs.
+    * ``shadow`` — both paths run, legacy verdict returned, disagreements
+      logged.
+    * ``enforce`` — LLM candidate is authoritative, legacy is the
+      fall-through safety net.
+
+    Additional per-domain knobs (thresholds, sampling, per-feature model
+    overrides) can be added here later without breaking callers; every
+    decision site gets its own :class:`AgenticDomainConfig` instance on
+    :class:`AgenticConfig` so the knobs fan out cleanly.
+    """
+
+    mode: Literal["off", "shadow", "enforce"] = "off"
+
+
+class AgenticConfig(StrictBaseModel):
+    """Flags for the Phase 2 LLM decision migrations.
+
+    Every field defaults to ``mode="off"`` so classic heuristics stay
+    authoritative until operators explicitly opt in. The full list
+    matches §3 of the 2026-Q2 agentic migration plan.
+    """
+
+    readiness: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    ci_triage: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    review_classification: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    issue_triage: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    cascade: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    stuck_pr: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    bot_identity: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    dispatch_guard: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    executor_routing: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    crystallizer_category: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+
+
 class MaintainerConfig(StrictBaseModel):
     version: Literal["v1"] = "v1"
     orchestrator: OrchestratorConfig = Field(default_factory=OrchestratorConfig)
@@ -866,6 +907,7 @@ class MaintainerConfig(StrictBaseModel):
     github_app: GitHubAppConfig = Field(default_factory=GitHubAppConfig)
     admin_dashboard: AdminDashboardConfig = Field(default_factory=AdminDashboardConfig)
     graph_store: GraphStoreConfig = Field(default_factory=GraphStoreConfig)
+    agentic: AgenticConfig = Field(default_factory=AgenticConfig)
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> MaintainerConfig:

--- a/src/caretaker/evolution/__init__.py
+++ b/src/caretaker/evolution/__init__.py
@@ -1,9 +1,24 @@
 """Evolution layer — learn-and-adapt subsystem for caretaker.
 
 Provides InsightStore (skill memory), ReflectionEngine, StrategyMutator,
-PlanMode, and AgentFileEvolver to close the learn-and-adapt gap.
+PlanMode, AgentFileEvolver to close the learn-and-adapt gap, plus the
+Phase-2 ``@shadow_decision`` infrastructure that lets LLM handovers
+run side-by-side with existing heuristics.
 """
 
 from caretaker.evolution.insight_store import InsightStore, Skill
+from caretaker.evolution.shadow import (
+    ShadowDecisionRecord,
+    ShadowMode,
+    ShadowOutcome,
+    shadow_decision,
+)
 
-__all__ = ["InsightStore", "Skill"]
+__all__ = [
+    "InsightStore",
+    "ShadowDecisionRecord",
+    "ShadowMode",
+    "ShadowOutcome",
+    "Skill",
+    "shadow_decision",
+]

--- a/src/caretaker/evolution/shadow.py
+++ b/src/caretaker/evolution/shadow.py
@@ -1,0 +1,519 @@
+"""Shadow-mode infrastructure for Phase 2 LLM decision migrations.
+
+This module exists so every Phase 2 LLM handover (readiness, CI triage,
+review classification, issue triage, cascade cleanup, stuck-PR detection,
+bot identity, dispatch guard, executor routing, crystallizer category)
+can be rolled out behind a uniform three-mode switch:
+
+* ``off`` — the classic heuristic is the sole authority; the LLM path
+  is never even called.
+* ``shadow`` — both paths execute side-by-side. The legacy verdict is
+  always returned to the caller (so behaviour is unchanged), but when
+  the two verdicts disagree we persist a :class:`ShadowDecisionRecord`
+  so operators can inspect the disagreement rate before flipping
+  authority.
+* ``enforce`` — the candidate is authoritative. Legacy runs only as a
+  safety net when the candidate errors or returns ``None``.
+
+The public surface is small by design:
+
+* :func:`shadow_decision` — the decorator call sites use.
+* :class:`ShadowDecisionRecord` — the pydantic model persisted to
+  Neo4j / the in-memory ring-buffer / the log fallback.
+* :func:`recent_records` / :func:`clear_records_for_tests` — the
+  in-memory ring buffer used by the admin endpoint and tests.
+
+Concurrent-caller-safety: the ring-buffer and counters are guarded by
+module-level :class:`threading.Lock` so multiple request handlers
+emitting shadow records in parallel do not corrupt each other's state.
+The Neo4j write path piggy-backs on
+:class:`caretaker.graph.writer.GraphWriter`, which already serialises
+writes through its own background drain task, so we do not need a
+second lock there.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import json
+import logging
+import threading
+import uuid
+from collections import deque
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from prometheus_client import Counter
+from pydantic import BaseModel, ConfigDict, Field
+
+from caretaker.observability.metrics import REGISTRY, get_service_label
+
+logger = logging.getLogger(__name__)
+
+
+# ── Types ────────────────────────────────────────────────────────────────
+
+T = TypeVar("T")
+
+ShadowMode = Literal["off", "shadow", "enforce"]
+"""One of the three supported modes.
+
+Kept as a :data:`Literal` alias (rather than a :class:`StrEnum`) so the
+config surface can reuse the identical string literal without a second
+type marshalling step."""
+
+ShadowOutcome = Literal[
+    "agree",
+    "disagree",
+    "candidate_error",
+    "legacy_only",
+    "enforced_candidate",
+]
+"""The five outcomes surfaced to Prometheus + the :class:`ShadowDecisionRecord`.
+
+* ``agree`` / ``disagree`` — both paths ran, the legacy verdict was
+  returned, and the comparison agreed/disagreed.
+* ``candidate_error`` — candidate raised; legacy verdict returned.
+* ``legacy_only`` — ``mode == "off"`` so only legacy ran. No record
+  is written for this outcome (see :func:`_should_persist`); the
+  counter exists purely so dashboards can prove the mode switch is
+  live.
+* ``enforced_candidate`` — ``mode == "enforce"`` and the candidate
+  succeeded; no legacy comparison happened.
+"""
+
+
+# ── Prometheus counter ───────────────────────────────────────────────────
+#
+# Cardinality analysis: ``name`` is a bounded enum governed by
+# :class:`~caretaker.config.AgenticConfig`'s fields (currently 10);
+# ``mode`` is 3; ``outcome`` is 5. Upper bound: 150 series, well under
+# the cardinality budget in the Prometheus SKILL.
+
+SHADOW_DECISIONS_TOTAL = Counter(
+    "caretaker_shadow_decisions_total",
+    "Total shadow-mode decisions executed per (name, mode, outcome).",
+    ["name", "mode", "outcome"],
+    registry=REGISTRY,
+)
+
+
+# ── Ring buffer + record model ───────────────────────────────────────────
+
+_MAX_RECORDS = 1000
+
+_records_lock = threading.Lock()
+_records: deque[ShadowDecisionRecord] = deque(maxlen=_MAX_RECORDS)
+
+
+class ShadowDecisionRecord(BaseModel):
+    """A single shadow-mode decision, persisted to Neo4j or logs.
+
+    Matches the ``:ShadowDecision`` node schema in §4.5 of the
+    2026-Q2 agentic migration plan. The JSON-serialised verdict fields
+    keep the node property set scalar-only, which is both Neo4j-friendly
+    and keeps the Prometheus label set small.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        description=(
+            "Stable unique id so the Neo4j node can be MERGE'd without "
+            "writing the same record twice. Generated when the record is "
+            "built, so even a transient Neo4j outage that forces a fall-"
+            "through to the log path produces a record reconstructable "
+            "from logs alone."
+        )
+    )
+    name: str = Field(description="Decision site name (matches AgenticConfig field).")
+    repo_slug: str = Field(
+        default="",
+        description=(
+            "Best-effort ``owner/repo`` attribution. Callers pass this in "
+            "via the ``context`` dict under the ``repo_slug`` key; empty "
+            "string when unknown."
+        ),
+    )
+    run_at: datetime = Field(description="When the shadow decision was made (tz-aware UTC).")
+    outcome: ShadowOutcome = Field(
+        description="Comparison outcome. ``legacy_only`` is filtered out before persisting.",
+    )
+    mode: ShadowMode = Field(description="The mode that was active when the decision ran.")
+    legacy_verdict_json: str = Field(
+        description="JSON-serialised legacy verdict. Always populated.",
+    )
+    candidate_verdict_json: str | None = Field(
+        default=None,
+        description="JSON-serialised candidate verdict, or ``None`` on candidate_error.",
+    )
+    disagreement_reason: str | None = Field(
+        default=None,
+        description="One-line human summary of the disagreement, if known.",
+    )
+    context_json: str = Field(
+        default="{}",
+        description="JSON-serialised caller context (repo, pr number, etc.).",
+    )
+
+
+# ── Graph-store write helper ─────────────────────────────────────────────
+
+
+def write_shadow_decision(record: ShadowDecisionRecord) -> None:
+    """Persist one ``:ShadowDecision`` record.
+
+    Single code path that chooses Neo4j vs a structured log line based on
+    whether :class:`~caretaker.graph.writer.GraphWriter` is enabled. The
+    record must be reconstructable from the log line alone, so every
+    field is emitted — truncated or not — in a stable ``shadow_decision``
+    event body.
+
+    Also appends to the in-memory ring buffer regardless of the backend:
+    the admin endpoint uses the ring as the dev-mode fallback and tests
+    assert on it without needing a live Neo4j.
+    """
+    # Ring buffer first: that is what the admin endpoint reads in dev,
+    # and it is the only path that is always on.
+    with _records_lock:
+        _records.append(record)
+
+    # Graph writer: no-op when Neo4j is not configured.
+    from caretaker.graph.writer import get_writer
+
+    writer = get_writer()
+    properties: dict[str, Any] = {
+        "name": record.name,
+        "repo_slug": record.repo_slug,
+        "run_at": record.run_at.isoformat(),
+        "outcome": record.outcome,
+        "mode": record.mode,
+        "legacy_verdict_json": record.legacy_verdict_json,
+        "candidate_verdict_json": record.candidate_verdict_json or "",
+        "disagreement_reason": record.disagreement_reason or "",
+        "context_json": record.context_json,
+    }
+    stats = writer.stats()
+    if stats.get("enabled"):
+        writer.record_node("ShadowDecision", record.id, properties)
+    else:
+        # Structured log line — reconstructable. The ``event`` key is how
+        # the log pipeline routes it; downstream tooling can pick up any
+        # record by ``id`` alone.
+        logger.info(
+            "shadow_decision event=shadow_decision id=%s name=%s outcome=%s "
+            "mode=%s repo=%s payload=%s",
+            record.id,
+            record.name,
+            record.outcome,
+            record.mode,
+            record.repo_slug,
+            json.dumps(properties, default=str, sort_keys=True),
+        )
+
+
+def recent_records(
+    *, name: str | None = None, since: datetime | None = None, limit: int = 100
+) -> list[ShadowDecisionRecord]:
+    """Return the most-recent shadow-decision records (newest-first).
+
+    Reads the in-memory ring buffer; used by the admin endpoint's dev
+    fallback path when Neo4j is disabled.
+    """
+    with _records_lock:
+        snapshot = list(_records)
+    # Newest-first; deque is append-right so reverse.
+    filtered: list[ShadowDecisionRecord] = []
+    for rec in reversed(snapshot):
+        if name is not None and rec.name != name:
+            continue
+        if since is not None and rec.run_at < since:
+            continue
+        filtered.append(rec)
+        if len(filtered) >= limit:
+            break
+    return filtered
+
+
+def clear_records_for_tests() -> None:
+    """Drop the in-memory ring buffer. Used by tests between cases."""
+    with _records_lock:
+        _records.clear()
+
+
+# ── Decorator ────────────────────────────────────────────────────────────
+#
+# The decorator wraps an async function with the signature
+#
+#     async def decide(*args, legacy, candidate, **kwargs) -> T:
+#
+# and returns a same-signature callable that dispatches on
+# ``config.agentic.<name>.mode``. Callers provide both implementations
+# explicitly — no global registry — so migrations can be done in a
+# single PR without a cross-module import spaghetti.
+
+
+# Callables the decorator dispatches through. Typed as ``Any`` because
+# call sites hand in implementations with business-specific signatures
+# that vary per decision site — a Protocol would impose more structure
+# than the runtime needs and ``Any`` keeps call sites from fighting the
+# type checker.
+_LegacyFn = Callable[..., Any]
+_CandidateFn = Callable[..., Any]
+
+
+def _resolve_mode(name: str) -> ShadowMode:
+    """Resolve the currently configured mode for ``name``.
+
+    Uses :func:`caretaker.evolution.shadow_config.get_active_config` which
+    caretaker wires at orchestrator startup. Falls back to ``"off"`` when
+    no config is installed, which matches the default-safe behaviour of
+    every other Phase 2 knob: unconfigured means classic heuristics
+    stay authoritative.
+    """
+    from caretaker.evolution import shadow_config
+
+    cfg = shadow_config.get_active_config()
+    if cfg is None:
+        return "off"
+    domain = getattr(cfg, name, None)
+    if domain is None:
+        return "off"
+    mode = getattr(domain, "mode", "off")
+    if mode not in ("off", "shadow", "enforce"):
+        return "off"
+    return cast("ShadowMode", mode)
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Await ``value`` if it is awaitable, otherwise return it unchanged."""
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _serialise_verdict(verdict: Any) -> str:
+    """Best-effort JSON serialisation for a verdict (pydantic-aware)."""
+    if verdict is None:
+        return "null"
+    if isinstance(verdict, BaseModel):
+        return verdict.model_dump_json()
+    try:
+        return json.dumps(verdict, default=str, sort_keys=True)
+    except (TypeError, ValueError):
+        # Fall back to ``repr`` — the audit trail is more important than
+        # perfect JSON. The record is still reconstructable from logs.
+        return json.dumps({"repr": repr(verdict)})
+
+
+def _serialise_context(context: dict[str, Any] | None) -> str:
+    if not context:
+        return "{}"
+    try:
+        return json.dumps(context, default=str, sort_keys=True)
+    except (TypeError, ValueError):
+        return json.dumps({"repr": repr(context)})
+
+
+def _default_compare(a: Any, b: Any) -> bool:
+    try:
+        return bool(a == b)
+    except Exception:  # noqa: BLE001 — exotic __eq__ that raises
+        return False
+
+
+def shadow_decision(
+    name: str,
+    *,
+    compare: Callable[[Any, Any], bool] | None = None,
+) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
+    """Decorate a decision site to run legacy + candidate side-by-side.
+
+    The decorated function must be ``async`` and must accept ``legacy``
+    and ``candidate`` keyword-only (or keyword-passable) arguments so
+    call sites are the ones supplying both implementations. The
+    decorator itself never imports anything from the caller's module.
+
+    Parameters
+    ----------
+    name:
+        Matches an :class:`~caretaker.config.AgenticDomainConfig` field
+        on :class:`~caretaker.config.AgenticConfig`. The mode comes from
+        ``config.agentic.<name>.mode`` — unknown names silently default
+        to ``off``.
+    compare:
+        Predicate used to decide whether two verdicts agree. Defaults to
+        ``==``. Provide a custom one when verdicts carry noisy fields
+        (e.g. timestamps, rationale strings) that should not count as
+        disagreements.
+
+    The decorator always returns the legacy verdict in ``shadow`` mode
+    so the existing behaviour is byte-identical to the non-migrated
+    world. Candidate errors in ``shadow`` mode are swallowed and
+    recorded; the legacy path is never affected by a candidate failure.
+    """
+    compare_fn = compare or _default_compare
+
+    def decorator(
+        func: Callable[..., Awaitable[T]],
+    ) -> Callable[..., Awaitable[T]]:
+        if not inspect.iscoroutinefunction(func):
+            raise TypeError(f"@shadow_decision requires an async function; got {func!r}.")
+
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> T:
+            legacy: _LegacyFn | None = kwargs.pop("legacy", None)
+            candidate: _CandidateFn | None = kwargs.pop("candidate", None)
+            # ``context`` is a control-plane kwarg used only to attribute
+            # the record; it is *not* forwarded to the legacy / candidate
+            # callables. Use ``pop`` so the downstream functions don't
+            # see an unexpected keyword.
+            context = kwargs.pop("context", None)
+            if legacy is None or candidate is None:
+                raise TypeError(
+                    "@shadow_decision-wrapped callable must be invoked with "
+                    "'legacy' and 'candidate' keyword arguments."
+                )
+
+            mode = _resolve_mode(name)
+            # ``service`` is captured for metric label consistency but is
+            # not used here; the Counter already pins the label set and
+            # standard ``logging`` would reject an ``extra={"name": ...}``
+            # kwarg because ``name`` is a reserved :class:`LogRecord`
+            # attribute.
+            _ = get_service_label()
+
+            # ── off ────────────────────────────────────────────────
+            if mode == "off":
+                SHADOW_DECISIONS_TOTAL.labels(name=name, mode=mode, outcome="legacy_only").inc()
+                return cast("T", await _maybe_await(legacy(*args, **kwargs)))
+
+            # ── enforce ────────────────────────────────────────────
+            if mode == "enforce":
+                try:
+                    candidate_result = await _maybe_await(candidate(*args, **kwargs))
+                except Exception as exc:  # noqa: BLE001 — enforce must fall through
+                    logger.warning(
+                        "shadow_decision enforce: candidate raised for name=%s; "
+                        "falling through to legacy (%s: %s)",
+                        name,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    SHADOW_DECISIONS_TOTAL.labels(
+                        name=name, mode=mode, outcome="candidate_error"
+                    ).inc()
+                    return cast("T", await _maybe_await(legacy(*args, **kwargs)))
+
+                if candidate_result is None:
+                    logger.warning(
+                        "shadow_decision enforce: candidate returned None for "
+                        "name=%s; falling through to legacy",
+                        name,
+                    )
+                    SHADOW_DECISIONS_TOTAL.labels(
+                        name=name, mode=mode, outcome="candidate_error"
+                    ).inc()
+                    return cast("T", await _maybe_await(legacy(*args, **kwargs)))
+
+                SHADOW_DECISIONS_TOTAL.labels(
+                    name=name, mode=mode, outcome="enforced_candidate"
+                ).inc()
+                return cast("T", candidate_result)
+
+            # ── shadow ─────────────────────────────────────────────
+            # Legacy first so a candidate failure never blocks the hot path.
+            legacy_result = await _maybe_await(legacy(*args, **kwargs))
+
+            candidate_verdict: Any = None
+            candidate_error: BaseException | None = None
+            try:
+                candidate_verdict = await _maybe_await(candidate(*args, **kwargs))
+            except Exception as exc:  # noqa: BLE001 — shadow must swallow
+                candidate_error = exc
+
+            now = datetime.now(UTC)
+            repo_slug = ""
+            if isinstance(context, dict):
+                raw_repo = context.get("repo_slug", "")
+                repo_slug = str(raw_repo) if raw_repo is not None else ""
+
+            ctx_dict = context if isinstance(context, dict) else None
+
+            if candidate_error is not None:
+                err_reason = f"candidate_error: {type(candidate_error).__name__}: {candidate_error}"
+                err_record = ShadowDecisionRecord(
+                    id=str(uuid.uuid4()),
+                    name=name,
+                    repo_slug=repo_slug,
+                    run_at=now,
+                    outcome="candidate_error",
+                    mode=mode,
+                    legacy_verdict_json=_serialise_verdict(legacy_result),
+                    candidate_verdict_json=None,
+                    disagreement_reason=err_reason,
+                    context_json=_serialise_context(ctx_dict),
+                )
+                write_shadow_decision(err_record)
+                SHADOW_DECISIONS_TOTAL.labels(name=name, mode=mode, outcome="candidate_error").inc()
+                return cast("T", legacy_result)
+
+            agreed = compare_fn(legacy_result, candidate_verdict)
+            outcome: ShadowOutcome = "agree" if agreed else "disagree"
+            reason: str | None = (
+                None
+                if agreed
+                else (
+                    f"legacy={_short_repr(legacy_result)} "
+                    f"!= candidate={_short_repr(candidate_verdict)}"
+                )
+            )
+            record = ShadowDecisionRecord(
+                id=str(uuid.uuid4()),
+                name=name,
+                repo_slug=repo_slug,
+                run_at=now,
+                outcome=outcome,
+                mode=mode,
+                legacy_verdict_json=_serialise_verdict(legacy_result),
+                candidate_verdict_json=_serialise_verdict(candidate_verdict),
+                disagreement_reason=reason,
+                context_json=_serialise_context(ctx_dict),
+            )
+            write_shadow_decision(record)
+            SHADOW_DECISIONS_TOTAL.labels(name=name, mode=mode, outcome=outcome).inc()
+            return cast("T", legacy_result)
+
+        return wrapper
+
+    return decorator
+
+
+def _short_repr(value: Any, *, limit: int = 120) -> str:
+    """Truncate a ``repr`` so a disagreement reason fits in one log line."""
+    try:
+        text = repr(value)
+    except Exception:  # noqa: BLE001
+        text = f"<unreprable {type(value).__name__}>"
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+__all__ = [
+    "SHADOW_DECISIONS_TOTAL",
+    "ShadowDecisionRecord",
+    "ShadowMode",
+    "ShadowOutcome",
+    "clear_records_for_tests",
+    "recent_records",
+    "shadow_decision",
+    "write_shadow_decision",
+]

--- a/src/caretaker/evolution/shadow_config.py
+++ b/src/caretaker/evolution/shadow_config.py
@@ -1,0 +1,57 @@
+"""Process-wide :class:`AgenticConfig` resolver for the shadow decorator.
+
+The decorator in :mod:`caretaker.evolution.shadow` needs to know the
+current mode (``off`` / ``shadow`` / ``enforce``) per decision name at
+call time, but it must not pull a MaintainerConfig instance through
+every wrapped signature — call sites are existing heuristics and
+changing each signature would be invasive.
+
+The pattern mirrors :class:`~caretaker.graph.writer.GraphWriter`:
+the orchestrator / admin backend calls :func:`configure` once at
+startup with the loaded config, and the decorator reads from the
+module-level cache. Tests use :func:`configure` and
+:func:`reset_for_tests` to set and clear the override without side-
+effects.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from caretaker.config import AgenticConfig
+
+_lock = threading.Lock()
+_active: AgenticConfig | None = None
+
+
+def configure(config: AgenticConfig) -> None:
+    """Install the active :class:`AgenticConfig`.
+
+    Called from :class:`~caretaker.orchestrator.Orchestrator` startup
+    and from the FastAPI lifespan hook in the admin backend. Idempotent.
+    """
+    global _active  # noqa: PLW0603 — process singleton.
+    with _lock:
+        _active = config
+
+
+def get_active_config() -> AgenticConfig | None:
+    """Return the installed config, or ``None`` when uncofigured.
+
+    The decorator treats ``None`` as equivalent to every mode being
+    ``off`` so import-order during tests does not matter.
+    """
+    with _lock:
+        return _active
+
+
+def reset_for_tests() -> None:
+    """Clear the active config. Used by test fixtures."""
+    global _active  # noqa: PLW0603 — process singleton.
+    with _lock:
+        _active = None
+
+
+__all__ = ["configure", "get_active_config", "reset_for_tests"]

--- a/tests/test_shadow_admin_api.py
+++ b/tests/test_shadow_admin_api.py
@@ -1,0 +1,200 @@
+"""Tests for ``GET /api/admin/shadow/decisions``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from caretaker.admin import auth as admin_auth
+from caretaker.admin import shadow_api
+from caretaker.evolution.shadow import (
+    ShadowDecisionRecord,
+    clear_records_for_tests,
+    write_shadow_decision,
+)
+from caretaker.graph import writer as graph_writer
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state() -> None:
+    clear_records_for_tests()
+    graph_writer.reset_for_tests()
+    shadow_api.configure(None)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(shadow_api.router)
+
+    async def _fake_user() -> admin_auth.UserInfo:
+        return admin_auth.UserInfo(sub="u", email="u@example.com", name="U", picture=None)
+
+    app.dependency_overrides[admin_auth.require_session] = _fake_user
+    return TestClient(app)
+
+
+def _record(
+    *,
+    rid: str = "rec-1",
+    name: str = "readiness",
+    outcome: str = "agree",
+    repo_slug: str = "ian/demo",
+    minutes_ago: int = 0,
+) -> ShadowDecisionRecord:
+    return ShadowDecisionRecord(
+        id=rid,
+        name=name,
+        repo_slug=repo_slug,
+        run_at=datetime.now(UTC) - timedelta(minutes=minutes_ago),
+        outcome=outcome,  # type: ignore[arg-type]
+        mode="shadow",
+        legacy_verdict_json='{"v": 1}',
+        candidate_verdict_json='{"v": 2}' if outcome == "disagree" else '{"v": 1}',
+        disagreement_reason="mismatch" if outcome == "disagree" else None,
+        context_json='{"pr": 1}',
+    )
+
+
+class TestShadowAdminAPI:
+    def test_ring_buffer_fallback_empty(self, client: TestClient) -> None:
+        resp = client.get("/api/admin/shadow/decisions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"] == []
+        assert data["agreement_rate"] == 1.0
+        assert data["source"] == "ring_buffer"
+
+    def test_ring_buffer_returns_newest_first(self, client: TestClient) -> None:
+        write_shadow_decision(_record(rid="old", minutes_ago=10))
+        write_shadow_decision(_record(rid="new", minutes_ago=0))
+
+        resp = client.get("/api/admin/shadow/decisions")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert [i["id"] for i in items] == ["new", "old"]
+
+    def test_name_filter(self, client: TestClient) -> None:
+        write_shadow_decision(_record(rid="a", name="readiness"))
+        write_shadow_decision(_record(rid="b", name="ci_triage"))
+
+        resp = client.get("/api/admin/shadow/decisions?name=ci_triage")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert [i["id"] for i in items] == ["b"]
+
+    def test_since_filter(self, client: TestClient) -> None:
+        write_shadow_decision(_record(rid="old", minutes_ago=60))
+        write_shadow_decision(_record(rid="recent", minutes_ago=1))
+
+        cutoff = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+        # Pass via ``params`` so the ``+00:00`` suffix gets URL-encoded
+        # instead of surfacing as a literal space.
+        resp = client.get("/api/admin/shadow/decisions", params={"since": cutoff})
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert [i["id"] for i in items] == ["recent"]
+
+    def test_agreement_rate_mixed(self, client: TestClient) -> None:
+        write_shadow_decision(_record(rid="a1", outcome="agree"))
+        write_shadow_decision(_record(rid="a2", outcome="agree"))
+        write_shadow_decision(_record(rid="a3", outcome="agree"))
+        write_shadow_decision(_record(rid="d1", outcome="disagree"))
+        # candidate_error rows must be excluded from the denominator.
+        write_shadow_decision(_record(rid="e1", outcome="candidate_error"))
+
+        resp = client.get("/api/admin/shadow/decisions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["agreement_rate"] == pytest.approx(0.75)
+
+    def test_limit_capped(self, client: TestClient) -> None:
+        for i in range(10):
+            write_shadow_decision(_record(rid=f"r{i}"))
+        resp = client.get("/api/admin/shadow/decisions?limit=3")
+        assert resp.status_code == 200
+        assert len(resp.json()["items"]) == 3
+
+    def test_neo4j_backend_used_when_configured(self, client: TestClient) -> None:
+        class _FakeSession:
+            def __init__(self, rows: list[dict[str, Any]]) -> None:
+                self._rows = rows
+
+            async def __aenter__(self) -> _FakeSession:
+                return self
+
+            async def __aexit__(self, *exc: object) -> None:
+                return None
+
+            async def run(self, query: str, **params: Any) -> _FakeResult:  # noqa: ARG002
+                return _FakeResult(self._rows)
+
+        class _FakeResult:
+            def __init__(self, rows: list[dict[str, Any]]) -> None:
+                self._rows = rows
+
+            def __aiter__(self) -> _FakeResult:
+                self._iter = iter(self._rows)
+                return self
+
+            async def __anext__(self) -> dict[str, Any]:
+                try:
+                    return next(self._iter)
+                except StopIteration as exc:
+                    raise StopAsyncIteration from exc
+
+        class _FakeDriver:
+            def __init__(self, rows: list[dict[str, Any]]) -> None:
+                self._rows = rows
+
+            def session(self, *, database: str) -> _FakeSession:  # noqa: ARG002
+                return _FakeSession(self._rows)
+
+        class _FakeGraphStore:
+            def __init__(self, rows: list[dict[str, Any]]) -> None:
+                self._driver = _FakeDriver(rows)
+                self._database = "caretaker"
+
+        now = datetime.now(UTC).isoformat()
+        rows = [
+            {
+                "s": {
+                    "id": "node-1",
+                    "name": "readiness",
+                    "repo_slug": "ian/demo",
+                    "run_at": now,
+                    "outcome": "disagree",
+                    "mode": "shadow",
+                    "legacy_verdict_json": '{"ready": true}',
+                    "candidate_verdict_json": '{"ready": false}',
+                    "disagreement_reason": "verdict mismatch",
+                    "context_json": '{"pr": 1}',
+                }
+            },
+        ]
+        shadow_api.configure(_FakeGraphStore(rows))
+
+        resp = client.get("/api/admin/shadow/decisions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"] == "neo4j"
+        assert len(data["items"]) == 1
+        assert data["items"][0]["id"] == "node-1"
+        assert data["items"][0]["outcome"] == "disagree"
+        # agreement_rate over one disagreement = 0.
+        assert data["agreement_rate"] == 0.0
+
+    def test_requires_authenticated_session(self) -> None:
+        """Endpoint is protected by ``require_session`` (no override → 401)."""
+        app = FastAPI()
+        app.include_router(shadow_api.router)
+        # No dependency override — require_session fires and should 401.
+        # But the underlying helper needs _signer/_redis; when those are
+        # not configured, require_session raises 401 before getting there.
+        client = TestClient(app)
+        resp = client.get("/api/admin/shadow/decisions")
+        assert resp.status_code == 401

--- a/tests/test_shadow_config.py
+++ b/tests/test_shadow_config.py
@@ -1,0 +1,93 @@
+"""Tests for ``AgenticConfig`` + YAML round-trip."""
+
+from __future__ import annotations
+
+import tempfile
+
+from caretaker.config import AgenticConfig, AgenticDomainConfig, MaintainerConfig
+
+
+class TestAgenticConfigDefaults:
+    def test_every_domain_defaults_to_off(self) -> None:
+        cfg = AgenticConfig()
+        domains = (
+            "readiness",
+            "ci_triage",
+            "review_classification",
+            "issue_triage",
+            "cascade",
+            "stuck_pr",
+            "bot_identity",
+            "dispatch_guard",
+            "executor_routing",
+            "crystallizer_category",
+        )
+        for name in domains:
+            domain = getattr(cfg, name)
+            assert isinstance(domain, AgenticDomainConfig)
+            assert domain.mode == "off"
+
+    def test_maintainer_config_embeds_agentic(self) -> None:
+        cfg = MaintainerConfig()
+        assert cfg.agentic.readiness.mode == "off"
+        assert cfg.agentic.crystallizer_category.mode == "off"
+
+
+class TestAgenticConfigYAMLRoundTrip:
+    def test_readiness_shadow_loads(self) -> None:
+        yaml_content = """
+version: v1
+agentic:
+  readiness:
+    mode: shadow
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            cfg = MaintainerConfig.from_yaml(f.name)
+
+        assert cfg.agentic.readiness.mode == "shadow"
+        # Other domains untouched.
+        assert cfg.agentic.ci_triage.mode == "off"
+        assert cfg.agentic.stuck_pr.mode == "off"
+
+    def test_multiple_domains_load(self) -> None:
+        # ``off`` is a YAML 1.1 boolean literal — quote it so pydantic
+        # sees the string ``"off"`` rather than ``False``.
+        yaml_content = """
+version: v1
+agentic:
+  readiness:
+    mode: shadow
+  ci_triage:
+    mode: enforce
+  crystallizer_category:
+    mode: "off"
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            cfg = MaintainerConfig.from_yaml(f.name)
+
+        assert cfg.agentic.readiness.mode == "shadow"
+        assert cfg.agentic.ci_triage.mode == "enforce"
+        assert cfg.agentic.crystallizer_category.mode == "off"
+
+    def test_invalid_mode_raises(self) -> None:
+        yaml_content = """
+version: v1
+agentic:
+  readiness:
+    mode: authoritative   # not a valid value
+"""
+        import pydantic
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            try:
+                MaintainerConfig.from_yaml(f.name)
+            except pydantic.ValidationError:
+                pass
+            else:
+                raise AssertionError("expected ValidationError for unknown mode")

--- a/tests/test_shadow_decorator.py
+++ b/tests/test_shadow_decorator.py
@@ -1,0 +1,389 @@
+"""Tests for the @shadow_decision decorator + ShadowDecision graph write.
+
+Covers every branch called out in T-D1 Part E:
+
+* ``off`` — legacy-only.
+* ``shadow-agree`` — both paths run, no disagreement recorded.
+* ``shadow-disagree`` — both paths run, disagreement recorded.
+* ``shadow-candidate-raises`` — candidate swallowed, legacy returned.
+* ``enforce-candidate-returns`` — candidate authoritative.
+* ``enforce-candidate-raises-falls-through`` — legacy is the safety net.
+
+Also verifies the graph writer path (fake Neo4j store) and the
+no-Neo4j log fallback.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from caretaker.config import AgenticConfig, AgenticDomainConfig
+from caretaker.evolution import shadow_config
+from caretaker.evolution.shadow import (
+    SHADOW_DECISIONS_TOTAL,
+    ShadowDecisionRecord,
+    clear_records_for_tests,
+    recent_records,
+    shadow_decision,
+    write_shadow_decision,
+)
+from caretaker.graph import writer as graph_writer
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state() -> None:
+    """Clear cross-test state (ring buffer, active config, graph writer)."""
+    clear_records_for_tests()
+    shadow_config.reset_for_tests()
+    graph_writer.reset_for_tests()
+
+
+def _set_mode(name: str, mode: str) -> None:
+    """Install an ``AgenticConfig`` with ``<name>.mode = mode``."""
+    kwargs: dict[str, AgenticDomainConfig] = {
+        name: AgenticDomainConfig(mode=mode)  # type: ignore[arg-type]
+    }
+    cfg = AgenticConfig(**kwargs)
+    shadow_config.configure(cfg)
+
+
+# ── Decorator: off ───────────────────────────────────────────────────────
+
+
+async def test_off_mode_returns_legacy_and_skips_candidate() -> None:
+    _set_mode("readiness", "off")
+
+    legacy = AsyncMock(return_value="LEGACY")
+    candidate = AsyncMock(return_value="CANDIDATE")
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper should short-circuit off-mode")
+
+    result = await decide(legacy=legacy, candidate=candidate)
+
+    assert result == "LEGACY"
+    legacy.assert_awaited_once()
+    candidate.assert_not_awaited()
+    # No record should have been written in off-mode.
+    assert recent_records() == []
+
+
+# ── Decorator: shadow / agree ────────────────────────────────────────────
+
+
+async def test_shadow_agree_returns_legacy_and_writes_no_disagreement_reason() -> None:
+    _set_mode("readiness", "shadow")
+
+    legacy = AsyncMock(return_value={"ready": True})
+    candidate = AsyncMock(return_value={"ready": True})
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> dict[str, bool]:
+        raise AssertionError("wrapper is the one doing the work")
+
+    result = await decide(
+        legacy=legacy,
+        candidate=candidate,
+        context={"repo_slug": "ian/demo", "pr_number": 7},
+    )
+
+    assert result == {"ready": True}
+    legacy.assert_awaited_once()
+    candidate.assert_awaited_once()
+
+    records = recent_records()
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.outcome == "agree"
+    assert rec.name == "readiness"
+    assert rec.mode == "shadow"
+    assert rec.disagreement_reason is None
+    assert rec.repo_slug == "ian/demo"
+    assert rec.candidate_verdict_json is not None
+    assert "ready" in rec.candidate_verdict_json
+
+
+# ── Decorator: shadow / disagree ─────────────────────────────────────────
+
+
+async def test_shadow_disagree_records_reason_and_still_returns_legacy() -> None:
+    _set_mode("ci_triage", "shadow")
+
+    @shadow_decision("ci_triage")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives the call")
+
+    async def legacy() -> str:
+        return "flaky"
+
+    async def candidate() -> str:
+        return "real-failure"
+
+    result = await decide(legacy=legacy, candidate=candidate)
+
+    assert result == "flaky"  # legacy wins in shadow mode
+    records = recent_records()
+    assert len(records) == 1
+    assert records[0].outcome == "disagree"
+    assert records[0].disagreement_reason is not None
+    assert "flaky" in records[0].disagreement_reason
+    assert "real-failure" in records[0].disagreement_reason
+
+
+async def test_shadow_custom_compare_function() -> None:
+    _set_mode("review_classification", "shadow")
+
+    def compare(a: Any, b: Any) -> bool:
+        # Ignore the rationale field when comparing verdicts.
+        return a["label"] == b["label"]
+
+    @shadow_decision("review_classification", compare=compare)
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> dict[str, str]:
+        raise AssertionError("wrapper drives")
+
+    async def legacy() -> dict[str, str]:
+        return {"label": "nit", "rationale": "no issues"}
+
+    async def candidate() -> dict[str, str]:
+        return {"label": "nit", "rationale": "different wording"}
+
+    await decide(legacy=legacy, candidate=candidate)
+    records = recent_records()
+    assert len(records) == 1
+    assert records[0].outcome == "agree"
+
+
+# ── Decorator: shadow / candidate raises ─────────────────────────────────
+
+
+async def test_shadow_candidate_raises_is_swallowed() -> None:
+    _set_mode("readiness", "shadow")
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    async def legacy() -> str:
+        return "OK"
+
+    async def candidate() -> str:
+        raise RuntimeError("boom")
+
+    result = await decide(legacy=legacy, candidate=candidate)
+    assert result == "OK"
+    records = recent_records()
+    assert len(records) == 1
+    assert records[0].outcome == "candidate_error"
+    assert records[0].candidate_verdict_json is None
+    assert records[0].disagreement_reason is not None
+    assert "RuntimeError" in records[0].disagreement_reason
+
+
+# ── Decorator: enforce / candidate returns ───────────────────────────────
+
+
+async def test_enforce_candidate_returns_is_authoritative() -> None:
+    _set_mode("readiness", "enforce")
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    legacy = AsyncMock(return_value="LEGACY")
+    candidate = AsyncMock(return_value="CANDIDATE")
+
+    result = await decide(legacy=legacy, candidate=candidate)
+    assert result == "CANDIDATE"
+    candidate.assert_awaited_once()
+    legacy.assert_not_awaited()
+
+
+async def test_enforce_candidate_returns_none_falls_through_to_legacy() -> None:
+    _set_mode("readiness", "enforce")
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    legacy = AsyncMock(return_value="LEGACY")
+    candidate = AsyncMock(return_value=None)
+
+    result = await decide(legacy=legacy, candidate=candidate)
+    assert result == "LEGACY"
+    legacy.assert_awaited_once()
+
+
+# ── Decorator: enforce / candidate raises ────────────────────────────────
+
+
+async def test_enforce_candidate_raises_falls_through_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _set_mode("readiness", "enforce")
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    async def legacy() -> str:
+        return "LEGACY"
+
+    async def candidate() -> str:
+        raise ValueError("bad model")
+
+    with caplog.at_level(logging.WARNING, logger="caretaker.evolution.shadow"):
+        result = await decide(legacy=legacy, candidate=candidate)
+
+    assert result == "LEGACY"
+    assert any("falling through" in rec.message for rec in caplog.records)
+
+
+# ── Decorator validation ─────────────────────────────────────────────────
+
+
+def test_decorator_rejects_sync_function() -> None:
+    with pytest.raises(TypeError, match="async function"):
+
+        @shadow_decision("readiness")
+        def sync_decide(*, legacy: Any, candidate: Any) -> str:  # pragma: no cover
+            return "nope"
+
+
+async def test_decorator_rejects_call_without_legacy_candidate() -> None:
+    _set_mode("readiness", "shadow")
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    with pytest.raises(TypeError, match="legacy"):
+        await decide()  # type: ignore[call-arg]
+
+
+# ── Graph writer integration ─────────────────────────────────────────────
+
+
+class _FakeGraphStore:
+    """Minimal ``GraphStore`` shim capturing ``merge_node`` calls."""
+
+    def __init__(self) -> None:
+        self.nodes: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def merge_node(self, label: str, node_id: str, properties: dict[str, Any]) -> None:
+        self.nodes.append((label, node_id, properties))
+
+    async def merge_edge(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("shadow writer never emits edges")
+
+
+async def test_write_shadow_decision_goes_to_graph_when_enabled() -> None:
+    store = _FakeGraphStore()
+    writer = graph_writer.get_writer()
+    writer.configure(store)  # type: ignore[arg-type]
+    await writer.start()
+    try:
+        from datetime import UTC, datetime
+
+        rec = ShadowDecisionRecord(
+            id="abc",
+            name="readiness",
+            repo_slug="ian/demo",
+            run_at=datetime.now(UTC),
+            outcome="disagree",
+            mode="shadow",
+            legacy_verdict_json='{"ready": true}',
+            candidate_verdict_json='{"ready": false}',
+            disagreement_reason="legacy says ready, candidate says not",
+            context_json='{"pr": 7}',
+        )
+        write_shadow_decision(rec)
+        await writer.flush(timeout=2.0)
+    finally:
+        await writer.stop()
+        graph_writer.reset_for_tests()
+
+    assert len(store.nodes) == 1
+    label, node_id, props = store.nodes[0]
+    assert label == "ShadowDecision"
+    assert node_id == "abc"
+    assert props["name"] == "readiness"
+    assert props["outcome"] == "disagree"
+    assert props["candidate_verdict_json"] == '{"ready": false}'
+
+
+async def test_write_shadow_decision_falls_back_to_log_when_graph_disabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Writer left disabled by the autouse fixture.
+    from datetime import UTC, datetime
+
+    rec = ShadowDecisionRecord(
+        id="xyz",
+        name="ci_triage",
+        repo_slug="ian/demo",
+        run_at=datetime.now(UTC),
+        outcome="disagree",
+        mode="shadow",
+        legacy_verdict_json='"flaky"',
+        candidate_verdict_json='"real-failure"',
+        disagreement_reason="classification mismatch",
+        context_json="{}",
+    )
+    with caplog.at_level(logging.INFO, logger="caretaker.evolution.shadow"):
+        write_shadow_decision(rec)
+
+    # One structured event line — must be reconstructable.
+    matching = [r for r in caplog.records if "shadow_decision" in r.message]
+    assert matching, "expected a shadow_decision log line"
+    msg = matching[0].message
+    assert "id=xyz" in msg
+    assert "name=ci_triage" in msg
+    assert "outcome=disagree" in msg
+    assert "classification mismatch" in msg
+
+
+# ── Prometheus counter coverage ──────────────────────────────────────────
+
+
+def _counter_value(name: str, mode: str, outcome: str) -> float:
+    labels = SHADOW_DECISIONS_TOTAL.labels(name=name, mode=mode, outcome=outcome)
+    return labels._value.get()  # type: ignore[no-any-return]
+
+
+async def test_prometheus_counter_increments_per_outcome() -> None:
+    _set_mode("readiness", "shadow")
+    before_agree = _counter_value("readiness", "shadow", "agree")
+    before_disagree = _counter_value("readiness", "shadow", "disagree")
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError
+
+    await decide(legacy=AsyncMock(return_value="A"), candidate=AsyncMock(return_value="A"))
+    await decide(legacy=AsyncMock(return_value="A"), candidate=AsyncMock(return_value="B"))
+
+    assert _counter_value("readiness", "shadow", "agree") == before_agree + 1
+    assert _counter_value("readiness", "shadow", "disagree") == before_disagree + 1
+
+
+# ── Unconfigured decision names default to off ──────────────────────────
+
+
+async def test_unconfigured_name_defaults_to_off_mode() -> None:
+    shadow_config.reset_for_tests()
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError
+
+    candidate = AsyncMock(return_value="CAND")
+    result = await decide(legacy=AsyncMock(return_value="LEGACY"), candidate=candidate)
+    assert result == "LEGACY"
+    candidate.assert_not_awaited()


### PR DESCRIPTION
## Motivation

Phase 2 of the 2026-Q2 agentic migration plan (`docs/plans/2026-Q2-agentic-migration.md` §4.5 and §6 W4) lists **T-D1** as the blocker for every LLM-decision migration: before flipping authority from a heuristic to an LLM, we need to run both side-by-side, log disagreement, and measure agreement rate. Without this infrastructure, each migration in §3 has to invent its own shadow shim.

This PR ships that infrastructure as one uniform primitive so Phase 2 workstreams (readiness, CI triage, review classification, issue triage, cascade cleanup, stuck-PR detection, bot identity, dispatch guard, executor routing, crystallizer category) can start shipping shadow data immediately.

## Decorator API

```python
from caretaker.evolution.shadow import shadow_decision

@shadow_decision("readiness")
async def decide(
    pr,
    *,
    legacy,            # classic heuristic
    candidate,         # LLM implementation
    context=None,      # optional dict passed through to the record
):
    raise RuntimeError("wrapper drives the call; decorated body is never run")

verdict = await decide(
    pr,
    legacy=classic_readiness,
    candidate=llm_readiness,
    context={"repo_slug": "ian/demo", "pr_number": pr.number},
)
```

The decorator dispatches on `config.agentic.<name>.mode`:

| mode      | behaviour                                                                   |
|-----------|-----------------------------------------------------------------------------|
| `off`     | Legacy only. Candidate never runs.                                          |
| `shadow`  | Both run. Legacy verdict is returned. Disagreements are persisted.          |
| `enforce` | Candidate is authoritative. On exception or `None` return, legacy fallback. |

Candidate errors in `shadow` mode are swallowed and recorded — the legacy path is never affected by a candidate failure.

Optional `compare` argument lets call sites ignore noisy fields (timestamps, rationale text) when deciding whether two verdicts agree.

## Config shape

```yaml
version: v1
agentic:
  readiness:
    mode: shadow
  ci_triage:
    mode: enforce
  crystallizer_category:
    mode: "off"      # YAML 1.1 treats bare ``off`` as False, so quote it
```

Every decision site defaults to `mode: "off"` so classic heuristics stay authoritative until operators explicitly opt in.

## ShadowDecision schema

Persisted as `:ShadowDecision` nodes in Neo4j (via the existing `GraphWriter` singleton) or as structured log lines when Neo4j is off:

| field                     | type            | notes                                                   |
|---------------------------|-----------------|---------------------------------------------------------|
| `id`                      | `str`           | UUID — stable so Neo4j `MERGE` never double-writes      |
| `name`                    | `str`           | decision site name (matches `AgenticConfig` field)      |
| `repo_slug`               | `str`           | best-effort owner/name from `context["repo_slug"]`      |
| `run_at`                  | tz-aware UTC    | ISO-8601 in Neo4j                                       |
| `outcome`                 | enum            | `agree` / `disagree` / `candidate_error`                |
| `mode`                    | enum            | `shadow` / `enforce`                                    |
| `legacy_verdict_json`     | JSON string     |                                                         |
| `candidate_verdict_json`  | JSON string \| null | null on `candidate_error`                           |
| `disagreement_reason`     | str \| null     | one-line human summary                                  |
| `context_json`            | JSON string     | caller-supplied dict                                    |

The log-fallback event carries every field, so records are reconstructable without Neo4j.

Prometheus counter: `caretaker_shadow_decisions_total{name, mode, outcome}` (bounded cardinality — 10 names × 3 modes × 5 outcomes = 150 series max).

## Admin endpoint

`GET /api/admin/shadow/decisions?name=<>&since=<iso>&limit=100` returns:

```json
{
  "items":           [ShadowDecisionRow, ...],
  "agreement_rate":  0.95,
  "source":          "neo4j"
}
```

`agreement_rate` excludes `candidate_error` rows from the denominator (1.0 when there is nothing to compare). Reads from Neo4j when `graph_store.enabled` is true; otherwise returns the last 1000 records from the process-local ring buffer so dev/test have something to render. Gated by the existing OIDC `require_session` dependency.

Frontend wiring for the Fleet/Shadow tab is deliberately out of scope — this PR only ships the backend.

## Test plan

- [x] Decorator unit tests — `off`, `shadow-agree`, `shadow-disagree`, `shadow-candidate-raises`, `enforce-candidate-returns`, `enforce-candidate-returns-None`, `enforce-candidate-raises`, custom `compare`, unconfigured-name defaults to `off`, sync-function rejection, missing-`legacy`/`candidate` rejection.
- [x] Prometheus counter increments per `(name, mode, outcome)`.
- [x] `AgenticConfig` YAML round-trip — `readiness.mode: shadow`, multi-domain mix, invalid-mode rejection.
- [x] `write_shadow_decision` integration — fake Neo4j store captures the `ShadowDecision` node; no-Neo4j path emits a reconstructable log line.
- [x] Admin endpoint via `TestClient` — ring-buffer fallback, name/since filters, agreement-rate math, limit cap, fake-Neo4j path, 401 without session.
- [x] Gates: `pytest -q` (1213 passed, 1 skipped), `ruff check src tests`, `ruff format --check src tests`, `mypy src/caretaker` (remaining errors are the pre-existing `k8s_worker/launcher.py` ones explicitly listed as acceptable in the task brief).

Do not merge until a Phase 2 workstream adopts it as a canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)