### PR TITLE
feat(pr_agent): stuck-PR detection migration + shadow

### DIFF
--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -39,6 +39,12 @@ from caretaker.pr_agent.states import (
     ReadinessEvaluation,
     evaluate_pr,
 )
+from caretaker.pr_agent.stuck_pr_llm import (
+    PRStuckContext,
+    StuckVerdict,
+    evaluate_stuck_pr_llm,
+    stuck_from_legacy,
+)
 from caretaker.state.models import OwnershipState, PRTrackingState, TrackedPR
 from caretaker.tools.debug_dump import render_debug_dump
 
@@ -70,6 +76,29 @@ def _readiness_verdicts_agree(a: Readiness, b: Readiness) -> bool:
 @shadow_decision("readiness", compare=_readiness_verdicts_agree)
 async def _decide_readiness(*, legacy: Any, candidate: Any, context: Any = None) -> Readiness:
     """Shadow-mode decision point wrapping the legacy + LLM readiness paths.
+
+    The body never runs — the decorator short-circuits to ``legacy`` in
+    ``off`` / ``shadow`` modes and to ``candidate`` in ``enforce`` mode.
+    """
+    raise AssertionError("shadow_decision wrapper short-circuits this placeholder")
+
+
+def _stuck_verdicts_agree(a: StuckVerdict, b: StuckVerdict) -> bool:
+    """Compare two :class:`StuckVerdict` verdicts at the decision level.
+
+    Only ``is_stuck`` and ``recommended_action`` affect downstream
+    behaviour (escalate vs. wait vs. nudge vs. self-approve). The
+    ``stuck_reason`` and free-text ``explanation`` are informational —
+    the legacy adapter can emit only ``abandoned`` / ``not_stuck`` and
+    can never match the LLM's richer reason taxonomy, so comparing on
+    those fields would spam the disagreement counter without signal.
+    """
+    return a.is_stuck == b.is_stuck and a.recommended_action == b.recommended_action
+
+
+@shadow_decision("stuck_pr", compare=_stuck_verdicts_agree)
+async def _decide_stuck_pr(*, legacy: Any, candidate: Any, context: Any = None) -> StuckVerdict:
+    """Shadow-mode decision point for the stuck-PR gate.
 
     The body never runs — the decorator short-circuits to ``legacy`` in
     ``off`` / ``shadow`` modes and to ``candidate`` in ``enforce`` mode.
@@ -239,6 +268,13 @@ class PRAgent:
         approval review on file. CI state is intentionally NOT considered —
         a PR that's been failing for 24h with no human attention is exactly
         what this gate catches.
+
+        Retained as the ``legacy`` branch of the
+        ``@shadow_decision("stuck_pr")`` gate in
+        :meth:`_evaluate_stuck_verdict`. The ``stuck_age_hours`` threshold
+        also acts as a minimum-age pre-filter: callers skip the whole
+        shadow decision when the PR is younger than the threshold, so the
+        LLM candidate is never called on freshly-opened PRs.
         """
         from caretaker.github_client.models import ReviewState
 
@@ -254,6 +290,135 @@ class PRAgent:
                     return False
         return True
 
