### PR TITLE
feat(dispatch): webhook self-echo detector migration + shadow

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -77,6 +77,13 @@ jobs:
     steps:
       - name: Decide whether this event should run caretaker
         id: guard
+        # NOTE: This JS block is a cheap prefilter. The richer Python
+        # self-echo detector lives in
+        # ``src/caretaker/github_app/dispatch_guard.py`` and runs behind
+        # the ``agentic.dispatch_guard`` shadow-mode switch. Keep this
+        # regex + actor allowlist in sync with
+        # ``legacy_dispatch_verdict`` there — both encode the same
+        # deterministic rules.
         uses: actions/github-script@v7
         with:
           script: |

--- a/src/caretaker/github_app/__init__.py
+++ b/src/caretaker/github_app/__init__.py
@@ -13,6 +13,14 @@ and the FastAPI webhook receiver without circular imports.
 
 from __future__ import annotations
 
+from .dispatch_guard import (
+    DispatchEvent,
+    DispatchVerdict,
+    evaluate_dispatch,
+    judge_dispatch,
+    judge_dispatch_llm,
+    legacy_dispatch_verdict,
+)
 from .events import (
     EVENT_AGENT_MAP,
     agents_for_event,
@@ -34,12 +42,18 @@ from .webhooks import (
 __all__ = [
     "EVENT_AGENT_MAP",
     "AppJWTSigner",
+    "DispatchEvent",
+    "DispatchVerdict",
     "GitHubAppCredentialsProvider",
     "InstallationToken",
     "InstallationTokenCache",
     "InstallationTokenMinter",
     "WebhookSignatureError",
     "agents_for_event",
+    "evaluate_dispatch",
+    "judge_dispatch",
+    "judge_dispatch_llm",
+    "legacy_dispatch_verdict",
     "normalize_event_name",
     "parse_webhook",
     "verify_signature",

--- a/src/caretaker/github_app/dispatch_guard.py
+++ b/src/caretaker/github_app/dispatch_guard.py
@@ -1,0 +1,448 @@
+"""Dispatch-guard webhook self-echo detector (Phase 2, §3.2).
+
+The GitHub App webhook receiver has to decide — cheaply and defensively —
+whether an incoming event is a genuine human signal or caretaker's own
+output bouncing back through the webhook fabric. A marker regex +
+bot-login allowlist gets the common cases right but fails on two edges:
+
+* a real maintainer pastes caretaker's output into a comment so the
+  *body* looks like a self-echo even though the actor is human;
+* caretaker-authored content routes through a PAT-identified user (not a
+  bot login), so an actor-only filter lets it through.
+
+Both miscategorisations waste a CI minute at best and create a
+self-trigger loop at worst.
+
+This module encodes both the existing deterministic guard and an LLM
+candidate behind the standard :func:`~caretaker.evolution.shadow.shadow_decision`
+three-mode switch. The YAML-level JS guard in
+``.github/workflows/maintainer.yml`` stays in place as a cheap prefilter
+— the workflow can't import Python and the regex saves a CI minute when
+the answer is obviously "skip".
+
+Public surface
+--------------
+
+* :class:`DispatchVerdict` — pydantic verdict shared by legacy + LLM.
+* :class:`DispatchEvent` — a minimal view of a webhook event. Call sites
+  construct this from a :class:`~caretaker.github_app.webhooks.ParsedWebhook`.
+* :func:`legacy_dispatch_verdict` — the deterministic adapter. Equivalent
+  to the existing JS logic. Authoritative when the LLM mode is ``off``
+  and the fall-through safety net otherwise.
+* :func:`judge_dispatch_llm` — the structured-LLM candidate. Returns
+  ``None`` on the cheap-and-unambiguous branches to keep token spend
+  bounded.
+* :func:`judge_dispatch` — the :func:`shadow_decision`-wrapped entry
+  point that call sites should use.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+from caretaker.evolution.shadow import shadow_decision
+from caretaker.identity import is_automated
+
+if TYPE_CHECKING:
+    from caretaker.llm.claude import ClaudeClient
+
+logger = logging.getLogger(__name__)
+
+
+# ── Schema ────────────────────────────────────────────────────────────────
+
+
+SuggestedAgent = Literal[
+    "pr_agent",
+    "issue_agent",
+    "review_agent",
+    "self_heal_agent",
+    "devops_agent",
+    "docs_agent",
+    "triage",
+    "none",
+]
+
+
+class DispatchVerdict(BaseModel):
+    """Decision for a single webhook delivery.
+
+    Both legacy and LLM paths produce this shape so the shadow decorator
+    can compare them on identical fields.
+
+    Attributes:
+        is_self_echo: ``True`` when the event originated from caretaker's
+            own output (bot actor + caretaker marker, PAT-routed
+            caretaker content, or a comment that the LLM recognised as
+            one of caretaker's recent outputs).
+        is_human_intent: ``True`` when a human is asking caretaker to do
+            something (``@caretaker``/``/caretaker``/``/maintain``
+            mention on an otherwise unambiguous body).
+        suggested_agent: When ``is_human_intent`` is true, the agent the
+            LLM thinks the request is aimed at. Legacy always returns
+            ``"none"`` — it has no signal to distinguish agents.
+        reason: Short human-readable rationale (capped at 200 chars so
+            the shadow record stays log-line sized).
+    """
+
+    is_self_echo: bool
+    is_human_intent: bool
+    suggested_agent: SuggestedAgent = "none"
+    reason: str = Field(default="", max_length=200)
+
+
+# ── Event view ────────────────────────────────────────────────────────────
+#
+# We don't pass the raw :class:`ParsedWebhook` around because the dispatch
+# guard only needs a handful of fields and it is useful in tests to hand
+# in a minimal object without faking a full webhook delivery.
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchEvent:
+    """Minimal view of a webhook event for dispatch-guard purposes.
+
+    Attributes:
+        event_type: ``X-GitHub-Event`` header value (``issue_comment``,
+            ``pull_request_review``, ``push``, ``workflow_dispatch``, …).
+        actor_login: Login of the user/bot that caused the event. Empty
+            string when unknown.
+        comment_body: Raw body of the comment/review for events that
+            carry one. ``None`` for events without a body (``push``,
+            ``workflow_dispatch``, ``check_suite``, …).
+        recent_markers: Last few caretaker-authored marker strings on
+            the same thread. Forwarded to the LLM so it can spot echoes
+            of content caretaker itself produced.
+    """
+
+    event_type: str
+    actor_login: str = ""
+    comment_body: str | None = None
+    recent_markers: list[str] = field(default_factory=list)
+
+
+# ── Legacy adapter ────────────────────────────────────────────────────────
+
+
+# Matches the JS regex in .github/workflows/maintainer.yml (``<!--\\s*caretaker:[a-z0-9:_-]+``).
+# The pattern looks for the ``<!-- caretaker:…`` HTML-comment marker that
+# every caretaker-authored comment carries.
+_CARETAKER_MARKER_RE = re.compile(r"<!--\s*caretaker:[a-z0-9:_-]+", re.IGNORECASE)
+
+# Lowercase mention tokens that count as explicit human intent to invoke
+# caretaker. Keep in sync with the JS guard in ``maintainer.yml``.
+_EXPLICIT_TRIGGERS = (
+    "@the-care-taker",
+    "@caretaker",
+    "/caretaker",
+    "/maintain",
+)
+
+# Events whose payloads carry no meaningful comment body for self-echo
+# reasoning — skipping the LLM path for these saves tokens and always
+# produces an unambiguous legacy verdict anyway.
+_BODILESS_EVENTS: frozenset[str] = frozenset(
+    {
+        "push",
+        "workflow_dispatch",
+        "schedule",
+        "installation",
+        "installation_repositories",
+        "ping",
+    }
+)
+
+
+def _marker_matches(body: str | None) -> bool:
+    if not body:
+        return False
+    return _CARETAKER_MARKER_RE.search(body) is not None
+
+
+def _explicit_trigger_matches(body: str | None) -> bool:
+    if not body:
+        return False
+    lower = body.lower()
+    return any(token in lower for token in _EXPLICIT_TRIGGERS)
+
+
+def legacy_dispatch_verdict(event: DispatchEvent) -> DispatchVerdict:
+    """Return the deterministic verdict for ``event``.
+
+    This is a faithful port of the JS guard in
+    ``.github/workflows/maintainer.yml``:
+
+    * ``is_self_echo`` → ``is_automated(actor) AND marker_regex_matches(body)``.
+      The actor-only and marker-only branches individually miss cases
+      (PAT-routed caretaker; humans pasting caretaker output); the
+      conjunction is deliberately conservative.
+    * ``is_human_intent`` → ``NOT is_automated(actor) AND
+      explicit_trigger_matches(body)``.
+    * ``suggested_agent`` is always ``"none"`` here — the deterministic
+      path has no signal to distinguish agents.
+
+    Bodiless events (``push``, ``workflow_dispatch``, …) produce
+    ``is_self_echo=False, is_human_intent=False``: the caller is expected
+    to route them via the event-type map without a dispatch-guard call.
+    """
+    actor_automated = is_automated(event.actor_login) if event.actor_login else False
+    marker_hit = _marker_matches(event.comment_body)
+    trigger_hit = _explicit_trigger_matches(event.comment_body)
+
+    is_self_echo = actor_automated and marker_hit
+    is_human_intent = (not actor_automated) and trigger_hit
+
+    if is_self_echo:
+        reason = f"legacy: bot actor {event.actor_login!r} + caretaker marker"
+    elif is_human_intent:
+        reason = f"legacy: human actor {event.actor_login!r} with explicit trigger"
+    elif actor_automated:
+        reason = f"legacy: bot actor {event.actor_login!r} without marker"
+    elif marker_hit:
+        reason = "legacy: non-bot actor carrying caretaker marker (ambiguous)"
+    else:
+        reason = "legacy: no self-echo / no explicit trigger"
+
+    return DispatchVerdict(
+        is_self_echo=is_self_echo,
+        is_human_intent=is_human_intent,
+        suggested_agent="none",
+        reason=reason[:200],
+    )
+
+
+# ── LLM candidate ─────────────────────────────────────────────────────────
+
+
+# Keep the prompt stable-prefixed so the provider's prompt cache can kick
+# in. The schema and guidance never change; only the event-specific
+# suffix does.
+_SYSTEM_PROMPT = (
+    "You are caretaker's dispatch guard. Decide whether an incoming GitHub "
+    "webhook is (a) caretaker's own output looping back (self-echo), or (b) "
+    "a human asking caretaker to do something (human_intent). Humans who "
+    "paste caretaker output are NOT self-echoes — distinguish intent from "
+    "format. Bot actors emitting plain CI output are not human_intent. "
+    "When in doubt about suggested_agent, return 'none'. Keep 'reason' "
+    "under 200 chars."
+)
+
+
+def _short_body(body: str | None, *, limit: int = 500) -> str:
+    if not body:
+        return ""
+    if len(body) <= limit:
+        return body
+    # Tail-end is more informative than head for comments that start with
+    # boilerplate banners; keep the most-recent 500 chars.
+    return body[-limit:]
+
+
+def _should_consult_llm(event: DispatchEvent, legacy: DispatchVerdict) -> bool:
+    """Return ``True`` when the LLM candidate should actually run.
+
+    Cost-control rules (see Part E of T-A2):
+
+    * Events without a body (``push``, ``workflow_dispatch``, …) are
+      skipped — there is no comment body for the LLM to judge.
+    * Legacy-unambiguous self-echoes (bot actor + marker, body absent)
+      and legacy-unambiguous noops (no marker, no trigger) are skipped —
+      the deterministic path already produces the right answer and we
+      save the tokens.
+    * Every other combination is *ambiguous* from the deterministic
+      path's perspective (PAT-routed caretaker, humans pasting caretaker
+      output, weird mention spellings) and worth the tokens.
+    """
+    if event.event_type in _BODILESS_EVENTS:
+        return False
+    if event.comment_body is None:
+        return False
+
+    actor_automated = is_automated(event.actor_login) if event.actor_login else False
+    marker_hit = _marker_matches(event.comment_body)
+    trigger_hit = _explicit_trigger_matches(event.comment_body)
+
+    # Bot actor + no marker + no trigger → legacy already says "skip, no
+    # self-echo"; nothing for the LLM to disambiguate.
+    if actor_automated and not marker_hit and not trigger_hit:
+        return False
+    # No marker + no trigger + non-bot actor → plain comment, legacy
+    # already says "no self-echo, no explicit trigger"; save the tokens.
+    if (not actor_automated) and not marker_hit and not trigger_hit:
+        return False
+
+    # Everything else — humans pasting caretaker output, PAT-routed
+    # caretaker, bot reviews with mentions, etc. — is genuinely
+    # ambiguous; spend the tokens.
+    _ = legacy  # reserved for future per-branch policies
+    return True
+
+
+async def judge_dispatch_llm(
+    event: DispatchEvent,
+    *,
+    claude: ClaudeClient | None,
+) -> DispatchVerdict | None:
+    """LLM candidate for :func:`shadow_decision`.
+
+    Returns a :class:`DispatchVerdict` when the model is consulted, or
+    ``None`` on the cheap-and-unambiguous short-circuit path. The
+    shadow-wrap treats ``None`` as "keep legacy authoritative", which
+    exactly matches the cost-control policy we want: only pay tokens
+    when the deterministic path is ambiguous.
+
+    Errors (provider outage, schema validation, JSON decode) are
+    swallowed and returned as ``None``. The shadow decorator's ``enforce``
+    branch falls through to legacy on ``None`` too, so callers never see
+    a half-broken candidate bubble up.
+    """
+    if claude is None or not getattr(claude, "available", False):
+        return None
+
+    # Re-run the legacy check here so the short-circuit is self-contained
+    # and the candidate can be invoked in isolation (tests, retries).
+    legacy = legacy_dispatch_verdict(event)
+    if not _should_consult_llm(event, legacy):
+        return None
+
+    prompt = _build_prompt(event)
+    try:
+        verdict = await claude.structured_complete(
+            prompt,
+            schema=DispatchVerdict,
+            feature="dispatch_guard",
+            system=_SYSTEM_PROMPT,
+        )
+    except Exception as exc:  # provider outage, bad JSON, schema mismatch
+        logger.warning(
+            "dispatch_guard LLM candidate failed (event=%s actor=%s): %s: %s",
+            event.event_type,
+            event.actor_login,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+    # Clamp the reason field defensively — ``structured_complete`` already
+    # validates ``max_length=200`` but a forgiving model may slip a
+    # longer string past if we ever relax the schema.
+    if len(verdict.reason) > 200:
+        verdict = verdict.model_copy(update={"reason": verdict.reason[:200]})
+    return verdict
+
+
+def _build_prompt(event: DispatchEvent) -> str:
+    """Serialise the variable suffix of the LLM prompt.
+
+    Kept separate from :data:`_SYSTEM_PROMPT` so call-site-invariant text
+    lands in the stable system block (cache-friendly) while the
+    per-event payload lives in the user turn.
+    """
+    body_snippet = _short_body(event.comment_body)
+    markers = "\n".join(f"  - {m}" for m in event.recent_markers[:5]) or "  (none)"
+    return (
+        f"event_type: {event.event_type}\n"
+        f"actor_login: {event.actor_login or '(unknown)'}\n"
+        f"recent_caretaker_markers:\n{markers}\n"
+        f"comment_body (last 500 chars):\n{body_snippet}"
+    )
+
+
+# ── Shadow-wrapped entry point ────────────────────────────────────────────
+
+
+def _dispatch_compare(a: DispatchVerdict | None, b: DispatchVerdict | None) -> bool:
+    """Treat two verdicts as equal when the dispatch-affecting fields match.
+
+    The ``reason`` string is advisory and legacy/LLM phrase it differently
+    even when they agree on the outcome; comparing on it would flood the
+    disagreement stream with noise.  ``suggested_agent`` is also excluded
+    because legacy can never produce anything but ``"none"``.
+
+    The candidate may return ``None`` on purpose (cost-control
+    short-circuit) — treat that as "no signal, no disagreement" rather
+    than a raw inequality. The shadow decorator tags those records as
+    ``agree`` which avoids filling the disagreement stream with
+    expected short-circuits.
+    """
+    if a is None or b is None:
+        return True
+    return (a.is_self_echo, a.is_human_intent) == (b.is_self_echo, b.is_human_intent)
+
+
+@shadow_decision("dispatch_guard", compare=_dispatch_compare)
+async def judge_dispatch(
+    event: DispatchEvent,
+    *,
+    claude: ClaudeClient | None = None,
+    legacy: object = None,  # supplied by the decorator
+    candidate: object = None,  # supplied by the decorator
+    context: dict[str, object] | None = None,  # supplied by the decorator
+) -> DispatchVerdict:
+    """Public dispatch-guard decision site.
+
+    Callers invoke this directly and the :func:`shadow_decision`
+    decorator takes care of picking legacy / candidate based on
+    ``config.agentic.dispatch_guard.mode``. The two implementations are
+    supplied via the ``legacy``/``candidate`` keyword arguments so the
+    decorator stays importless.
+    """
+    # The body of this function is only reached on decorator
+    # misconfiguration — the wrapper always returns before dispatching
+    # here. Raise a descriptive TypeError to surface programmer errors
+    # early rather than silently shadowing.
+    raise TypeError(  # pragma: no cover — decorator handles dispatch
+        "judge_dispatch must be invoked via its shadow_decision wrapper; "
+        "pass legacy=..., candidate=..., context=... keyword arguments."
+    )
+
+
+async def evaluate_dispatch(
+    event: DispatchEvent,
+    *,
+    claude: ClaudeClient | None = None,
+    context: dict[str, object] | None = None,
+) -> DispatchVerdict:
+    """Convenience wrapper that wires legacy + candidate into :func:`judge_dispatch`.
+
+    Call sites that already have a :class:`ClaudeClient` available should
+    prefer this — it hides the ``legacy=``/``candidate=`` kwargs that the
+    shadow decorator needs.
+
+    ``legacy`` and ``candidate`` accept the same ``(event, *, claude=...)``
+    signature :func:`judge_dispatch` itself exposes so the shadow
+    decorator can forward positional + keyword args through unchanged.
+    """
+
+    async def _legacy(ev: DispatchEvent, *, claude: ClaudeClient | None = None) -> DispatchVerdict:
+        _ = claude  # legacy path is deterministic; no LLM needed
+        return legacy_dispatch_verdict(ev)
+
+    async def _candidate(
+        ev: DispatchEvent, *, claude: ClaudeClient | None = None
+    ) -> DispatchVerdict | None:
+        return await judge_dispatch_llm(ev, claude=claude)
+
+    return await judge_dispatch(
+        event,
+        claude=claude,
+        legacy=_legacy,
+        candidate=_candidate,
+        context=context,
+    )
+
+
+__all__ = [
+    "DispatchEvent",
+    "DispatchVerdict",
+    "SuggestedAgent",
+    "evaluate_dispatch",
+    "judge_dispatch",
+    "judge_dispatch_llm",
+    "legacy_dispatch_verdict",
+]

--- a/tests/test_github_app/test_dispatch_guard.py
+++ b/tests/test_github_app/test_dispatch_guard.py
@@ -1,0 +1,641 @@
+"""Tests for the dispatch-guard self-echo detector (T-A2).
+
+Covers:
+
+* :class:`DispatchVerdict` schema (length cap on ``reason``, default
+  ``suggested_agent``, strict literal on ``suggested_agent``).
+* :func:`legacy_dispatch_verdict` parity with the JS guard in
+  ``.github/workflows/maintainer.yml``.
+* :func:`judge_dispatch_llm` short-circuit for bodiless events + the
+  unambiguous-legacy fast paths.
+* :func:`judge_dispatch_llm` ambiguous case → LLM consulted → mocked
+  response returned.
+* :func:`judge_dispatch_llm` provider error → candidate returns ``None``
+  → :func:`evaluate_dispatch` falls back to legacy.
+* :func:`evaluate_dispatch` under all three shadow modes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from caretaker.config import AgenticConfig, AgenticDomainConfig
+from caretaker.evolution import shadow_config
+from caretaker.evolution.shadow import clear_records_for_tests, recent_records
+from caretaker.github_app.dispatch_guard import (
+    _CARETAKER_MARKER_RE,
+    DispatchEvent,
+    DispatchVerdict,
+    _should_consult_llm,
+    evaluate_dispatch,
+    judge_dispatch_llm,
+    legacy_dispatch_verdict,
+)
+from caretaker.graph import writer as graph_writer
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state() -> None:
+    clear_records_for_tests()
+    shadow_config.reset_for_tests()
+    graph_writer.reset_for_tests()
+
+
+def _set_dispatch_mode(mode: str) -> None:
+    cfg = AgenticConfig(dispatch_guard=AgenticDomainConfig(mode=mode))  # type: ignore[arg-type]
+    shadow_config.configure(cfg)
+
+
+# ── Schema ───────────────────────────────────────────────────────────────
+
+
+class TestDispatchVerdictSchema:
+    def test_defaults(self) -> None:
+        verdict = DispatchVerdict(is_self_echo=False, is_human_intent=False)
+        assert verdict.suggested_agent == "none"
+        assert verdict.reason == ""
+
+    def test_reason_length_is_capped(self) -> None:
+        with pytest.raises(ValidationError):
+            DispatchVerdict(
+                is_self_echo=False,
+                is_human_intent=False,
+                reason="x" * 201,
+            )
+
+    def test_suggested_agent_is_literal(self) -> None:
+        with pytest.raises(ValidationError):
+            DispatchVerdict(  # type: ignore[call-arg]
+                is_self_echo=False,
+                is_human_intent=True,
+                suggested_agent="not_a_real_agent",
+            )
+
+    def test_all_agent_labels_validate(self) -> None:
+        labels = [
+            "pr_agent",
+            "issue_agent",
+            "review_agent",
+            "self_heal_agent",
+            "devops_agent",
+            "docs_agent",
+            "triage",
+            "none",
+        ]
+        for label in labels:
+            verdict = DispatchVerdict(
+                is_self_echo=False,
+                is_human_intent=True,
+                suggested_agent=label,  # type: ignore[arg-type]
+            )
+            assert verdict.suggested_agent == label
+
+
+# ── Legacy adapter parity ────────────────────────────────────────────────
+
+
+class TestLegacyDispatchVerdict:
+    """Mirror the JS branches in ``.github/workflows/maintainer.yml``."""
+
+    def test_bot_actor_with_marker_is_self_echo(self) -> None:
+        verdict = legacy_dispatch_verdict(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="the-care-taker[bot]",
+                comment_body="<!-- caretaker:review-result -->\nhello",
+            )
+        )
+        assert verdict.is_self_echo is True
+        assert verdict.is_human_intent is False
+        assert verdict.suggested_agent == "none"
+
+    def test_bot_actor_without_marker_is_not_self_echo(self) -> None:
+        # JS guard: bot-authored + no marker → skipped by the actor
+        # allowlist, but that isn't "self-echo" — it's just "bot noise".
+        # Deterministic verdict encodes that as both fields False.
+        verdict = legacy_dispatch_verdict(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="github-actions[bot]",
+                comment_body="lint failed",
+            )
+        )
+        assert verdict.is_self_echo is False
+        assert verdict.is_human_intent is False
+
+    def test_human_with_explicit_mention_is_human_intent(self) -> None:
+        verdict = legacy_dispatch_verdict(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="@caretaker please triage this",
+            )
+        )
+        assert verdict.is_self_echo is False
+        assert verdict.is_human_intent is True
+
+    def test_human_with_slash_command_is_human_intent(self) -> None:
+        for cmd in ("/caretaker run", "/maintain now", "@the-care-taker hi"):
+            verdict = legacy_dispatch_verdict(
+                DispatchEvent(
+                    event_type="issue_comment",
+                    actor_login="ianlintner",
+                    comment_body=cmd,
+                )
+            )
+            assert verdict.is_human_intent is True, cmd
+
+    def test_human_pasting_caretaker_output_is_ambiguous_from_legacy(self) -> None:
+        # Legacy verdict: not self-echo (actor is human), not human-intent
+        # (no explicit mention). This is the edge the LLM exists to fix.
+        verdict = legacy_dispatch_verdict(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="<!-- caretaker:triage-result -->\nfyi this ran",
+            )
+        )
+        assert verdict.is_self_echo is False
+        assert verdict.is_human_intent is False
+        # The reason string flags the ambiguity.
+        assert "ambiguous" in verdict.reason
+
+    def test_bodiless_event_is_silent(self) -> None:
+        verdict = legacy_dispatch_verdict(
+            DispatchEvent(event_type="push", actor_login="ianlintner")
+        )
+        assert verdict.is_self_echo is False
+        assert verdict.is_human_intent is False
+
+    def test_empty_actor_treats_as_non_bot(self) -> None:
+        verdict = legacy_dispatch_verdict(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="",
+                comment_body="@caretaker hi",
+            )
+        )
+        assert verdict.is_human_intent is True
+
+    def test_marker_regex_matches_known_caretaker_markers(self) -> None:
+        # Parity check against the JS regex in the workflow.
+        for marker in (
+            "<!-- caretaker:causal id=abc source=pr -->",
+            "<!--caretaker:result-->",
+            "<!-- caretaker:triage -->",
+            "<!-- caretaker:scope-gap -->",
+            "<!-- caretaker:claude-code-handoff -->",
+        ):
+            assert _CARETAKER_MARKER_RE.search(marker), marker
+
+    def test_marker_regex_rejects_unrelated_html_comments(self) -> None:
+        for not_marker in (
+            "<!-- not-us -->",
+            "<!-- somebody:else -->",
+            "plain text",
+        ):
+            assert _CARETAKER_MARKER_RE.search(not_marker) is None, not_marker
+
+
+# ── Cost-control short-circuit ───────────────────────────────────────────
+
+
+class TestCostControl:
+    async def test_push_event_skips_llm(self) -> None:
+        claude = AsyncMock()
+        result = await judge_dispatch_llm(
+            DispatchEvent(event_type="push", actor_login="ianlintner"),
+            claude=claude,
+        )
+        assert result is None
+        claude.structured_complete.assert_not_awaited()
+
+    async def test_workflow_dispatch_skips_llm(self) -> None:
+        claude = AsyncMock()
+        result = await judge_dispatch_llm(
+            DispatchEvent(event_type="workflow_dispatch", actor_login="ianlintner"),
+            claude=claude,
+        )
+        assert result is None
+        claude.structured_complete.assert_not_awaited()
+
+    async def test_missing_claude_returns_none(self) -> None:
+        result = await judge_dispatch_llm(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="@caretaker help",
+            ),
+            claude=None,
+        )
+        assert result is None
+
+    async def test_unavailable_claude_returns_none(self) -> None:
+        claude = AsyncMock()
+        claude.available = False
+        result = await judge_dispatch_llm(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="@caretaker help",
+            ),
+            claude=claude,
+        )
+        assert result is None
+        claude.structured_complete.assert_not_awaited()
+
+    async def test_bot_no_marker_no_trigger_skips_llm(self) -> None:
+        # Legacy already unambiguously says "skip": bot actor with a
+        # plain CI comment. No tokens spent.
+        claude = AsyncMock()
+        claude.available = True
+        result = await judge_dispatch_llm(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="github-actions[bot]",
+                comment_body="lint failed",
+            ),
+            claude=claude,
+        )
+        assert result is None
+        claude.structured_complete.assert_not_awaited()
+
+    async def test_human_plain_comment_skips_llm(self) -> None:
+        # Legacy already unambiguously says "skip": human, no marker, no
+        # trigger. Plain chatter, no LLM needed.
+        claude = AsyncMock()
+        claude.available = True
+        result = await judge_dispatch_llm(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="looks good to me",
+            ),
+            claude=claude,
+        )
+        assert result is None
+        claude.structured_complete.assert_not_awaited()
+
+    def test_should_consult_llm_covers_human_with_marker(self) -> None:
+        # Exercised directly — the ambiguous branch that the
+        # evaluate_dispatch test hits via the AsyncMock wiring.
+        event = DispatchEvent(
+            event_type="issue_comment",
+            actor_login="ianlintner",
+            comment_body="<!-- caretaker:triage --> fyi",
+        )
+        assert _should_consult_llm(event, legacy_dispatch_verdict(event)) is True
+
+
+# ── Ambiguous case → LLM invoked ─────────────────────────────────────────
+
+
+class TestJudgeDispatchLlmAmbiguous:
+    async def test_human_pasting_caretaker_output_invokes_llm(self) -> None:
+        claude = AsyncMock()
+        claude.available = True
+        claude.structured_complete.return_value = DispatchVerdict(
+            is_self_echo=False,
+            is_human_intent=True,
+            suggested_agent="triage",
+            reason="user quoted caretaker output but is asking for triage help",
+        )
+
+        verdict = await judge_dispatch_llm(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="<!-- caretaker:triage --> why did you skip this?",
+                recent_markers=["<!-- caretaker:triage -->"],
+            ),
+            claude=claude,
+        )
+
+        assert verdict is not None
+        assert verdict.is_human_intent is True
+        assert verdict.suggested_agent == "triage"
+        claude.structured_complete.assert_awaited_once()
+        kwargs = claude.structured_complete.await_args.kwargs
+        assert kwargs["schema"] is DispatchVerdict
+        assert kwargs["feature"] == "dispatch_guard"
+        assert "self-echo" in kwargs["system"].lower()
+
+    async def test_bot_reviewer_with_human_style_mention_invokes_llm(self) -> None:
+        # Marker absent, trigger present, actor is a bot → legacy says
+        # "not self-echo, not human intent"; ambiguous from the guard's
+        # perspective so we should consult the LLM.
+        claude = AsyncMock()
+        claude.available = True
+        claude.structured_complete.return_value = DispatchVerdict(
+            is_self_echo=True,
+            is_human_intent=False,
+            suggested_agent="none",
+            reason="bot echoing an earlier @caretaker mention",
+        )
+
+        verdict = await judge_dispatch_llm(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="copilot-pull-request-reviewer[bot]",
+                comment_body="@caretaker please look at this nit",
+            ),
+            claude=claude,
+        )
+
+        assert verdict is not None
+        assert verdict.is_self_echo is True
+        claude.structured_complete.assert_awaited_once()
+
+    async def test_llm_provider_error_returns_none(self) -> None:
+        claude = AsyncMock()
+        claude.available = True
+        claude.structured_complete.side_effect = RuntimeError("provider down")
+
+        result = await judge_dispatch_llm(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="<!-- caretaker:triage --> fyi",
+            ),
+            claude=claude,
+        )
+        assert result is None
+
+    async def test_prompt_includes_recent_markers(self) -> None:
+        claude = AsyncMock()
+        claude.available = True
+        claude.structured_complete.return_value = DispatchVerdict(
+            is_self_echo=True, is_human_intent=False
+        )
+
+        await judge_dispatch_llm(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="<!-- caretaker:triage --> fyi",
+                recent_markers=["<!-- caretaker:alpha -->", "<!-- caretaker:beta -->"],
+            ),
+            claude=claude,
+        )
+
+        user_prompt = claude.structured_complete.await_args.args[0]
+        assert "<!-- caretaker:alpha -->" in user_prompt
+        assert "<!-- caretaker:beta -->" in user_prompt
+        assert "event_type: issue_comment" in user_prompt
+
+    async def test_prompt_truncates_long_body(self) -> None:
+        claude = AsyncMock()
+        claude.available = True
+        claude.structured_complete.return_value = DispatchVerdict(
+            is_self_echo=False, is_human_intent=True
+        )
+        big_body = "X" * 2000 + "\n@caretaker tail"
+        await judge_dispatch_llm(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body=big_body,
+            ),
+            claude=claude,
+        )
+        user_prompt = claude.structured_complete.await_args.args[0]
+        # Tail-end retained, leading padding dropped.
+        assert "@caretaker tail" in user_prompt
+        # We cap at 500 chars + scaffolding; the full 2000 X block must
+        # not be present verbatim.
+        assert "X" * 600 not in user_prompt
+
+
+# ── Shadow three-modes ───────────────────────────────────────────────────
+
+
+class TestEvaluateDispatchShadow:
+    async def test_off_mode_uses_legacy_only(self) -> None:
+        _set_dispatch_mode("off")
+        claude = AsyncMock()
+        claude.available = True
+
+        verdict = await evaluate_dispatch(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="@caretaker triage",
+            ),
+            claude=claude,
+        )
+
+        assert verdict.is_human_intent is True
+        claude.structured_complete.assert_not_awaited()
+        assert recent_records() == []
+
+    async def test_shadow_mode_runs_both_and_records_disagreement(self) -> None:
+        _set_dispatch_mode("shadow")
+        claude = AsyncMock()
+        claude.available = True
+        # Legacy says "self-echo" (bot + marker). LLM disagrees — model
+        # thinks it's actually a human follow-up. Legacy wins in shadow.
+        claude.structured_complete.return_value = DispatchVerdict(
+            is_self_echo=False,
+            is_human_intent=True,
+            suggested_agent="triage",
+            reason="bot relaying a human's escalation request",
+        )
+
+        verdict = await evaluate_dispatch(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="the-care-taker[bot]",
+                comment_body="<!-- caretaker:triage --> escalation",
+            ),
+            claude=claude,
+            context={"repo_slug": "ian/demo", "delivery_id": "abc"},
+        )
+
+        # Legacy verdict authoritative in shadow.
+        assert verdict.is_self_echo is True
+        assert verdict.is_human_intent is False
+        records = recent_records()
+        assert len(records) == 1
+        assert records[0].name == "dispatch_guard"
+        assert records[0].outcome == "disagree"
+        assert records[0].repo_slug == "ian/demo"
+
+    async def test_shadow_mode_agreement_records_agree(self) -> None:
+        _set_dispatch_mode("shadow")
+        claude = AsyncMock()
+        claude.available = True
+        # Ambiguous input (human pasting caretaker marker). LLM agrees
+        # with legacy that it is not a self-echo.
+        claude.structured_complete.return_value = DispatchVerdict(
+            is_self_echo=False,
+            is_human_intent=False,
+            suggested_agent="none",
+            reason="human paste, no request",
+        )
+
+        verdict = await evaluate_dispatch(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="<!-- caretaker:triage --> interesting",
+            ),
+            claude=claude,
+        )
+
+        assert verdict.is_self_echo is False
+        assert verdict.is_human_intent is False
+        records = recent_records()
+        assert len(records) == 1
+        assert records[0].outcome == "agree"
+
+    async def test_shadow_mode_candidate_short_circuit_falls_through(self) -> None:
+        # Legacy-unambiguous input (bot + no marker + no trigger) should
+        # return None from the candidate and land in candidate_error
+        # (the shadow wrapper treats None explicitly only in enforce —
+        # in shadow None flows through as the candidate verdict).
+        _set_dispatch_mode("shadow")
+        claude = AsyncMock()
+        claude.available = True
+
+        verdict = await evaluate_dispatch(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="github-actions[bot]",
+                comment_body="CI passed",
+            ),
+            claude=claude,
+        )
+
+        assert verdict.is_self_echo is False
+        assert verdict.is_human_intent is False
+        # LLM must not have been invoked — cost control.
+        claude.structured_complete.assert_not_awaited()
+
+    async def test_enforce_mode_candidate_wins(self) -> None:
+        _set_dispatch_mode("enforce")
+        claude = AsyncMock()
+        claude.available = True
+        claude.structured_complete.return_value = DispatchVerdict(
+            is_self_echo=False,
+            is_human_intent=True,
+            suggested_agent="triage",
+            reason="human pasted output; actually asking a question",
+        )
+
+        verdict = await evaluate_dispatch(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="<!-- caretaker:triage --> why skip?",
+            ),
+            claude=claude,
+        )
+
+        assert verdict.is_human_intent is True
+        assert verdict.suggested_agent == "triage"
+        claude.structured_complete.assert_awaited_once()
+
+    async def test_enforce_mode_candidate_none_falls_through_to_legacy(self) -> None:
+        # Bodiless event → candidate returns None → enforce falls through
+        # to legacy, which also returns (False, False). The important
+        # property is that we didn't crash.
+        _set_dispatch_mode("enforce")
+        claude = AsyncMock()
+        claude.available = True
+
+        verdict = await evaluate_dispatch(
+            DispatchEvent(event_type="push", actor_login="ianlintner"),
+            claude=claude,
+        )
+        assert verdict.is_self_echo is False
+        assert verdict.is_human_intent is False
+        claude.structured_complete.assert_not_awaited()
+
+    async def test_enforce_mode_candidate_error_falls_through_to_legacy(self) -> None:
+        _set_dispatch_mode("enforce")
+        claude = AsyncMock()
+        claude.available = True
+        claude.structured_complete.side_effect = RuntimeError("provider down")
+
+        verdict = await evaluate_dispatch(
+            DispatchEvent(
+                event_type="issue_comment",
+                actor_login="ianlintner",
+                comment_body="@caretaker help",
+            ),
+            claude=claude,
+        )
+        # Candidate returned None (error swallowed inside
+        # judge_dispatch_llm) → legacy verdict is authoritative.
+        assert verdict.is_human_intent is True
+
+
+# ── Unconfigured → default off ───────────────────────────────────────────
+
+
+async def test_unconfigured_defaults_to_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No shadow_config.configure() → decorator treats as ``off``.
+    claude = AsyncMock()
+    claude.available = True
+
+    verdict = await evaluate_dispatch(
+        DispatchEvent(
+            event_type="issue_comment",
+            actor_login="ianlintner",
+            comment_body="@caretaker hi",
+        ),
+        claude=claude,
+    )
+    assert verdict.is_human_intent is True
+    claude.structured_complete.assert_not_awaited()
+
+
+# ── Cast check: call paths don't mutate the DispatchEvent ────────────────
+
+
+def test_dispatch_event_is_immutable() -> None:
+    event = DispatchEvent(
+        event_type="issue_comment",
+        actor_login="ianlintner",
+        comment_body="hi",
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        event.actor_login = "someone-else"  # type: ignore[misc]
+
+
+def test_dispatch_event_default_markers_are_not_aliased() -> None:
+    first = DispatchEvent(event_type="issue_comment")
+    second = DispatchEvent(event_type="issue_comment")
+    assert first.recent_markers == []
+    assert first.recent_markers is not second.recent_markers
+
+
+# ── Guards against accidental use of AsyncMock with ClaudeClient.available ──
+
+
+def test_dispatch_event_comment_body_none_is_bodiless() -> None:
+    event = DispatchEvent(event_type="issue_comment", actor_login="ianlintner")
+    verdict = legacy_dispatch_verdict(event)
+    assert verdict.is_self_echo is False
+    assert verdict.is_human_intent is False
+
+
+def test_repr_does_not_leak_long_bodies() -> None:
+    # dataclass repr leaks everything but we only care that the comment
+    # body isn't mutated on construction.
+    big = "hello" * 200
+    event = DispatchEvent(event_type="issue_comment", comment_body=big)
+    assert event.comment_body == big
+    assert _CARETAKER_MARKER_RE.search(big) is None
+
+
+def _make_fake_claude(**kwargs: Any) -> AsyncMock:  # pragma: no cover - helper
+    mock = AsyncMock(**kwargs)
+    mock.available = True
+    return mock


### PR DESCRIPTION
## Motivation

The dispatch guard decides whether a webhook delivery is a real human
signal or caretaker's own output bouncing back. Today that decision
lives in two places:

1. A JS block in `.github/workflows/maintainer.yml` (cheap prefilter).
2. A mirrored Python actor allowlist in `caretaker.pr_agent._constants`
   (now shimmed through `caretaker.identity` per T-A7).

Both are marker regex + bot-login allowlist and both miss the same two
edges:

- A real maintainer pastes caretaker's output into a follow-up comment.
  The body looks self-echo even though the actor is a human asking for
  help.
- Caretaker-authored content gets routed through a PAT-identified user
  (not a bot login), so actor-only filtering lets it through.

This PR migrates the Python-side decision to
`structured_complete[DispatchVerdict]` behind `agentic.dispatch_guard`,
keeping the YAML regex as the cheap prefilter (the workflow can't
import Python and the regex saves a CI minute when the answer is
obviously "skip").

## Schema

```python
class DispatchVerdict(BaseModel):
    is_self_echo: bool
    is_human_intent: bool
    suggested_agent: Literal[
        "pr_agent", "issue_agent", "review_agent",
        "self_heal_agent", "devops_agent", "docs_agent",
        "triage", "none",
    ] = "none"
    reason: str = Field(default="", max_length=200)
```

`DispatchEvent` is a minimal immutable view with the event type, actor
login, last 500 chars of the comment body, and the last 5
caretaker-authored markers on the thread (so the LLM can spot echoes of
content caretaker itself produced).

## Cost-control short-circuit

The candidate returns `None` — which the shadow decorator treats as
"keep legacy authoritative" — on every branch where the deterministic
path is unambiguous:

- bodiless events (`push`, `workflow_dispatch`, `schedule`, ping,
  installation lifecycle)
- bot actor + no marker + no trigger (plain CI output)
- human actor + no marker + no trigger (plain chatter)
- missing / unavailable `ClaudeClient`
- provider errors, JSON decode errors, schema validation errors
  (logged, then swallowed)

The LLM only fires on genuinely ambiguous inputs: humans pasting
caretaker output, PAT-routed caretaker content, bot reviews that carry
mention-style tokens, and so on.

The prompt is split into a stable system block (schema + guidance) and
a variable user turn (event fields), so Anthropic prompt caching can
pin the invariants across deliveries.

## Rollout

Default `agentic.dispatch_guard.mode: off` — no behavioural change.

1. `off` → classic heuristic is sole authority. LLM path never runs.
2. `shadow` → both paths run. Legacy verdict returned. Disagreements
   land in the `ShadowDecision` ring buffer / Neo4j writer / log
   fallback via `@shadow_decision` for operators to inspect.
3. `enforce` → LLM candidate is authoritative. Legacy is the
   fall-through safety net on `None` / error.

The compare function ignores `reason` (advisory; legacy and LLM phrase
agreements differently) and `suggested_agent` (legacy can't produce
anything but `"none"`). It also treats `None` candidates as "no signal"
so cost-control short-circuits don't fill the disagreement stream.

## YAML

Added a comment on the `dispatch-guard` step pointing at the Python
module and flagging the need to keep the regex + actor allowlist in
sync.

## Test plan

- [x] `DispatchVerdict` schema — length cap on `reason`, literal on
  `suggested_agent`, defaults, every agent label validates.
- [x] Legacy adapter parity — every JS branch mapped: bot+marker,
  human mention, slash commands, human-pastes-caretaker-output,
  bodiless, bot CI noise, empty actor.
- [x] Candidate short-circuit — `push`, `workflow_dispatch`, missing
  `ClaudeClient`, unavailable `ClaudeClient`, bot+no-marker+no-trigger,
  human+no-marker+no-trigger.
- [x] Ambiguous case — human pasting caretaker output, bot reviewer
  with human-style mention → LLM consulted with
  `feature="dispatch_guard"`, schema=`DispatchVerdict`, stable system
  prompt.
- [x] Prompt shape — recent markers forwarded, long body
  tail-truncated to 500 chars.
- [x] Error path — `structured_complete` raises → candidate returns
  `None` → shadow falls through to legacy.
- [x] Shadow three-modes — `off` (legacy only, no records), `shadow`
  (agree + disagree records, legacy wins), `enforce` (candidate wins,
  `None` falls through, error falls through).

Gates:

- `PYTHONPATH=$PWD/src pytest -q` → **1321 passed, 1 skipped**.
- `ruff check src tests` → clean.
- `ruff format --check src tests` → clean.
- `PYTHONPATH=$PWD/src mypy src/caretaker` → only pre-existing baseline
  errors in `k8s_worker/launcher.py` (same on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)