### PR TITLE
feat(evolution): crystallizer category reuses FailureTriage classifier + shadow

### DIFF
--- a/src/caretaker/evolution/crystallizer.py
+++ b/src/caretaker/evolution/crystallizer.py
@@ -4,12 +4,21 @@ Called from StateTracker.save() (and optionally from agent code) whenever a
 TrackedPR transitions to MERGED or ESCALATED.  The crystallizer extracts the
 problem category and signature from the PR's notes field and records the
 outcome so the skill library stays current.
+
+Phase 2 T-A10 migrates the category-inference path (but not the signature
+extraction or the terminal-transition filter) onto the shared
+:class:`~caretaker.pr_agent.ci_triage.FailureTriage` classifier. The
+``@shadow_decision("crystallizer_category")`` wrapper lets us flip between
+the legacy regex ladder (:func:`_infer_category`) and the LLM candidate
+(:func:`_infer_category_llm`) from the ``agentic.crystallizer_category.mode``
+config knob.
 """
 
 from __future__ import annotations
 
 import logging
 import re
+from typing import TYPE_CHECKING, Any
 
 from caretaker.evolution.insight_store import (
     CATEGORY_BUILD,
@@ -17,11 +26,28 @@ from caretaker.evolution.insight_store import (
     CATEGORY_SECURITY,
     InsightStore,
 )
+from caretaker.evolution.shadow import shadow_decision
+from caretaker.github_client.models import CheckConclusion, CheckRun, CheckStatus
+from caretaker.pr_agent.ci_triage import (
+    FailureCategory,
+    FailureTriage,
+    classify_failure_llm,
+)
 from caretaker.state.models import PRTrackingState, TrackedPR
+
+if TYPE_CHECKING:
+    from caretaker.llm.router import LLMRouter
 
 logger = logging.getLogger(__name__)
 
-# Regex patterns used to infer category from PR notes / CI failure text
+# Regex patterns used to infer category from PR notes / CI failure text.
+#
+# Phase 2 T-A10: kept in place for the shadow rollout. Once
+# ``agentic.crystallizer_category.mode`` has been at ``enforce`` long
+# enough to show parity with the LLM classifier (tracked in the
+# ``caretaker_shadow_decisions_total{name="crystallizer_category"}``
+# counter), a follow-up PR can delete this table together with
+# :func:`_infer_category`.
 _CATEGORY_PATTERNS: list[tuple[str, str]] = [
     (CATEGORY_CI, r"jest|mocha|pytest|vitest|timeout|test|spec"),
     (CATEGORY_BUILD, r"build|webpack|tsc|typescript|compile|import|module"),
@@ -30,23 +56,125 @@ _CATEGORY_PATTERNS: list[tuple[str, str]] = [
 ]
 
 
-def _infer_category(notes: str) -> str:
-    """Infer failure category from free-text notes. Defaults to CATEGORY_CI.
+# ── FailureTriage.category → InsightStore CATEGORY_* mapping ──────────────
+#
+# The LLM schema (see :class:`FailureTriage`) has a richer vocabulary than
+# the InsightStore's three-value category enum. We collapse every
+# FailureCategory onto one of ``CATEGORY_CI`` / ``CATEGORY_BUILD`` /
+# ``CATEGORY_SECURITY``.
+#
+# TODO(T-A10, crystallizer_category): FailureTriage has no ``security``
+# analogue, so the candidate can never produce ``CATEGORY_SECURITY``
+# even when the legacy regex would (``secret``/``vuln``/``cve``/
+# ``dependabot``/``snyk``). Those notes fall through to ``CATEGORY_CI``
+# in the candidate path — shadow-mode disagreement records will surface
+# how often this happens. If the rate is non-trivial, extend
+# :data:`FailureCategory` with a ``security`` row before flipping
+# ``mode=enforce``.
+_FAILURE_CATEGORY_TO_STORE: dict[FailureCategory, str] = {
+    "test": CATEGORY_CI,
+    "lint": CATEGORY_CI,
+    "type": CATEGORY_CI,
+    "timeout": CATEGORY_CI,
+    "build": CATEGORY_BUILD,
+    # Infra / flaky / backpressure are all CI-flavoured in the legacy
+    # crystallizer vocabulary — the skill library only cares about
+    # "what family of fix works", not the transience of the failure.
+    "flaky": CATEGORY_CI,
+    "backpressure": CATEGORY_CI,
+    "infra": CATEGORY_CI,
+    "unknown": CATEGORY_CI,
+}
 
