### PR TITLE
feat(fleet): union :Skill + :GlobalSkill in prompt-relevant retrieval

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -675,10 +675,18 @@ class FleetConfig(StrictBaseModel):
       ``repo`` values a ``:Skill`` signature must appear in before it
       is eligible for the two-gate promotion (the other gate being the
       abstraction pass in ``caretaker.fleet.abstraction``).
+    * ``include_global_in_prompts`` closes the read-loop on promotion
+      (T-E3). When ``True`` (the default), ``InsightStore.get_relevant``
+      returns the union of local ``:Skill`` hits and fleet-promoted
+      ``:GlobalSkill`` hits so the prompt builder can surface
+      cross-repo skills with a ``[fleet]`` prefix. Operators can flip
+      this off per-repo if a shared skill misfires — promotion itself
+      is unaffected.
     """
 
     share_skills: bool = False
     min_repos_for_promotion: int = 3
+    include_global_in_prompts: bool = True
 
 
 class GitHubAppConfig(StrictBaseModel):

--- a/src/caretaker/evolution/__init__.py
+++ b/src/caretaker/evolution/__init__.py
@@ -6,7 +6,12 @@ Phase-2 ``@shadow_decision`` infrastructure that lets LLM handovers
 run side-by-side with existing heuristics.
 """
 
