### PR TITLE
feat(foundry,pr_reviewer): executor routing migration + shadow

### DIFF
--- a/src/caretaker/evolution/executor_routing.py
+++ b/src/caretaker/evolution/executor_routing.py
@@ -1,0 +1,461 @@
+"""LLM-backed executor routing decision (Phase 2, §3.9 of the 2026-Q2 plan).
+
+Replaces the two point systems that historically chose between inline LLM
+review, the claude-code-action hand-off, the Foundry executor, and Copilot:
+
+* :mod:`caretaker.pr_reviewer.routing` — LOC + file count + sensitive-path
+  regex for PR-review routing (inline vs claude_code).
+* :mod:`caretaker.foundry.size_classifier` — cheap pre/post-flight gates
+  that decide Foundry vs Copilot.
+
+Both rubrics claim to be formulas but are really classifiers: the score
+thresholds drift against repo practice, the regex list rots, and neither
+system can explain why it picked the path it did beyond listing the rules
+that matched. That cost is what the migration is buying down.
+
+This module introduces:
+
+* :class:`ExecutorRoute` — pydantic v2 schema emitted by both the LLM
+  candidate and the legacy adapters. The schema is small and closed so
+  the shadow decorator can compare legacy vs. candidate on the
+  authoritative ``path`` field without free-text drift.
+* :class:`ExecutorRouteContext` — the variable payload the LLM candidate
+  sees. Built once at the call site and fed in last so the stable prefix
+  (the system prompt) stays cache-friendly.
+* :func:`route_executor_llm` — the LLM candidate. Builds a cache-friendly
+  prompt and calls ``structured_complete``. Any
+  :class:`caretaker.llm.claude.StructuredCompleteError` yields ``None``
+  so ``@shadow_decision`` falls through to the legacy adapter.
+* :func:`route_from_pr_reviewer_legacy` — adapts a legacy
+  :class:`caretaker.pr_reviewer.routing.RoutingDecision` onto
+  :class:`ExecutorRoute` (path=``inline`` or ``claude_code``).
+* :func:`route_from_foundry_legacy` — adapts a legacy
+  :class:`caretaker.foundry.size_classifier.ClassifierResult` onto
+  :class:`ExecutorRoute` (path=``foundry`` or ``copilot``).
+
+The two call sites in ``pr_reviewer/agent.py`` and
+``foundry/executor.py`` (via the dispatcher) both wrap their decision
+with ``@shadow_decision("executor_routing")`` — the same decorator name
+— so shadow data aggregates across them in a single ``executor_routing``
+disagreement feed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+from caretaker.llm.claude import StructuredCompleteError
+from caretaker.pr_reviewer.routing import _SENSITIVE_PATTERNS
+
+if TYPE_CHECKING:
+    from caretaker.foundry.size_classifier import ClassifierResult
+    from caretaker.llm.claude import ClaudeClient
+    from caretaker.pr_reviewer.routing import RoutingDecision
+
+logger = logging.getLogger(__name__)
+
+
+# ── Schema ───────────────────────────────────────────────────────────────
+
+ExecutorPath = Literal["inline", "foundry", "claude_code", "copilot"]
+"""Closed set of executor destinations.
+
+* ``inline`` — synchronous inline LLM review (pr-reviewer fast path).
+* ``foundry`` — caretaker's self-owned tool-loop executor (Foundry).
+* ``claude_code`` — claude-code-action hand-off (GitHub Action dispatch).
+* ``copilot`` — legacy Copilot task comment (the ultimate fallback).
+"""
+
+RiskTag = Literal[
+    "workflows_touched",
+    "auth_touched",
+    "migration_touched",
+    "public_api_touched",
+    "large_diff",
+    "cross_package",
+    "security_review_needed",
+    "safe",
+]
+"""Structured risk tags attached to a route decision.
+
+Kept as a closed enum so the shadow decorator can compare tag sets
+without free-text drift. ``security_review_needed`` is the catch-all
+for anything a human reviewer should eyeball regardless of executor
+choice.
+"""
+
+
+class ExecutorRoute(BaseModel):
+    """Structured routing verdict emitted by both the LLM and legacy adapters.
+
+    ``path`` is the authoritative field for shadow-mode comparison — the
+    ``reason`` and ``confidence`` fields carry observability metadata but
+    are not part of the equality check. ``risk_tags`` is a *set-like*
+    list (order is not significant); callers treat it as a set.
+    """
+
+    path: ExecutorPath
+    reason: str = Field(max_length=300)
+    risk_tags: list[RiskTag] = Field(default_factory=list)
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+# ── LLM candidate context ────────────────────────────────────────────────
+
+
+@dataclass
+class ExecutorRouteFile:
+    """One file entry fed into the routing prompt.
+
+    Kept as a plain dataclass (rather than pydantic) so call sites can
+    build it cheaply from either a GitHub API payload or a Foundry
+    ``CodingTask`` without a second validation pass.
+    """
+
+    path: str
+    additions: int = 0
+    deletions: int = 0
+
+
+@dataclass
+class ExecutorRouteContext:
+    """Variable payload for :func:`route_executor_llm`.
+
+    The prompt builder places the stable prefix (system prompt) first and
+    this payload last so Anthropic prompt caching hits on the prefix
+    across every routing call in a run.
+
+    Fields are deliberately small: the routing decision is a classifier,
+    not a reviewer, so the LLM never needs raw diff content.
+    """
+
+    # What kind of task is being routed. For PRs this is the PR action
+    # (e.g. ``opened``/``synchronize``); for Foundry it's the Copilot
+    # task-type enum value. Free text so the prompt can handle both.
+    task_type: str = ""
+    # Files touched, with per-file LOC counts. Foundry may populate this
+    # from the post-flight diff stats; pr_reviewer populates it from the
+    # PR file list.
+    files: list[ExecutorRouteFile] = field(default_factory=list)
+    # Labels on the host PR / issue. Used as a soft signal — the LLM can
+    # use them but should not be bound by them.
+    labels: list[str] = field(default_factory=list)
+    # Repo identity ("owner/repo") for log attribution and prompt context.
+    repo_slug: str = ""
+    # Candidate paths the caller is willing to consider. ``inline`` +
+    # ``claude_code`` for pr_reviewer, ``foundry`` + ``copilot`` for the
+    # dispatcher. Empty means "any".
+    candidate_paths: list[ExecutorPath] = field(default_factory=list)
+    # Short free-text description of the change, when available (PR title
+    # / issue title / task summary). Optional — omitted when caller has
+    # nothing cheap to hand.
+    title: str = ""
+    # A short body excerpt (already truncated by the caller). Optional.
+    body: str = ""
+
+
+# ── LLM prompt ───────────────────────────────────────────────────────────
+
+
+_ROUTING_SYSTEM_PROMPT = """\
+You are caretaker's executor router. Given a task or PR snapshot, pick
+the cheapest executor that is *still safe* for the change and explain
+your reasoning in one short sentence.
+
+Rules:
+- ``path`` must be one of: inline, foundry, claude_code, copilot.
+  When the caller restricts candidate_paths, choose from that set only.
+- Prefer ``inline`` for small, non-sensitive code review where a single
+  LLM review is sufficient.
+- Prefer ``foundry`` for small, well-scoped coding tasks (XS/S, few
+  files, narrow blast radius).
+- Prefer ``claude_code`` or ``copilot`` for complex or sensitive
+  changes — anything touching CI workflows, auth/secrets, database
+  migrations, public APIs, or many packages.
+- Populate ``risk_tags`` with the closed-enum tags that apply:
+  * ``workflows_touched`` — any file under ``.github/workflows/``.
+  * ``auth_touched``      — secrets, tokens, credentials, auth code.
+  * ``migration_touched`` — alembic / schema migration files.
+  * ``public_api_touched``— exported interfaces, SDKs, public handlers.
+  * ``large_diff``        — total additions + deletions > 400, or > 20
+    files.
+  * ``cross_package``     — changes span more than 3 top-level dirs.
+  * ``security_review_needed`` — anything you are uncertain about or
+    that warrants a human eyeball before merge.
+  * ``safe``              — none of the above apply.
+- ``reason`` is a single line no longer than 300 characters.
+- ``confidence`` is your self-assessed probability the route is correct.
+"""
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)] + "..."
+
+
+def _detect_sensitive_hints(paths: list[str]) -> list[str]:
+    """Return sensitive-path regex hints matched by ``paths``.
+
+    Reuses the legacy sensitivity regex table as a *signal* to the LLM,
+    not as an authoritative decision. The hints are echoed back in the
+    prompt so the model can cite the same evidence the legacy rubric
+    used without us re-implementing the regex ourselves.
+    """
+    hints: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        for pattern, _pts in _SENSITIVE_PATTERNS:
+            key = pattern.pattern
+            if key in seen:
+                continue
+            if pattern.search(path):
+                hints.append(key)
+                seen.add(key)
+    return hints
+
+
+def build_routing_prompt(context: ExecutorRouteContext) -> str:
+    """Assemble the variable-payload prompt body.
+
+    The stable prefix is passed through to ``structured_complete`` as
+    ``system=`` — that's where Anthropic prompt caching looks for a
+    cache-able prefix. Only the per-task payload changes across calls;
+    that's what this function renders.
+    """
+    paths = [f.path for f in context.files]
+    total_additions = sum(f.additions for f in context.files)
+    total_deletions = sum(f.deletions for f in context.files)
+    top_dirs = sorted({p.split("/")[0] for p in paths if "/" in p})
+
+    files_block = (
+        "\n".join(f"- {f.path} (+{f.additions}/-{f.deletions})" for f in context.files)
+        or "(no files listed)"
+    )
+    labels_block = ", ".join(context.labels) or "(none)"
+    candidates_block = ", ".join(context.candidate_paths) or "any"
+    sensitive_hints = _detect_sensitive_hints(paths)
+    hints_block = "\n".join(f"- {h}" for h in sensitive_hints) or "(none)"
+    body_snippet = _truncate(context.body.strip(), 1000)
+
+    return (
+        f"Task type: {context.task_type or '?'}\n"
+        f"Repo: {context.repo_slug or '?'}\n"
+        f"Title: {context.title or '?'}\n"
+        f"Candidate paths: {candidates_block}\n"
+        f"Labels: {labels_block}\n"
+        f"File count: {len(context.files)}\n"
+        f"Total additions: {total_additions}\n"
+        f"Total deletions: {total_deletions}\n"
+        f"Top-level dirs touched ({len(top_dirs)}): "
+        f"{', '.join(top_dirs) if top_dirs else '(none)'}\n"
+        f"Sensitive-path hints (from legacy regex table):\n{hints_block}\n"
+        f"Files:\n{files_block}\n"
+        f"Body (truncated to 1000 chars):\n{body_snippet}\n"
+    )
+
+
+async def route_executor_llm(
+    context: ExecutorRouteContext,
+    *,
+    claude: ClaudeClient,
+) -> ExecutorRoute | None:
+    """Call the LLM and return its :class:`ExecutorRoute`, or ``None``.
+
+    Returns ``None`` on any :class:`StructuredCompleteError` so the
+    ``@shadow_decision`` wrapper can fall through to the legacy adapter.
+    All other exceptions propagate — shadow mode swallows them and
+    records a ``candidate_error`` event, enforce mode falls through.
+    """
+    prompt = build_routing_prompt(context)
+    try:
+        return await claude.structured_complete(
+            prompt,
+            schema=ExecutorRoute,
+            feature="executor_routing",
+            system=_ROUTING_SYSTEM_PROMPT,
+        )
+    except StructuredCompleteError as exc:
+        logger.info(
+            "route_executor_llm: structured_complete failed (%s)",
+            exc,
+        )
+        return None
+
+
+# ── Legacy adapters ──────────────────────────────────────────────────────
+
+
+def _infer_risk_tags(
+    *,
+    file_paths: list[str],
+    additions: int,
+    deletions: int,
+    file_count: int,
+) -> list[RiskTag]:
+    """Derive :class:`RiskTag` entries from the inputs the legacy point
+    systems already see.
+
+    The mapping intentionally matches how the LLM is told to think about
+    the tags in ``_ROUTING_SYSTEM_PROMPT`` so the shadow-mode comparison
+    has a hope of agreeing on tag sets when both paths see the same
+    signals.
+    """
+    tags: list[RiskTag] = []
+    seen: set[RiskTag] = set()
+
+    def add(tag: RiskTag) -> None:
+        if tag not in seen:
+            seen.add(tag)
+            tags.append(tag)
+
+    sensitive_matched = False
+    for path in file_paths:
+        lower = path.lower()
+        if ".github/workflows/" in lower:
+            add("workflows_touched")
+            sensitive_matched = True
+            continue
+        if any(token in lower for token in ("secret", "credential", "auth", "token", "password")):
+            add("auth_touched")
+            sensitive_matched = True
+            continue
+        if any(token in lower for token in ("migration", "alembic", "schema")):
+            add("migration_touched")
+            sensitive_matched = True
+            continue
+
+    if "workflows_touched" in seen or "auth_touched" in seen:
+        add("security_review_needed")
+
+    total_lines = additions + deletions
+    if total_lines > 400 or file_count > 20:
+        add("large_diff")
+
+    top_dirs: set[str] = set()
+    for p in file_paths:
+        if "/" in p:
+            top_dirs.add(p.split("/")[0])
+    if len(top_dirs) > 3:
+        add("cross_package")
+
+    if not tags and not sensitive_matched:
+        add("safe")
+
+    return tags
+
+
+def route_from_pr_reviewer_legacy(
+    decision: RoutingDecision,
+    *,
+    additions: int = 0,
+    deletions: int = 0,
+    file_count: int = 0,
+    file_paths: list[str] | None = None,
+) -> ExecutorRoute:
+    """Lift a legacy :class:`RoutingDecision` onto :class:`ExecutorRoute`.
+
+    Maps the pr_reviewer score-threshold categories:
+
+    * ``use_inline == True``  → :attr:`ExecutorRoute.path` == ``"inline"``.
+    * ``use_inline == False`` → :attr:`ExecutorRoute.path` == ``"claude_code"``.
+
+    The ``reason`` string preserves the legacy score + triggered rules
+    verbatim so the shadow-mode disagreement feed can show exactly what
+    the point system was thinking.
+    """
+    path: ExecutorPath = "inline" if decision.use_inline else "claude_code"
+    risk_tags = _infer_risk_tags(
+        file_paths=file_paths or [],
+        additions=additions,
+        deletions=deletions,
+        file_count=file_count,
+    )
+    reason = f"Legacy routing: score={decision.score}, {decision.reason}"
+    # confidence: high when far from threshold, sagging as we get closer.
+    distance = abs(decision.score - 40)
+    confidence = max(0.5, min(1.0, 0.5 + (distance / 100.0)))
+    return ExecutorRoute(
+        path=path,
+        reason=_truncate(reason, 300),
+        risk_tags=risk_tags,
+        confidence=round(confidence, 2),
+    )
+
+
+def route_from_foundry_legacy(
+    result: ClassifierResult,
+    *,
+    additions: int = 0,
+    deletions: int = 0,
+    file_count: int = 0,
+    file_paths: list[str] | None = None,
+) -> ExecutorRoute:
+    """Lift a legacy Foundry :class:`ClassifierResult` onto :class:`ExecutorRoute`.
+
+    Maps the classifier decisions:
+
+    * :attr:`Decision.ROUTE_FOUNDRY`    → path=``"foundry"``.
+    * :attr:`Decision.ESCALATE_COPILOT` → path=``"copilot"``.
+    * :attr:`Decision.ABORT`            → path=``"copilot"`` (caller
+      still has to refuse, but the route verdict is "not us"; the
+      shadow record captures the abort reason in ``reason``).
+    """
+    # Local import avoids a module-level cycle with foundry.size_classifier.
+    from caretaker.foundry.size_classifier import Decision
+
+    if result.decision == Decision.ROUTE_FOUNDRY:
+        path: ExecutorPath = "foundry"
+        triggered = "route_foundry"
+    else:
+        path = "copilot"
+        triggered = "escalate_copilot" if result.decision == Decision.ESCALATE_COPILOT else "abort"
+
+    risk_tags = _infer_risk_tags(
+        file_paths=file_paths or [],
+        additions=additions,
+        deletions=deletions,
+        file_count=file_count,
+    )
+    reason = f"Legacy routing: score=N, triggered rules=[{triggered}]: {result.reason}"
+    # Legacy classifier is a pure rule engine, so it is confidently right
+    # inside its scope. Confidence is 0.9 — a deliberate shade under 1.0
+    # so the shadow comparison can surface ties to the LLM's verdict.
+    return ExecutorRoute(
+        path=path,
+        reason=_truncate(reason, 300),
+        risk_tags=risk_tags,
+        confidence=0.9,
+    )
+
+
+# ── Shadow compare helper ───────────────────────────────────────────────
+
+
+def executor_routes_agree(a: ExecutorRoute, b: ExecutorRoute) -> bool:
+    """Compare two :class:`ExecutorRoute` verdicts at the decision level.
+
+    Only the ``path`` field matters for shadow-mode disagreement
+    accounting — ``reason``/``confidence`` drift between the legacy
+    adapter and the LLM, and ``risk_tags`` ordering is insignificant.
+    Agreement on ``path`` is what unblocks enforce-mode rollout.
+    """
+    return a.path == b.path
+
+
+__all__ = [
+    "ExecutorPath",
+    "ExecutorRoute",
+    "ExecutorRouteContext",
+    "ExecutorRouteFile",
+    "RiskTag",
+    "build_routing_prompt",
+    "executor_routes_agree",
+    "route_executor_llm",
+    "route_from_foundry_legacy",
+    "route_from_pr_reviewer_legacy",
+]

--- a/src/caretaker/foundry/executor.py
+++ b/src/caretaker/foundry/executor.py
@@ -20,8 +20,22 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from caretaker.evolution.executor_routing import (
+    ExecutorRoute,
+    ExecutorRouteContext,
+    ExecutorRouteFile,
+    executor_routes_agree,
+    route_executor_llm,
+    route_from_foundry_legacy,
+)
+from caretaker.evolution.shadow import shadow_decision
 from caretaker.foundry.prompts import build_prompt
-from caretaker.foundry.size_classifier import Decision, post_flight, pre_flight
+from caretaker.foundry.size_classifier import (
+    ClassifierResult,
+    Decision,
+    post_flight,
+    pre_flight,
+)
 from caretaker.foundry.tool_loop import ToolLoopError, run_tool_loop
 from caretaker.foundry.tools import ToolContext, build_tool_registry
 from caretaker.foundry.workspace import Workspace, WorkspaceError
@@ -34,16 +48,32 @@ from caretaker.llm.copilot import (
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+    from typing import Any
 
     from caretaker.config import FoundryExecutorConfig
     from caretaker.evolution.insight_store import Skill
     from caretaker.github_client.api import GitHubClient
     from caretaker.github_client.models import PullRequest
+    from caretaker.llm.claude import ClaudeClient
     from caretaker.llm.provider import LLMProvider
 
 type TokenSupplier = Callable[[], Awaitable[str]]
 
 logger = logging.getLogger(__name__)
+
+
+@shadow_decision("executor_routing", compare=executor_routes_agree)
+async def _decide_executor_route(
+    *, legacy: Any, candidate: Any, context: Any = None
+) -> ExecutorRoute:
+    """Shadow-mode decision point wrapping the legacy + LLM routing paths.
+
+    Placeholder body — the decorator short-circuits to ``legacy`` in
+    ``off`` / ``shadow`` modes and to ``candidate`` in ``enforce`` mode.
+    Shares the ``executor_routing`` name with the pr-reviewer call site
+    so shadow data aggregates across both executors.
+    """
+    raise AssertionError("shadow_decision wrapper short-circuits this placeholder")
 
 
 class ExecutorOutcome(StrEnum):
@@ -137,6 +167,7 @@ class FoundryExecutor:
         config: FoundryExecutorConfig,
         source_repo_path: Path | None = None,
         token_supplier: TokenSupplier | None = None,
+        claude: ClaudeClient | None = None,
     ) -> None:
         self._provider = provider
         self._github = github
@@ -149,6 +180,12 @@ class FoundryExecutor:
             else Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd()))
         )
         self._token_supplier = token_supplier
+        # Optional ``ClaudeClient`` used by the executor_routing shadow
+        # candidate. ``None`` disables the LLM path (shadow mode will
+        # record candidate_error, enforce mode will fall through to
+        # legacy), matching the default-safe rollout pattern used by
+        # every other Phase 2 migration.
+        self._claude = claude
         # Per-branch asyncio lock so two concurrent tasks on the same PR
         # branch don't clobber each other's worktree.
         self._branch_locks: dict[str, asyncio.Lock] = {}
@@ -159,6 +196,59 @@ class FoundryExecutor:
             lock = asyncio.Lock()
             self._branch_locks[branch] = lock
         return lock
+
+    async def _route_via_shadow(
+        self,
+        *,
+        task: CodingTask,
+        pr: PullRequest,
+        classifier_result: ClassifierResult,
+    ) -> ExecutorRoute | None:
+        """Run the ``executor_routing`` shadow gate for the Foundry site.
+
+        Returns the legacy-adapted :class:`ExecutorRoute` in
+        ``off`` / ``shadow`` modes; returns the LLM verdict when
+        ``enforce`` mode succeeds. Defensive: swallows every exception —
+        the classifier verdict is still authoritative on the control
+        path inside :meth:`run`.
+        """
+
+        async def _legacy_path() -> ExecutorRoute:
+            return route_from_foundry_legacy(classifier_result)
+
+        async def _candidate_path() -> ExecutorRoute | None:
+            if self._claude is None or not self._claude.available:
+                return None
+            context = ExecutorRouteContext(
+                task_type=task.task_type.value,
+                files=[ExecutorRouteFile(path=pr.head_ref or f"pr-{pr.number}")],
+                labels=list(getattr(pr, "labels", []) or []),
+                repo_slug=f"{self._owner}/{self._repo}",
+                candidate_paths=["foundry", "copilot"],
+                title=task.job_name,
+                body=task.instructions,
+            )
+            return await route_executor_llm(context, claude=self._claude)
+
+        try:
+            return await _decide_executor_route(
+                legacy=_legacy_path,
+                candidate=_candidate_path,
+                context={
+                    "pr_number": pr.number,
+                    "repo_slug": f"{self._owner}/{self._repo}",
+                    "site": "foundry",
+                    "task_type": task.task_type.value,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive: never fail the executor
+            logger.warning(
+                "foundry: executor_routing shadow-decision failed for PR #%d (%s: %s)",
+                pr.number,
+                type(exc).__name__,
+                exc,
+            )
+            return None
 
     async def run(self, task: CodingTask, pr: PullRequest) -> ExecutorResult:
         """Execute ``task`` end-to-end. Never raises — always returns an