-    TODO(T-A10, crystallizer_category): replace this regex ladder with the
-    structured LLM verdict produced by
-    :class:`caretaker.pr_agent.ci_triage.FailureTriage` (see T-A3). The
-    ``agentic.crystallizer_category`` flag is already wired in
-    :class:`~caretaker.config.AgenticConfig` — once T-A3's shadow data
-    shows the LLM classifier is reliable, this function becomes the
-    legacy branch and ``FailureTriage.category`` feeds directly into
-    :data:`~caretaker.evolution.insight_store.CATEGORY_*` lookups.
+
+def _infer_category(notes: str) -> str:
+    """Infer failure category from free-text notes (legacy regex ladder).
+
+    Kept as the legacy branch of :func:`_dispatch_category`. In
+    ``agentic.crystallizer_category.mode=off`` (the default), this is the
+    sole authority — behaviour is byte-identical to the pre-T-A10 world.
+
+    A follow-up PR removes this function once shadow-mode data shows the
+    LLM candidate agrees with the regex at an acceptable rate.
     """
     lower = notes.lower()
     for category, pattern in _CATEGORY_PATTERNS:
         if re.search(pattern, lower):
             return category
     return CATEGORY_CI
+
+
+def _notes_to_check_run(notes: str) -> CheckRun:
+    """Wrap free-text PR notes in a synthetic :class:`CheckRun`.
+
+    The shared :func:`~caretaker.pr_agent.ci_triage.classify_failure_llm`
+    classifier consumes :class:`CheckRun` / log-tail inputs. The
+    crystallizer, by contrast, sees only the free-text notes field a
+    previous agent wrote onto a :class:`TrackedPR`. We build a throw-away
+    ``CheckRun`` so the LLM receives the same shape of prompt it does in
+    the CI-triage path — this keeps the prompt cache key stable across
+    the two call sites and avoids a second, subtly-different triage
+    prompt we would then have to keep in sync.
+    """
+    return CheckRun(
+        id=0,
+        name="crystallizer",
+        status=CheckStatus.COMPLETED,
+        conclusion=CheckConclusion.FAILURE,
+        output_summary=notes,
+    )
+
+
+def _map_triage_category(category: FailureCategory) -> str:
+    """Translate a :data:`FailureCategory` into an InsightStore CATEGORY_*."""
+    return _FAILURE_CATEGORY_TO_STORE.get(category, CATEGORY_CI)
+
+
+async def _infer_category_llm(
+    notes: str,
+    *,
+    llm_router: LLMRouter | None,
+) -> str | None:
+    """LLM candidate — reuses the T-A3 :class:`FailureTriage` classifier.
+
+    Returns ``None`` when the LLM router isn't wired up or the candidate
+    errors out so the shadow decorator falls through to the legacy regex
+    without disrupting the hot path.
+    """
+    if llm_router is None or not llm_router.claude_available:
+        return None
+    claude = llm_router.claude
+    if claude is None or not claude.available:
+        return None
+
+    check_run = _notes_to_check_run(notes)
+    verdict: FailureTriage | None = await classify_failure_llm(
+        check_run,
+        notes,
+        claude=claude,
+    )
+    if verdict is None:
+        return None
+    return _map_triage_category(verdict.category)
+
+
+@shadow_decision("crystallizer_category")
+async def _dispatch_category(
+    *,
+    legacy: Any,
+    candidate: Any,
+    context: Any = None,
+) -> str:
+    """Thin shim the shadow decorator drives.
+
+    The decorator wires the legacy / candidate callables supplied by
+    :meth:`SkillCrystallizer._infer_category_for_notes`; this body is
+    never executed directly. See :mod:`caretaker.evolution.shadow` for
+    the full contract.
+    """
+    raise AssertionError(
+        "@shadow_decision wrapper should dispatch via legacy/candidate"
+    )  # pragma: no cover
 
 
 def _extract_signature(notes: str) -> str:
@@ -73,17 +201,32 @@ class SkillCrystallizer:
     the pre-save state snapshot against the post-agent state.
     """
 
-    def __init__(self, insight_store: InsightStore) -> None:
+    def __init__(
+        self,
+        insight_store: InsightStore,
+        *,
+        llm_router: LLMRouter | None = None,
+    ) -> None:
         self._store = insight_store
+        self._llm_router = llm_router
 
-    def crystallize_transitions(
+    async def crystallize_transitions(
         self,
         previous_prs: dict[int, TrackedPR],
         current_prs: dict[int, TrackedPR],
+        *,
+        repo_slug: str | None = None,
     ) -> int:
         """Compare old vs new PR states and crystallize outcomes.
 
         Returns the count of skills recorded.
