### PR TITLE
feat(issue_agent): issue triage + dup detection migration

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -864,6 +864,30 @@ class AgenticDomainConfig(StrictBaseModel):
     mode: Literal["off", "shadow", "enforce"] = "off"
 
 
+class IssueTriageAgenticConfig(AgenticDomainConfig):
+    """Per-decision knobs for the issue-triage shadow migration (T-A5).
+
+    Extends :class:`AgenticDomainConfig` with the candidate-pool sizing knob
+    the migration plan calls out. When the LLM candidate runs, the caller
+    pre-selects at most ``dup_candidate_pool_size`` nearby open issues via
+    embedding similarity (not yet wired) or keyword Jaccard overlap, and
+    passes them into the structured-complete prompt so the model can cite
+    a concrete duplicate_of number instead of inventing one.
+    """
+
+    dup_candidate_pool_size: int = Field(
+        default=5,
+        ge=0,
+        le=50,
+        description=(
+            "Maximum number of nearby open issues to pre-select as duplicate "
+            "candidates. 0 disables candidate pre-selection (LLM must judge "
+            "duplicate_of from title alone, which typically means it returns "
+            "null). Capped at 50 to bound prompt size."
+        ),
+    )
+
+
 class AgenticConfig(StrictBaseModel):
     """Flags for the Phase 2 LLM decision migrations.
 
@@ -875,7 +899,7 @@ class AgenticConfig(StrictBaseModel):
     readiness: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
     ci_triage: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
     review_classification: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
-    issue_triage: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    issue_triage: IssueTriageAgenticConfig = Field(default_factory=IssueTriageAgenticConfig)
     cascade: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
     stuck_pr: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
     bot_identity: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)

--- a/src/caretaker/issue_agent/agent.py
+++ b/src/caretaker/issue_agent/agent.py
@@ -8,8 +8,17 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
+from caretaker.evolution.shadow import shadow_decision
+from caretaker.evolution.shadow_config import get_active_config
 from caretaker.issue_agent.classifier import IssueClassification, classify_issue
 from caretaker.issue_agent.dispatcher import IssueDispatcher
+from caretaker.issue_agent.triage_llm import (
+    IssueTriage,
+    classify_issue_llm,
+    compare_triage,
+    legacy_to_triage,
+    select_candidates_by_jaccard,
+)
 from caretaker.state.models import IssueTrackingState, TrackedIssue
 from caretaker.tools.debug_dump import render_debug_dump
 from caretaker.tools.github import GitHubIssueTools, GitHubPullRequestTools
@@ -31,6 +40,41 @@ class IssueAgentReport:
     closed: list[int] = field(default_factory=list)
     escalated: list[int] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+
+
+def _compare_triage_tuple(
+    legacy_v: tuple[IssueClassification, IssueTriage] | IssueClassification,
+    candidate_v: tuple[IssueClassification, IssueTriage] | IssueClassification,
+) -> bool:
+    """Compare shadow verdicts on ``(classification, duplicate_of)``.
+
+    Both sides are expected to return a ``(IssueClassification, IssueTriage)``
+    tuple so the shadow record captures the full triage payload for audit,
+    while the caller-facing return type is the classification enum. We
+    compare on ``(kind, duplicate_of)`` (per the migration plan: minor
+    label-list deltas should not trip the disagreement counter).
+    """
+    legacy_triage = legacy_v[1] if isinstance(legacy_v, tuple) else None
+    candidate_triage = candidate_v[1] if isinstance(candidate_v, tuple) else None
+    if legacy_triage is None or candidate_triage is None:
+        return legacy_v == candidate_v
+    return compare_triage(legacy_triage, candidate_triage)
+
+
+@shadow_decision("issue_triage", compare=_compare_triage_tuple)
+async def _triage_issue_shadow(
+    *,
+    legacy: Any,
+    candidate: Any,
+    context: Any = None,
+) -> tuple[IssueClassification, IssueTriage]:
+    """Shadow-mode wrapper — return legacy in ``off``/``shadow``, candidate in ``enforce``.
+
+    The decorator supplies the legacy/candidate dispatch and disagreement
+    bookkeeping; this body is never executed directly. See
+    :mod:`caretaker.evolution.shadow` for the full contract.
+    """
+    raise AssertionError("shadow_decision wrapper should short-circuit this function")
 
 
 class IssueAgent:
@@ -97,7 +141,7 @@ class IssueAgent:
                     tracked_issues[issue.number] = tracking
                     continue
 
-                classification = classify_issue(issue, self._config)
+                classification = await self._classify(issue, issues)
                 tracking.classification = classification.value
                 report.triaged += 1
 
@@ -110,6 +154,110 @@ class IssueAgent:
                 report.errors.append(f"Issue #{issue.number}: {e}")
 
         return report, tracked_issues
+
+    async def _classify(
+        self,
+        issue: Issue,
+        open_issues: list[Issue],
+    ) -> IssueClassification:
+        """Classify ``issue`` via the shadow decorator.
+
+        ``off`` and ``shadow`` modes return the legacy heuristic verdict
+        byte-identically to the pre-migration behaviour. In ``enforce``
+        mode the LLM candidate is authoritative; we map its
+        :class:`IssueTriage` verdict back onto the legacy
+        :class:`IssueClassification` vocabulary so the rest of the agent
+        state machine is untouched.
+
+        Returns a ``(classification, triage)`` tuple through the shadow
+        decorator so the persisted ``ShadowDecisionRecord`` captures the
+        full triage payload (labels, severity, summary) for audit, while
+        the caller only sees the classification.
+        """
+
+        async def _legacy_fn() -> tuple[IssueClassification, IssueTriage]:
+            cls = classify_issue(issue, self._config)
+            return cls, legacy_to_triage(cls, issue)
+
+        async def _candidate_fn() -> tuple[IssueClassification, IssueTriage] | None:
+            claude = self._claude_client()
+            if claude is None:
+                # No LLM wired — mimic a structured-complete failure so the
+                # shadow decorator records it and falls through to legacy.
+                return None
+            pool_size = self._dup_candidate_pool_size()
+            candidates = (
+                select_candidates_by_jaccard(issue, open_issues, limit=pool_size)
+                if pool_size > 0
+                else []
+            )
+            triage = await classify_issue_llm(
+                issue,
+                candidates=candidates,
+                claude=claude,
+            )
+            if triage is None:
+                return None
+            return self._triage_to_legacy(triage, issue), triage
+
+        verdict = await _triage_issue_shadow(
+            legacy=_legacy_fn,
+            candidate=_candidate_fn,
+            context={"repo_slug": f"{self._owner}/{self._repo}", "issue_number": issue.number},
+        )
+        return verdict[0]
+
+    def _claude_client(self) -> Any | None:
+        """Return the configured :class:`ClaudeClient`, or ``None``."""
+        if self._llm is None:
+            return None
+        claude = getattr(self._llm, "claude", None)
+        if claude is None or not getattr(claude, "available", False):
+            return None
+        return claude
+
+    @staticmethod
+    def _dup_candidate_pool_size() -> int:
+        """Read the pool-size knob from the active AgenticConfig.
+
+        Returns 5 (the plan default) when no config is installed, which
+        keeps the test harness — which never calls ``shadow_config.configure``
+        — from crashing on import order.
+        """
+        cfg = get_active_config()
+        if cfg is None:
+            return 5
+        domain = getattr(cfg, "issue_triage", None)
+        return int(getattr(domain, "dup_candidate_pool_size", 5))
+
+    @staticmethod
+    def _triage_to_legacy(triage: IssueTriage, issue: Issue) -> IssueClassification:
+        """Collapse an :class:`IssueTriage` back to an :class:`IssueClassification`.
+
+        Needed only when the shadow decorator is in ``enforce`` mode and
+        the LLM candidate is authoritative. In ``off``/``shadow`` the
+        legacy adapter round-trips exactly, so this mapping is still
+        stable for those paths.
+        """
+        if triage.duplicate_of is not None:
+            return IssueClassification.DUPLICATE
+        if issue.is_maintainer_issue:
+            return IssueClassification.MAINTAINER_INTERNAL
+        if triage.staleness in ("stale", "ancient"):
+            return IssueClassification.STALE
+        if triage.kind == "bug":
+            is_complex = triage.severity in ("blocker", "major")
+            return IssueClassification.BUG_COMPLEX if is_complex else IssueClassification.BUG_SIMPLE
+        if triage.kind == "feature":
+            # Large feature signal comes from the LLM's summary; without
+            # a dedicated size field, default to small and let the caller
+            # escalate on suggested labels later.
+            return IssueClassification.FEATURE_SMALL
+        if triage.kind == "question":
+            return IssueClassification.QUESTION
+        if triage.kind in ("chore", "security", "docs"):
+            return IssueClassification.INFRA_OR_CONFIG
+        return IssueClassification.FEATURE_SMALL
 
     async def _process_issue(
         self,

--- a/src/caretaker/issue_agent/triage_llm.py
+++ b/src/caretaker/issue_agent/triage_llm.py
@@ -1,0 +1,410 @@
+"""LLM-backed issue triage candidate for the Phase 2 agentic migration.
+
+This module implements the §3.5 "Issue triage + duplicate detection"
+handover: one :func:`~caretaker.llm.claude.ClaudeClient.structured_complete`
+call replaces the keyword ladder in
+:func:`caretaker.issue_agent.classifier.classify_issue` plus the title-hash
+grouping in :mod:`caretaker.issue_agent.issue_triage` (for the in-process
+classification path only — the bulk triage pass keeps the deterministic
+hash grouping since it is a batch operation over hundreds of issues).
+
+Surface:
+
+* :class:`IssueTriage` — pydantic schema the LLM fills in.
+* :class:`IssueCandidate` — compact record of a nearby issue the LLM
+  may cite as a duplicate source.
+* :func:`classify_issue_llm` — the candidate side of the shadow pair.
+* :func:`legacy_to_triage` — adapter that wraps the classic
+  :class:`~caretaker.issue_agent.classifier.IssueClassification` verdict
+  as an :class:`IssueTriage`, so the shadow decorator can compare the two
+  on a single type without every call site knowing both vocabularies.
+* :func:`select_candidates_by_jaccard` — keyword-overlap candidate
+  pre-selection. The repo has no embedding provider configured today, so
+  the fall-back path is the primary path; if an embedding provider lands
+  later it can live behind the same signature.
+
+The CVE regex pre-filter is preserved on purpose: structured CVE
+identifiers are the one thing the legacy regex grouping gets right, so
+when a title or body mentions a CVE we feed it as a typed hint to the
+LLM prompt ("issues that share this CVE are duplicate candidates") and
+still let the LLM weigh severity + duplicate-of independently.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+from caretaker.issue_agent.classifier import IssueClassification
+from caretaker.llm.claude import StructuredCompleteError
+
+if TYPE_CHECKING:
+    from caretaker.github_client.models import Issue
+    from caretaker.llm.claude import ClaudeClient
+
+logger = logging.getLogger(__name__)
+
+
+_CVE_RE = re.compile(r"CVE-\d{4}-\d+", re.IGNORECASE)
+# Body trim — 2k chars is enough for the LLM to judge severity and still
+# leaves room for candidate context in the 8k prompt window the shared
+# Claude config budgets for structured_complete calls.
+_BODY_TRUNCATE = 2000
+# Keyword-overlap tokeniser. Strips markdown fences and punctuation, keeps
+# words of length ≥3 so "bug"/"crash" survive but "is"/"to" do not.
+_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_]{2,}")
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "the",
+        "and",
+        "for",
+        "with",
+        "this",
+        "that",
+        "from",
+        "into",
+        "have",
+        "has",
+        "was",
+        "were",
+        "are",
+        "you",
+        "your",
+        "but",
+        "not",
+        "out",
+        "off",
+        "its",
+        "also",
+        "when",
+        "while",
+        "then",
+        "than",
+        "issue",
+        "issues",
+        "bug",
+        "error",
+        "problem",
+    }
+)
+
+
+IssueKind = Literal["bug", "feature", "question", "docs", "chore", "security", "other"]
+IssueSeverity = Literal["blocker", "major", "minor", "nit"]
+IssueStaleness = Literal["fresh", "stale", "ancient"]
+
+
+class IssueCandidate(BaseModel):
+    """Compact representation of a nearby issue the LLM may cite as a dup source.
+
+    Kept deliberately small (number + title + labels) so a batch of 5 fits
+    well under the prompt budget; the caller is responsible for picking
+    which candidates are worth showing (see :func:`select_candidates_by_jaccard`).
+    """
+
+    number: int
+    title: str
+    labels: list[str] = Field(default_factory=list)
+
+
+class IssueTriage(BaseModel):
+    """Structured triage verdict for a single issue.
+
+    This is the schema the LLM fills in and the common type the shadow
+    decorator compares over — :func:`legacy_to_triage` wraps the classic
+    heuristic verdict into the same shape so both sides speak the same
+    vocabulary.
+    """
+
+    kind: IssueKind
+    severity: IssueSeverity | None = None  # bugs only; None for non-bug kinds
+    suggested_labels: list[str] = Field(default_factory=list)
+    duplicate_of: int | None = None  # issue number if the LLM identifies a dup
+    duplicate_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    staleness: IssueStaleness = "fresh"
+    summary_one_line: str = Field(max_length=150)
+
+
+# ── Candidate selection ─────────────────────────────────────────────────
+
+
+def _tokenise(text: str) -> set[str]:
+    """Return the set of normalised tokens from ``text`` for Jaccard."""
+    tokens = {tok.lower() for tok in _TOKEN_RE.findall(text)}
+    return tokens - _STOPWORDS
+
+
+def select_candidates_by_jaccard(
+    issue: Issue,
+    pool: list[Issue],
+    *,
+    limit: int = 5,
+) -> list[IssueCandidate]:
+    """Pick up to ``limit`` nearby issues from ``pool`` by title+body Jaccard.
+
+    The repo currently has no embedding provider wired in; this is the
+    fallback path called out in the migration plan. If one lands later,
+    a sibling ``select_candidates_by_embedding`` can slot in behind the
+    same :class:`IssueCandidate` surface.
+
+    Self-match is filtered out so an issue never gets cited as its own
+    duplicate.
+    """
+    if limit <= 0 or not pool:
+        return []
+
+    target_tokens = _tokenise(f"{issue.title}\n{issue.body or ''}")
+    if not target_tokens:
+        return []
+
+    scored: list[tuple[float, Issue]] = []
+    for other in pool:
+        if other.number == issue.number:
+            continue
+        other_tokens = _tokenise(f"{other.title}\n{other.body or ''}")
+        if not other_tokens:
+            continue
+        intersection = target_tokens & other_tokens
+        if not intersection:
+            continue
+        union = target_tokens | other_tokens
+        score = len(intersection) / len(union)
+        scored.append((score, other))
+
+    # Highest similarity first; stable on ties via issue number ascending.
+    scored.sort(key=lambda pair: (-pair[0], pair[1].number))
+    return [
+        IssueCandidate(
+            number=other.number,
+            title=other.title,
+            labels=[lbl.name for lbl in other.labels],
+        )
+        for _score, other in scored[:limit]
+    ]
+
+
+# ── Prompt construction ─────────────────────────────────────────────────
+
+
+_PROMPT_TEMPLATE = """\
+You are triaging a GitHub issue for the caretaker automation bot.
+
+Classify the issue into one of: bug, feature, question, docs, chore, security, other.
+For bugs, also pick severity: blocker, major, minor, or nit. For non-bugs, leave severity null.
+
+Also judge:
+- suggested_labels: up to 4 labels that would apply (free-form strings).
+- duplicate_of: if one of the candidate issues below clearly covers the same problem,
+  set this to its number and set duplicate_confidence in [0, 1]. Otherwise leave both null.
+- staleness: "fresh", "stale", or "ancient" — use the age_days field below to decide.
+- summary_one_line: ≤150 chars, plain English, no markdown.
+
+Return exactly one JSON object matching the schema provided in the system prompt.
+
+Issue:
+  title: {title}
+  age_days: {age_days}
+  labels: {labels}
+  assignees: {assignees}
+{cve_hint}
+  body:
+{body}
+
+Duplicate candidates (nearby open issues; pick at most one as duplicate_of, or none):
+{candidates_block}
+"""
+
+
+def _render_candidates(candidates: list[IssueCandidate]) -> str:
+    if not candidates:
+        return "  (no nearby candidates)"
+    lines: list[str] = []
+    for cand in candidates:
+        label_str = ",".join(cand.labels) if cand.labels else "-"
+        # Truncate title so one misbehaving title can't dominate the prompt.
+        title = cand.title if len(cand.title) <= 120 else cand.title[:117] + "..."
+        lines.append(f"  #{cand.number} [{label_str}] {title}")
+    return "\n".join(lines)
+
+
+def _age_days(issue: Issue) -> int:
+    ts = issue.updated_at or issue.created_at
+    if ts is None:
+        return 0
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return max(0, (datetime.now(UTC) - ts).days)
+
+
+def _extract_cve(issue: Issue) -> str | None:
+    """Return an upper-cased CVE id if the title or body mentions one.
+
+    The CVE regex pre-filter is preserved from the legacy duplicate-grouping
+    path; structured CVE identifiers are the one thing regex gets right and
+    the LLM benefits from being told that issues sharing a CVE are likely
+    duplicates.
+    """
+    haystack = f"{issue.title}\n{issue.body or ''}"
+    match = _CVE_RE.search(haystack)
+    return match.group(0).upper() if match else None
+
+
+def build_prompt(issue: Issue, candidates: list[IssueCandidate]) -> str:
+    """Render the user-turn prompt for :func:`classify_issue_llm`.
+
+    Exposed for testing and for reviewers who want to eyeball what we
+    actually send to the model.
+    """
+    body = (issue.body or "").strip()
+    if len(body) > _BODY_TRUNCATE:
+        body = body[:_BODY_TRUNCATE] + "\n[... body truncated]"
+    body_indented = "    " + body.replace("\n", "\n    ") if body else "    (empty)"
+
+    cve = _extract_cve(issue)
+    cve_hint = (
+        f"  cve_hint: {cve} — issues that share this CVE are duplicate candidates.\n" if cve else ""
+    )
+
+    return _PROMPT_TEMPLATE.format(
+        title=issue.title,
+        age_days=_age_days(issue),
+        labels=",".join(lbl.name for lbl in issue.labels) or "-",
+        assignees=",".join(a.login for a in issue.assignees) or "-",
+        cve_hint=cve_hint,
+        body=body_indented,
+        candidates_block=_render_candidates(candidates),
+    )
+
+
+# ── Candidate function ──────────────────────────────────────────────────
+
+
+async def classify_issue_llm(
+    issue: Issue,
+    *,
+    candidates: list[IssueCandidate],
+    claude: ClaudeClient,
+) -> IssueTriage | None:
+    """Ask the LLM to triage ``issue``; return ``None`` on any failure.
+
+    The signature matches the Phase 2 candidate-function convention: all
+    inputs are keyword-only except the issue itself, and the return type
+    is ``IssueTriage | None`` so the ``@shadow_decision`` wrapper can treat
+    a ``None`` as a candidate failure and fall through to legacy.
+
+    Errors raised by :func:`ClaudeClient.structured_complete` are logged and
+    converted to ``None`` — the shadow decorator handles the rest.
+    """
+    prompt = build_prompt(issue, candidates)
+    try:
+        verdict = await claude.structured_complete(
+            prompt,
+            schema=IssueTriage,
+            feature="issue_triage",
+        )
+    except StructuredCompleteError as exc:
+        logger.warning(
+            "classify_issue_llm: structured_complete failed for issue #%d: %s",
+            issue.number,
+            exc,
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 — candidate must never raise up
+        logger.warning(
+            "classify_issue_llm: unexpected error for issue #%d: %s",
+            issue.number,
+            exc,
+        )
+        return None
+
+    # If the LLM claimed a duplicate_of that is not in the candidate set,
+    # drop it — models will occasionally hallucinate numbers. Keeping the
+    # kind/severity/summary fields still adds value.
+    if verdict.duplicate_of is not None:
+        valid_numbers = {c.number for c in candidates}
+        if verdict.duplicate_of not in valid_numbers:
+            logger.info(
+                "classify_issue_llm: dropping hallucinated duplicate_of=%d "
+                "for issue #%d (not in candidate set)",
+                verdict.duplicate_of,
+                issue.number,
+            )
+            verdict = verdict.model_copy(
+                update={"duplicate_of": None, "duplicate_confidence": None}
+            )
+    return verdict
+
+
+# ── Legacy adapter ──────────────────────────────────────────────────────
+
+
+# Mapping from the legacy StrEnum vocabulary to the new structured kind/
+# severity pair. Kept explicit (rather than derived) so future legacy
+# additions fail noisily in review instead of silently mapping to ``other``.
+_LEGACY_KIND_MAP: dict[IssueClassification, tuple[IssueKind, IssueSeverity | None]] = {
+    IssueClassification.BUG_SIMPLE: ("bug", "minor"),
+    IssueClassification.BUG_COMPLEX: ("bug", "major"),
+    IssueClassification.FEATURE_SMALL: ("feature", None),
+    IssueClassification.FEATURE_LARGE: ("feature", None),
+    IssueClassification.QUESTION: ("question", None),
+    IssueClassification.DUPLICATE: ("other", None),
+    IssueClassification.STALE: ("other", None),
+    IssueClassification.INFRA_OR_CONFIG: ("chore", None),
+    IssueClassification.MAINTAINER_INTERNAL: ("chore", None),
+}
+
+
+def legacy_to_triage(classification: IssueClassification, issue: Issue) -> IssueTriage:
+    """Wrap a legacy :class:`IssueClassification` verdict as an :class:`IssueTriage`.
+
+    Keeps ``duplicate_of`` as ``None`` (the legacy hash grouping is run
+    separately in :mod:`issue_triage` and not per-issue), and ``staleness``
+    as ``"fresh"`` unless the classifier said STALE. The resulting triage
+    record is what the shadow decorator actually compares against so both
+    sides speak one vocabulary.
+    """
+    kind, severity = _LEGACY_KIND_MAP.get(classification, ("other", None))
+    staleness: IssueStaleness = "stale" if classification == IssueClassification.STALE else "fresh"
+    # Legacy summary is the issue title — capped at 150 chars to satisfy
+    # the schema without a silent truncate at call time.
+    raw_summary = issue.title.strip() or f"Issue #{issue.number}"
+    summary = raw_summary if len(raw_summary) <= 150 else raw_summary[:147] + "..."
+    return IssueTriage(
+        kind=kind,
+        severity=severity,
+        suggested_labels=[],
+        duplicate_of=None,
+        duplicate_confidence=None,
+        staleness=staleness,
+        summary_one_line=summary,
+    )
+
+
+def compare_triage(a: IssueTriage, b: IssueTriage) -> bool:
+    """Shadow-mode comparator: agree iff ``(kind, duplicate_of)`` match.
+
+    Suggested labels, severity, and one-line summaries are noisy by design
+    (the LLM rewords things, the legacy adapter can't guess severity), so
+    counting every micro-delta as a disagreement would drown the real
+    signal. ``(kind, duplicate_of)`` captures the two decisions operators
+    actually need to audit before flipping authority.
+    """
+    return (a.kind, a.duplicate_of) == (b.kind, b.duplicate_of)
+
+
+__all__ = [
+    "IssueCandidate",
+    "IssueKind",
+    "IssueSeverity",
+    "IssueStaleness",
+    "IssueTriage",
+    "build_prompt",
+    "classify_issue_llm",
+    "compare_triage",
+    "legacy_to_triage",
+    "select_candidates_by_jaccard",
+]

--- a/tests/test_issue_agent/test_triage_llm.py
+++ b/tests/test_issue_agent/test_triage_llm.py
@@ -1,0 +1,496 @@
+"""Tests for the LLM-backed issue triage candidate (T-A5).
+
+Covers:
+
+* :class:`IssueTriage` schema validation (severity bounds, staleness enum).
+* :func:`legacy_to_triage` maps each :class:`IssueClassification` to the
+  right kind/severity tuple.
+* :func:`select_candidates_by_jaccard` picks overlap-rich candidates and
+  excludes self-matches.
+* :func:`build_prompt` surfaces the CVE hint when the title mentions one.
+* :func:`classify_issue_llm` returns the structured verdict on success,
+  ``None`` on :class:`StructuredCompleteError`, and drops hallucinated
+  duplicate_of numbers.
+* Shadow decorator integration — the three modes (off / shadow / enforce)
+  dispatch the legacy + candidate pair correctly through
+  :func:`_triage_issue_shadow`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from caretaker.config import (
+    AgenticConfig,
+    AgenticDomainConfig,
+    IssueAgentConfig,
+    IssueTriageAgenticConfig,
+)
+from caretaker.evolution import shadow_config
+from caretaker.evolution.shadow import clear_records_for_tests, recent_records
+from caretaker.github_client.models import Issue, Label, User
+from caretaker.issue_agent.agent import IssueAgent, _triage_issue_shadow
+from caretaker.issue_agent.classifier import IssueClassification
+from caretaker.issue_agent.triage_llm import (
+    IssueCandidate,
+    IssueTriage,
+    build_prompt,
+    classify_issue_llm,
+    compare_triage,
+    legacy_to_triage,
+    select_candidates_by_jaccard,
+)
+from caretaker.llm.claude import StructuredCompleteError
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def make_issue(
+    number: int = 1,
+    title: str = "Issue",
+    body: str = "Body",
+    labels: list[str] | None = None,
+    updated_at: datetime | None = None,
+) -> Issue:
+    return Issue(
+        number=number,
+        title=title,
+        body=body,
+        user=User(login="reporter", id=10, type="User"),
+        labels=[Label(name=n) for n in (labels or [])],
+        updated_at=updated_at,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state() -> None:
+    clear_records_for_tests()
+    shadow_config.reset_for_tests()
+
+
+def _set_issue_triage_mode(mode: str) -> None:
+    cfg = AgenticConfig(issue_triage=IssueTriageAgenticConfig(mode=mode))  # type: ignore[arg-type]
+    shadow_config.configure(cfg)
+
+
+# ── Schema validation ────────────────────────────────────────────────────
+
+
+class TestIssueTriageSchema:
+    def test_minimal_valid(self) -> None:
+        triage = IssueTriage(kind="bug", summary_one_line="parser crashes")
+        assert triage.kind == "bug"
+        assert triage.staleness == "fresh"
+        assert triage.severity is None
+
+    def test_summary_length_enforced(self) -> None:
+        with pytest.raises(ValidationError):
+            IssueTriage(kind="bug", summary_one_line="x" * 151)
+
+    def test_duplicate_confidence_bounds(self) -> None:
+        # Valid endpoints.
+        IssueTriage(
+            kind="bug",
+            summary_one_line="s",
+            duplicate_of=1,
+            duplicate_confidence=0.0,
+        )
+        IssueTriage(
+            kind="bug",
+            summary_one_line="s",
+            duplicate_of=1,
+            duplicate_confidence=1.0,
+        )
+        with pytest.raises(ValidationError):
+            IssueTriage(
+                kind="bug",
+                summary_one_line="s",
+                duplicate_of=1,
+                duplicate_confidence=1.01,
+            )
+
+    def test_invalid_kind(self) -> None:
+        with pytest.raises(ValidationError):
+            IssueTriage(kind="urgent", summary_one_line="s")  # type: ignore[arg-type]
+
+
+# ── Legacy adapter ───────────────────────────────────────────────────────
+
+
+class TestLegacyAdapter:
+    def test_bug_simple_maps_to_minor(self) -> None:
+        triage = legacy_to_triage(IssueClassification.BUG_SIMPLE, make_issue(title="crash"))
+        assert triage.kind == "bug"
+        assert triage.severity == "minor"
+        assert triage.staleness == "fresh"
+
+    def test_bug_complex_maps_to_major(self) -> None:
+        triage = legacy_to_triage(IssueClassification.BUG_COMPLEX, make_issue(title="huge bug"))
+        assert triage.kind == "bug"
+        assert triage.severity == "major"
+
+    def test_feature_small_maps_to_feature(self) -> None:
+        triage = legacy_to_triage(IssueClassification.FEATURE_SMALL, make_issue(title="add flag"))
+        assert triage.kind == "feature"
+        assert triage.severity is None
+
+    def test_question_maps_to_question(self) -> None:
+        triage = legacy_to_triage(IssueClassification.QUESTION, make_issue(title="how do I?"))
+        assert triage.kind == "question"
+
+    def test_stale_propagates_staleness(self) -> None:
+        triage = legacy_to_triage(IssueClassification.STALE, make_issue(title="old issue"))
+        assert triage.staleness == "stale"
+
+    def test_duplicate_leaves_duplicate_of_none(self) -> None:
+        # Legacy hash grouping runs in a separate pass, not per-issue;
+        # the adapter cannot invent an issue number.
+        triage = legacy_to_triage(IssueClassification.DUPLICATE, make_issue(title="dup of #1"))
+        assert triage.duplicate_of is None
+
+    def test_summary_truncated_to_150(self) -> None:
+        triage = legacy_to_triage(IssueClassification.BUG_SIMPLE, make_issue(title="x" * 200))
+        assert len(triage.summary_one_line) <= 150
+
+
+# ── Candidate selection ──────────────────────────────────────────────────
+
+
+class TestJaccardCandidates:
+    def test_picks_highest_overlap(self) -> None:
+        target = make_issue(1, "login redirect loop", body="infinite redirect when SAML")
+        other_good = make_issue(2, "SAML login redirect loop", body="redirect keeps looping")
+        other_bad = make_issue(3, "docs update", body="fix typo")
+        picks = select_candidates_by_jaccard(target, [other_good, other_bad], limit=5)
+        assert [c.number for c in picks] == [2]
+
+    def test_excludes_self(self) -> None:
+        target = make_issue(1, "crash on startup", body="crash")
+        picks = select_candidates_by_jaccard(target, [target], limit=5)
+        assert picks == []
+
+    def test_respects_limit(self) -> None:
+        target = make_issue(1, "crash during startup parsing JSON", body="parser crash")
+        pool = [
+            make_issue(
+                n,
+                title="crash startup parsing JSON",
+                body="parser crash",
+            )
+            for n in range(2, 10)
+        ]
+        picks = select_candidates_by_jaccard(target, pool, limit=3)
+        assert len(picks) == 3
+
+    def test_zero_limit_returns_empty(self) -> None:
+        target = make_issue(1, "x", body="y")
+        picks = select_candidates_by_jaccard(target, [make_issue(2)], limit=0)
+        assert picks == []
+
+
+# ── Prompt / CVE pre-filter ──────────────────────────────────────────────
+
+
+class TestPromptCVEHint:
+    def test_cve_in_title_surfaces_hint(self) -> None:
+        issue = make_issue(1, title="CVE-2025-1234 in dep foo", body="patch needed")
+        prompt = build_prompt(issue, [])
+        assert "cve_hint: CVE-2025-1234" in prompt
+        assert "share this CVE are duplicate candidates" in prompt
+
+    def test_cve_in_body_surfaces_hint(self) -> None:
+        issue = make_issue(1, title="security: upgrade", body="relates to cve-2024-5555")
+        prompt = build_prompt(issue, [])
+        assert "CVE-2024-5555" in prompt
+
+    def test_no_cve_no_hint(self) -> None:
+        issue = make_issue(1, title="normal bug", body="no cve here")
+        prompt = build_prompt(issue, [])
+        assert "cve_hint" not in prompt
+
+    def test_candidates_rendered(self) -> None:
+        issue = make_issue(1, title="t", body="b")
+        cands = [IssueCandidate(number=42, title="dup candidate", labels=["bug"])]
+        prompt = build_prompt(issue, cands)
+        assert "#42" in prompt
+        assert "dup candidate" in prompt
+        assert "[bug]" in prompt
+
+
+# ── LLM candidate function ───────────────────────────────────────────────
+
+
+class TestClassifyIssueLLM:
+    async def test_returns_structured_verdict(self) -> None:
+        claude = MagicMock()
+        verdict = IssueTriage(
+            kind="bug",
+            severity="major",
+            summary_one_line="parser crashes on empty input",
+            duplicate_of=42,
+            duplicate_confidence=0.9,
+        )
+        claude.structured_complete = AsyncMock(return_value=verdict)
+        issue = make_issue(1, "parser crash", body="throws on empty")
+        result = await classify_issue_llm(
+            issue,
+            candidates=[IssueCandidate(number=42, title="crashes")],
+            claude=claude,
+        )
+        assert result is not None
+        assert result.kind == "bug"
+        assert result.duplicate_of == 42
+        assert result.duplicate_confidence == 0.9
+        claude.structured_complete.assert_awaited_once()
+
+    async def test_structured_complete_error_returns_none(self) -> None:
+        claude = MagicMock()
+        claude.structured_complete = AsyncMock(
+            side_effect=StructuredCompleteError(
+                raw_text="garbage", validation_error=ValueError("bad")
+            )
+        )
+        result = await classify_issue_llm(
+            make_issue(1),
+            candidates=[],
+            claude=claude,
+        )
+        assert result is None
+
+    async def test_unexpected_error_returns_none(self) -> None:
+        claude = MagicMock()
+        claude.structured_complete = AsyncMock(side_effect=RuntimeError("boom"))
+        result = await classify_issue_llm(make_issue(1), candidates=[], claude=claude)
+        assert result is None
+
+    async def test_hallucinated_duplicate_of_dropped(self) -> None:
+        """A duplicate_of number that's not in the candidate set is cleared."""
+        claude = MagicMock()
+        verdict = IssueTriage(
+            kind="bug",
+            summary_one_line="crash",
+            duplicate_of=99999,  # not in the candidate set
+            duplicate_confidence=0.8,
+        )
+        claude.structured_complete = AsyncMock(return_value=verdict)
+        result = await classify_issue_llm(
+            make_issue(1, "crash"),
+            candidates=[IssueCandidate(number=42, title="other")],
+            claude=claude,
+        )
+        assert result is not None
+        assert result.duplicate_of is None
+        assert result.duplicate_confidence is None
+
+
+# ── compare_triage ───────────────────────────────────────────────────────
+
+
+class TestCompareTriage:
+    def test_agrees_on_kind_and_duplicate_of(self) -> None:
+        a = IssueTriage(
+            kind="bug",
+            severity="minor",
+            summary_one_line="x",
+            suggested_labels=["bug"],
+        )
+        b = IssueTriage(
+            kind="bug",
+            severity="major",  # differs but ignored
+            summary_one_line="y",  # differs but ignored
+            suggested_labels=["bug", "p1"],  # differs but ignored
+        )
+        assert compare_triage(a, b) is True
+
+    def test_disagrees_on_kind(self) -> None:
+        a = IssueTriage(kind="bug", summary_one_line="x")
+        b = IssueTriage(kind="feature", summary_one_line="x")
+        assert compare_triage(a, b) is False
+
+    def test_disagrees_on_duplicate_of(self) -> None:
+        a = IssueTriage(kind="bug", summary_one_line="x", duplicate_of=1)
+        b = IssueTriage(kind="bug", summary_one_line="x", duplicate_of=2)
+        assert compare_triage(a, b) is False
+
+
+# ── Shadow decorator integration ────────────────────────────────────────
+
+
+class TestShadowDecoratorModes:
+    async def test_off_mode_returns_legacy_and_skips_candidate(self) -> None:
+        _set_issue_triage_mode("off")
+
+        legacy_result = (
+            IssueClassification.BUG_SIMPLE,
+            IssueTriage(kind="bug", severity="minor", summary_one_line="legacy bug"),
+        )
+        legacy_fn = AsyncMock(return_value=legacy_result)
+        candidate_fn = AsyncMock()
+
+        result = await _triage_issue_shadow(
+            legacy=legacy_fn,
+            candidate=candidate_fn,
+            context={"repo_slug": "o/r", "issue_number": 1},
+        )
+        assert result == legacy_result
+        legacy_fn.assert_awaited_once()
+        candidate_fn.assert_not_awaited()
+        assert recent_records() == []
+
+    async def test_shadow_disagree_records_and_still_returns_legacy(self) -> None:
+        _set_issue_triage_mode("shadow")
+
+        legacy_result = (
+            IssueClassification.FEATURE_SMALL,
+            IssueTriage(kind="feature", summary_one_line="legacy says feature"),
+        )
+        candidate_result = (
+            IssueClassification.BUG_SIMPLE,
+            IssueTriage(kind="bug", severity="minor", summary_one_line="candidate says bug"),
+        )
+        legacy_fn = AsyncMock(return_value=legacy_result)
+        candidate_fn = AsyncMock(return_value=candidate_result)
+
+        result = await _triage_issue_shadow(
+            legacy=legacy_fn,
+            candidate=candidate_fn,
+            context={"repo_slug": "o/r"},
+        )
+
+        assert result == legacy_result  # legacy authoritative
+        records = recent_records()
+        assert len(records) == 1
+        assert records[0].outcome == "disagree"
+        assert records[0].name == "issue_triage"
+        assert records[0].mode == "shadow"
+
+    async def test_enforce_returns_candidate_when_available(self) -> None:
+        _set_issue_triage_mode("enforce")
+
+        legacy_result = (
+            IssueClassification.FEATURE_SMALL,
+            IssueTriage(kind="feature", summary_one_line="legacy"),
+        )
+        candidate_result = (
+            IssueClassification.BUG_SIMPLE,
+            IssueTriage(kind="bug", summary_one_line="candidate"),
+        )
+        legacy_fn = AsyncMock(return_value=legacy_result)
+        candidate_fn = AsyncMock(return_value=candidate_result)
+
+        result = await _triage_issue_shadow(
+            legacy=legacy_fn,
+            candidate=candidate_fn,
+        )
+        assert result == candidate_result
+        candidate_fn.assert_awaited_once()
+
+
+# ── End-to-end: agent uses legacy verdict in off-mode, enforce in enforce-mode ──
+
+
+class TestIssueAgentEnforceIntegration:
+    async def test_enforce_mode_overrides_classification_when_llm_wired(self) -> None:
+        """In enforce mode, the agent honours the LLM verdict even when the legacy
+        heuristic would say FEATURE_SMALL.
+        """
+        _set_issue_triage_mode("enforce")
+
+        issue = make_issue(
+            1,
+            title="the widget renders weirdly",
+            body="please adjust alignment.",
+        )
+        # Legacy would classify this as FEATURE_SMALL (no bug keywords).
+        from caretaker.issue_agent.classifier import classify_issue
+
+        assert classify_issue(issue, IssueAgentConfig()) == IssueClassification.FEATURE_SMALL
+
+        # Fake LLM router that exposes a .claude client with structured_complete.
+        llm_router = MagicMock()
+        llm_router.claude = MagicMock()
+        llm_router.claude.available = True
+        llm_router.claude.structured_complete = AsyncMock(
+            return_value=IssueTriage(
+                kind="bug",
+                severity="major",
+                summary_one_line="widget render bug",
+            )
+        )
+
+        github = AsyncMock()
+        github.list_issues.return_value = [issue]
+        github.list_pull_requests.return_value = []
+
+        agent = IssueAgent(
+            github=github,
+            owner="o",
+            repo="r",
+            config=IssueAgentConfig(auto_assign_bugs=False),  # no dispatch side-effects
+            llm_router=llm_router,
+        )
+
+        report, tracked = await agent.run({})
+        assert report.triaged == 1
+        assert tracked[1].classification == IssueClassification.BUG_COMPLEX.value
+
+    async def test_off_mode_ignores_llm_and_uses_legacy(self) -> None:
+        _set_issue_triage_mode("off")
+
+        issue = make_issue(1, title="feature request", body="add a new flag")
+        llm_router = MagicMock()
+        llm_router.claude = MagicMock()
+        llm_router.claude.available = True
+        llm_router.claude.structured_complete = AsyncMock(
+            side_effect=AssertionError("should not be called in off-mode")
+        )
+
+        github = AsyncMock()
+        github.list_issues.return_value = [issue]
+        github.list_pull_requests.return_value = []
+
+        agent = IssueAgent(
+            github=github,
+            owner="o",
+            repo="r",
+            config=IssueAgentConfig(auto_assign_features=False),
+            llm_router=llm_router,
+        )
+        report, tracked = await agent.run({})
+        assert report.triaged == 1
+        # Legacy verdict: FEATURE_SMALL. State machine does not escalate
+        # since auto_assign_features=False — issue stays TRIAGED.
+        assert tracked[1].classification == IssueClassification.FEATURE_SMALL.value
+
+
+# ── Agentic config knob ─────────────────────────────────────────────────
+
+
+class TestIssueTriageAgenticConfig:
+    def test_default_pool_size_is_five(self) -> None:
+        cfg = IssueTriageAgenticConfig()
+        assert cfg.dup_candidate_pool_size == 5
+        assert cfg.mode == "off"
+
+    def test_pool_size_bounds_enforced(self) -> None:
+        with pytest.raises(ValidationError):
+            IssueTriageAgenticConfig(dup_candidate_pool_size=-1)
+        with pytest.raises(ValidationError):
+            IssueTriageAgenticConfig(dup_candidate_pool_size=51)
+
+    def test_inherits_from_agentic_domain_config(self) -> None:
+        # The shadow decorator looks up ``getattr(cfg, name).mode`` on the
+        # active AgenticConfig — the subclass must still carry the ``mode``
+        # field it inherits from AgenticDomainConfig.
+        cfg = IssueTriageAgenticConfig(mode="shadow", dup_candidate_pool_size=10)
+        assert isinstance(cfg, AgenticDomainConfig)
+        assert cfg.mode == "shadow"
+        assert cfg.dup_candidate_pool_size == 10


### PR DESCRIPTION
## Summary

Migrates the keyword-ladder classifier in `caretaker.issue_agent.classifier.classify_issue` and the in-process duplicate-detection path onto a single `structured_complete[IssueTriage]` call behind `agentic.issue_triage` (Phase 2 T-A5, §3.5 of the 2026-Q2 agentic migration plan).

- **Schema (`IssueTriage`)** — `kind` (bug/feature/question/docs/chore/security/other), `severity` (blocker/major/minor/nit, nullable for non-bugs), `suggested_labels`, `duplicate_of` + `duplicate_confidence [0, 1]`, `staleness`, `summary_one_line (≤150)`. Defined in `src/caretaker/issue_agent/triage_llm.py`.
- **Legacy adapter** — `legacy_to_triage()` wraps the classic `IssueClassification` enum into the same `IssueTriage` type so the shadow decorator can compare apples-to-apples. Comparison is restricted to `(kind, duplicate_of)` per the plan, so noisy severity/label deltas don't trip the disagreement counter.
- **Shadow wiring** — `IssueAgent._classify` runs both paths through `@shadow_decision("issue_triage")`. Off/shadow return the legacy verdict byte-identically; enforce returns the LLM verdict, translated back onto `IssueClassification` so the state machine is untouched.

## CVE-regex-as-prefilter rationale

The legacy duplicate grouper used `re.compile(r"CVE-\d{4}-\d+", re.IGNORECASE)` before falling back to a SHA1 of the normalized title. The CVE regex is the one piece of that grouper that gets things right — CVEs are *structured identifiers*, not free-form text. Rather than drop it, this PR keeps the pre-filter and surfaces its output to the LLM as a typed hint:

> `cve_hint: CVE-2025-1234 — issues that share this CVE are duplicate candidates.`

The LLM still judges severity and `duplicate_of` independently; the pre-filter only bootstraps the prompt. This gives us deterministic CVE-level matching plus fuzzy match on everything else.

## Candidate pre-selection (keyword Jaccard)

The plan called for embedding-similarity candidate pre-selection, with keyword-overlap Jaccard as the fallback when no embedding provider is configured. Caretaker has no embedding provider wired today, so this PR ships with Jaccard only. A sibling `select_candidates_by_embedding` can slot in behind the same `IssueCandidate` surface when one lands.

New config knob: `IssueTriageAgenticConfig.dup_candidate_pool_size: int = 5` (range 0–50) bounds prompt size. Hallucinated `duplicate_of` numbers (not in the candidate set) are dropped in `classify_issue_llm` before the verdict returns.

## Rollout

- **Default `mode: off`** — no behaviour change. Legacy classifier is sole authority.
- **`shadow`** — both paths run, legacy wins, disagreements persisted to `:ShadowDecision` via the existing `/admin/shadow-decisions` endpoint + `recent_records()` ring buffer.
- **`enforce`** — LLM verdict authoritative, legacy is the fall-through when the LLM returns `None` or raises.

## Test plan

- [x] Schema validation (severity bounds, staleness enum, summary length, duplicate_confidence in [0, 1])
- [x] Legacy adapter: BUG_SIMPLE→minor, BUG_COMPLEX→major, FEATURE_*→feature, QUESTION→question, STALE→staleness=stale
- [x] CVE pre-filter: `CVE-2025-1234` in title surfaces as `cve_hint` in the prompt (body match also covered)
- [x] Jaccard candidate selection: picks highest overlap, excludes self, respects limit, `limit=0` → empty
- [x] LLM candidate: mock returning `kind="bug"`, `duplicate_of=42`, `duplicate_confidence=0.9` round-trips
- [x] Error path: `StructuredCompleteError` and unexpected exceptions both collapse to `None`
- [x] Hallucinated `duplicate_of` (not in candidate set) is cleared to `None`
- [x] Shadow decorator 3-mode integration (off / shadow-disagree / enforce) through `_triage_issue_shadow`
- [x] End-to-end: `IssueAgent.run` in enforce mode honours LLM verdict over legacy heuristic
- [x] `IssueTriageAgenticConfig.dup_candidate_pool_size` bounds (0–50) + inheritance from `AgenticDomainConfig`
- [x] Gates: `pytest -q` (1318 passed, 1 skipped), `ruff check`, `ruff format --check`, `mypy` (pre-existing k8s_worker errors only; no new errors from this PR)

Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)