@@ -180,6 +270,14 @@ class FoundryExecutor:
             route_same_repo_only=self._config.route_same_repo_only,
             error_output=task.error_output,
         )
+
+        # Shadow-mode wrapper around the classifier verdict. Shares the
+        # ``executor_routing`` decoration name with the pr-reviewer call
+        # site so disagreement data aggregates across both executors.
+        # The control-flow remains driven by the legacy ``pre.decision``
+        # field — this is purely observability until enforce mode flips.
+        await self._route_via_shadow(task=task, pr=pr, classifier_result=pre)
+
         if pre.decision != Decision.ROUTE_FOUNDRY:
             return ExecutorResult(
                 outcome=ExecutorOutcome.ESCALATED,

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -44,6 +44,7 @@ from caretaker.state.tracker import StateTracker
 if TYPE_CHECKING:
     from caretaker.evolution.insight_store import InsightStore
     from caretaker.goals.models import GoalEvaluation
+    from caretaker.llm.claude import ClaudeClient
     from caretaker.registry import AgentRegistry
 
 logger = logging.getLogger(__name__)
@@ -327,7 +328,9 @@ class Orchestrator:
         # ── Executor dispatcher (Copilot / Foundry routing) ────────────
         self._executor_dispatcher: ExecutorDispatcher | None = None
         try:
-            self._executor_dispatcher = self._build_executor_dispatcher(config, github, owner, repo)
+            self._executor_dispatcher = self._build_executor_dispatcher(
+                config, github, owner, repo, claude=self._llm.claude
+            )
         except Exception as exc:  # never block agent boot on Foundry config issues
             logger.warning("Failed to build ExecutorDispatcher; falling back to Copilot: %s", exc)
             self._executor_dispatcher = None
@@ -360,6 +363,8 @@ class Orchestrator:
         github: GitHubClient,
         owner: str,
         repo: str,
+        *,
+        claude: ClaudeClient | None = None,
     ) -> ExecutorDispatcher | None:
         """Build the Foundry executor + dispatcher, or return None when disabled.
 
@@ -404,6 +409,7 @@ class Orchestrator:
                     repo=repo,
                     config=executor_cfg.foundry,
                     token_supplier=_push_token,
+                    claude=claude,
                 )
                 logger.info(
                     "FoundryExecutor ready: model=%s allowed_task_types=%s",

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -21,12 +21,34 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from caretaker.agent_protocol import AgentResult, BaseAgent
+from caretaker.evolution.executor_routing import (
+    ExecutorRoute,
+    ExecutorRouteContext,
+    ExecutorRouteFile,
+    executor_routes_agree,
+    route_executor_llm,
+    route_from_pr_reviewer_legacy,
+)
+from caretaker.evolution.shadow import shadow_decision
 from caretaker.pr_reviewer import claude_code_reviewer, inline_reviewer
 from caretaker.pr_reviewer.github_review import post_review
 from caretaker.pr_reviewer.routing import decide
 
 if TYPE_CHECKING:
     from caretaker.state.models import OrchestratorState, RunSummary
+
+
+@shadow_decision("executor_routing", compare=executor_routes_agree)
+async def _decide_executor_route(
+    *, legacy: Any, candidate: Any, context: Any = None
+) -> ExecutorRoute:
+    """Shadow-mode decision point wrapping the legacy + LLM routing paths.
+
+    The body never runs — the decorator short-circuits to ``legacy`` in
+    ``off`` / ``shadow`` modes and to ``candidate`` in ``enforce`` mode.
+    """
+    raise AssertionError("shadow_decision wrapper short-circuits this placeholder")
+
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +186,23 @@ class PRReviewerAgent(BaseAgent):
         )
         logger.info("pr-reviewer: #%d routing — %s", pr_number, decision.reason)
 
+        # Shadow-mode wrapper: compares legacy point-system verdict with
+        # the LLM candidate under the ``executor_routing`` flag. The
+        # return value is the authoritative ``ExecutorRoute`` (legacy in
+        # off/shadow, candidate in enforce) but we continue to use the
+        # raw ``decision`` object below so inline-path behavior stays
+        # byte-identical until enforce mode flips.
+        await self._route_via_shadow(
+            pr_number=pr_number,
+            decision=decision,
+            files=files,
+            file_paths=file_paths,
+            additions=additions,
+            deletions=deletions,
+            pr_labels=pr_labels,
+            pr=pr,
+        )
+
         if decision.use_inline:
             if self._ctx.llm_router is None or not self._ctx.llm_router.available:
                 logger.warning(
@@ -241,6 +280,77 @@ class PRReviewerAgent(BaseAgent):
             report.dispatched.append(pr_number)
         else:
             report.errors.append(f"claude-code dispatch failed for #{pr_number}")
+
+    async def _route_via_shadow(
+        self,
+        *,
+        pr_number: int,
+        decision: Any,
+        files: list[dict[str, Any]],
+        file_paths: list[str],
+        additions: int,
+        deletions: int,
+        pr_labels: list[str],
+        pr: dict[str, Any],
+    ) -> ExecutorRoute | None:
+        """Run the ``executor_routing`` shadow gate for a PR-reviewer decision.
+
+        Always returns the legacy-adapted :class:`ExecutorRoute` in
+        ``off`` / ``shadow`` modes; returns the LLM verdict when
+        ``enforce`` mode succeeds. Defensive: any exception bubbling out
+        of the decorator is swallowed and ``None`` is returned so the
+        caller continues to use the point-system ``decision`` object.
+        """
+
+        async def _legacy_path() -> ExecutorRoute:
+            return route_from_pr_reviewer_legacy(
+                decision,
+                additions=additions,
+                deletions=deletions,
+                file_count=len(files),
+                file_paths=file_paths,
+            )
+
+        async def _candidate_path() -> ExecutorRoute | None:
+            if self._ctx.llm_router is None or not self._ctx.llm_router.available:
+                return None
+            route_files = [
+                ExecutorRouteFile(
+                    path=f.get("path", ""),
+                    additions=int(f.get("additions", 0)),
+                    deletions=int(f.get("deletions", 0)),
+                )
+                for f in files
+            ]
+            context = ExecutorRouteContext(
+                task_type="pr_review",
+                files=route_files,
+                labels=pr_labels,
+                repo_slug=f"{self._ctx.owner}/{self._ctx.repo}",
+                candidate_paths=["inline", "claude_code"],
+                title=str(pr.get("title", "")),
+                body=str(pr.get("body") or ""),
+            )
+            return await route_executor_llm(context, claude=self._ctx.llm_router.claude)
+
+        try:
+            return await _decide_executor_route(
+                legacy=_legacy_path,
+                candidate=_candidate_path,
+                context={
+                    "pr_number": pr_number,
+                    "repo_slug": f"{self._ctx.owner}/{self._ctx.repo}",
+                    "site": "pr_reviewer",
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive: never fail the agent
+            logger.warning(
+                "pr-reviewer: executor_routing shadow-decision failed for #%d (%s: %s)",
+                pr_number,
+                type(exc).__name__,
+                exc,
+            )
+            return None
 
     def apply_summary(self, result: AgentResult, summary: RunSummary) -> None:
         pass

--- a/tests/test_evolution_executor_routing.py
+++ b/tests/test_evolution_executor_routing.py
@@ -1,0 +1,533 @@
+"""Tests for the Phase 2 LLM-backed executor routing migration (T-A9).
+
+Covers every call-out in the task brief:
+
+* Schema validation (happy path + enum/length guards).
+* Legacy adapter mapping for both call sites:
+  * :func:`route_from_pr_reviewer_legacy` — inline vs claude_code.
+  * :func:`route_from_foundry_legacy`     — foundry vs copilot.
+* LLM candidate: prompt payload + return value on happy path +
+  :class:`StructuredCompleteError` handling.
+* Shadow decorator integration in all three modes (off/shadow/enforce).
+* Risk-tag assertions for a PR touching ``.github/workflows/``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from caretaker.config import AgenticConfig, AgenticDomainConfig
+from caretaker.evolution import shadow_config
+from caretaker.evolution.executor_routing import (
+    ExecutorRoute,
+    ExecutorRouteContext,
+    ExecutorRouteFile,
+    build_routing_prompt,
+    executor_routes_agree,
+    route_executor_llm,
+    route_from_foundry_legacy,
+    route_from_pr_reviewer_legacy,
+)
+from caretaker.evolution.shadow import (
+    clear_records_for_tests,
+    recent_records,
+    shadow_decision,
+)
+from caretaker.foundry.size_classifier import ClassifierResult, Decision
+from caretaker.graph import writer as graph_writer
+from caretaker.llm.claude import StructuredCompleteError
+from caretaker.pr_reviewer.routing import RoutingDecision
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state() -> None:
+    clear_records_for_tests()
+    shadow_config.reset_for_tests()
+    graph_writer.reset_for_tests()
+
+
+def _set_routing_mode(mode: str) -> None:
+    cfg = AgenticConfig(executor_routing=AgenticDomainConfig(mode=mode))  # type: ignore[arg-type]
+    shadow_config.configure(cfg)
+
+
+# ── Schema validation ────────────────────────────────────────────────────
+
+
+class TestExecutorRouteSchema:
+    def test_happy_path_parses(self) -> None:
+        route = ExecutorRoute(
+            path="inline",
+            reason="small docs-only PR",
+            risk_tags=["safe"],
+            confidence=0.8,
+        )
+        assert route.path == "inline"
+        assert route.reason == "small docs-only PR"
+        assert route.risk_tags == ["safe"]
+        assert route.confidence == 0.8
+
+    def test_invalid_path_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExecutorRoute(path="invalid", reason="r", confidence=0.5)  # type: ignore[arg-type]
+
+    def test_invalid_risk_tag_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExecutorRoute(
+                path="inline",
+                reason="r",
+                risk_tags=["bogus"],  # type: ignore[list-item]
+                confidence=0.5,
+            )
+
+    def test_confidence_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExecutorRoute(path="inline", reason="r", confidence=1.5)
+
+    def test_reason_length_capped(self) -> None:
+        with pytest.raises(ValidationError):
+            ExecutorRoute(path="inline", reason="x" * 301, confidence=0.5)
+
+    def test_risk_tags_default_empty(self) -> None:
+        route = ExecutorRoute(path="foundry", reason="x", confidence=0.7)
+        assert route.risk_tags == []
+
+
+# ── Legacy adapter: pr_reviewer ──────────────────────────────────────────
+
+
+class TestRouteFromPRReviewerLegacy:
+    def test_use_inline_maps_to_inline_path(self) -> None:
+        decision = RoutingDecision(score=12, use_inline=True, reason="loc=50(+6)")
+        route = route_from_pr_reviewer_legacy(decision)
+        assert route.path == "inline"
+        assert "Legacy routing" in route.reason
+        assert "score=12" in route.reason
+
+    def test_score_above_threshold_maps_to_claude_code(self) -> None:
+        decision = RoutingDecision(score=58, use_inline=False, reason="loc=800(+30)")
+        route = route_from_pr_reviewer_legacy(decision)
+        assert route.path == "claude_code"
+
+    def test_workflows_path_produces_sensitive_tags(self) -> None:
+        decision = RoutingDecision(score=72, use_inline=False, reason="sensitive_files(+15)")
+        route = route_from_pr_reviewer_legacy(
+            decision,
+            additions=30,
+            deletions=5,
+            file_count=1,
+            file_paths=[".github/workflows/ci.yml"],
+        )
+        assert route.path == "claude_code"
+        assert "workflows_touched" in route.risk_tags
+        assert "security_review_needed" in route.risk_tags
+
+    def test_large_cross_package_diff_tagged(self) -> None:
+        decision = RoutingDecision(score=80, use_inline=False, reason="loc=900(+30)")
+        route = route_from_pr_reviewer_legacy(
+            decision,
+            additions=700,
+            deletions=300,
+            file_count=30,
+            file_paths=[
+                "a/file.py",
+                "b/file.py",
+                "c/file.py",
+                "d/file.py",
+                "e/file.py",
+            ],
+        )
+        assert "large_diff" in route.risk_tags
+        assert "cross_package" in route.risk_tags
+
+    def test_auth_path_tagged(self) -> None:
+        decision = RoutingDecision(score=55, use_inline=False, reason="sensitive(+10)")
+        route = route_from_pr_reviewer_legacy(
+            decision,
+            file_paths=["src/app/auth_token.py"],
+        )
+        assert "auth_touched" in route.risk_tags
+        assert "security_review_needed" in route.risk_tags
+
+    def test_safe_when_nothing_matches(self) -> None:
+        decision = RoutingDecision(score=5, use_inline=True, reason="low-complexity")
+        route = route_from_pr_reviewer_legacy(
+            decision,
+            additions=10,
+            deletions=5,
+            file_count=1,
+            file_paths=["README.md"],
+        )
+        assert route.risk_tags == ["safe"]
+
+    def test_reason_truncated_to_schema_limit(self) -> None:
+        decision = RoutingDecision(
+            score=12,
+            use_inline=True,
+            reason="x" * 500,
+        )
+        route = route_from_pr_reviewer_legacy(decision)
+        assert len(route.reason) <= 300
+
+
+# ── Legacy adapter: foundry ──────────────────────────────────────────────
+
+
+class TestRouteFromFoundryLegacy:
+    def test_route_foundry_maps_to_foundry_path(self) -> None:
+        result = ClassifierResult(decision=Decision.ROUTE_FOUNDRY, reason="eligible")
+        route = route_from_foundry_legacy(result)
+        assert route.path == "foundry"
+        assert "route_foundry" in route.reason
+        assert "Legacy routing" in route.reason
+
+    def test_escalate_copilot_maps_to_copilot_path(self) -> None:
+        result = ClassifierResult(
+            decision=Decision.ESCALATE_COPILOT,
+            reason="task_type 'ARCH_REFACTOR' not in allowlist",
+        )
+        route = route_from_foundry_legacy(result)
+        assert route.path == "copilot"
+        assert "escalate_copilot" in route.reason
+
+    def test_abort_maps_to_copilot_with_abort_reason(self) -> None:
+        result = ClassifierResult(decision=Decision.ABORT, reason="refused")
+        route = route_from_foundry_legacy(result)
+        assert route.path == "copilot"
+        assert "abort" in route.reason
+
+    def test_workflows_file_raises_risk_tag(self) -> None:
+        result = ClassifierResult(decision=Decision.ESCALATE_COPILOT, reason="too big")
+        route = route_from_foundry_legacy(
+            result,
+            file_paths=[".github/workflows/release.yml"],
+            additions=40,
+            deletions=5,
+            file_count=1,
+        )
+        assert "workflows_touched" in route.risk_tags
+        assert "security_review_needed" in route.risk_tags
+
+
+# ── Prompt builder ───────────────────────────────────────────────────────
+
+
+class TestBuildRoutingPrompt:
+    def test_prompt_contains_required_payload(self) -> None:
+        ctx = ExecutorRouteContext(
+            task_type="pr_review",
+            files=[
+                ExecutorRouteFile(path="src/a.py", additions=10, deletions=2),
+                ExecutorRouteFile(path=".github/workflows/ci.yml", additions=5, deletions=0),
+            ],
+            labels=["maintainer:upgrade"],
+            repo_slug="ian/demo",
+            candidate_paths=["inline", "claude_code"],
+            title="Bump ruff",
+            body="Why not.",
+        )
+        prompt = build_routing_prompt(ctx)
+        assert "pr_review" in prompt
+        assert "ian/demo" in prompt
+        assert "Bump ruff" in prompt
+        assert "maintainer:upgrade" in prompt
+        assert "src/a.py" in prompt
+        assert ".github/workflows/ci.yml" in prompt
+        # Sensitive-path hint echoed from legacy regex table.
+        assert "workflows" in prompt
+        # Candidate paths enumerated.
+        assert "inline" in prompt and "claude_code" in prompt
+        # Totals computed.
+        assert "Total additions: 15" in prompt
+        assert "Total deletions: 2" in prompt
+
+    def test_prompt_body_truncated(self) -> None:
+        ctx = ExecutorRouteContext(body="x" * 2000)
+        prompt = build_routing_prompt(ctx)
+        # Body trimmed to 1000 chars plus marker.
+        assert "..." in prompt
+        assert prompt.count("x") <= 1000
+
+
+# ── LLM candidate ────────────────────────────────────────────────────────
+
+
+class TestRouteExecutorLLM:
+    async def test_happy_path_returns_schema_instance(self) -> None:
+        fake_route = ExecutorRoute(
+            path="inline",
+            reason="Small doc-only PR; no sensitive paths.",
+            risk_tags=["safe"],
+            confidence=0.92,
+        )
+
+        class _FakeClaude:
+            def __init__(self) -> None:
+                self.calls: list[dict[str, Any]] = []
+                self.available = True
+
+            async def structured_complete(
+                self,
+                prompt: str,
+                *,
+                schema: type,
+                feature: str,
+                system: str | None = None,
+            ) -> Any:
+                self.calls.append(
+                    {
+                        "prompt": prompt,
+                        "schema": schema,
+                        "feature": feature,
+                        "system": system,
+                    }
+                )
+                return fake_route
+
+        claude = _FakeClaude()
+        ctx = ExecutorRouteContext(
+            task_type="pr_review",
+            repo_slug="ian/demo",
+            candidate_paths=["inline", "claude_code"],
+            title="docs: typo",
+        )
+        result = await route_executor_llm(ctx, claude=claude)  # type: ignore[arg-type]
+        assert result is fake_route
+        assert len(claude.calls) == 1
+        call = claude.calls[0]
+        assert call["feature"] == "executor_routing"
+        assert call["schema"] is ExecutorRoute
+        assert "ian/demo" in call["prompt"]
+        assert call["system"] is not None
+        assert "executor router" in call["system"]
+
+    async def test_structured_complete_error_returns_none(self) -> None:
+        claude = AsyncMock()
+        claude.structured_complete.side_effect = StructuredCompleteError(
+            raw_text="nope", validation_error=ValueError("bad")
+        )
+        ctx = ExecutorRouteContext(repo_slug="ian/demo")
+        result = await route_executor_llm(ctx, claude=claude)
+        assert result is None
+
+
+# ── Risk-tag assertion for workflows-touched PR ──────────────────────────
+
+
+class TestWorkflowsTouchedRiskTags:
+    """Brief-mandated test: a PR that touches ``.github/workflows/`` must
+    surface ``workflows_touched`` + ``security_review_needed`` in the
+    legacy adapter's risk-tag output.
+    """
+
+    def test_pr_reviewer_legacy_adds_both_tags(self) -> None:
+        decision = RoutingDecision(score=85, use_inline=False, reason="workflows touched")
+        route = route_from_pr_reviewer_legacy(
+            decision,
+            additions=20,
+            deletions=10,
+            file_count=1,
+            file_paths=[".github/workflows/deploy.yml"],
+        )
+        assert route.path == "claude_code"
+        assert "workflows_touched" in route.risk_tags
+        assert "security_review_needed" in route.risk_tags
+
+    def test_foundry_legacy_adds_both_tags(self) -> None:
+        result = ClassifierResult(decision=Decision.ESCALATE_COPILOT, reason="not a candidate")
+        route = route_from_foundry_legacy(
+            result,
+            file_paths=[".github/workflows/release.yml"],
+        )
+        assert "workflows_touched" in route.risk_tags
+        assert "security_review_needed" in route.risk_tags
+
+
+# ── Compare helper ───────────────────────────────────────────────────────
+
+
+class TestExecutorRoutesAgree:
+    def test_same_path_agrees_regardless_of_reason(self) -> None:
+        a = ExecutorRoute(path="inline", reason="legacy", confidence=0.9)
+        b = ExecutorRoute(path="inline", reason="llm says so", confidence=0.7)
+        assert executor_routes_agree(a, b) is True
+
+    def test_different_path_disagrees(self) -> None:
+        a = ExecutorRoute(path="inline", reason="legacy", confidence=0.9)
+        b = ExecutorRoute(path="claude_code", reason="llm", confidence=0.7)
+        assert executor_routes_agree(a, b) is False
+
+
+# ── Shadow decorator integration ─────────────────────────────────────────
+
+
+class TestShadowDecoratorIntegration:
+    async def test_off_mode_skips_candidate(self) -> None:
+        _set_routing_mode("off")
+
+        @shadow_decision("executor_routing", compare=executor_routes_agree)
+        async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> ExecutorRoute:
+            raise AssertionError("wrapper short-circuits")
+
+        legacy_called = 0
+        candidate_called = 0
+
+        async def legacy() -> ExecutorRoute:
+            nonlocal legacy_called
+            legacy_called += 1
+            return ExecutorRoute(path="inline", reason="legacy", confidence=0.9)
+
+        async def candidate() -> ExecutorRoute | None:
+            nonlocal candidate_called
+            candidate_called += 1
+            return ExecutorRoute(path="claude_code", reason="candidate", confidence=0.7)
+
+        verdict = await decide(legacy=legacy, candidate=candidate)
+        assert verdict.path == "inline"
+        assert legacy_called == 1
+        assert candidate_called == 0
+        assert recent_records() == []
+
+    async def test_shadow_mode_records_disagreement(self) -> None:
+        _set_routing_mode("shadow")
+
+        @shadow_decision("executor_routing", compare=executor_routes_agree)
+        async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> ExecutorRoute:
+            raise AssertionError("wrapper short-circuits")
+
+        async def legacy() -> ExecutorRoute:
+            return ExecutorRoute(path="inline", reason="legacy", confidence=0.5)
+
+        async def candidate() -> ExecutorRoute | None:
+            return ExecutorRoute(path="claude_code", reason="candidate", confidence=0.9)
+
+        verdict = await decide(
+            legacy=legacy,
+            candidate=candidate,
+            context={"repo_slug": "ian/demo", "pr_number": 4},
+        )
+        # Shadow mode always returns the legacy verdict so downstream
+        # behavior stays byte-identical.
+        assert verdict.path == "inline"
+        records = recent_records()
+        assert len(records) == 1
+        assert records[0].outcome == "disagree"
+        assert records[0].name == "executor_routing"
+        assert records[0].repo_slug == "ian/demo"
+
+    async def test_shadow_mode_agrees_when_paths_match(self) -> None:
+        _set_routing_mode("shadow")
+
+        @shadow_decision("executor_routing", compare=executor_routes_agree)
+        async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> ExecutorRoute:
+            raise AssertionError("wrapper short-circuits")
+
+        async def legacy() -> ExecutorRoute:
+            # Differ on reason/confidence/risk_tags but agree on path.
+            return ExecutorRoute(
+                path="foundry",
+                reason="Legacy routing: score=N, ...",
+                risk_tags=["safe"],
+                confidence=0.9,
+            )
+
+        async def candidate() -> ExecutorRoute | None:
+            return ExecutorRoute(
+                path="foundry",
+                reason="LLM: small well-scoped change",
+                risk_tags=[],
+                confidence=0.7,
+            )
+
+        verdict = await decide(
+            legacy=legacy,
+            candidate=candidate,
+            context={"repo_slug": "ian/demo"},
+        )
+        assert verdict.path == "foundry"
+        records = recent_records()
+        # Agreement — no disagreement record written (but an ``agree``
+        # record is persisted for audit).
+        assert len(records) == 1
+        assert records[0].outcome == "agree"
+
+    async def test_enforce_mode_promotes_candidate(self) -> None:
+        _set_routing_mode("enforce")
+
+        @shadow_decision("executor_routing", compare=executor_routes_agree)
+        async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> ExecutorRoute:
+            raise AssertionError("wrapper short-circuits")
+
+        async def legacy() -> ExecutorRoute:
+            return ExecutorRoute(path="inline", reason="legacy", confidence=0.5)
+
+        async def candidate() -> ExecutorRoute | None:
+            return ExecutorRoute(path="claude_code", reason="llm", confidence=0.95)
+
+        verdict = await decide(legacy=legacy, candidate=candidate)
+        assert verdict.path == "claude_code"
+        # enforced_candidate outcome is counted but not persisted as a
+        # disagreement record.
+        assert recent_records() == []
+
+    async def test_enforce_mode_falls_through_on_none(self) -> None:
+        _set_routing_mode("enforce")
+
+        @shadow_decision("executor_routing", compare=executor_routes_agree)
+        async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> ExecutorRoute:
+            raise AssertionError("wrapper short-circuits")
+
+        async def legacy() -> ExecutorRoute:
+            return ExecutorRoute(path="inline", reason="legacy ok", confidence=1.0)
+
+        async def candidate() -> ExecutorRoute | None:
+            return None  # simulates StructuredCompleteError inside candidate
+
+        verdict = await decide(legacy=legacy, candidate=candidate)
+        assert verdict.path == "inline"
+
+    async def test_shared_name_aggregates_across_sites(self) -> None:
+        """Both call sites register under the same ``executor_routing``
+        name, so a single config switch controls both and the ring buffer
+        / Prometheus counter report aggregate disagreement rates across
+        the full executor fleet.
+        """
+        _set_routing_mode("shadow")
+
+        @shadow_decision("executor_routing", compare=executor_routes_agree)
+        async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> ExecutorRoute:
+            raise AssertionError("wrapper short-circuits")
+
+        async def legacy_pr_reviewer() -> ExecutorRoute:
+            return ExecutorRoute(path="inline", reason="pr-reviewer legacy", confidence=0.9)
+
+        async def candidate_pr_reviewer() -> ExecutorRoute | None:
+            return ExecutorRoute(path="claude_code", reason="pr-reviewer llm", confidence=0.8)
+
+        async def legacy_foundry() -> ExecutorRoute:
+            return ExecutorRoute(path="foundry", reason="foundry legacy", confidence=0.9)
+
+        async def candidate_foundry() -> ExecutorRoute | None:
+            return ExecutorRoute(path="copilot", reason="foundry llm", confidence=0.8)
+
+        await decide(
+            legacy=legacy_pr_reviewer,
+            candidate=candidate_pr_reviewer,
+            context={"site": "pr_reviewer"},
+        )
+        await decide(
+            legacy=legacy_foundry,
+            candidate=candidate_foundry,
+            context={"site": "foundry"},
+        )
+        records = recent_records()
+        # Two disagreement records, both under the shared decision name.
+        assert len(records) == 2
+        assert {r.name for r in records} == {"executor_routing"}
+        assert all(r.outcome == "disagree" for r in records)