-from caretaker.evolution.insight_store import InsightStore, Skill
+from caretaker.evolution.insight_store import (
+    GlobalSkillReader,
+    InsightStore,
+    Skill,
+    SkillScope,
+)
 from caretaker.evolution.shadow import (
     ShadowDecisionRecord,
     ShadowMode,
@@ -15,10 +20,12 @@ from caretaker.evolution.shadow import (
 )
 
 __all__ = [
+    "GlobalSkillReader",
     "InsightStore",
     "ShadowDecisionRecord",
     "ShadowMode",
     "ShadowOutcome",
     "Skill",
+    "SkillScope",
     "shadow_decision",
 ]

--- a/src/caretaker/evolution/backends/factory.py
+++ b/src/caretaker/evolution/backends/factory.py
@@ -7,9 +7,36 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from caretaker.config import MaintainerConfig
-    from caretaker.evolution.insight_store import InsightStore
+    from caretaker.evolution.insight_store import GlobalSkillReader, InsightStore
 
 logger = logging.getLogger(__name__)
+
+
+def _build_global_skill_reader(config: MaintainerConfig) -> GlobalSkillReader | None:
+    """Return a sync :GlobalSkill reader when fleet + graph are wired, else None.
+
+    T-E3 closes the promotion read-loop: ``promote_global_skills`` was
+    previously write-only. When ``fleet.include_global_in_prompts`` is
+    true AND a graph store is enabled, we build a
+    :class:`GraphBackedGlobalSkillReader` so ``InsightStore.get_relevant``
+    can union local + global hits. Operators who disable either knob get
+    the legacy local-only behaviour.
+    """
+    fleet_cfg = getattr(config, "fleet", None)
+    if fleet_cfg is None or not getattr(fleet_cfg, "include_global_in_prompts", True):
+        return None
+    graph_cfg = getattr(config, "graph_store", None)
+    if graph_cfg is None or not getattr(graph_cfg, "enabled", False):
+        return None
+    try:
+        from caretaker.fleet.graph import GraphBackedGlobalSkillReader
+        from caretaker.graph.store import GraphStore
+
+        store = GraphStore(database=graph_cfg.database)
+        return GraphBackedGlobalSkillReader(store)
+    except Exception as exc:  # pragma: no cover — defensive; graph driver optional
+        logger.warning("GlobalSkillReader wiring failed: %s", exc)
+        return None
 
 
 def build_evolution_store(config: MaintainerConfig) -> InsightStore | None:
@@ -25,11 +52,20 @@ def build_evolution_store(config: MaintainerConfig) -> InsightStore | None:
         → InsightStore backed by SQLite (path from ``evolution.db_path``)
 
     Falls back to SQLite when the MongoDB URL env var is missing.
+
+    Fleet integration (T-E3): when ``fleet.include_global_in_prompts``
+    is true and a graph store is configured, the returned
+    :class:`InsightStore` is wired to a
+    :class:`caretaker.fleet.graph.GraphBackedGlobalSkillReader` so
+    ``get_relevant`` returns the union of local and fleet-promoted hits.
     """
     from caretaker.evolution.insight_store import InsightStore
 
     if not config.evolution.enabled:
         return None
+
+    reader = _build_global_skill_reader(config)
+    include_global = bool(getattr(config.fleet, "include_global_in_prompts", True))
 
     backend_name = getattr(config.evolution, "backend", "sqlite")
 
@@ -49,7 +85,11 @@ def build_evolution_store(config: MaintainerConfig) -> InsightStore | None:
                     mutations_collection=config.mongo.evolution_mutations_collection,
                 )
                 logger.info("Using MongoDB evolution backend")
-                return InsightStore(backend=mongo_backend)
+                return InsightStore(
+                    backend=mongo_backend,
+                    global_skill_reader=reader,
+                    include_global=include_global,
+                )
             except RuntimeError as exc:
                 logger.warning(
                     "MongoDB evolution backend unavailable (%s) — falling back to SQLite", exc
@@ -57,4 +97,8 @@ def build_evolution_store(config: MaintainerConfig) -> InsightStore | None:
 
     # Default: SQLite InsightStore
     logger.info("Using SQLite evolution backend: %s", config.evolution.db_path)
-    return InsightStore(db_path=config.evolution.db_path)
+    return InsightStore(
+        db_path=config.evolution.db_path,
+        global_skill_reader=reader,
+        include_global=include_global,
+    )

--- a/src/caretaker/evolution/insight_store.py
+++ b/src/caretaker/evolution/insight_store.py
@@ -17,7 +17,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from caretaker.evolution.backends.base import EvolutionBackend
@@ -62,6 +62,9 @@ CREATE INDEX IF NOT EXISTS idx_mutations_outcome ON mutations(outcome);
 """
 
 
+SkillScope = Literal["local", "global"]
+
+
 @dataclass
 class Skill:
     id: str
@@ -72,6 +75,12 @@ class Skill:
     fail_count: int
     last_used_at: datetime | None
     created_at: datetime
+    # T-E3: scope marker used by the prompt renderer to distinguish a
+    # skill learned in *this* repo (``"local"``) from one promoted from
+    # another repo in the fleet (``"global"``). Defaults to ``"local"``
+    # so every existing backend/factory path keeps its current meaning
+    # without having to set the field explicitly.
+    scope: SkillScope = "local"
 
     @property
     def confidence(self) -> float:
@@ -83,6 +92,33 @@ class Skill:
     @property
     def total_attempts(self) -> int:
         return self.success_count + self.fail_count
+
+
+@runtime_checkable
+class GlobalSkillReader(Protocol):
+    """Sync adapter that surfaces :GlobalSkill rows from the fleet graph.
+
+    ``InsightStore.get_relevant`` uses this to close the read-loop on
+    :func:`caretaker.fleet.graph.promote_global_skills` — promotion was
+    write-only before T-E3. Implementations are expected to hit the
+    live graph (e.g. via a sync Neo4j wrapper) or return pre-baked rows
+    in tests.
+
+    The reader is sync because every caller of ``get_relevant`` today
+    is sync (the PR agent CI path, the foundry prompt renderer). An
+    async variant can be layered in later without breaking callers.
+    """
+
+    def list_global_skills(self, category: str) -> list[Skill]:
+        """Return :GlobalSkill rows for a category as :class:`Skill` records.
+
+        Implementations must set ``scope="global"`` on every returned
+        row so :class:`InsightStore` can tag them without a second pass.
+        Implementations should return an empty list on failure rather
+        than raising — a flaky graph must never block the local hot
+        path.
+        """
+        ...
 
 
 @dataclass
@@ -307,15 +343,31 @@ class InsightStore:
         db_path: SQLite file path (ignored when *backend* is provided).
         backend: Optional pre-built backend.  When provided, *db_path* is
                  unused and no SQLite connection is opened.
+        global_skill_reader: Optional sync reader that returns
+            ``:GlobalSkill`` rows from the fleet graph. When provided
+            (and ``include_global`` is true), :meth:`get_relevant`
+            returns the union of local + global hits, tagged via
+            ``Skill.scope``. Leave ``None`` to keep the legacy
+            local-only behaviour.
+        include_global: Master switch for the global union — used by
+            the config knob ``fleet.include_global_in_prompts``. Defaults
+            to ``True`` because T-E3's whole point is to close the
+            write-only promotion loop; operators can flip it off per-repo
+            if a shared skill misfires.
     """
 
     def __init__(
         self,
         db_path: str = ":memory:",
         backend: EvolutionBackend | None = None,
+        *,
+        global_skill_reader: GlobalSkillReader | None = None,
+        include_global: bool = True,
     ) -> None:
         self._db_path = db_path
         self._conn: sqlite3.Connection | None = None
+        self._global_skill_reader = global_skill_reader
+        self._include_global = include_global
 
         if backend is not None:
             self._backend: EvolutionBackend = backend
@@ -384,9 +436,64 @@ class InsightStore:
         signature: str,
         min_confidence: float = 0.5,
     ) -> list[Skill]:
-        """Return skills for this category with confidence >= min_confidence."""
-        skills = self._backend.query_skills(category, min_attempts=3, limit=10)
-        return [s for s in skills if s.confidence >= min_confidence]
+        """Return skills for this category with confidence >= min_confidence.
+
+        Returns the union of local ``:Skill`` hits from the configured
+        backend and fleet-promoted ``:GlobalSkill`` hits from the
+        optional :class:`GlobalSkillReader`. Rules:
+
+        * Local hits are tagged ``scope="local"``; they always come
+          back with whatever ``Skill.scope`` the backend populated
+          (default ``"local"``).
+        * Global hits are tagged ``scope="global"`` by the reader.
+        * Deduplication: when the same signature exists in both tiers
+          the local copy wins — the repo's own verified counters are
+          preferred over the fleet's abstracted aggregate.
+        * Global hits are only appended when
+          ``fleet.include_global_in_prompts`` is ``True`` AND a reader
+          has been wired; flipping either off falls back to the legacy
+          local-only behaviour.
+        * Reader failures never propagate — a broken graph must not
+          blow up the PR-agent hot path. The daily reconciliation pass
+          heals any drift.
+        """
+        local_skills = self._backend.query_skills(category, min_attempts=3, limit=10)
+        local_filtered = [s for s in local_skills if s.confidence >= min_confidence]
+
+        if not self._include_global or self._global_skill_reader is None:
+            return local_filtered
+
+        try:
+            global_skills = self._global_skill_reader.list_global_skills(category)
+        except Exception:  # pragma: no cover — defensive; readers should swallow
+            logger.debug("global_skill_reader.list_global_skills failed", exc_info=True)
+            return local_filtered
+
+        seen: set[str] = {s.signature for s in local_filtered if s.signature}
+        merged: list[Skill] = list(local_filtered)
+        for gs in global_skills:
+            if gs.signature and gs.signature in seen:
+                # Local hit takes precedence — the repo's own counters
+                # are more trustworthy than the fleet's aggregate.
+                continue
+            # Defensive: some readers may forget to tag scope; normalise
+            # so the prompt renderer can rely on it.
+            if gs.scope != "global":
+                gs = Skill(
+                    id=gs.id,
+                    category=gs.category,
+                    signature=gs.signature,
+                    sop_text=gs.sop_text,
+                    success_count=gs.success_count,
+                    fail_count=gs.fail_count,
+                    last_used_at=gs.last_used_at,
+                    created_at=gs.created_at,
+                    scope="global",
+                )
+            merged.append(gs)
+            if gs.signature:
+                seen.add(gs.signature)
+        return merged
 
     def get_by_signature(self, category: str, signature: str) -> Skill | None:
         """Return the skill for an exact signature, or None."""

--- a/src/caretaker/fleet/__init__.py
+++ b/src/caretaker/fleet/__init__.py
@@ -9,7 +9,11 @@ from caretaker.fleet.emitter import (
     emit_heartbeat,
     sign_payload,
 )
-from caretaker.fleet.graph import promote_global_skills, sync_repos_to_graph
+from caretaker.fleet.graph import (
+    GraphBackedGlobalSkillReader,
+    promote_global_skills,
+    sync_repos_to_graph,
+)
 from caretaker.fleet.store import (
     FleetClient,
     FleetRegistryStore,
@@ -22,6 +26,7 @@ __all__ = [
     "FleetHeartbeat",
     "FleetOAuthClientCache",
     "FleetRegistryStore",
+    "GraphBackedGlobalSkillReader",
     "abstract_sop",
     "admin_router",
     "build_heartbeat",

--- a/src/caretaker/fleet/graph.py
+++ b/src/caretaker/fleet/graph.py
@@ -37,10 +37,13 @@ Design notes
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import threading
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol
 
+from caretaker.evolution.insight_store import Skill
 from caretaker.fleet.abstraction import abstract_sop
 from caretaker.graph.models import NodeType, RelType
 
@@ -67,6 +70,12 @@ class _GraphStoreProtocol(Protocol):
     ) -> None: ...
 
     async def list_skill_rows(self) -> list[dict[str, Any]]: ...
+
+
+class _GlobalSkillStoreProtocol(Protocol):
+    """Async source of ``:GlobalSkill`` rows (a subset of :class:`GraphStore`)."""
+
+    async def list_global_skill_rows(self, category: str | None = None) -> list[dict[str, Any]]: ...
 
 
 def _repo_node_id(slug: str) -> str:
@@ -319,4 +328,104 @@ async def promote_global_skills(
     return promoted
 
 
-__all__ = ["promote_global_skills", "sync_repos_to_graph"]
+def _row_to_global_skill(row: dict[str, Any]) -> Skill:
+    """Adapt a ``:GlobalSkill`` row into a :class:`Skill` tagged as global.
+
+    ``:GlobalSkill`` nodes don't carry per-repo success/fail counters
+    — those only make sense at the per-repo tier. We synthesise a
+    confidence story from ``repo_count`` instead:
+
+    * ``success_count`` = ``repo_count`` (each contributing repo is one
+      cross-repo success signal).
+    * ``fail_count`` = 0.
+    * ``Skill.confidence`` already requires ``total_attempts >= 3`` to
+      return a non-zero value, which lines up with the default
+      ``fleet.min_repos_for_promotion = 3`` threshold: a signature
+      that just barely cleared promotion starts at confidence 1.0,
+      same as a repo-local skill that has only ever succeeded.
+    """
+    signature = row.get("signature", "")
+    repo_count = int(row.get("repo_count", 0) or 0)
+    now = datetime.now(UTC)
+    return Skill(
+        id=row.get("id") or f"global_skill:{signature}",
+        category=row.get("category", "") or "",
+        signature=signature,
+        sop_text=row.get("sop_text", "") or row.get("name", "") or signature,
+        success_count=repo_count,
+        fail_count=0,
+        last_used_at=None,
+        created_at=now,
+        scope="global",
+    )
+
+
+class GraphBackedGlobalSkillReader:
+    """Sync :class:`GlobalSkillReader` impl on top of the async :class:`GraphStore`.
+
+    Bridges the async ``list_global_skill_rows`` call through a
+    dedicated background event loop so the sync ``get_relevant`` code
+    path (PR agent CI triage, foundry prompt renderer) can surface
+    fleet-promoted skills without touching the caller's loop.
+
+    The reader is resilient: any exception propagating out of the
+    underlying driver is logged and swallowed. Promotion write-loops
+    and prompt builds must not take each other down.
+    """
+
+    def __init__(self, store: _GlobalSkillStoreProtocol) -> None:
+        self._store = store
+
+    def list_global_skills(self, category: str) -> list[Skill]:
+        try:
+            rows = self._run(self._store.list_global_skill_rows(category))
+        except Exception:  # pragma: no cover — swallowed to protect hot path
+            logger.debug("GraphBackedGlobalSkillReader.list_global_skills failed", exc_info=True)
+            return []
+        return [_row_to_global_skill(row) for row in rows]
+
+    @staticmethod
+    def _run(coro: Any) -> Any:
+        """Drive *coro* to completion regardless of the caller's loop state.
+
+        Three cases:
+
+        1. No event loop running on this thread → ``asyncio.run``.
+        2. A loop is running on this thread (unusual for the sync
+           callers but defensive) → spin up a fresh loop in a dedicated
+           worker thread so the current loop isn't re-entered.
+        3. Same as (2) for safety if ``get_event_loop`` raises.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop on this thread — the common case.
+            return asyncio.run(coro)
+
+        # A loop is active: run the coro in a worker thread with its own loop.
+        result: dict[str, Any] = {}
+        error: dict[str, BaseException] = {}
+
+        def _worker() -> None:
+            try:
+                loop = asyncio.new_event_loop()
+                try:
+                    result["value"] = loop.run_until_complete(coro)
+                finally:
+                    loop.close()
+            except BaseException as exc:  # noqa: BLE001 — re-raised on join
+                error["exc"] = exc
+
+        thread = threading.Thread(target=_worker, daemon=True)
+        thread.start()
+        thread.join()
+        if "exc" in error:
+            raise error["exc"]
+        return result.get("value")
+
+
+__all__ = [
+    "GraphBackedGlobalSkillReader",
+    "promote_global_skills",
+    "sync_repos_to_graph",
+]

--- a/src/caretaker/foundry/prompts.py
+++ b/src/caretaker/foundry/prompts.py
@@ -92,13 +92,22 @@ def _fence(tag: str, body: str) -> str:
 def _format_skills(skills: list[Skill] | None) -> str:
     if not skills:
         return ""
-    lines = ["# Hints from past successful fixes in this repo"]
+    # Header intentionally mentions "this repo and the fleet" because the
+    # list may now include :GlobalSkill promotions surfaced via
+    # :class:`caretaker.evolution.insight_store.GlobalSkillReader` —
+    # those are prefixed with ``[fleet]`` below so the model can tell
+    # them apart from the repo's own verified fixes.
+    lines = ["# Hints from past successful fixes in this repo and the fleet"]
     for s in skills[:3]:
         confidence = getattr(s, "confidence", 0.0)
         attempts = getattr(s, "total_attempts", 0)
         successes = getattr(s, "success_count", 0)
         text = getattr(s, "sop_text", str(s))
-        lines.append(f"- {text} (confidence: {confidence:.0%}, {successes}/{attempts} attempts)")
+        scope = getattr(s, "scope", "local")
+        prefix = "[fleet] " if scope == "global" else ""
+        lines.append(
+            f"- {prefix}{text} (confidence: {confidence:.0%}, {successes}/{attempts} attempts)"
+        )
     return "\n".join(lines)
 
 

--- a/src/caretaker/graph/store.py
+++ b/src/caretaker/graph/store.py
@@ -345,6 +345,69 @@ class GraphStore:
                 )
         return rows
 