+    async def _evaluate_stuck_verdict(
+        self,
+        pr: PullRequest,
+        check_runs: list[Any],
+        reviews: list[Any],
+        readiness_verdict: Readiness | None,
+    ) -> StuckVerdict | None:
+        """Evaluate the stuck-PR gate under the ``stuck_pr`` shadow switch.
+
+        Returns ``None`` when the PR is younger than ``stuck_age_hours``
+        (the minimum-age pre-filter) — in that case neither the legacy
+        heuristic nor the LLM candidate runs. Otherwise dispatches through
+        ``@shadow_decision("stuck_pr")`` so behaviour tracks the Phase 2
+        rollout: ``off`` returns the legacy binary verdict, ``shadow``
+        returns the legacy verdict and records disagreements, ``enforce``
+        returns the LLM candidate (falling through to legacy on error).
+        """
+        if self._config.stuck_age_hours <= 0:
+            return None
+        age_hours = self._pr_age_hours(pr)
+        if age_hours < self._config.stuck_age_hours:
+            return None
+
+        is_stuck_legacy = self._is_pr_stuck_by_age(pr, reviews)
+
+        last_activity: datetime | None = pr.updated_at or pr.created_at
+        last_activity_hours: float | None = None
+        if last_activity is not None:
+            stamp = last_activity
+            if stamp.tzinfo is None:
+                stamp = stamp.replace(tzinfo=UTC)
+            last_activity_hours = (datetime.now(UTC) - stamp).total_seconds() / 3600.0
+
+        # On a solo-maintainer repo ``required_reviews == 0`` so
+        # :class:`ReadinessConfig` is the right signal — it mirrors the
+        # solo check used by the readiness gate.
+        collaborator_count: int | None = 1 if self._config.readiness.required_reviews == 0 else None
+
+        async def _legacy_path() -> StuckVerdict:
+            return stuck_from_legacy(is_stuck_legacy)
+
+        async def _candidate_path() -> StuckVerdict | None:
+            if self._llm is None or not self._llm.available:
+                return None
+            context = PRStuckContext(
+                pr=pr,
+                age_hours=age_hours,
+                last_activity_hours=last_activity_hours,
+                check_runs=list(check_runs),
+                reviews=list(reviews),
+                readiness_verdict=readiness_verdict,
+                repo_slug=f"{self._owner}/{self._repo}",
+                collaborator_count=collaborator_count,
+            )
+            return await evaluate_stuck_pr_llm(context, claude=self._llm.claude)
+
+        try:
+            verdict: StuckVerdict = await _decide_stuck_pr(
+                legacy=_legacy_path,
+                candidate=_candidate_path,
+                context={
+                    "pr_number": pr.number,
+                    "repo_slug": f"{self._owner}/{self._repo}",
+                    "age_hours": round(age_hours, 1),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive: never fail the agent
+            logger.warning(
+                "PR #%d: stuck-PR shadow-decision failed (%s: %s); falling back to legacy adapter",
+                pr.number,
+                type(exc).__name__,
+                exc,
+            )
+            verdict = stuck_from_legacy(is_stuck_legacy)
+
+        return verdict
+
+    @staticmethod
+    def _stuck_verdict_requires_escalation(verdict: StuckVerdict) -> bool:
+        """Return True when a stuck verdict warrants the escalation path.
+
+        Every action except ``wait`` and ``request_fix`` lands on the
+        escalation path for now. ``request_fix`` is already handled by
+        the CI-fix lifecycle downstream and a duplicate escalation
+        comment would spam the PR. ``wait`` is, obviously, a no-op.
+        The remaining actions — ``escalate``, ``nudge_reviewer``,
+        ``close_stale``, ``self_approve_on_solo`` — all surface as an
+        escalation with an action-specific reason so humans see *why*
+        caretaker stopped touching the PR.
+        """
+        if not verdict.is_stuck:
+            return False
+        return verdict.recommended_action in {
+            "escalate",
+            "nudge_reviewer",
+            "close_stale",
+            "self_approve_on_solo",
+        }
+
+    def _stuck_escalation_reason(self, verdict: StuckVerdict) -> str:
+        """Render an escalation-comment reason for a stuck verdict.
+
+        Action-shaped so the operator sees the recommended next step,
+        not just the diagnosis. Preserves the legacy reason verbatim
+        when the action is ``escalate`` (the ``off`` / ``shadow`` path),
+        so the comment body doesn't drift when the flag is flipped from
+        ``off`` to ``shadow``.
+        """
+        action = verdict.recommended_action
+        if action == "escalate":
+            return f"Open >{self._config.stuck_age_hours}h with no human approval — needs review"
+        if action == "nudge_reviewer":
+            return (
+                f"Stuck waiting on a review — reviewer nudge recommended ({verdict.stuck_reason})."
+            )
+        if action == "close_stale":
+            return f"Stuck and stale — recommended action is ``close_stale``. {verdict.explanation}"
+        if action == "self_approve_on_solo":
+            return (
+                "Solo-maintainer repo: the PR is ready but cannot clear the "
+                "required-review gate without a second approver."
+            )
+        # Defensive: any other action falls back to the legacy wording so
+        # a surprise candidate can't produce an empty or confusing reason.
+        return (
+            f"Stuck PR ({verdict.stuck_reason}) — recommended action "
+            f"``{action}``. {verdict.explanation}"
+        )
+
     async def _process_pr(
         self, pr: PullRequest, tracking: TrackedPR, report: PRAgentReport
     ) -> TrackedPR:
@@ -265,48 +430,8 @@ class PRAgent:
         check_runs = await self._github.get_check_runs(self._owner, self._repo, pr.head_ref)
         reviews = await self._github.get_pr_reviews(self._owner, self._repo, pr.number)
 
-        # Stuck-PR age gate (E1): if the PR has been open for longer than
-        # ``stuck_age_hours`` AND no human approval AND no recent merge
-        # transition, escalate to a human. Catches long-tail abandonment
-        # (portfolio #4 was open 10 days; #28 was open 7 days). Skipped if
-        # already escalated (terminal) or PR is closed/merged.
-        if (
-            self._config.stuck_age_hours > 0
-            and not tracking.escalated
-            and tracking.state
-            not in (PRTrackingState.ESCALATED, PRTrackingState.MERGED, PRTrackingState.CLOSED)
-            and self._is_pr_stuck_by_age(pr, reviews)
-        ):
-            await self._escalate(
-                pr,
-                f"Open >{self._config.stuck_age_hours}h with no human approval — needs review",
-                debug_data={
-                    "pr_age_hours": self._pr_age_hours(pr),
-                    "stuck_age_hours": self._config.stuck_age_hours,
-                    "fix_cycles": tracking.fix_cycles,
-                    "copilot_attempts": tracking.copilot_attempts,
-                },
-            )
-            tracking.state = PRTrackingState.ESCALATED
-            tracking.escalated = True
-            report.escalated.append(pr.number)
-            # Still flow through ownership handling so the status comment
-            # transitions to "released — escalated" cleanly.
-            evaluation = evaluate_pr(
-                pr=pr,
-                check_runs=check_runs,
-                reviews=reviews,
-                current_state=tracking.state,
-                ignore_jobs=self._config.ci.ignore_jobs,
-                auto_approve_workflows=self._config.ci.auto_approve_workflows,
-                required_reviews=self._config.readiness.required_reviews,
-                auto_merge=self._config.auto_merge,
-            )
-            await self._attach_readiness_verdict(pr, evaluation, check_runs, reviews)
-            tracking = await self._handle_ownership(pr, tracking, evaluation, report)
-            return tracking
-
-        # Evaluate PR state
+        # Evaluate PR state (shared by both the stuck-PR gate and the
+        # main action ladder below).
         evaluation = evaluate_pr(
             pr=pr,
             check_runs=check_runs,
@@ -323,6 +448,46 @@ class PRAgent:
         # side-by-side and records disagreements; enforce promotes the LLM
         # verdict. Controlled by ``AgenticConfig.readiness.mode``.
         await self._attach_readiness_verdict(pr, evaluation, check_runs, reviews)
+
+        # Stuck-PR gate (E1, Phase 2 §3.8): if the PR has been open long
+        # enough to be a stuck candidate, run the ``stuck_pr`` shadow
+        # decision. In ``off`` mode this is the legacy binary
+        # age-heuristic (portfolio #4 was open 10 days; #28 was open
+        # 7 days). In ``shadow`` / ``enforce`` modes an LLM candidate
+        # distinguishes abandoned / ci_deadlock / awaiting_human_decision
+        # / merge_queue / solo_repo_no_reviewer and picks a matching
+        # action. Skipped if already escalated (terminal) or the PR is
+        # closed/merged.
+        if not tracking.escalated and tracking.state not in (
+            PRTrackingState.ESCALATED,
+            PRTrackingState.MERGED,
+            PRTrackingState.CLOSED,
+        ):
+            stuck_verdict = await self._evaluate_stuck_verdict(
+                pr, check_runs, reviews, evaluation.readiness_verdict
+            )
+            if stuck_verdict is not None and self._stuck_verdict_requires_escalation(stuck_verdict):
+                reason = self._stuck_escalation_reason(stuck_verdict)
+                await self._escalate(
+                    pr,
+                    reason,
+                    debug_data={
+                        "pr_age_hours": self._pr_age_hours(pr),
+                        "stuck_age_hours": self._config.stuck_age_hours,
+                        "fix_cycles": tracking.fix_cycles,
+                        "copilot_attempts": tracking.copilot_attempts,
+                        "stuck_reason": stuck_verdict.stuck_reason,
+                        "recommended_action": stuck_verdict.recommended_action,
+                        "stuck_confidence": stuck_verdict.confidence,
+                    },
+                )
+                tracking.state = PRTrackingState.ESCALATED
+                tracking.escalated = True
+                report.escalated.append(pr.number)
+                # Still flow through ownership handling so the status
+                # comment transitions to "released — escalated" cleanly.
+                tracking = await self._handle_ownership(pr, tracking, evaluation, report)
+                return tracking
 
         logger.info(
             "PR #%d: %s → %s (action: %s)",

--- a/src/caretaker/pr_agent/stuck_pr_llm.py
+++ b/src/caretaker/pr_agent/stuck_pr_llm.py
@@ -1,0 +1,327 @@
+"""LLM-backed stuck-PR detection (Phase 2 §3.8 of the 2026-Q2 plan).
+
+The legacy :meth:`caretaker.pr_agent.agent.PRAgent._is_pr_stuck_by_age`
+is a two-signal heuristic: PR open longer than ``stuck_age_hours`` *and*
+no human approval on file. That fires correctly for the long-tail
+abandonment cases (portfolio #4 / #28) but is blind to the three other
+stuck-shapes observed in the fleet audit:
+
+* **CI deadlock** — checks forever ``in_progress`` with no progress; no
+  humans can unstick this, only an infrastructure nudge.
+* **Awaiting human decision** — the PR is structurally ready but a
+  maintainer has to choose between two acceptable paths (breaking-change
+  gate, policy debate).
+* **Solo-repo / no-reviewer** — P4/M3 pattern. The PR is ready but the
+  repo has exactly one maintainer, who is also the author, so the
+  ``required_review_missing`` blocker can never clear without
+  self-approval.
+
+This module introduces:
+
+* :class:`StuckVerdict` — the pydantic v2 schema emitted by the LLM
+  candidate and by the legacy adapter, so
+  :func:`caretaker.evolution.shadow.shadow_decision` can compare both
+  paths without a bespoke comparator.
+* :func:`stuck_from_legacy` — lifts the binary
+  :meth:`_is_pr_stuck_by_age` signal onto the richer :class:`StuckVerdict`
+  shape with a stable ``recommended_action`` choice.
+* :func:`evaluate_stuck_pr_llm` — the LLM candidate. Builds a stable
+  cache-friendly prompt (system prefix, variable payload last) and calls
+  ``structured_complete``. Any
+  :class:`caretaker.llm.claude.StructuredCompleteError` yields ``None``
+  so the shadow decorator falls through to the legacy adapter.
+
+The wiring from :class:`~caretaker.pr_agent.agent.PRAgent._process_pr`
+lives in ``pr_agent/agent.py``. A minimum-age pre-filter
+(``PRAgentConfig.stuck_age_hours``) runs *before* either path so the
+LLM is never called on freshly-opened PRs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+from caretaker.llm.claude import StructuredCompleteError
+
+if TYPE_CHECKING:
+    from caretaker.github_client.models import CheckRun, PullRequest, Review
+    from caretaker.llm.claude import ClaudeClient
+    from caretaker.pr_agent.readiness_llm import Readiness
+
+logger = logging.getLogger(__name__)
+
+
+# ── Schema ───────────────────────────────────────────────────────────────
+
+StuckReason = Literal[
+    "abandoned",
+    "awaiting_human_decision",
+    "ci_deadlock",
+    "merge_queue",
+    "solo_repo_no_reviewer",
+    "not_stuck",
+]
+"""The six stuck-shapes the classifier distinguishes.
+
+* ``abandoned`` — opened long ago, no progress; the legacy heuristic's
+  bread-and-butter. Recommended follow-up is ``escalate`` or
+  ``close_stale``.
+* ``awaiting_human_decision`` — maintainer has to choose between two
+  acceptable paths. Recommended follow-up is ``nudge_reviewer``.
+* ``ci_deadlock`` — CI runs are perpetually in-progress or require an
+  infrastructure approval. Recommended follow-up is usually ``wait`` or
+  ``escalate``.
+* ``merge_queue`` — structurally ready but sitting in a queue behind
+  other PRs. Recommended follow-up is ``wait``.
+* ``solo_repo_no_reviewer`` — the P4/M3 solo-maintainer pattern; the
+  PR cannot clear ``required_review_missing`` because there is nobody
+  else to approve it. Recommended follow-up is ``self_approve_on_solo``.
+* ``not_stuck`` — baseline. Recommended follow-up is ``wait``.
+"""
+
+
+RecommendedAction = Literal[
+    "escalate",
+    "nudge_reviewer",
+    "request_fix",
+    "wait",
+    "close_stale",
+    "self_approve_on_solo",
+]
+"""Closed enum of the actions the caller can take on a stuck PR.
+
+``self_approve_on_solo`` and ``close_stale`` are new — the legacy binary
+gate only produced ``escalate`` / ``wait``. When the shadow decorator
+runs in ``off`` / ``shadow`` modes the adapter picks between those two
+so the disagreement signal is meaningful.
+"""
+
+
+class StuckVerdict(BaseModel):
+    """Structured verdict for the stuck-PR decision site.
+
+    Emitted by :func:`evaluate_stuck_pr_llm` and by
+    :func:`stuck_from_legacy`. The schema is deliberately small — the
+    shadow comparator only looks at ``is_stuck`` and
+    ``recommended_action``, so keeping the other fields free-text avoids
+    noisy disagreements on rewordings of the explanation.
+    """
+
+    is_stuck: bool
+    stuck_reason: StuckReason
+    recommended_action: RecommendedAction
+    explanation: str = Field(max_length=300)
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+# ── Legacy adapter ───────────────────────────────────────────────────────
+
+
+def stuck_from_legacy(is_stuck_by_age: bool) -> StuckVerdict:
+    """Lift the binary age-heuristic verdict onto the :class:`StuckVerdict`.
+
+    The legacy heuristic only emits two states — stuck-by-age (True)
+    and not-stuck-by-age (False). We map those to ``abandoned`` /
+    ``escalate`` and ``not_stuck`` / ``wait`` respectively so the
+    shadow-mode comparator has something to chew on.
+
+    The ``confidence`` is hard-coded at 0.5 — we have no evidence the
+    age cutoff was correct, only that it triggered. Higher values would
+    be dishonest.
+    """
+    if is_stuck_by_age:
+        return StuckVerdict(
+            is_stuck=True,
+            stuck_reason="abandoned",
+            recommended_action="escalate",
+            explanation="Legacy heuristic: age > threshold with no human approval.",
+            confidence=0.5,
+        )
+    return StuckVerdict(
+        is_stuck=False,
+        stuck_reason="not_stuck",
+        recommended_action="wait",
+        explanation="Legacy heuristic: no stuck-by-age signal.",
+        confidence=0.5,
+    )
+
+
+# ── LLM candidate ────────────────────────────────────────────────────────
+
+
+@dataclass
+class PRStuckContext:
+    """Variable payload for :func:`evaluate_stuck_pr_llm`.
+
+    Kept as a plain dataclass (rather than pydantic) so call sites can
+    build it cheaply in the hot path; the :class:`PullRequest` field is
+    already pydantic-validated and everything else is primitive.
+
+    The prompt builder places the system prefix first and this payload
+    last so Anthropic prompt caching hits on the stable prefix across
+    every stuck-PR evaluation in a run.
+    """
+
+    pr: PullRequest
+    age_hours: float
+    last_activity_hours: float | None = None
+    check_runs: list[CheckRun] = field(default_factory=list)
+    reviews: list[Review] = field(default_factory=list)
+    readiness_verdict: Readiness | None = None
+    linked_issues: list[str] = field(default_factory=list)
+    repo_slug: str = ""
+    collaborator_count: int | None = None
+
+
+_STUCK_SYSTEM_PROMPT = """\
+You are caretaker's stuck-PR classifier. Given a pull request snapshot,
+decide whether the PR is stuck and — if so — why.
+
+Rules:
+- ``stuck_reason`` must be one of: abandoned, awaiting_human_decision,
+  ci_deadlock, merge_queue, solo_repo_no_reviewer, not_stuck.
+- ``recommended_action`` must be one of: escalate, nudge_reviewer,
+  request_fix, wait, close_stale, self_approve_on_solo.
+- ``is_stuck`` must be False iff ``stuck_reason`` is ``not_stuck``.
+- Use ``solo_repo_no_reviewer`` (and ``self_approve_on_solo``) when the
+  readiness verdict says ``ready`` and ``collaborator_count`` is 1 — the
+  PR cannot clear ``required_review_missing`` because the repo has
+  exactly one maintainer, who is almost certainly also the author.
+- Use ``ci_deadlock`` when check runs have been ``in_progress`` for
+  many hours with no recent transition, or when they require a
+  workflow-approval action the author cannot perform.
+- Use ``abandoned`` for long-open PRs whose last activity is stale and
+  whose readiness verdict is not ``ready``.
+- Use ``awaiting_human_decision`` when the readiness verdict is
+  ``needs_human`` (policy gate, breaking-change, upstream dep) and the
+  PR is otherwise structurally ready.
+- Use ``merge_queue`` for PRs that are structurally ready but waiting
+  behind a queue or a scheduled auto-merge window.
+- ``close_stale`` is only appropriate when the PR has been abandoned
+  for many days and the underlying change is no longer relevant (linked
+  issues closed, base branch moved on).
+- ``confidence`` is your self-assessed probability the verdict is
+  correct. Prefer 0.5 when the signals conflict.
+- ``explanation`` must be a single line no longer than 300 characters.
+"""
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)] + "..."
+
+
+def _render_review_summary(review: Review) -> str:
+    user = getattr(review.user, "login", "?")
+    state = getattr(review.state, "value", str(review.state))
+    body = _truncate((review.body or "").strip(), 200)
+    if not body:
+        return f"- @{user} ({state})"
+    return f"- @{user} ({state}): {body}"
+
+
+def _render_check_summary(run: CheckRun) -> str:
+    status = getattr(run.status, "value", str(run.status))
+    concl = getattr(run.conclusion, "value", "") if run.conclusion else ""
+    suffix = f":{concl}" if concl else ""
+    title = (run.output_title or "").strip()
+    return f"- {run.name} [{status}{suffix}]" + (f" — {title}" if title else "")
+
+
+def build_stuck_pr_prompt(context: PRStuckContext) -> str:
+    """Assemble the variable-payload prompt body.
+
+    The stable prefix (system prompt) is passed through to
+    ``structured_complete`` as ``system=``, which is where Anthropic
+    prompt caching looks for a cache-able prefix. Only the per-PR payload
+    changes across calls; that's what this function renders.
+    """
+    pr = context.pr
+    labels = ", ".join(label.name for label in pr.labels) or "(none)"
+    body_snippet = _truncate((pr.body or "").strip(), 1500)
+    reviews_block = (
+        "\n".join(_render_review_summary(r) for r in context.reviews) or "(no reviews yet)"
+    )
+    checks_block = (
+        "\n".join(_render_check_summary(c) for c in context.check_runs) or "(no check runs)"
+    )
+    linked_block = "\n".join(f"- {ref}" for ref in context.linked_issues) or "(none)"
+    last_activity = (
+        f"{context.last_activity_hours:.1f}h ago"
+        if context.last_activity_hours is not None
+        else "unknown"
+    )
+
+    readiness_line = "(none)"
+    if context.readiness_verdict is not None:
+        readiness_line = (
+            f"verdict={context.readiness_verdict.verdict} "
+            f"summary={_truncate(context.readiness_verdict.summary, 200)}"
+        )
+
+    collaborator_line = (
+        str(context.collaborator_count) if context.collaborator_count is not None else "unknown"
+    )
+
+    return (
+        "PR title: "
+        f"{pr.title}\n"
+        f"PR number: #{pr.number}\n"
+        f"Repo: {context.repo_slug or '?'}\n"
+        f"Draft: {pr.draft}\n"
+        f"Mergeable: {pr.mergeable}\n"
+        f"Labels: {labels}\n"
+        f"Age: {context.age_hours:.1f}h\n"
+        f"Last activity: {last_activity}\n"
+        f"Collaborator count: {collaborator_line}\n"
+        f"Readiness verdict: {readiness_line}\n"
+        f"Linked issues:\n{linked_block}\n"
+        f"Checks:\n{checks_block}\n"
+        f"Reviews:\n{reviews_block}\n"
+        f"PR body (truncated to 1500 chars):\n{body_snippet}\n"
+    )
+
+
+async def evaluate_stuck_pr_llm(
+    context: PRStuckContext,
+    *,
+    claude: ClaudeClient,
+) -> StuckVerdict | None:
+    """Call the LLM and return its :class:`StuckVerdict`, or ``None``.
+
+    Returns ``None`` on any :class:`StructuredCompleteError` so the
+    ``@shadow_decision`` wrapper can fall through to the legacy adapter.
+    All other exceptions propagate — shadow mode swallows them and
+    records a ``candidate_error`` event, enforce mode falls through.
+    """
+    prompt = build_stuck_pr_prompt(context)
+    try:
+        return await claude.structured_complete(
+            prompt,
+            schema=StuckVerdict,
+            feature="pr_stuck",
+            system=_STUCK_SYSTEM_PROMPT,
+        )
+    except StructuredCompleteError as exc:
+        logger.info(
+            "evaluate_stuck_pr_llm: structured_complete failed for PR #%s: %s",
+            context.pr.number,
+            exc,
+        )
+        return None
+
+
+__all__ = [
+    "PRStuckContext",
+    "RecommendedAction",
+    "StuckReason",
+    "StuckVerdict",
+    "build_stuck_pr_prompt",
+    "evaluate_stuck_pr_llm",
+    "stuck_from_legacy",
+]

--- a/tests/test_pr_agent/test_stuck_pr_llm.py
+++ b/tests/test_pr_agent/test_stuck_pr_llm.py
@@ -1,0 +1,685 @@
+"""Tests for T-A8: LLM-backed stuck-PR detection migration.
+
+Covers every call-out in T-A8:
+
+* :class:`StuckVerdict` schema validation.
+* Legacy adapter mapping: binary age-heuristic -> stuck/not-stuck.
+* LLM candidate prompt payload + happy path + ``StructuredCompleteError``
+  short-circuit to ``None``.
+* Minimum-age pre-filter: PRs younger than ``stuck_age_hours`` skip
+  both paths entirely.
+* Shadow dispatch wiring in all three modes.
+* Solo-repo special case: when readiness says ``ready`` and
+  ``collaborator_count`` is 1, the candidate returns
+  ``solo_repo_no_reviewer`` / ``self_approve_on_solo``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from caretaker.config import (
+    AgenticConfig,
+    AgenticDomainConfig,
+    CIConfig,
+    CopilotConfig,
+    OwnershipConfig,
+    PRAgentConfig,
+    ReadinessConfig,
+)
+from caretaker.evolution import shadow_config
+from caretaker.evolution.shadow import (
+    clear_records_for_tests,
+    recent_records,
+)
+from caretaker.github_client.models import (
+    CheckConclusion,
+    Label,
+    ReviewState,
+    User,
+)
+from caretaker.llm.claude import StructuredCompleteError
+from caretaker.pr_agent.agent import PRAgent, PRAgentReport
+from caretaker.pr_agent.readiness_llm import Readiness
+from caretaker.pr_agent.stuck_pr_llm import (
+    PRStuckContext,
+    StuckVerdict,
+    build_stuck_pr_prompt,
+    evaluate_stuck_pr_llm,
+    stuck_from_legacy,
+)
+from caretaker.state.models import PRTrackingState, TrackedPR
+from tests.conftest import make_check_run, make_pr, make_review
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state() -> None:
+    """Clear ring buffer + active shadow config between tests."""
+    clear_records_for_tests()
+    shadow_config.reset_for_tests()
+
+
+def _set_stuck_pr_mode(mode: str) -> None:
+    """Install an :class:`AgenticConfig` with the stuck-PR mode set."""
+    cfg = AgenticConfig(stuck_pr=AgenticDomainConfig(mode=mode))  # type: ignore[arg-type]
+    shadow_config.configure(cfg)
+
+
+def _make_pr_config(*, stuck_age_hours: int = 24, required_reviews: int = 1) -> PRAgentConfig:
+    config = PRAgentConfig()
+    config.ci = CIConfig()
+    config.copilot = CopilotConfig(max_retries=2)
+    config.ownership = OwnershipConfig()
+    config.readiness = ReadinessConfig(required_reviews=required_reviews)
+    config.stuck_age_hours = stuck_age_hours
+    return config
+
+
+# ── Part 1: Schema validation ────────────────────────────────────────────
+
+
+class TestStuckVerdictSchema:
+    def test_happy_path(self) -> None:
+        verdict = StuckVerdict(
+            is_stuck=True,
+            stuck_reason="abandoned",
+            recommended_action="escalate",
+            explanation="PR open 10 days with no review",
+            confidence=0.8,
+        )
+        assert verdict.is_stuck is True
+        assert verdict.stuck_reason == "abandoned"
+        assert verdict.recommended_action == "escalate"
+
+    def test_round_trip(self) -> None:
+        verdict = StuckVerdict(
+            is_stuck=True,
+            stuck_reason="solo_repo_no_reviewer",
+            recommended_action="self_approve_on_solo",
+            explanation="Solo maintainer, ready PR",
+            confidence=0.9,
+        )
+        dumped = verdict.model_dump_json()
+        restored = StuckVerdict.model_validate_json(dumped)
+        assert restored == verdict
+
+    def test_not_stuck_verdict(self) -> None:
+        verdict = StuckVerdict(
+            is_stuck=False,
+            stuck_reason="not_stuck",
+            recommended_action="wait",
+            explanation="Fresh PR — just wait",
+            confidence=0.95,
+        )
+        assert verdict.is_stuck is False
+
+    def test_confidence_out_of_range(self) -> None:
+        with pytest.raises(ValidationError):
+            StuckVerdict(
+                is_stuck=True,
+                stuck_reason="abandoned",
+                recommended_action="escalate",
+                explanation="x",
+                confidence=1.5,
+            )
+
+    def test_confidence_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            StuckVerdict(
+                is_stuck=True,
+                stuck_reason="abandoned",
+                recommended_action="escalate",
+                explanation="x",
+                confidence=-0.1,
+            )
+
+    def test_stuck_reason_closed_enum(self) -> None:
+        with pytest.raises(ValidationError):
+            StuckVerdict(
+                is_stuck=True,
+                stuck_reason="bogus",  # type: ignore[arg-type]
+                recommended_action="escalate",
+                explanation="x",
+                confidence=0.5,
+            )
+
+    def test_recommended_action_closed_enum(self) -> None:
+        with pytest.raises(ValidationError):
+            StuckVerdict(
+                is_stuck=True,
+                stuck_reason="abandoned",
+                recommended_action="nuke_from_orbit",  # type: ignore[arg-type]
+                explanation="x",
+                confidence=0.5,
+            )
+
+    def test_explanation_length_capped(self) -> None:
+        with pytest.raises(ValidationError):
+            StuckVerdict(
+                is_stuck=True,
+                stuck_reason="abandoned",
+                recommended_action="escalate",
+                explanation="x" * 301,
+                confidence=0.5,
+            )
+
+
+# ── Part 2: Legacy adapter ──────────────────────────────────────────────
+
+
+class TestStuckFromLegacy:
+    def test_stuck_true_maps_to_abandoned_escalate(self) -> None:
+        verdict = stuck_from_legacy(True)
+        assert verdict.is_stuck is True
+        assert verdict.stuck_reason == "abandoned"
+        assert verdict.recommended_action == "escalate"
+        assert "Legacy heuristic" in verdict.explanation
+
+    def test_stuck_false_maps_to_not_stuck_wait(self) -> None:
+        verdict = stuck_from_legacy(False)
+        assert verdict.is_stuck is False
+        assert verdict.stuck_reason == "not_stuck"
+        assert verdict.recommended_action == "wait"
+
+    def test_legacy_confidence_is_bounded(self) -> None:
+        # Legacy confidence is deliberately low — we have no evidence
+        # the age cutoff was correct, only that it triggered.
+        assert 0.0 <= stuck_from_legacy(True).confidence <= 1.0
+        assert 0.0 <= stuck_from_legacy(False).confidence <= 1.0
+
+
+# ── Part 3: LLM candidate prompt + happy path ───────────────────────────
+
+
+class TestEvaluateStuckPRLLM:
+    def test_prompt_contains_required_payload(self) -> None:
+        pr = make_pr(
+            number=42,
+            labels=[Label(name="maintainer:upgrade"), Label(name="area:config")],
+            created_at=datetime.now(UTC) - timedelta(hours=50),
+        )
+        pr = pr.model_copy(update={"title": "Migrate stuck-PR gate"})
+        readiness_verdict = Readiness(
+            verdict="needs_human",
+            confidence=0.7,
+            blockers=[],
+            summary="Blocked by upstream dependency.",
+        )
+        ctx = PRStuckContext(
+            pr=pr,
+            age_hours=50.0,
+            last_activity_hours=48.0,
+            check_runs=[make_check_run(name="lint")],
+            reviews=[make_review(body="LGTM")],
+            readiness_verdict=readiness_verdict,
+            linked_issues=["#37"],
+            repo_slug="ianlintner/caretaker",
+            collaborator_count=1,
+        )
+        prompt = build_stuck_pr_prompt(ctx)
+        assert "Migrate stuck-PR gate" in prompt
+        assert "#42" in prompt
+        assert "ianlintner/caretaker" in prompt
+        assert "maintainer:upgrade" in prompt
+        assert "Age: 50.0h" in prompt
+        assert "Collaborator count: 1" in prompt
+        assert "needs_human" in prompt
+        assert "lint" in prompt
+        assert "LGTM" in prompt
+        assert "#37" in prompt
+
+    def test_prompt_handles_missing_optional_fields(self) -> None:
+        pr = make_pr(number=1)
+        ctx = PRStuckContext(pr=pr, age_hours=5.0)
+        prompt = build_stuck_pr_prompt(ctx)
+        assert "(no reviews yet)" in prompt
+        assert "(no check runs)" in prompt
+        assert "Last activity: unknown" in prompt
+        assert "Collaborator count: unknown" in prompt
+        assert "(none)" in prompt
+
+    async def test_happy_path_returns_schema_instance(self) -> None:
+        pr = make_pr(number=7)
+        fake_verdict = StuckVerdict(
+            is_stuck=True,
+            stuck_reason="ci_deadlock",
+            recommended_action="escalate",
+            explanation="CI stuck in_progress for 48h",
+            confidence=0.85,
+        )
+
+        class _FakeClaude:
+            def __init__(self) -> None:
+                self.calls: list[dict[str, Any]] = []
+
+            async def structured_complete(
+                self,
+                prompt: str,
+                *,
+                schema: type,
+                feature: str,
+                system: str | None = None,
+            ) -> Any:
+                self.calls.append(
+                    {
+                        "prompt": prompt,
+                        "schema": schema,
+                        "feature": feature,
+                        "system": system,
+                    }
+                )
+                return fake_verdict
+
+        claude = _FakeClaude()
+        ctx = PRStuckContext(pr=pr, age_hours=48.0, repo_slug="ian/demo")
+        result = await evaluate_stuck_pr_llm(ctx, claude=claude)  # type: ignore[arg-type]
+        assert result is fake_verdict
+        assert len(claude.calls) == 1
+        call = claude.calls[0]
+        assert call["feature"] == "pr_stuck"
+        assert call["schema"] is StuckVerdict
+        assert "ian/demo" in call["prompt"]
+        assert "#7" in call["prompt"]
+        assert call["system"] is not None
+        assert "stuck-PR classifier" in call["system"]
+
+    async def test_structured_complete_error_returns_none(self) -> None:
+        pr = make_pr(number=9)
+
+        claude = AsyncMock()
+        claude.structured_complete.side_effect = StructuredCompleteError(
+            raw_text="not-json", validation_error=ValueError("bad")
+        )
+
+        ctx = PRStuckContext(pr=pr, age_hours=30.0, repo_slug="ian/demo")
+        result = await evaluate_stuck_pr_llm(ctx, claude=claude)
+        assert result is None
+
+
+# ── Part 4: Agent-level pre-filter + shadow integration ─────────────────
+
+
+async def _run_process_pr(
+    pr: Any,
+    tracking: TrackedPR,
+    config: PRAgentConfig,
+    *,
+    reviews: list[Any] | None = None,
+    check_runs: list[Any] | None = None,
+    llm_router: Any = None,
+) -> tuple[TrackedPR, PRAgentReport, PRAgent]:
+    github = AsyncMock()
+    github.get_check_runs = AsyncMock(return_value=check_runs or [])
+    github.get_pr_reviews = AsyncMock(return_value=reviews or [])
+    agent = PRAgent(
+        github=github,
+        owner="o",
+        repo="r",
+        config=config,
+        llm_router=llm_router,
+    )
+    report = PRAgentReport()
+    updated = await agent._process_pr(pr, tracking, report)
+    return updated, report, agent
+
+
+class TestPreFilter:
+    """The minimum-age pre-filter: PRs younger than ``stuck_age_hours``
+    must skip the shadow decision entirely — no legacy call, no LLM call,
+    no ring-buffer record."""
+
+    async def test_young_pr_skips_shadow_decision_entirely(self) -> None:
+        _set_stuck_pr_mode("shadow")
+
+        pr = make_pr(
+            number=1,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=2),  # well under 24h
+        )
+        tracking = TrackedPR(number=1)
+        config = _make_pr_config(stuck_age_hours=24)
+
+        # Wire a claude that would count calls — none should happen.
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(
+            return_value=StuckVerdict(
+                is_stuck=True,
+                stuck_reason="abandoned",
+                recommended_action="escalate",
+                explanation="x",
+                confidence=0.5,
+            )
+        )
+        router = MagicMock()
+        router.available = True
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        _, report, _ = await _run_process_pr(pr, tracking, config, llm_router=router)
+        assert 1 not in report.escalated
+        # Crucially, no shadow record at all.
+        assert recent_records(name="stuck_pr") == []
+        # And the candidate must never have been called.
+        claude.structured_complete.assert_not_called()
+
+    async def test_gate_disabled_when_stuck_age_hours_zero(self) -> None:
+        _set_stuck_pr_mode("shadow")
+
+        pr = make_pr(
+            number=2,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(days=30),
+        )
+        tracking = TrackedPR(number=2)
+        config = _make_pr_config(stuck_age_hours=0)
+
+        _, report, _ = await _run_process_pr(pr, tracking, config)
+        assert 2 not in report.escalated
+        assert recent_records(name="stuck_pr") == []
+
+
+class TestShadowIntegration:
+    """Three-mode shadow dispatch through ``PRAgent._process_pr``."""
+
+    async def test_off_mode_uses_legacy_binary_verdict(self) -> None:
+        _set_stuck_pr_mode("off")
+
+        pr = make_pr(
+            number=1,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=48),
+        )
+        tracking = TrackedPR(number=1)
+        config = _make_pr_config(stuck_age_hours=24)
+
+        updated, report, _ = await _run_process_pr(pr, tracking, config)
+        # Legacy says stuck -> escalate.
+        assert updated.state == PRTrackingState.ESCALATED
+        assert 1 in report.escalated
+        # Off mode must not persist any shadow record.
+        assert recent_records(name="stuck_pr") == []
+
+    async def test_shadow_mode_records_disagreement_returns_legacy(self) -> None:
+        _set_stuck_pr_mode("shadow")
+
+        # Legacy says stuck (48h old, no human review); LLM says merge_queue/wait.
+        llm_verdict = StuckVerdict(
+            is_stuck=False,
+            stuck_reason="merge_queue",
+            recommended_action="wait",
+            explanation="Sitting in merge queue",
+            confidence=0.9,
+        )
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(return_value=llm_verdict)
+        router = MagicMock()
+        router.available = True
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        pr = make_pr(
+            number=2,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=48),
+        )
+        tracking = TrackedPR(number=2)
+        config = _make_pr_config(stuck_age_hours=24)
+
+        updated, report, _ = await _run_process_pr(pr, tracking, config, llm_router=router)
+        # Shadow mode returns legacy verdict -> escalation still fires.
+        assert updated.state == PRTrackingState.ESCALATED
+        assert 2 in report.escalated
+        records = recent_records(name="stuck_pr")
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.outcome == "disagree"
+        assert rec.mode == "shadow"
+        assert rec.repo_slug == "o/r"
+        assert rec.disagreement_reason is not None
+
+    async def test_shadow_mode_agrees_when_actions_match(self) -> None:
+        _set_stuck_pr_mode("shadow")
+
+        # LLM agrees with legacy on is_stuck + recommended_action.
+        llm_verdict = StuckVerdict(
+            is_stuck=True,
+            stuck_reason="abandoned",
+            recommended_action="escalate",
+            explanation="Different wording",
+            confidence=0.9,
+        )
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(return_value=llm_verdict)
+        router = MagicMock()
+        router.available = True
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        pr = make_pr(
+            number=3,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=48),
+        )
+        tracking = TrackedPR(number=3)
+        config = _make_pr_config(stuck_age_hours=24)
+
+        await _run_process_pr(pr, tracking, config, llm_router=router)
+        records = recent_records(name="stuck_pr")
+        assert len(records) == 1
+        assert records[0].outcome == "agree"
+        assert records[0].disagreement_reason is None
+
+    async def test_shadow_mode_swallows_candidate_runtime_error(self) -> None:
+        _set_stuck_pr_mode("shadow")
+
+        claude = MagicMock()
+        claude.available = True
+        # Raise a bare RuntimeError so the decorator records candidate_error.
+        claude.structured_complete = AsyncMock(side_effect=RuntimeError("boom"))
+        router = MagicMock()
+        router.available = True
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        pr = make_pr(
+            number=4,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=48),
+        )
+        tracking = TrackedPR(number=4)
+        config = _make_pr_config(stuck_age_hours=24)
+
+        updated, report, _ = await _run_process_pr(pr, tracking, config, llm_router=router)
+        # Legacy still fires -> PR escalated.
+        assert updated.state == PRTrackingState.ESCALATED
+        assert 4 in report.escalated
+        records = recent_records(name="stuck_pr")
+        assert len(records) == 1
+        assert records[0].outcome == "candidate_error"
+
+    async def test_enforce_mode_promotes_llm_verdict(self) -> None:
+        _set_stuck_pr_mode("enforce")
+
+        # Legacy would say stuck (48h, no human review); LLM says not-stuck/wait.
+        llm_verdict = StuckVerdict(
+            is_stuck=False,
+            stuck_reason="merge_queue",
+            recommended_action="wait",
+            explanation="In a merge queue",
+            confidence=0.92,
+        )
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(return_value=llm_verdict)
+        router = MagicMock()
+        router.available = True
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        pr = make_pr(
+            number=5,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=48),
+        )
+        tracking = TrackedPR(number=5)
+        config = _make_pr_config(stuck_age_hours=24)
+
+        updated, report, _ = await _run_process_pr(pr, tracking, config, llm_router=router)
+        # Enforce mode: LLM says not stuck -> no escalation.
+        assert 5 not in report.escalated
+        assert updated.state != PRTrackingState.ESCALATED
+
+    async def test_enforce_falls_through_to_legacy_without_llm(self) -> None:
+        _set_stuck_pr_mode("enforce")
+
+        pr = make_pr(
+            number=6,
+            user=User(login="copilot[bot]", id=1, type="Bot"),
+            created_at=datetime.now(UTC) - timedelta(hours=48),
+        )
+        tracking = TrackedPR(number=6)
+        config = _make_pr_config(stuck_age_hours=24)
+
+        # No llm_router — _candidate returns None; decorator falls
+        # through to legacy, which says stuck -> escalate.
+        updated, report, _ = await _run_process_pr(pr, tracking, config)
+        assert updated.state == PRTrackingState.ESCALATED
+        assert 6 in report.escalated
+
+
+# ── Part 5: Solo-repo special case ──────────────────────────────────────
+
+
+class TestSoloRepoNoReviewerPattern:
+    """The P4 / M3 pattern from the fleet audit: a ready PR on a solo-
+    maintainer repo that cannot clear the ``required_review_missing``
+    blocker because there's nobody else to approve it."""
+
+    async def test_solo_repo_ready_triggers_self_approve_on_solo(self) -> None:
+        _set_stuck_pr_mode("enforce")
+
+        # Candidate sees readiness.verdict=ready + collaborator_count=1
+        # -> recommends self_approve_on_solo.
+        expected_verdict = StuckVerdict(
+            is_stuck=True,
+            stuck_reason="solo_repo_no_reviewer",
+            recommended_action="self_approve_on_solo",
+            explanation="Solo maintainer repo with ready PR, nobody else can approve",
+            confidence=0.93,
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def _fake_structured_complete(
+            prompt: str,
+            *,
+            schema: type,
+            feature: str,
+            system: str | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            captured["prompt"] = prompt
+            captured["feature"] = feature
+            return expected_verdict
+
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(side_effect=_fake_structured_complete)
+        router = MagicMock()
+        router.available = True
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        pr = make_pr(
+            number=99,
+            user=User(login="ian", id=10, type="User"),
+            created_at=datetime.now(UTC) - timedelta(hours=72),
+        )
+        tracking = TrackedPR(number=99)
+        # Solo-repo: required_reviews=0 -> agent reports collaborator_count=1
+        # into the prompt context.
+        config = _make_pr_config(stuck_age_hours=24, required_reviews=0)
+
+        # Preload a green CI check + an approved review so readiness says "ready".
+        check_runs = [make_check_run(name="lint", conclusion=CheckConclusion.SUCCESS)]
+        reviews = [
+            make_review(
+                user=User(login="ian", id=10, type="User"),
+                state=ReviewState.APPROVED,
+            )
+        ]
+        updated, report, _ = await _run_process_pr(
+            pr,
+            tracking,
+            config,
+            reviews=reviews,
+            check_runs=check_runs,
+            llm_router=router,
+        )
+
+        # In enforce mode the LLM verdict wins → is_stuck=True +
+        # self_approve_on_solo → we escalate with the solo-repo reason.
+        assert updated.state == PRTrackingState.ESCALATED
+        assert 99 in report.escalated
+        # Sanity-check the prompt saw the solo-repo signal.
+        assert "Collaborator count: 1" in captured["prompt"]
+
+    async def test_solo_repo_flag_flows_into_prompt(self) -> None:
+        """When ``readiness.required_reviews == 0`` the agent passes
+        ``collaborator_count=1`` to the stuck-PR context so the prompt
+        can condition on the solo-repo signal."""
+        _set_stuck_pr_mode("shadow")
+
+        llm_verdict = StuckVerdict(
+            is_stuck=True,
+            stuck_reason="solo_repo_no_reviewer",
+            recommended_action="self_approve_on_solo",
+            explanation="solo repo",
+            confidence=0.9,
+        )
+        captured: dict[str, Any] = {}
+
+        async def _fake_structured_complete(
+            prompt: str,
+            *,
+            schema: type,
+            feature: str,
+            system: str | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            captured["prompt"] = prompt
+            return llm_verdict
+
+        claude = MagicMock()
+        claude.available = True
+        claude.structured_complete = AsyncMock(side_effect=_fake_structured_complete)
+        router = MagicMock()
+        router.available = True
+        router.claude_available = True
+        router.claude = claude
+        router.feature_enabled = MagicMock(return_value=False)
+
+        pr = make_pr(
+            number=100,
+            user=User(login="ian", id=10, type="User"),
+            created_at=datetime.now(UTC) - timedelta(hours=72),
+        )
+        tracking = TrackedPR(number=100)
+        config = _make_pr_config(stuck_age_hours=24, required_reviews=0)
+
+        await _run_process_pr(pr, tracking, config, llm_router=router)
+        assert "Collaborator count: 1" in captured["prompt"]


### PR DESCRIPTION
## Summary

- T-A8 (Phase 2 §3.8): migrates the binary `_is_pr_stuck_by_age` heuristic to a structured `StuckVerdict` behind `AgenticConfig.stuck_pr`, with `PRAgentConfig.stuck_age_hours` retained as a minimum-age pre-filter so the LLM candidate never evaluates freshly-opened PRs.
- New `StuckVerdict` schema distinguishes six stuck-shapes — `abandoned`, `awaiting_human_decision`, `ci_deadlock`, `merge_queue`, `solo_repo_no_reviewer`, `not_stuck` — each mapped to a concrete `recommended_action`. The `solo_repo_no_reviewer` / `self_approve_on_solo` pair addresses the P4/M3 pattern from the fleet audit (solo-maintainer PRs that can never clear `required_review_missing`).
- Wired through `@shadow_decision("stuck_pr")` with a compare predicate that checks `is_stuck + recommended_action` (ignoring noisy free-text fields). The T-A1 readiness verdict is threaded into the candidate prompt so the classifier can distinguish `awaiting_human_decision` from `abandoned`. Default mode stays `off`; existing behaviour is byte-identical until operators opt in.

## Test plan

- [x] `pytest -q` — 1449 passed, 1 skipped (+25 new tests)
- [x] `ruff check src tests`
- [x] `ruff format --check src tests`
- [x] `mypy src/caretaker` — only the 2 pre-existing `k8s_worker/launcher.py` errors remain
- [x] Existing `TestStuckPRAgeGate` regression suite still passes (off-mode legacy path)
- [x] New `test_stuck_pr_llm.py` covers schema, legacy adapter, LLM candidate + error handling, pre-filter short-circuit, three-mode shadow dispatch, solo-repo `self_approve_on_solo` case

Do not merge — default `mode: off` keeps this dormant until operators flip the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)