### PR DESCRIPTION
## Summary

Phase 2 §3.9 of the 2026-Q2 agentic migration plan. Replaces the two
historical point systems that chose between executors — the LOC /
file-count / sensitive-path regex in `pr_reviewer/routing.py` and the
pre/post-flight gates in `foundry/size_classifier.py` — with a single
`structured_complete[ExecutorRoute]` candidate behind the shared
`agentic.executor_routing` flag (default `mode: off`).

- New module `caretaker.evolution.executor_routing` exposing:
  - `ExecutorRoute` closed pydantic schema with `path`
    (inline/foundry/claude_code/copilot), `reason`, closed-enum
    `risk_tags`, and `confidence`.
  - `route_executor_llm` — cache-friendly LLM candidate (stable system
    prefix, variable payload last). `StructuredCompleteError` yields
    `None` so the shadow wrapper falls through to the legacy adapter.
  - Legacy adapters that lift each point-system verdict onto the new
    schema, preserving the legacy score / triggered-rules metadata in
    `reason`. `_infer_risk_tags` derives the closed-enum tag set from
    the same inputs each legacy system sees so shadow-mode comparisons
    have a fair shot at agreeing on the risk side channel too.
- Both call sites — `pr_reviewer/agent.py` and `foundry/executor.py` —
  wrap the decision with `@shadow_decision("executor_routing")` under
  the **same** decorator name so shadow disagreement data aggregates
  across the full executor fleet. Comparison is `path` equality only.
- `FoundryExecutor` takes an optional `ClaudeClient`; the orchestrator
  threads `self._llm.claude` through so the foundry shadow candidate
  has a client to call. Runtime flow is still driven by the legacy
  classifier verdict — enforce mode is the next milestone.

## Test plan

- [x] `pytest -q` — 1455 passed, 1 skipped
- [x] `ruff check src tests` — all checks passed
- [x] `ruff format --check src tests` — 301 files already formatted
- [x] `mypy src/caretaker` — no new errors (only pre-existing
      k8s_worker/launcher.py kubernetes stubs warnings)
- [x] Added `tests/test_evolution_executor_routing.py` — 31 tests
      covering schema validation, both legacy adapters, LLM candidate
      happy + error path, shadow/enforce/off modes, shared-name
      aggregation across both call sites, and the brief-mandated
      workflows-touched risk-tag assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)