+    async def list_global_skill_rows(self, category: str | None = None) -> list[dict[str, Any]]:
+        """Return one row per ``:GlobalSkill`` node.
+
+        Mirrors :meth:`list_skill_rows` but targets the fleet-promoted
+        tier. Used by :class:`caretaker.fleet.graph.GraphBackedGlobalSkillReader`
+        (T-E3) to close the read-loop on skill promotion — promotion
+        was previously write-only.
+
+        ``:GlobalSkill`` nodes do not carry per-repo counters; the
+        ``confidence`` / ``success_count`` / ``fail_count`` fields are
+        synthesised downstream from ``repo_count`` so the fleet hit
+        surfaces with a plausible rank in the prompt renderer.
+
+        When *category* is supplied the result is filtered to that
+        category; a ``GlobalSkill`` whose source ``:Skill`` nodes all
+        shared one category will carry it on the node itself, but the
+        filter is lenient — nodes with no ``category`` property are
+        returned for every category so a partial backfill does not
+        silently hide hits.
+        """
+        rows: list[dict[str, Any]] = []
+        if category is None:
+            query = (
+                "MATCH (g:GlobalSkill) "
+                "RETURN g.id AS id, "
+                "       coalesce(g.signature, '') AS signature, "
+                "       coalesce(g.name, '') AS name, "
+                "       coalesce(g.category, '') AS category, "
+                "       coalesce(g.abstracted_sop_text, '') AS sop_text, "
+                "       coalesce(g.repo_count, 0) AS repo_count, "
+                "       coalesce(g.abstracted_at, '') AS abstracted_at"
+            )
+            params: dict[str, Any] = {}
+        else:
+            query = (
+                "MATCH (g:GlobalSkill) "
+                "WHERE g.category = $category OR g.category IS NULL OR g.category = '' "
+                "RETURN g.id AS id, "
+                "       coalesce(g.signature, '') AS signature, "
+                "       coalesce(g.name, '') AS name, "
+                "       coalesce(g.category, '') AS category, "
+                "       coalesce(g.abstracted_sop_text, '') AS sop_text, "
+                "       coalesce(g.repo_count, 0) AS repo_count, "
+                "       coalesce(g.abstracted_at, '') AS abstracted_at"
+            )
+            params = {"category": category}
+
+        async with self._driver.session(database=self._database) as session:
+            result = await session.run(query, **params)
+            async for record in result:
+                rows.append(
+                    {
+                        "id": record["id"],
+                        "signature": record["signature"],
+                        "name": record["name"],
+                        "category": record["category"],
+                        "sop_text": record["sop_text"],
+                        "repo_count": record["repo_count"],
+                        "abstracted_at": record["abstracted_at"],
+                    }
+                )
+        return rows
+
     async def get_stats(self) -> GraphStats:
         """Return node and edge counts by type."""
         stats = GraphStats()

