### PR TITLE
feat(pr_agent): CI failure triage migration to structured_complete + shadow

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -164,6 +164,7 @@ DEFAULT_REASONING_MODEL = "claude-opus-4-5"
 DEFAULT_FEATURE_MODELS: dict[str, dict[str, int | str]] = {
     # Short classification/triage tasks — route to the faster/cheaper tier.
     "ci_log_analysis": {"model": DEFAULT_TRIAGE_MODEL, "max_tokens": 2000},
+    "ci_triage": {"model": DEFAULT_TRIAGE_MODEL, "max_tokens": 800},
     "analyze_review_comment": {"model": DEFAULT_TRIAGE_MODEL, "max_tokens": 1000},
     "analyze_stuck_pr": {"model": DEFAULT_TRIAGE_MODEL, "max_tokens": 800},
     # Longer reasoning tasks — keep on the default (Sonnet) tier.

--- a/src/caretaker/evolution/crystallizer.py
+++ b/src/caretaker/evolution/crystallizer.py
@@ -31,7 +31,17 @@ _CATEGORY_PATTERNS: list[tuple[str, str]] = [
 
 
 def _infer_category(notes: str) -> str:
-    """Infer failure category from free-text notes. Defaults to CATEGORY_CI."""
+    """Infer failure category from free-text notes. Defaults to CATEGORY_CI.
+
+    TODO(T-A10, crystallizer_category): replace this regex ladder with the
+    structured LLM verdict produced by
+    :class:`caretaker.pr_agent.ci_triage.FailureTriage` (see T-A3). The
+    ``agentic.crystallizer_category`` flag is already wired in
+    :class:`~caretaker.config.AgenticConfig` — once T-A3's shadow data
+    shows the LLM classifier is reliable, this function becomes the
+    legacy branch and ``FailureTriage.category`` feeds directly into
+    :data:`~caretaker.evolution.insight_store.CATEGORY_*` lookups.
+    """
     lower = notes.lower()
     for category, pattern in _CATEGORY_PATTERNS:
         if re.search(pattern, lower):

--- a/src/caretaker/pr_agent/ci_triage.py
+++ b/src/caretaker/pr_agent/ci_triage.py
@@ -1,4 +1,23 @@
-"""CI failure triage — classifies and creates fix instructions."""
+"""CI failure triage — classifies and creates fix instructions.
+
+Part of the Phase 2 agentic migration (see
+``docs/plans/2026-Q2-agentic-migration.md`` §3.3 and task T-A3). Shipping
+two classifiers side-by-side:
+
+* :func:`classify_failure` — the legacy keyword-regex ladder. Returns a
+  coarse :class:`FailureType` from job name + output title + summary. On
+  ``main`` this ladder has been dropping most real failures into
+  :attr:`FailureType.UNKNOWN` (issues #412/#413/#462), which is why we
+  need the LLM candidate below.
+* :func:`classify_failure_llm` — the LLM candidate. Calls
+  :meth:`ClaudeClient.structured_complete` with :class:`FailureTriage` as
+  the schema. Returns ``None`` on provider / parsing failure so callers
+  can fall through to legacy.
+
+Both paths are exposed so :func:`triage_failure` can run them under
+``@shadow_decision("ci_triage")`` — no behaviour change until the flag
+flips from ``off`` to ``shadow``/``enforce``.
+"""
 
 from __future__ import annotations
 
@@ -6,10 +25,16 @@ import logging
 import re
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, Field
+
+from caretaker.evolution.shadow import shadow_decision
+from caretaker.llm.claude import StructuredCompleteError
 
 if TYPE_CHECKING:
     from caretaker.github_client.models import CheckRun
+    from caretaker.llm.claude import ClaudeClient
     from caretaker.llm.router import LLMRouter
 
 logger = logging.getLogger(__name__)
@@ -25,6 +50,84 @@ class FailureType(StrEnum):
     UNKNOWN = "UNKNOWN"
 
 
+# ── LLM schema (T-A3) ────────────────────────────────────────────────────
+#
+# The Phase 2 schema is deliberately richer than :class:`FailureType`.
+# ``is_transient`` subsumes both the current ``NON_ACTIONABLE_CONCLUSIONS``
+# frozenset and the ``CIConfig.flaky_retries`` counter: once the candidate
+# is authoritative (mode=enforce), callers should branch on that bool
+# rather than re-deriving transience from the raw conclusion.
+
+FailureCategory = Literal[
+    "test",
+    "lint",
+    "build",
+    "type",
+    "timeout",
+    "flaky",
+    "backpressure",
+    "infra",
+    "unknown",
+]
+
+
+class FailureTriage(BaseModel):
+    """LLM-structured CI failure triage verdict.
+
+    Returned by :func:`classify_failure_llm` and by
+    :func:`classify_failure_adapter` (which lifts the legacy regex verdict
+    into the same shape so shadow-mode comparisons work).
+    """
+
+    category: FailureCategory
+    confidence: float = Field(ge=0.0, le=1.0)
+    is_transient: bool = Field(
+        description=(
+            "True when the failure should be retried without code changes "
+            "(flaky test, backpressure, infra blip, timeout). False means "
+            "the change needs a fix."
+        ),
+    )
+    root_cause_hypothesis: str = Field(max_length=300)
+    minimal_reproduction: str | None = Field(
+        default=None,
+        description="Shell one-liner that reproduces the failure, when feasible.",
+    )
+    suggested_fix: str = Field(max_length=500)
+    files_to_touch: list[str] = Field(
+        default_factory=list,
+        description="Repo-relative paths the fix most likely needs to touch.",
+    )
+
+
+# ── Legacy → FailureCategory mapping ────────────────────────────────────
+#
+# Used by :func:`classify_failure_adapter` so the legacy regex verdict
+# can be lifted into a :class:`FailureTriage`. Keep in sync with the
+# regex ladder below.
+
+_LEGACY_TO_CATEGORY: dict[FailureType, FailureCategory] = {
+    FailureType.TEST_FAILURE: "test",
+    FailureType.LINT_FAILURE: "lint",
+    FailureType.BUILD_FAILURE: "build",
+    FailureType.TYPE_ERROR: "type",
+    FailureType.TIMEOUT: "timeout",
+    FailureType.BACKLOG: "backpressure",
+    FailureType.UNKNOWN: "unknown",
+}
+
+
+# Legacy regex categories that denote transient / non-fix failures. Used
+# both by the legacy fallback classifier and by the LLM fallback adapter
+# so ``is_transient`` stays meaningful in shadow mode.
+_LEGACY_TRANSIENT = {FailureType.BACKLOG, FailureType.TIMEOUT}
+
+
+# Default per-category instructions for the legacy path. Kept here
+# because :func:`build_fix_instructions` still references them in
+# :func:`triage_failure`.
+
+
 @dataclass
 class TriageResult:
     failure_type: FailureType
@@ -32,6 +135,14 @@ class TriageResult:
     error_summary: str
     instructions: str
     raw_output: str
+    # Populated only when the ``ci_triage`` domain runs in ``enforce`` mode
+    # and the LLM candidate succeeds. In ``off`` / ``shadow`` modes this
+    # remains ``None`` so downstream behaviour is byte-identical.
+    #
+    # Callers that want to branch on the rich verdict should fall back to
+    # the legacy fields (``failure_type``, ``error_summary``) when this
+    # attribute is absent.
+    triage: FailureTriage | None = None
 
 
 # Patterns for classifying CI failures by job name / output
@@ -114,7 +225,13 @@ def is_actionable_conclusion(conclusion: object) -> bool:
 
 
 def classify_failure(check_run: CheckRun) -> FailureType:
-    """Classify a CI failure by job name and output."""
+    """Classify a CI failure by job name and output (legacy regex ladder).
+
+    Retained so shadow-mode still has something to compare against. On
+    ``main`` this consistently returns :attr:`FailureType.UNKNOWN` for
+    anything that isn't a classic ``lint``/``test``/``build`` job name;
+    that's the gap T-A3 closes with :func:`classify_failure_llm`.
+    """
     text = f"{check_run.name} {check_run.output_title or ''} {check_run.output_summary or ''}"
 
     if check_run.conclusion and check_run.conclusion.value == "timed_out":
@@ -126,6 +243,165 @@ def classify_failure(check_run: CheckRun) -> FailureType:
                 return failure_type
 
     return FailureType.UNKNOWN
+
+
+def classify_failure_adapter(check_run: CheckRun) -> FailureTriage:
+    """Lift the legacy :func:`classify_failure` verdict into a :class:`FailureTriage`.
+
+    Used as the shadow-mode *legacy* branch (and as the ``enforce``
+    safety-net when the LLM candidate errors). Missing LLM-only fields
+    get templated placeholders so the pydantic model still validates.
+    """
+    failure_type = classify_failure(check_run)
+    category = _LEGACY_TO_CATEGORY.get(failure_type, "unknown")
+    is_transient = failure_type in _LEGACY_TRANSIENT
+    # Deliberately not guessing confidence from the regex ladder —
+    # anything higher than 0.5 would be dishonest when the ladder's
+    # well-known failure mode is "match lint by substring".
+    confidence = 0.5 if failure_type is not FailureType.UNKNOWN else 0.1
+    root_cause = f"Legacy heuristic: matched pattern {failure_type.value}"
+    suggested_fix = "Follow the category-specific instructions produced by build_fix_instructions."
+    return FailureTriage(
+        category=category,
+        confidence=confidence,
+        is_transient=is_transient,
+        root_cause_hypothesis=root_cause,
+        minimal_reproduction=None,
+        suggested_fix=suggested_fix,
+        files_to_touch=[],
+    )
+
+
+# ── LLM candidate ────────────────────────────────────────────────────────
+
+# Approximate char budget for the log tail. Matches the 8 KiB cap used by
+# the existing ``analyze_ci_logs`` helper so prompt cache keys stay stable
+# across the two paths.
+_LOG_TAIL_CHAR_BUDGET = 8000
+
+
+def _extract_log_tail(check_run: CheckRun, log_tail: str | None) -> str:
+    """Return the last ~200 lines of log text for the LLM prompt.
+
+    Callers hand in ``log_tail`` directly when they have the full job
+    log; when they don't, we fall back to the ``output_summary`` /
+    ``output_title`` that GitHub returns with the ``CheckRun``. Either
+    way, the returned string is capped at :data:`_LOG_TAIL_CHAR_BUDGET`
+    characters to keep the prompt cache-friendly.
+    """
+    text = log_tail
+    if not text:
+        text = check_run.output_summary or check_run.output_title or ""
+    if not text:
+        return ""
+    # Keep the last ~200 lines — the failure is almost always at the
+    # end of the log.
+    lines = text.splitlines()
+    if len(lines) > 200:
+        lines = lines[-200:]
+    tail = "\n".join(lines)
+    if len(tail) > _LOG_TAIL_CHAR_BUDGET:
+        # Preserve the tail (more diagnostic value than the head).
+        tail = tail[-_LOG_TAIL_CHAR_BUDGET:]
+    return tail
+
+
+def _build_ci_triage_prompt(
+    check_run: CheckRun,
+    log_tail: str,
+    *,
+    language_hint: str | None = None,
+    framework_hint: str | None = None,
+) -> tuple[str, str]:
+    """Build the (system, user) prompt pair for :func:`classify_failure_llm`.
+
+    Keeps the stable prefix (instructions, language/framework hints) in
+    the *system* slot so Anthropic prompt caching can cover it across
+    invocations; the variable log tail goes into the user slot at the
+    end, which is the shape cache-aware providers optimise for.
+    """
+    conclusion_value = check_run.conclusion.value if check_run.conclusion is not None else "unknown"
+    duration_s: float | None = None
+    if check_run.started_at and check_run.completed_at:
+        duration_s = (check_run.completed_at - check_run.started_at).total_seconds()
+    duration_str = f"{duration_s:.1f}s" if duration_s is not None else "n/a"
+
+    hints: list[str] = []
+    if language_hint:
+        hints.append(f"Language: {language_hint}")
+    if framework_hint:
+        hints.append(f"Framework: {framework_hint}")
+
+    system = (
+        "You are a CI failure triager. Categorise a single CI check run "
+        "and suggest a concrete fix. Focus on the failure, not the PR. "
+        "Do not speculate about the PR title or author. If the log is "
+        "empty or truncated, say so in root_cause_hypothesis and set "
+        "confidence accordingly.\n\n"
+        "Category definitions:\n"
+        "  test — unit/integration test assertion or collection failure\n"
+        "  lint — style or static-analysis gate (ruff, eslint, prettier)\n"
+        "  build — compile/package/bundle failure\n"
+        "  type — static type checker failure (mypy, pyright, tsc --noEmit)\n"
+        "  timeout — the job hit its wall-clock or test timeout\n"
+        "  flaky — the failure is intermittent; rerun likely succeeds\n"
+        "  backpressure — queue-guard / too-many-runs rejection\n"
+        "  infra — runner / network / credentials / external outage\n"
+        "  unknown — none of the above fit\n\n"
+        "Set is_transient=true only for flaky/backpressure/infra and "
+        "timeouts that look environmental. Prefer is_transient=false "
+        "when the log names a specific assertion, missing import, or "
+        "type error."
+    )
+    if hints:
+        system = system + "\n\nRepo context: " + "; ".join(hints)
+
+    user = (
+        f"Check run: {check_run.name}\n"
+        f"Conclusion: {conclusion_value}\n"
+        f"Duration: {duration_str}\n\n"
+        "Log tail (most recent lines last):\n"
+        f"```\n{log_tail}\n```"
+    )
+    return system, user
+
+
+async def classify_failure_llm(
+    check_run: CheckRun,
+    log_tail: str | None,
+    *,
+    claude: ClaudeClient,
+    language_hint: str | None = None,
+    framework_hint: str | None = None,
+) -> FailureTriage | None:
+    """Ask the LLM to classify a CI failure into a :class:`FailureTriage`.
+
+    Returns ``None`` on :class:`StructuredCompleteError` (provider
+    unavailable, bad JSON, schema validation failure) so shadow-mode
+    comparisons can fall through to the legacy adapter without disrupting
+    the hot path.
+    """
+    tail = _extract_log_tail(check_run, log_tail)
+    system, prompt = _build_ci_triage_prompt(
+        check_run,
+        tail,
+        language_hint=language_hint,
+        framework_hint=framework_hint,
+    )
+    try:
+        return await claude.structured_complete(
+            prompt,
+            schema=FailureTriage,
+            feature="ci_triage",
+            system=system,
+            max_tokens=800,
+        )
+    except StructuredCompleteError as exc:
+        logger.info(
+            "ci_triage: LLM candidate failed validation (%s) — falling through to legacy",
+            exc,
+        )
+        return None
 
 
 def build_fix_instructions(failure_type: FailureType, check_run: CheckRun) -> str:
@@ -185,13 +461,89 @@ def build_fix_instructions(failure_type: FailureType, check_run: CheckRun) -> st
     return instructions.get(failure_type, instructions[FailureType.UNKNOWN])
 
 
-async def triage_failure(check_run: CheckRun, llm_router: LLMRouter | None = None) -> TriageResult:
-    """Triage a CI failure — classify and generate fix instructions."""
-    failure_type = classify_failure(check_run)
-    raw_output = check_run.output_summary or check_run.output_title or ""
-    error_summary = raw_output[:500]
+# ── Shadow-wrapped dispatch ──────────────────────────────────────────────
+#
+# The decorator runs both paths under ``agentic.ci_triage.mode=shadow``
+# and only the candidate under ``enforce``. The custom ``compare``
+# predicate ignores the noisy free-text fields so small rewording in
+# ``root_cause_hypothesis`` doesn't spam the disagreement counter.
 
-    # If Claude is available, get enhanced analysis
+
+def _triage_compare(a: Any, b: Any) -> bool:
+    """Shadow-mode comparator: match on category + transience only."""
+    if a is None or b is None:
+        return a is b
+    try:
+        return bool(a.category == b.category and a.is_transient == b.is_transient)
+    except AttributeError:
+        return False
+
+
+@shadow_decision("ci_triage", compare=_triage_compare)
+async def _dispatch_triage(
+    *,
+    legacy: Any,
+    candidate: Any,
+    context: Any = None,
+) -> FailureTriage:
+    """Thin shim the decorator drives. The actual work lives in
+    ``legacy`` / ``candidate`` callables supplied by :func:`triage_failure`.
+    """
+    raise AssertionError(
+        "@shadow_decision wrapper should dispatch via legacy/candidate"
+    )  # pragma: no cover
+
+
+async def triage_failure(
+    check_run: CheckRun,
+    llm_router: LLMRouter | None = None,
+    *,
+    repo_slug: str | None = None,
+) -> TriageResult:
+    """Triage a CI failure — classify and generate fix instructions.
+
+    Runs under the ``agentic.ci_triage`` flag via :func:`shadow_decision`:
+
+    * ``off`` (default) — legacy regex ladder only; byte-identical to the
+      pre-T-A3 behaviour.
+    * ``shadow`` — both paths run, legacy verdict is returned, the LLM
+      verdict is recorded next to it so operators can inspect the
+      disagreement rate before flipping authority.
+    * ``enforce`` — the LLM verdict wins; legacy is the fall-through
+      safety net when the candidate errors or returns ``None``.
+    """
+    raw_output = check_run.output_summary or check_run.output_title or ""
+
+    claude: ClaudeClient | None = None
+    if llm_router is not None and llm_router.claude_available:
+        claude = llm_router.claude
+
+    async def _legacy() -> FailureTriage:
+        return classify_failure_adapter(check_run)
+
+    async def _candidate() -> FailureTriage | None:
+        # ``enforce`` needs a real candidate — if the LLM isn't wired up
+        # we return None so the decorator falls through to legacy.
+        if claude is None or not claude.available:
+            return None
+        return await classify_failure_llm(check_run, raw_output, claude=claude)
+
+    verdict = await _dispatch_triage(
+        legacy=_legacy,
+        candidate=_candidate,
+        context={"repo_slug": repo_slug or "", "job_name": check_run.name},
+    )
+
+    # Translate the FailureTriage verdict back into the legacy dataclass
+    # shape PR agent / copilot bridge consume. While ``mode`` stays ``off``
+    # or ``shadow``, ``verdict`` came from the legacy adapter, so
+    # :func:`classify_failure` on the same ``check_run`` yields the same
+    # ``FailureType`` — the conversion is loss-free. Only in ``enforce``
+    # mode might the LLM verdict disagree with the legacy regex, and we
+    # document below how the new category rows map back.
+    failure_type = _category_to_failure_type(verdict.category)
+
+    error_summary = raw_output[:500]
     if llm_router and llm_router.feature_enabled("ci_log_analysis") and raw_output:
         try:
             analysis = await llm_router.claude.analyze_ci_logs(raw_output)
@@ -208,4 +560,31 @@ async def triage_failure(check_run: CheckRun, llm_router: LLMRouter | None = Non
         error_summary=error_summary,
         instructions=instructions,
         raw_output=raw_output,
+        triage=verdict,
     )
+
+
+def _category_to_failure_type(category: FailureCategory) -> FailureType:
+    """Map a :data:`FailureCategory` back to the legacy :class:`FailureType`.
+
+    The mapping is 1:1 where the legacy enum has a row, and falls back
+    to :attr:`FailureType.UNKNOWN` for the LLM-only categories (``flaky``,
+    ``infra``). Callers that care about transience should read
+    :attr:`FailureTriage.is_transient` rather than re-deriving it from the
+    :class:`FailureType` — see T-A3 notes in the module docstring.
+    """
+    return {
+        "test": FailureType.TEST_FAILURE,
+        "lint": FailureType.LINT_FAILURE,
+        "build": FailureType.BUILD_FAILURE,
+        "type": FailureType.TYPE_ERROR,
+        "timeout": FailureType.TIMEOUT,
+        "backpressure": FailureType.BACKLOG,
+        # ``flaky`` / ``infra`` / ``unknown`` have no legacy row. Route
+        # them to UNKNOWN so the PR Agent's existing UNKNOWN-with-empty-
+        # logs guard still fires, and so the Copilot bridge falls back
+        # to the generic CI_FAILURE task type.
+        "flaky": FailureType.UNKNOWN,
+        "infra": FailureType.UNKNOWN,
+        "unknown": FailureType.UNKNOWN,
+    }[category]

--- a/tests/test_pr_agent/test_ci_triage_llm.py
+++ b/tests/test_pr_agent/test_ci_triage_llm.py
@@ -1,0 +1,492 @@
+"""Tests for T-A3: LLM-backed CI failure triage.
+
+Covers the new :class:`FailureTriage` schema, the legacy → schema
+adapter, the :func:`classify_failure_llm` candidate, and the
+``@shadow_decision``-wrapped :func:`triage_failure` dispatch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from caretaker.config import AgenticConfig, AgenticDomainConfig
+from caretaker.evolution import shadow_config
+from caretaker.evolution.shadow import clear_records_for_tests, recent_records
+from caretaker.github_client.models import CheckConclusion
+from caretaker.llm.claude import StructuredCompleteError
+from caretaker.pr_agent.ci_triage import (
+    FailureTriage,
+    FailureType,
+    classify_failure_adapter,
+    classify_failure_llm,
+    triage_failure,
+)
+from tests.conftest import make_check_run
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state() -> None:
+    """Clear ring buffer + active shadow config between tests."""
+    clear_records_for_tests()
+    shadow_config.reset_for_tests()
+
+
+def _set_ci_triage_mode(mode: str) -> None:
+    cfg = AgenticConfig(ci_triage=AgenticDomainConfig(mode=mode))  # type: ignore[arg-type]
+    shadow_config.configure(cfg)
+
+
+# ── Schema ──────────────────────────────────────────────────────────────
+
+
+class TestFailureTriageSchema:
+    def test_round_trip(self) -> None:
+        verdict = FailureTriage(
+            category="lint",
+            confidence=0.9,
+            is_transient=False,
+            root_cause_hypothesis="ruff E501 line too long",
+            minimal_reproduction="ruff check src",
+            suggested_fix="Wrap the offending line at 100 chars.",
+            files_to_touch=["src/caretaker/pr_agent/ci_triage.py"],
+        )
+        dumped = verdict.model_dump_json()
+        assert "lint" in dumped
+        restored = FailureTriage.model_validate_json(dumped)
+        assert restored == verdict
+
+    def test_confidence_lower_bound(self) -> None:
+        with pytest.raises(ValidationError):
+            FailureTriage(
+                category="test",
+                confidence=-0.1,
+                is_transient=False,
+                root_cause_hypothesis="x",
+                suggested_fix="x",
+            )
+
+    def test_confidence_upper_bound(self) -> None:
+        with pytest.raises(ValidationError):
+            FailureTriage(
+                category="test",
+                confidence=1.5,
+                is_transient=False,
+                root_cause_hypothesis="x",
+                suggested_fix="x",
+            )
+
+    def test_category_literal_rejects_unknown_value(self) -> None:
+        with pytest.raises(ValidationError):
+            FailureTriage(
+                category="not-a-real-category",  # type: ignore[arg-type]
+                confidence=0.5,
+                is_transient=False,
+                root_cause_hypothesis="x",
+                suggested_fix="x",
+            )
+
+    def test_root_cause_length_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            FailureTriage(
+                category="test",
+                confidence=0.5,
+                is_transient=False,
+                root_cause_hypothesis="x" * 301,
+                suggested_fix="x",
+            )
+
+    def test_suggested_fix_length_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            FailureTriage(
+                category="test",
+                confidence=0.5,
+                is_transient=False,
+                root_cause_hypothesis="x",
+                suggested_fix="x" * 501,
+            )
+
+    def test_files_to_touch_default_empty_list(self) -> None:
+        verdict = FailureTriage(
+            category="test",
+            confidence=0.5,
+            is_transient=False,
+            root_cause_hypothesis="x",
+            suggested_fix="x",
+        )
+        assert verdict.files_to_touch == []
+        assert verdict.minimal_reproduction is None
+
+
+# ── Legacy adapter ──────────────────────────────────────────────────────
+
+
+class TestClassifyFailureAdapter:
+    @pytest.mark.parametrize(
+        ("check_name", "expected_category", "expected_transient"),
+        [
+            ("test-unit", "test", False),
+            ("run-pytest", "test", False),
+            ("lint", "lint", False),
+            ("ruff-check", "lint", False),
+            ("eslint-check", "lint", False),
+            ("build", "build", False),
+            ("mypy", "type", False),
+            ("queue-guard", "backpressure", True),
+            # Unknown → unknown + not transient (fix expected).
+            ("deploy-staging", "unknown", False),
+        ],
+    )
+    def test_category_mapping(
+        self,
+        check_name: str,
+        expected_category: str,
+        expected_transient: bool,
+    ) -> None:
+        cr = make_check_run(name=check_name, conclusion=CheckConclusion.FAILURE)
+        verdict = classify_failure_adapter(cr)
+        assert verdict.category == expected_category
+        assert verdict.is_transient is expected_transient
+
+    def test_timeout_is_transient(self) -> None:
+        cr = make_check_run(name="integration", conclusion=CheckConclusion.TIMED_OUT)
+        verdict = classify_failure_adapter(cr)
+        assert verdict.category == "timeout"
+        assert verdict.is_transient is True
+
+    def test_root_cause_includes_matched_pattern(self) -> None:
+        cr = make_check_run(name="lint", conclusion=CheckConclusion.FAILURE)
+        verdict = classify_failure_adapter(cr)
+        assert "Legacy heuristic" in verdict.root_cause_hypothesis
+        assert "LINT_FAILURE" in verdict.root_cause_hypothesis
+
+    def test_unknown_has_low_confidence(self) -> None:
+        cr = make_check_run(name="deploy-staging", conclusion=CheckConclusion.FAILURE)
+        verdict = classify_failure_adapter(cr)
+        assert verdict.confidence <= 0.2
+
+    def test_known_has_moderate_confidence(self) -> None:
+        cr = make_check_run(name="lint", conclusion=CheckConclusion.FAILURE)
+        verdict = classify_failure_adapter(cr)
+        # Moderate at best — legacy ladder is cheerfully wrong sometimes.
+        assert 0.3 <= verdict.confidence <= 0.7
+
+
+# ── LLM candidate ───────────────────────────────────────────────────────
+
+
+class TestClassifyFailureLLM:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_verdict_on_success(self) -> None:
+        verdict = FailureTriage(
+            category="lint",
+            confidence=0.92,
+            is_transient=True,
+            root_cause_hypothesis="ruff E501 - cosmetic, re-run after autofix",
+            suggested_fix="Run `ruff format`.",
+            files_to_touch=["src/foo.py"],
+        )
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(return_value=verdict)
+
+        cr = make_check_run(
+            name="ruff-check",
+            conclusion=CheckConclusion.FAILURE,
+            output_summary="E501 line too long",
+        )
+        result = await classify_failure_llm(cr, "E501 line too long", claude=claude)
+        assert result is verdict
+        assert result is not None
+        assert result.category == "lint"
+        assert result.is_transient is True
+
+        # Prompt wiring sanity checks — stable prefix in system, log tail in user.
+        kwargs = claude.structured_complete.call_args.kwargs
+        assert kwargs["feature"] == "ci_triage"
+        assert kwargs["schema"] is FailureTriage
+        assert "You are a CI failure triager" in kwargs["system"]
+        prompt = claude.structured_complete.call_args.args[0]
+        assert "ruff-check" in prompt
+        assert "E501 line too long" in prompt
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_structured_complete_error(self) -> None:
+        claude = MagicMock()
+        claude.available = True
+        err = StructuredCompleteError(
+            raw_text="not json",
+            validation_error=ValueError("parse failed"),
+        )
+        claude.structured_complete = AsyncMock(side_effect=err)
+
+        cr = make_check_run(name="test", conclusion=CheckConclusion.FAILURE)
+        result = await classify_failure_llm(cr, "boom", claude=claude)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_log_tail(self) -> None:
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(
+            return_value=FailureTriage(
+                category="test",
+                confidence=0.5,
+                is_transient=False,
+                root_cause_hypothesis="x",
+                suggested_fix="x",
+            )
+        )
+
+        big_log = "\n".join(f"line {i}" for i in range(500))
+        cr = make_check_run(name="test", conclusion=CheckConclusion.FAILURE)
+        await classify_failure_llm(cr, big_log, claude=claude)
+
+        prompt = claude.structured_complete.call_args.args[0]
+        # Oldest lines should have been trimmed; newest 200 kept.
+        assert "line 0" not in prompt
+        assert "line 499" in prompt
+
+
+# ── Shadow dispatch wiring ──────────────────────────────────────────────
+
+
+class TestTriageFailureShadow:
+    @pytest.mark.asyncio
+    async def test_off_mode_uses_legacy_only(self) -> None:
+        _set_ci_triage_mode("off")
+
+        cr = make_check_run(name="ruff-check", conclusion=CheckConclusion.FAILURE)
+        result = await triage_failure(cr, llm_router=None)
+
+        assert result.failure_type == FailureType.LINT_FAILURE
+        assert result.triage is not None
+        assert result.triage.category == "lint"
+        # Off-mode should not produce any shadow records.
+        assert recent_records(name="ci_triage") == []
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_records_disagreement_but_returns_legacy(self) -> None:
+        _set_ci_triage_mode("shadow")
+
+        # LLM says flaky/transient; legacy says LINT_FAILURE/not-transient.
+        llm_verdict = FailureTriage(
+            category="flaky",
+            confidence=0.85,
+            is_transient=True,
+            root_cause_hypothesis="test timed out, ruff was unrelated",
+            suggested_fix="Rerun the job.",
+        )
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(return_value=llm_verdict)
+
+        router = MagicMock()
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        cr = make_check_run(
+            name="ruff-check",
+            conclusion=CheckConclusion.FAILURE,
+            output_summary="E501 line too long",
+        )
+        result = await triage_failure(cr, llm_router=router, repo_slug="ian/demo")
+
+        # Legacy wins in shadow mode.
+        assert result.failure_type == FailureType.LINT_FAILURE
+        assert result.triage is not None
+        assert result.triage.category == "lint"
+
+        records = recent_records(name="ci_triage")
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.outcome == "disagree"
+        assert rec.mode == "shadow"
+        assert rec.repo_slug == "ian/demo"
+        assert rec.disagreement_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_agrees_when_categories_match(self) -> None:
+        _set_ci_triage_mode("shadow")
+
+        # LLM agrees with legacy on category+transience, but uses
+        # different free-text fields; the custom comparator should ignore
+        # the free-text deltas.
+        llm_verdict = FailureTriage(
+            category="lint",
+            confidence=0.97,
+            is_transient=False,
+            root_cause_hypothesis="Different wording here",
+            suggested_fix="Different suggested fix wording.",
+        )
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(return_value=llm_verdict)
+
+        router = MagicMock()
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        cr = make_check_run(name="ruff-check", conclusion=CheckConclusion.FAILURE)
+        await triage_failure(cr, llm_router=router)
+
+        records = recent_records(name="ci_triage")
+        assert len(records) == 1
+        assert records[0].outcome == "agree"
+        assert records[0].disagreement_reason is None
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_swallows_candidate_error(self) -> None:
+        _set_ci_triage_mode("shadow")
+
+        claude = MagicMock()
+        claude.available = True
+        # classify_failure_llm returns None on StructuredCompleteError,
+        # which the decorator treats as a legitimate (non-error) return.
+        # Make the underlying structured_complete raise a bare exception
+        # so we exercise the ``candidate raises`` path of the decorator.
+        claude.structured_complete = AsyncMock(side_effect=RuntimeError("boom"))
+
+        router = MagicMock()
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        cr = make_check_run(name="lint", conclusion=CheckConclusion.FAILURE)
+        # classify_failure_llm catches StructuredCompleteError but *not*
+        # arbitrary runtime errors — so _candidate re-raises and the
+        # decorator records a ``candidate_error``. We assert that the
+        # hot path still returns the legacy verdict.
+        result = await triage_failure(cr, llm_router=router)
+        assert result.failure_type == FailureType.LINT_FAILURE
+
+        records = recent_records(name="ci_triage")
+        assert len(records) == 1
+        assert records[0].outcome == "candidate_error"
+
+    @pytest.mark.asyncio
+    async def test_shadow_falls_through_when_structured_complete_fails(self) -> None:
+        _set_ci_triage_mode("shadow")
+
+        claude = MagicMock()
+        claude.available = True
+        err = StructuredCompleteError(
+            raw_text="not json",
+            validation_error=ValueError("parse failed"),
+        )
+        claude.structured_complete = AsyncMock(side_effect=err)
+
+        router = MagicMock()
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        cr = make_check_run(name="lint", conclusion=CheckConclusion.FAILURE)
+        result = await triage_failure(cr, llm_router=router)
+        assert result.failure_type == FailureType.LINT_FAILURE
+
+        records = recent_records(name="ci_triage")
+        # classify_failure_llm swallows StructuredCompleteError and
+        # returns None — the decorator compares ``None`` (candidate)
+        # against the legacy adapter verdict (FailureTriage) and logs
+        # that as a disagreement.
+        assert len(records) == 1
+        assert records[0].outcome == "disagree"
+
+    @pytest.mark.asyncio
+    async def test_enforce_mode_uses_llm_verdict(self) -> None:
+        _set_ci_triage_mode("enforce")
+
+        llm_verdict = FailureTriage(
+            category="flaky",
+            confidence=0.9,
+            is_transient=True,
+            root_cause_hypothesis="Intermittent network flake.",
+            suggested_fix="Rerun the job.",
+        )
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(return_value=llm_verdict)
+
+        router = MagicMock()
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        # A lint-sounding job name; legacy would say LINT_FAILURE,
+        # not-transient. In enforce mode the LLM wins.
+        cr = make_check_run(name="ruff-check", conclusion=CheckConclusion.FAILURE)
+        result = await triage_failure(cr, llm_router=router)
+
+        # ``flaky`` has no legacy row — maps to UNKNOWN.
+        assert result.failure_type == FailureType.UNKNOWN
+        assert result.triage is not None
+        assert result.triage.is_transient is True
+        assert result.triage.category == "flaky"
+
+    @pytest.mark.asyncio
+    async def test_enforce_falls_back_to_legacy_when_llm_unavailable(self) -> None:
+        _set_ci_triage_mode("enforce")
+
+        # No llm_router — _candidate returns None; decorator falls
+        # through to legacy.
+        cr = make_check_run(name="ruff-check", conclusion=CheckConclusion.FAILURE)
+        result = await triage_failure(cr, llm_router=None)
+        assert result.failure_type == FailureType.LINT_FAILURE
+
+    @pytest.mark.asyncio
+    async def test_off_mode_back_compat_without_llm(self) -> None:
+        """T-A3 Part F: backward compat — existing call sites still work."""
+        _set_ci_triage_mode("off")
+
+        cr = make_check_run(
+            name="test-unit",
+            conclusion=CheckConclusion.FAILURE,
+            output_summary="FAILED test_foo.py::test_bar - AssertionError",
+        )
+        result = await triage_failure(cr, llm_router=None)
+        assert result.failure_type == FailureType.TEST_FAILURE
+        assert result.job_name == "test-unit"
+        assert "AssertionError" in result.raw_output
+
+
+class TestCategoryToFailureTypeMapping:
+    """Every legacy regex category has a FailureCategory row (round-trip)."""
+
+    @pytest.mark.parametrize(
+        ("legacy", "expected_category"),
+        [
+            (FailureType.TEST_FAILURE, "test"),
+            (FailureType.LINT_FAILURE, "lint"),
+            (FailureType.BUILD_FAILURE, "build"),
+            (FailureType.TYPE_ERROR, "type"),
+            (FailureType.TIMEOUT, "timeout"),
+            (FailureType.BACKLOG, "backpressure"),
+            (FailureType.UNKNOWN, "unknown"),
+        ],
+    )
+    def test_legacy_roundtrip(
+        self,
+        legacy: FailureType,
+        expected_category: str,
+    ) -> None:
+        # Build a check_run whose name triggers the legacy pattern, then
+        # confirm the adapter yields the expected category.
+        name_for: dict[FailureType, tuple[str, Any]] = {
+            FailureType.TEST_FAILURE: ("pytest-run", CheckConclusion.FAILURE),
+            FailureType.LINT_FAILURE: ("ruff-check", CheckConclusion.FAILURE),
+            FailureType.BUILD_FAILURE: ("build-docker", CheckConclusion.FAILURE),
+            FailureType.TYPE_ERROR: ("mypy", CheckConclusion.FAILURE),
+            FailureType.TIMEOUT: ("integration", CheckConclusion.TIMED_OUT),
+            FailureType.BACKLOG: ("queue-guard", CheckConclusion.FAILURE),
+            FailureType.UNKNOWN: ("deploy-staging", CheckConclusion.FAILURE),
+        }
+        name, conclusion = name_for[legacy]
+        cr = make_check_run(name=name, conclusion=conclusion)
+        verdict = classify_failure_adapter(cr)
+        assert verdict.category == expected_category


### PR DESCRIPTION
## Summary

Phase 2 T-A3. Replaces the keyword regex ladder in `src/caretaker/pr_agent/ci_triage.py` with a side-by-side `structured_complete[FailureTriage]` candidate, wired through the existing `@shadow_decision(\"ci_triage\")` infrastructure so the flip `off → shadow → enforce` can be driven entirely from `agentic.ci_triage.mode` in the maintainer config.

**Do not merge yet** — the migration is safe by default (`mode: off`) but needs shadow-mode telemetry before we flip authority.

## The broken `UNKNOWN` pattern today

On the caretaker repo itself, `classify_failure` returns `UNKNOWN` for the bulk of real CI failures (issues #412 / #413 / #462). The keyword ladder only catches stock job names (`test-*`, `ruff-*`, `mypy`); anything whose failure signal lives in the log body — or whose job name doesn't match a known substring — falls through to `UNKNOWN`, which in turn leaves the PR Agent posting `[WIP] Fix CI failure (unknown)` Copilot tasks that Copilot then auto-closes.

## The schema

```python
class FailureTriage(BaseModel):
    category: Literal[
        \"test\", \"lint\", \"build\", \"type\",
        \"timeout\", \"flaky\", \"backpressure\", \"infra\", \"unknown\",
    ]
    confidence: float = Field(ge=0.0, le=1.0)
    is_transient: bool      # subsumes NON_ACTIONABLE_CONCLUSIONS + flaky_retries
    root_cause_hypothesis: str = Field(max_length=300)
    minimal_reproduction: str | None = None  # shell one-liner when feasible
    suggested_fix: str = Field(max_length=500)
    files_to_touch: list[str] = Field(default_factory=list)
```

Once `mode: enforce` is live, callers that currently re-derive transience from `NON_ACTIONABLE_CONCLUSIONS` or `CIConfig.flaky_retries` should branch on `FailureTriage.is_transient` instead.

## Shadow wiring

- `classify_failure_llm(check_run, log_tail, *, claude)` — builds a cache-friendly prompt (stable system prefix with the category rubric; user message with job metadata + last ~200 log lines at the end) and calls `claude.structured_complete(..., feature=\"ci_triage\")`. Returns `None` on `StructuredCompleteError` so shadow-mode falls through without disrupting the hot path. The prompt deliberately omits the PR title/body — triage is about the failure, not the PR.
- `classify_failure_adapter(check_run)` — lifts the legacy regex verdict into a `FailureTriage` so the shadow decorator compares two same-shape values. Legacy's category/transience are preserved; LLM-only text fields get templated placeholders (`\"Legacy heuristic: matched pattern <X>\"`).
- `triage_failure()` — now dispatches through `@shadow_decision(\"ci_triage\", compare=<category + is_transient>)`. The custom comparator intentionally ignores the noisy free-text fields so minor rewording in `root_cause_hypothesis` doesn't spam the disagreement counter.
- `TriageResult` — grows an optional `triage: FailureTriage | None` field so callers in `enforce` mode can reach for the rich verdict; `off` / `shadow` modes populate it from the legacy adapter, which is loss-free vs. the pre-T-A3 `failure_type`.

## Rollout

1. **`agentic.ci_triage.mode: off`** (default, this PR) — no behaviour change. LLM path never runs.
2. **`shadow`** — flip on one repo (likely `ianlintner/caretaker` itself given the UNKNOWN churn). Inspect `/admin/shadow-decisions?name=ci_triage` for the agree / disagree / candidate_error distribution. Dashboard: `caretaker_shadow_decisions_total{name=\"ci_triage\"}`.
3. **`enforce`** — once disagreement < 10 % and no `candidate_error` storms, flip. Legacy remains the fall-through safety net when the LLM errors or returns `None`.

## Follow-ups

- **T-A10** (`crystallizer_category`) will reuse this classifier. A `TODO(T-A10, crystallizer_category)` pointer was added next to `evolution/crystallizer.py:_infer_category` so the next author can find the hand-off quickly.

## Test plan

- [x] `PYTHONPATH=\"$PWD/src\" pytest -q` — 1322 passed, 1 skipped
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src/caretaker` — 0 new errors (2 pre-existing in `k8s_worker/launcher.py` unrelated)
- [x] New `tests/test_pr_agent/test_ci_triage_llm.py`: 23 cases
  - [x] Schema round-trip + field bounds (confidence, max_length, Literal rejection)
  - [x] Legacy → `FailureTriage` adapter: every existing regex category maps correctly
  - [x] LLM candidate: mocked transient lint failure → `is_transient=True`, `category=\"lint\"`
  - [x] Error path: `StructuredCompleteError` → candidate returns `None` → shadow falls through
  - [x] Shadow decorator modes (off / shadow-agree / shadow-disagree / shadow-candidate-error / enforce-candidate-authoritative / enforce-fall-through)
  - [x] Backward compat: existing `classify_failure` call sites still work in `mode: off`
- [ ] Before flipping `mode: shadow` on any real repo, confirm the admin shadow-decisions endpoint renders `ci_triage` records and the Prometheus counter emits non-zero `{name=\"ci_triage\", mode=\"shadow\", outcome=...}` series.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>