+
+        The category-inference step runs through
+        :func:`_dispatch_category` so the
+        ``agentic.crystallizer_category.mode`` flag can shadow or enforce
+        the LLM classifier. ``off`` mode (the default) is byte-identical
+        to the pre-T-A10 behaviour — the regex ladder is the sole
+        authority and the LLM path is never invoked.
         """
         recorded = 0
         # Only MERGED / ESCALATED carry signal. CLOSED is often a human "abandon"
@@ -105,7 +248,9 @@ class SkillCrystallizer:
             if not notes or notes in ("ci_backlog_guard", "closed:ci_backlog_guard"):
                 continue
 
-            category = _infer_category(notes)
+            category = await self._infer_category_for_notes(
+                notes, pr_number=pr_number, repo_slug=repo_slug
+            )
             signature = _extract_signature(notes)
 
             if current.state == PRTrackingState.MERGED:
@@ -128,3 +273,25 @@ class SkillCrystallizer:
                 recorded += 1
 
         return recorded
+
+    async def _infer_category_for_notes(
+        self,
+        notes: str,
+        *,
+        pr_number: int,
+        repo_slug: str | None,
+    ) -> str:
+        """Run the category inference through the shadow decorator."""
+        router = self._llm_router
+
+        async def _legacy() -> str:
+            return _infer_category(notes)
+
+        async def _candidate() -> str | None:
+            return await _infer_category_llm(notes, llm_router=router)
+
+        return await _dispatch_category(
+            legacy=_legacy,
+            candidate=_candidate,
+            context={"repo_slug": repo_slug or "", "pr_number": pr_number},
+        )

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -308,7 +308,13 @@ class Orchestrator:
             store = build_evolution_store(config)
             assert store is not None, "Evolution store cannot be None when evolution is enabled"
             self._insight_store = store
-            self._skill_crystallizer = SkillCrystallizer(store)
+            # T-A10: SkillCrystallizer now accepts an LLMRouter so the
+            # ``crystallizer_category`` shadow candidate (see
+            # :func:`caretaker.evolution.crystallizer._infer_category_llm`)
+            # can reach Claude. ``agentic.crystallizer_category.mode`` is
+            # ``off`` by default so this adds no LLM traffic until the
+            # operator flips the flag.
+            self._skill_crystallizer = SkillCrystallizer(store, llm_router=self._llm)
             self._reflection_engine = ReflectionEngine()
             self._strategy_mutator = StrategyMutator(store)
             if config.evolution.plan_mode_enabled:
@@ -578,8 +584,10 @@ class Orchestrator:
 
             # ── Skill crystallization (Phase 1) ───────────────
             if self._skill_crystallizer is not None:
-                recorded = self._skill_crystallizer.crystallize_transitions(
-                    _pre_agent_prs, state.tracked_prs
+                recorded = await self._skill_crystallizer.crystallize_transitions(
+                    _pre_agent_prs,
+                    state.tracked_prs,
+                    repo_slug=f"{self._owner}/{self._repo}",
                 )
                 if recorded:
                     logger.info("Evolution: crystallized %d skill outcomes", recorded)

--- a/tests/test_crystallizer_category_shadow.py
+++ b/tests/test_crystallizer_category_shadow.py
@@ -1,0 +1,427 @@
+"""Tests for T-A10: crystallizer category migration.
+
+Covers the ``@shadow_decision("crystallizer_category")`` dispatch that
+routes category inference through the shared
+:class:`~caretaker.pr_agent.ci_triage.FailureTriage` classifier:
+
+* ``mode: off`` — legacy :func:`_infer_category` regex ladder is the
+  sole authority, behaviour is byte-identical to the pre-T-A10 world.
+* ``mode: shadow`` — both paths run, the legacy verdict is returned,
+  the disagreement counter records when categories diverge.
+* Mapping table — every :data:`FailureCategory` collapses cleanly onto
+  one of the InsightStore ``CATEGORY_*`` constants.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from caretaker.config import AgenticConfig, AgenticDomainConfig
+from caretaker.evolution import shadow_config
+from caretaker.evolution.crystallizer import (
+    _FAILURE_CATEGORY_TO_STORE,
+    SkillCrystallizer,
+    _infer_category,
+    _map_triage_category,
+    _notes_to_check_run,
+)
+from caretaker.evolution.insight_store import (
+    CATEGORY_BUILD,
+    CATEGORY_CI,
+    CATEGORY_SECURITY,
+    InsightStore,
+)
+from caretaker.evolution.shadow import clear_records_for_tests, recent_records
+from caretaker.llm.claude import StructuredCompleteError
+from caretaker.pr_agent.ci_triage import FailureTriage
+from caretaker.state.models import PRTrackingState, TrackedPR
+
+
+@pytest.fixture
+def store() -> InsightStore:
+    return InsightStore(db_path=":memory:")
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state() -> Iterator[None]:
+    """Clear ring buffer + active shadow config between tests."""
+    clear_records_for_tests()
+    shadow_config.reset_for_tests()
+    yield
+    clear_records_for_tests()
+    shadow_config.reset_for_tests()
+
+
+def _set_mode(mode: str) -> None:
+    cfg = AgenticConfig(
+        crystallizer_category=AgenticDomainConfig(mode=mode)  # type: ignore[arg-type]
+    )
+    shadow_config.configure(cfg)
+
+
+def _make_router(
+    verdict: FailureTriage | None = None,
+    *,
+    error: Exception | None = None,
+    available: bool = True,
+) -> MagicMock:
+    """Build a minimal LLMRouter-shaped mock."""
+    claude = MagicMock()
+    claude.available = available
+    if error is not None:
+        claude.structured_complete = AsyncMock(side_effect=error)
+    else:
+        claude.structured_complete = AsyncMock(return_value=verdict)
+    router = MagicMock()
+    router.claude_available = available
+    router.claude = claude
+    return router
+
+
+# ── Mapping table ────────────────────────────────────────────────────────
+
+
+class TestFailureCategoryMapping:
+    """Every FailureTriage.category value must map onto a CATEGORY_*.
+
+    Shadow-mode comparisons only make sense when the candidate's verdict
+    can be rendered in the legacy vocabulary — if a FailureCategory
+    silently drops to ``None`` / ``KeyError`` the disagreement counter
+    becomes unreadable.
+    """
+
+    def test_all_literal_values_covered(self) -> None:
+        # The Literal-typed FailureCategory values we expect the LLM to
+        # return. Kept in sync with
+        # :data:`caretaker.pr_agent.ci_triage.FailureCategory`.
+        expected = {
+            "test",
+            "lint",
+            "build",
+            "type",
+            "timeout",
+            "flaky",
+            "backpressure",
+            "infra",
+            "unknown",
+        }
+        assert set(_FAILURE_CATEGORY_TO_STORE.keys()) == expected
+
+    @pytest.mark.parametrize(
+        ("triage_category", "expected_store_category"),
+        [
+            ("test", CATEGORY_CI),
+            ("lint", CATEGORY_CI),
+            ("type", CATEGORY_CI),
+            ("timeout", CATEGORY_CI),
+            ("build", CATEGORY_BUILD),
+            ("flaky", CATEGORY_CI),
+            ("backpressure", CATEGORY_CI),
+            ("infra", CATEGORY_CI),
+            ("unknown", CATEGORY_CI),
+        ],
+    )
+    def test_triage_category_maps_to_store_category(
+        self, triage_category: str, expected_store_category: str
+    ) -> None:
+        assert _map_triage_category(triage_category) == expected_store_category  # type: ignore[arg-type]
+
+    def test_legacy_security_has_no_triage_analogue(self) -> None:
+        """Legacy regex hits CATEGORY_SECURITY; the LLM schema cannot.
+
+        This is documented in the ``TODO(T-A10, crystallizer_category)``
+        note on :data:`_FAILURE_CATEGORY_TO_STORE`. Until the
+        :data:`FailureCategory` Literal grows a ``security`` row, the
+        candidate will route security-flavoured notes to ``CATEGORY_CI``
+        and the shadow disagreement counter will surface how often.
+        """
+        assert _infer_category("dependabot cve patch for snyk alert") == CATEGORY_SECURITY
+        assert CATEGORY_SECURITY not in set(_FAILURE_CATEGORY_TO_STORE.values())
+
+
+# ── Synthetic CheckRun wrapper ────────────────────────────────────────────
+
+
+class TestNotesToCheckRun:
+    def test_wraps_notes_as_output_summary(self) -> None:
+        cr = _notes_to_check_run("jest timeout after 30s")
+        assert cr.output_summary == "jest timeout after 30s"
+        assert cr.name == "crystallizer"
+
+    def test_empty_notes_still_valid(self) -> None:
+        # Crystallizer callers always skip empty notes (see
+        # :meth:`SkillCrystallizer.crystallize_transitions`) but the
+        # adapter should not care — a valid CheckRun is all we owe the
+        # classifier.
+        cr = _notes_to_check_run("")
+        assert cr.output_summary == ""
+
+
+# ── mode: off ─────────────────────────────────────────────────────────────
+
+
+class TestOffMode:
+    """``mode: off`` — legacy path only, byte-identical to pre-T-A10.
+
+    Critically the LLM router must never be called — no prompt budget,
+    no provider round-trips, no Prometheus labels beyond ``legacy_only``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_legacy_path_still_works_without_router(self, store: InsightStore) -> None:
+        _set_mode("off")
+        crystallizer = SkillCrystallizer(store, llm_router=None)
+        previous = {
+            1: TrackedPR(
+                number=1, state=PRTrackingState.FIX_REQUESTED, notes="jest timeout failure"
+            )
+        }
+        current = {
+            1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="jest timeout failure")
+        }
+
+        recorded = await crystallizer.crystallize_transitions(previous, current)
+
+        assert recorded == 1
+        skills = store.all_skills(CATEGORY_CI)
+        assert len(skills) == 1
+        # Off-mode produces no shadow records.
+        assert recent_records(name="crystallizer_category") == []
+
+    @pytest.mark.asyncio
+    async def test_candidate_never_invoked_in_off_mode(self, store: InsightStore) -> None:
+        _set_mode("off")
+        # Even if a router is wired, ``off`` must never reach for Claude.
+        router = _make_router(
+            verdict=FailureTriage(
+                category="build",  # would disagree with legacy jest->CI
+                confidence=0.9,
+                is_transient=False,
+                root_cause_hypothesis="LLM says build",
+                suggested_fix="N/A",
+            )
+        )
+        crystallizer = SkillCrystallizer(store, llm_router=router)
+
+        previous = {
+            1: TrackedPR(
+                number=1, state=PRTrackingState.FIX_REQUESTED, notes="jest timeout failure"
+            )
+        }
+        current = {
+            1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="jest timeout failure")
+        }
+        await crystallizer.crystallize_transitions(previous, current)
+
+        # Legacy category wins and the LLM was never consulted.
+        assert router.claude.structured_complete.await_count == 0
+        assert len(store.all_skills(CATEGORY_CI)) == 1
+        assert len(store.all_skills(CATEGORY_BUILD)) == 0
+
+
+# ── mode: shadow ──────────────────────────────────────────────────────────
+
+
+class TestShadowMode:
+    """``mode: shadow`` — both paths run, legacy verdict returned.
+
+    Disagreement records let operators inspect the LLM vs regex
+    divergence rate before flipping ``enforce``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agreement_records_agree_outcome(self, store: InsightStore) -> None:
+        _set_mode("shadow")
+        # Legacy: "jest" → CATEGORY_CI. LLM: "test" → CATEGORY_CI. Agree.
+        router = _make_router(
+            verdict=FailureTriage(
+                category="test",
+                confidence=0.9,
+                is_transient=False,
+                root_cause_hypothesis="jest assertion failed",
+                suggested_fix="Fix the assertion.",
+            )
+        )
+        crystallizer = SkillCrystallizer(store, llm_router=router)
+
+        previous = {
+            1: TrackedPR(
+                number=1, state=PRTrackingState.FIX_REQUESTED, notes="jest timeout failure"
+            )
+        }
+        current = {
+            1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="jest timeout failure")
+        }
+        recorded = await crystallizer.crystallize_transitions(
+            previous, current, repo_slug="ian/demo"
+        )
+
+        assert recorded == 1
+        # Legacy verdict wins in shadow mode.
+        assert len(store.all_skills(CATEGORY_CI)) == 1
+
+        records = recent_records(name="crystallizer_category")
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.outcome == "agree"
+        assert rec.mode == "shadow"
+        assert rec.repo_slug == "ian/demo"
+
+    @pytest.mark.asyncio
+    async def test_disagreement_records_disagree_outcome(self, store: InsightStore) -> None:
+        _set_mode("shadow")
+        # Legacy: "jest" → CATEGORY_CI. LLM: "build" → CATEGORY_BUILD.
+        # Disagreement is captured but the legacy verdict is what
+        # reaches the InsightStore.
+        router = _make_router(
+            verdict=FailureTriage(
+                category="build",
+                confidence=0.8,
+                is_transient=False,
+                root_cause_hypothesis="webpack emitted missing chunk",
+                suggested_fix="Rebuild the bundle.",
+            )
+        )
+        crystallizer = SkillCrystallizer(store, llm_router=router)
+
+        previous = {
+            1: TrackedPR(number=1, state=PRTrackingState.FIX_REQUESTED, notes="jest flake in setup")
+        }
+        current = {
+            1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="jest flake in setup")
+        }
+        await crystallizer.crystallize_transitions(previous, current)
+
+        # Legacy wins: the skill is recorded under CATEGORY_CI, not BUILD.
+        assert len(store.all_skills(CATEGORY_CI)) == 1
+        assert len(store.all_skills(CATEGORY_BUILD)) == 0
+
+        records = recent_records(name="crystallizer_category")
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.outcome == "disagree"
+        assert rec.mode == "shadow"
+        assert rec.disagreement_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_candidate_error_does_not_break_hot_path(self, store: InsightStore) -> None:
+        _set_mode("shadow")
+        # The shared classifier swallows StructuredCompleteError and
+        # returns None; the shadow decorator then compares ``None`` vs
+        # the legacy string verdict → disagreement record.
+        router = _make_router(
+            error=StructuredCompleteError(
+                raw_text="not json",
+                validation_error=ValueError("parse failed"),
+            )
+        )
+        crystallizer = SkillCrystallizer(store, llm_router=router)
+
+        previous = {
+            1: TrackedPR(
+                number=1, state=PRTrackingState.FIX_REQUESTED, notes="jest timeout failure"
+            )
+        }
+        current = {
+            1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="jest timeout failure")
+        }
+        # Hot path stays green.
+        recorded = await crystallizer.crystallize_transitions(previous, current)
+        assert recorded == 1
+        assert len(store.all_skills(CATEGORY_CI)) == 1
+
+        records = recent_records(name="crystallizer_category")
+        assert len(records) == 1
+
+    @pytest.mark.asyncio
+    async def test_shadow_without_router_runs_legacy_only(self, store: InsightStore) -> None:
+        """Shadow + no LLM router → candidate returns None → disagreement.
+
+        Keeps the shadow-mode contract honest even when Claude is not
+        wired up: the hot path still resolves to the legacy verdict.
+        """
+        _set_mode("shadow")
+        crystallizer = SkillCrystallizer(store, llm_router=None)
+
+        previous = {
+            1: TrackedPR(
+                number=1, state=PRTrackingState.FIX_REQUESTED, notes="build failure in tsc"
+            )
+        }
+        current = {
+            1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="build failure in tsc")
+        }
+        recorded = await crystallizer.crystallize_transitions(previous, current)
+        assert recorded == 1
+        # Legacy: "build" in notes → CATEGORY_BUILD.
+        assert len(store.all_skills(CATEGORY_BUILD)) == 1
+
+
+# ── mode: enforce ─────────────────────────────────────────────────────────
+
+
+class TestEnforceMode:
+    """``mode: enforce`` — candidate is authoritative.
+
+    Smoke-test only; the bulk of the enforce-mode state-machine is
+    covered by the shared :func:`shadow_decision` tests.
+    """
+
+    @pytest.mark.asyncio
+    async def test_enforce_uses_candidate_category(self, store: InsightStore) -> None:
+        _set_mode("enforce")
+        # Legacy would classify "jest timeout" as CATEGORY_CI. The LLM
+        # says "build" → CATEGORY_BUILD. In enforce mode the candidate
+        # wins.
+        router = _make_router(
+            verdict=FailureTriage(
+                category="build",
+                confidence=0.95,
+                is_transient=False,
+                root_cause_hypothesis="test setup touches a webpack artifact",
+                suggested_fix="Pin the bundle before running tests.",
+            )
+        )
+        crystallizer = SkillCrystallizer(store, llm_router=router)
+
+        previous = {
+            1: TrackedPR(
+                number=1, state=PRTrackingState.FIX_REQUESTED, notes="jest timeout failure"
+            )
+        }
+        current = {
+            1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="jest timeout failure")
+        }
+        await crystallizer.crystallize_transitions(previous, current)
+
+        # Enforce → candidate wins.
+        assert len(store.all_skills(CATEGORY_BUILD)) == 1
+        assert len(store.all_skills(CATEGORY_CI)) == 0
+
+    @pytest.mark.asyncio
+    async def test_enforce_falls_through_to_legacy_on_candidate_none(
+        self, store: InsightStore
+    ) -> None:
+        _set_mode("enforce")
+        # Candidate returns None (no router) → decorator falls through
+        # to the legacy verdict.
+        crystallizer = SkillCrystallizer(store, llm_router=None)
+
+        previous = {
+            1: TrackedPR(
+                number=1, state=PRTrackingState.FIX_REQUESTED, notes="jest timeout failure"
+            )
+        }
+        current = {
+            1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="jest timeout failure")
+        }
+        await crystallizer.crystallize_transitions(previous, current)
+
+        # Legacy: "jest" → CATEGORY_CI.
+        assert len(store.all_skills(CATEGORY_CI)) == 1

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -211,7 +211,8 @@ class TestSkillInjection:
 
 
 class TestSkillCrystallizer:
-    def test_crystallize_merged_pr(self, store: InsightStore) -> None:
+    @pytest.mark.asyncio
+    async def test_crystallize_merged_pr(self, store: InsightStore) -> None:
         crystallizer = SkillCrystallizer(store)
         previous = {
             1: TrackedPR(
@@ -222,35 +223,38 @@ class TestSkillCrystallizer:
             1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="jest timeout failure")
         }
 
-        recorded = crystallizer.crystallize_transitions(previous, current)
+        recorded = await crystallizer.crystallize_transitions(previous, current)
         assert recorded == 1
         skills = store.all_skills()
         assert len(skills) == 1
         assert skills[0].success_count == 1
 
-    def test_crystallize_escalated_pr(self, store: InsightStore) -> None:
+    @pytest.mark.asyncio
+    async def test_crystallize_escalated_pr(self, store: InsightStore) -> None:
         crystallizer = SkillCrystallizer(store)
         previous = {
             2: TrackedPR(number=2, state=PRTrackingState.FIX_REQUESTED, notes="build failure")
         }
         current = {2: TrackedPR(number=2, state=PRTrackingState.ESCALATED, notes="build failure")}
 
-        recorded = crystallizer.crystallize_transitions(previous, current)
+        recorded = await crystallizer.crystallize_transitions(previous, current)
         assert recorded == 1
         skills = store.all_skills()
         assert skills[0].fail_count == 1
 