--- a/tests/test_fleet_skill_promotion_roundtrip.py
+++ b/tests/test_fleet_skill_promotion_roundtrip.py
@@ -1,0 +1,328 @@
+"""Tests for T-E3 — skill promotion round-trip.
+
+Covers the read-loop close-out on ``promote_global_skills``:
+
+* :meth:`InsightStore.get_relevant` returns the union of local
+  ``:Skill`` hits and ``:GlobalSkill`` hits exposed via the injected
+  :class:`GlobalSkillReader`.
+* Deduplication keys on ``signature`` — local wins over global.
+* ``fleet.include_global_in_prompts = False`` (i.e.
+  ``include_global=False`` on the store) returns only local hits.
+* The foundry prompt renderer prefixes global hits with ``[fleet]``.
+* Cross-repo end-to-end: skill promoted from two repo slugs via
+  :func:`promote_global_skills` is surfaced to a third repo's
+  ``get_relevant`` call through :class:`GraphBackedGlobalSkillReader`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from caretaker.evolution.insight_store import (
+    CATEGORY_CI,
+    GlobalSkillReader,
+    InsightStore,
+    Skill,
+)
+from caretaker.fleet.graph import (
+    GraphBackedGlobalSkillReader,
+    promote_global_skills,
+)
+from caretaker.foundry.prompts import _format_skills
+from caretaker.graph.models import NodeType
+
+# ── Fakes ────────────────────────────────────────────────────────────────
+
+
+class _StaticGlobalReader:
+    """Pre-baked :GlobalSkill rows for isolated ``get_relevant`` tests."""
+
+    def __init__(self, skills: list[Skill]) -> None:
+        self._skills = skills
+        self.calls: list[str] = []
+
+    def list_global_skills(self, category: str) -> list[Skill]:
+        self.calls.append(category)
+        return [s for s in self._skills if not s.category or s.category == category]
+
+
+def _global_skill(signature: str, sop: str, *, repo_count: int = 3) -> Skill:
+    """Shape a :class:`Skill` the way a graph-backed reader would."""
+    return Skill(
+        id=f"global_skill:{signature}",
+        category=CATEGORY_CI,
+        signature=signature,
+        sop_text=sop,
+        success_count=repo_count,
+        fail_count=0,
+        last_used_at=None,
+        created_at=datetime.now(UTC),
+        scope="global",
+    )
+
+
+class _FakeGraphStore:
+    """Minimal async :class:`GraphStore` supporting the T-E3 round-trip.
+
+    Stores nodes and edges in memory and serves ``list_skill_rows`` +
+    ``list_global_skill_rows`` from the same dict so writes made by
+    :func:`promote_global_skills` are visible to a subsequent read via
+    :class:`GraphBackedGlobalSkillReader`.
+    """
+
+    def __init__(self, skill_rows: list[dict[str, Any]] | None = None) -> None:
+        self._skill_rows = list(skill_rows or [])
+        self._global_skills: dict[str, dict[str, Any]] = {}
+        self.edges: list[tuple[str, str, str, str, str, dict[str, Any]]] = []
+
+    async def merge_node(self, label: str, node_id: str, properties: dict[str, Any]) -> None:
+        if label == NodeType.GLOBAL_SKILL:
+            self._global_skills[node_id] = {"id": node_id, **properties}
+
+    async def merge_edge(
+        self,
+        source_label: str,
+        source_id: str,
+        target_label: str,
+        target_id: str,
+        rel_type: str,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        self.edges.append(
+            (source_label, source_id, target_label, target_id, rel_type, properties or {})
+        )
+
+    async def list_skill_rows(self) -> list[dict[str, Any]]:
+        return list(self._skill_rows)
+
+    async def list_global_skill_rows(self, category: str | None = None) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for node in self._global_skills.values():
+            node_category = node.get("category") or ""
+            if category is not None and node_category and node_category != category:
+                continue
+            rows.append(
+                {
+                    "id": node["id"],
+                    "signature": node.get("signature", ""),
+                    "name": node.get("name", ""),
+                    "category": node_category,
+                    "sop_text": node.get("abstracted_sop_text", ""),
+                    "repo_count": node.get("repo_count", 0),
+                    "abstracted_at": node.get("abstracted_at", ""),
+                }
+            )
+        return rows
+
+
+class _FakeInsightStoreForPromotion:
+    """Duck-type matching :class:`InsightStore` for :func:`promote_global_skills`."""
+
+    def __init__(self, sops: dict[str, str]) -> None:
+        self._sops = sops
+
+    def all_skills(self) -> list[Any]:
+        class _S:
+            def __init__(self, signature: str, sop_text: str) -> None:
+                self.signature = signature
+                self.sop_text = sop_text
+
+        return [_S(sig, sop) for sig, sop in self._sops.items()]
+
+
+def _skill_row(*, signature: str, repo: str, category: str = CATEGORY_CI) -> dict[str, Any]:
+    return {
+        "id": f"skill:{category}:{signature}:{repo}",
+        "signature": signature,
+        "repo": repo,
+        "name": signature,
+        "category": category,
+    }
+
+
+# ── get_relevant: union + dedupe + scope ─────────────────────────────────
+
+
+class TestGetRelevantUnion:
+    def test_union_returns_local_and_global_with_scope(self) -> None:
+        store = InsightStore(
+            db_path=":memory:",
+            global_skill_reader=_StaticGlobalReader(
+                [_global_skill("fleet_only", "Apply fleet pattern.")]
+            ),
+            include_global=True,
+        )
+        # Build a local hit with confidence >= 0.5.
+        for _ in range(4):
+            store.record_success(CATEGORY_CI, "local_only", "Patch local issue.")
+
+        results = store.get_relevant(CATEGORY_CI, "anything")
+
+        signatures = {s.signature for s in results}
+        assert signatures == {"local_only", "fleet_only"}
+
+        scopes = {s.signature: s.scope for s in results}
+        assert scopes["local_only"] == "local"
+        assert scopes["fleet_only"] == "global"
+
+    def test_dedupe_prefers_local_over_global(self) -> None:
+        """Same signature in both tiers → local wins; global copy dropped."""
+        store = InsightStore(
+            db_path=":memory:",
+            global_skill_reader=_StaticGlobalReader(
+                [_global_skill("shared_sig", "Fleet-abstracted SOP.")]
+            ),
+            include_global=True,
+        )
+        for _ in range(4):
+            store.record_success(CATEGORY_CI, "shared_sig", "Repo-local verified SOP.")
+
+        results = store.get_relevant(CATEGORY_CI, "anything")
+
+        assert len(results) == 1
+        assert results[0].signature == "shared_sig"
+        assert results[0].scope == "local"
+        assert "Repo-local" in results[0].sop_text
+
+    def test_include_global_false_returns_only_local(self) -> None:
+        reader = _StaticGlobalReader([_global_skill("fleet_only", "Fleet SOP.")])
+        store = InsightStore(
+            db_path=":memory:",
+            global_skill_reader=reader,
+            include_global=False,
+        )
+        for _ in range(4):
+            store.record_success(CATEGORY_CI, "local_only", "Local SOP.")
+
+        results = store.get_relevant(CATEGORY_CI, "anything")
+
+        assert {s.signature for s in results} == {"local_only"}
+        # Reader isn't even consulted — a misfiring fleet skill must not
+        # cost a graph query when the operator has flipped this off.
+        assert reader.calls == []
+
+    def test_no_reader_is_local_only(self) -> None:
+        store = InsightStore(db_path=":memory:")  # no reader wired
+        for _ in range(4):
+            store.record_success(CATEGORY_CI, "local_only", "Local SOP.")
+
+        results = store.get_relevant(CATEGORY_CI, "anything")
+
+        assert [s.signature for s in results] == ["local_only"]
+        assert results[0].scope == "local"
+
+    def test_reader_hit_missing_scope_is_normalised(self) -> None:
+        """Defensive: readers that return scope="local" get re-tagged."""
+        leaky_hit = Skill(
+            id="global_skill:leaky",
+            category=CATEGORY_CI,
+            signature="leaky",
+            sop_text="Misbehaving reader SOP.",
+            success_count=3,
+            fail_count=0,
+            last_used_at=None,
+            created_at=datetime.now(UTC),
+            scope="local",  # intentionally wrong
+        )
+
+        class _LeakyReader:
+            def list_global_skills(self, category: str) -> list[Skill]:
+                return [leaky_hit]
+
+        reader: GlobalSkillReader = _LeakyReader()
+        store = InsightStore(db_path=":memory:", global_skill_reader=reader)
+
+        results = store.get_relevant(CATEGORY_CI, "anything")
+
+        assert len(results) == 1
+        assert results[0].signature == "leaky"
+        assert results[0].scope == "global"
+
+
+# ── Prompt renderer surfaces the scope ───────────────────────────────────
+
+
+class TestFormatSkillsScope:
+    def test_fleet_prefix_on_global_hit(self) -> None:
+        local = Skill(
+            id="ci:local",
+            category=CATEGORY_CI,
+            signature="local_sig",
+            sop_text="Restart the test runner.",
+            success_count=4,
+            fail_count=0,
+            last_used_at=None,
+            created_at=datetime.now(UTC),
+            scope="local",
+        )
+        fleet = _global_skill("fleet_sig", "Pin the flaky dep.")
+
+        rendered = _format_skills([local, fleet])
+
+        assert "Hints from past successful fixes" in rendered
+        assert "- Restart the test runner." in rendered
+        assert "- [fleet] Pin the flaky dep." in rendered
+        # Local hits must NOT carry the [fleet] prefix.
+        local_line = next(
+            line for line in rendered.splitlines() if "Restart the test runner" in line
+        )
+        assert "[fleet]" not in local_line
+
+    def test_empty_skills_block_is_empty_string(self) -> None:
+        assert _format_skills(None) == ""
+        assert _format_skills([]) == ""
+
+
+# ── Cross-repo end-to-end round-trip ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_repo_promotion_surfaces_via_get_relevant() -> None:
+    """Skill promoted in two repos → visible to a third repo's get_relevant.
+
+    1. Seed the graph with ``:Skill`` rows from *two* distinct repo
+       slugs carrying the same signature.
+    2. Run :func:`promote_global_skills` with ``min_repos=2`` and
+       ``share_skills=True`` — a ``:GlobalSkill`` node lands on the graph.
+    3. Build a third-repo :class:`InsightStore` (fresh SQLite, no local
+       ``:Skill`` for the signature) wired to a
+       :class:`GraphBackedGlobalSkillReader` pointing at the same graph.
+    4. ``get_relevant`` on the third repo surfaces the promoted signature
+       with ``scope="global"``.
+    """
+    rows = [
+        _skill_row(signature="retry_flaky_test", repo="acme/widgets"),
+        _skill_row(signature="retry_flaky_test", repo="acme/gadgets"),
+    ]
+    graph = _FakeGraphStore(skill_rows=rows)
+    insight_for_promotion = _FakeInsightStoreForPromotion(
+        {"retry_flaky_test": "Retry the failing job once, then escalate."}
+    )
+
+    promoted = await promote_global_skills(
+        graph,
+        insight_for_promotion,
+        min_repos=2,
+        share_skills=True,
+    )
+    assert promoted == ["retry_flaky_test"]
+
+    # Third-repo store: empty local backend, graph-backed reader.
+    reader = GraphBackedGlobalSkillReader(graph)
+    third_repo_store = InsightStore(
+        db_path=":memory:",
+        global_skill_reader=reader,
+        include_global=True,
+    )
+
+    # No local hit for the signature — purely fleet surfacing.
+    hits = third_repo_store.get_relevant(CATEGORY_CI, "retry_flaky_test")
+
+    assert len(hits) == 1
+    assert hits[0].signature == "retry_flaky_test"
+    assert hits[0].scope == "global"
+    # The abstracted SOP text survived the promotion pipeline.
+    assert "Retry" in hits[0].sop_text


### PR DESCRIPTION
## Summary

Closes the read-loop on M6 fleet-tier skill promotion. `promote_global_skills` has been projecting per-repo `:Skill` signatures seen across `fleet.min_repos_for_promotion` repos into `:GlobalSkill` nodes, but nothing on the prompt-building path read the promoted tier — promotion was write-only. This PR wires the union.

- `InsightStore.get_relevant` now returns the union of local `:Skill` hits and fleet-promoted `:GlobalSkill` hits from an optional `GlobalSkillReader`, tagged via the new `Skill.scope: Literal["local", "global"]` field. Dedup keys on signature; local wins.
- `_format_skills` (foundry prompt renderer) prefixes fleet-sourced hits with `[fleet]` so the model can tell apart "this repo has done this before" from "another repo in the fleet has done this".
- New config knob `fleet.include_global_in_prompts: bool = True` lets operators turn the union off per-repo if a shared skill misfires; promotion itself is unaffected.
- `GraphStore.list_global_skill_rows(category)` query mirrors the existing `list_skill_rows` Cypher style. `GraphBackedGlobalSkillReader` bridges the async driver for the existing sync `get_relevant` callers (PR agent, foundry prompt builder) with no event-loop churn in the caller.
- Factory wires the reader in when both `fleet.include_global_in_prompts` and `graph_store.enabled` are true. Reader failures are swallowed so a flaky graph cannot block the PR-agent hot path.

## Test plan

- [x] `PYTHONPATH="$PWD/src" pytest -q` — 1567 passed, 1 skipped
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src/caretaker` — same 2 pre-existing unrelated errors in `k8s_worker/launcher.py`; no new errors
- [x] New coverage:
  - Union + dedupe + scope tagging across mixed local/global hits.
  - `include_global=False` short-circuits the reader (no graph call).
  - `[fleet]` prefix on rendered global hit in the prompt renderer.
  - Defensive re-tagging when a reader returns `scope="local"` on a global row.
  - Cross-repo end-to-end: skill promoted from two repo slugs → surfaced to a third repo's `get_relevant` call via `GraphBackedGlobalSkillReader` on a shared in-memory graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)