-    def test_no_transition_not_crystallized(self, store: InsightStore) -> None:
+    @pytest.mark.asyncio
+    async def test_no_transition_not_crystallized(self, store: InsightStore) -> None:
         crystallizer = SkillCrystallizer(store)
         pr = TrackedPR(number=3, state=PRTrackingState.MERGED, notes="some notes")
-        recorded = crystallizer.crystallize_transitions({3: pr}, {3: pr})
+        recorded = await crystallizer.crystallize_transitions({3: pr}, {3: pr})
         assert recorded == 0
 
-    def test_empty_notes_skipped(self, store: InsightStore) -> None:
+    @pytest.mark.asyncio
+    async def test_empty_notes_skipped(self, store: InsightStore) -> None:
         crystallizer = SkillCrystallizer(store)
         previous = {4: TrackedPR(number=4, state=PRTrackingState.CI_FAILING)}
         current = {4: TrackedPR(number=4, state=PRTrackingState.MERGED)}
-        recorded = crystallizer.crystallize_transitions(previous, current)
+        recorded = await crystallizer.crystallize_transitions(previous, current)
         assert recorded == 0
 
 

--- a/tests/test_evolution_state_machine.py
+++ b/tests/test_evolution_state_machine.py
@@ -626,33 +626,37 @@ class TestCrystallizerTransitionFilters:
     crystallize — those signals are unreliable.
     """
 
-    def test_same_terminal_state_is_no_op(self, store: InsightStore) -> None:
+    @pytest.mark.asyncio
+    async def test_same_terminal_state_is_no_op(self, store: InsightStore) -> None:
         crystallizer = SkillCrystallizer(store)
         pr = TrackedPR(number=7, state=PRTrackingState.MERGED, notes="jest flake")
-        recorded = crystallizer.crystallize_transitions({7: pr}, {7: pr})
+        recorded = await crystallizer.crystallize_transitions({7: pr}, {7: pr})
         assert recorded == 0
 
-    def test_ci_backlog_notes_are_skipped(self, store: InsightStore) -> None:
+    @pytest.mark.asyncio
+    async def test_ci_backlog_notes_are_skipped(self, store: InsightStore) -> None:
         crystallizer = SkillCrystallizer(store)
         previous = {
             1: TrackedPR(number=1, state=PRTrackingState.CI_FAILING, notes="ci_backlog_guard")
         }
         current = {1: TrackedPR(number=1, state=PRTrackingState.MERGED, notes="ci_backlog_guard")}
-        assert crystallizer.crystallize_transitions(previous, current) == 0
+        assert await crystallizer.crystallize_transitions(previous, current) == 0
 
-    def test_closed_state_never_crystallizes(self, store: InsightStore) -> None:
+    @pytest.mark.asyncio
+    async def test_closed_state_never_crystallizes(self, store: InsightStore) -> None:
         """CLOSED represents abandon/backlog — no skill signal."""
         crystallizer = SkillCrystallizer(store)
         previous = {1: TrackedPR(number=1, state=PRTrackingState.CI_FAILING, notes="jest flake")}
         current = {1: TrackedPR(number=1, state=PRTrackingState.CLOSED, notes="jest flake")}
-        assert crystallizer.crystallize_transitions(previous, current) == 0
+        assert await crystallizer.crystallize_transitions(previous, current) == 0
 
-    def test_new_pr_transitioned_to_merged(self, store: InsightStore) -> None:
+    @pytest.mark.asyncio
+    async def test_new_pr_transitioned_to_merged(self, store: InsightStore) -> None:
         """PR discovered and merged in the same run — no previous snapshot exists."""
         crystallizer = SkillCrystallizer(store)
         current = {9: TrackedPR(number=9, state=PRTrackingState.MERGED, notes="pytest timeout")}
         # No previous entry — previous_state is None, current is MERGED → crystallize
-        recorded = crystallizer.crystallize_transitions({}, current)
+        recorded = await crystallizer.crystallize_transitions({}, current)
         assert recorded == 1
         skills = store.all_skills(CATEGORY_CI)
         assert len(skills) == 1


### PR DESCRIPTION
## Summary

Phase 2 T-A10. Routes `SkillCrystallizer`'s category inference through the shared T-A3 classifier (`classify_failure_llm` + `FailureTriage`) under the existing `@shadow_decision` infrastructure, keyed on the `agentic.crystallizer_category` config knob.

**Default remains `mode: off` — no behaviour change until the flag flips.** This is the mechanism migration only; the follow-up PR below deletes the regex table once shadow data proves parity.

## What changed

- New `_infer_category_llm` candidate wraps the PR notes in a synthetic `CheckRun` and reuses `classify_failure_llm` so the prompt cache key stays aligned with the CI-triage call site.
- `_FAILURE_CATEGORY_TO_STORE` collapses every `FailureCategory` Literal (`test` / `lint` / `build` / `type` / `timeout` / `flaky` / `backpressure` / `infra` / `unknown`) onto an `InsightStore` `CATEGORY_*` row.
- `@shadow_decision("crystallizer_category")` wires legacy/candidate through the existing three-mode switch.
- `SkillCrystallizer.crystallize_transitions` is now `async`; the orchestrator call site already lives in an async coroutine, so this is a local change.
- The existing `_CATEGORY_PATTERNS` regex table and `_infer_category` stay in place as the legacy branch.

## Known mismatch

`FailureTriage.category` has no `security` row today, but the legacy regex has `CATEGORY_SECURITY` (matches on `secret` / `vuln` / `cve` / `dependabot` / `snyk`). The candidate will therefore route security-flavoured notes to `CATEGORY_CI` and those will show up as `disagree` records in shadow mode. This is documented with a `TODO(T-A10, crystallizer_category)` next to the mapping table; **before flipping `mode: enforce`, extend the `FailureCategory` Literal with a `security` row** so we don't silently reclassify dependabot/snyk notes.

## Rollout

1. `agentic.crystallizer_category.mode: off` (default, this PR) — LLM path never runs.
2. `shadow` — flip on one repo; inspect `caretaker_shadow_decisions_total{name="crystallizer_category"}` and `/admin/shadow-decisions?name=crystallizer_category`.
3. `enforce` — once disagreement is understood (in particular the security-row gap above is resolved).

## Follow-up

Once shadow data confirms parity, a dedicated PR deletes `_CATEGORY_PATTERNS` + `_infer_category` + the legacy branch. Keeping them in this PR so the mechanism change is reviewable on its own.

## Test plan

- [x] `PYTHONPATH="$PWD/src" pytest -q` — 1445 passed, 1 skipped
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src/caretaker` — 0 new errors (2 pre-existing in `k8s_worker/launcher.py` unrelated)
- [x] New `tests/test_crystallizer_category_shadow.py`:
  - [x] Mapping table: every `FailureCategory` Literal value maps cleanly; legacy-only `CATEGORY_SECURITY` gap asserted so the next author can't silently forget it
  - [x] `mode: off` — legacy path unchanged; candidate is never invoked even when a router is wired
  - [x] `mode: shadow` — agree / disagree / candidate-error records
  - [x] `mode: enforce` — candidate category wins; falls through to legacy when candidate returns `None`
- [x] Existing `tests/test_evolution.py` + `tests/test_evolution_state_machine.py` updated to `await` the now-async `crystallize_transitions` — all passing.
- [ ] Before flipping `mode: shadow` on any real repo, confirm the admin shadow-decisions endpoint renders `crystallizer_category` records and the Prometheus counter emits non-zero `{name="crystallizer_category", mode="shadow", outcome=...}` series.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>