### PR TITLE
feat(fleet): :FleetAlert evaluator + admin endpoint

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -680,6 +680,24 @@ class FleetRegistryConfig(StrictBaseModel):
     oauth2: OAuth2ClientConfig = Field(default_factory=OAuth2ClientConfig)
 
 
+class FleetAlertConfig(StrictBaseModel):
+    """T-E4 — server-side :FleetAlert evaluator.
+
+    Attached to :class:`FleetConfig` (inbound / backend-owned fleet state)
+    and gated behind ``enabled = False`` by default so existing installs
+    see byte-identical behaviour. The evaluator is pure Python; the only
+    observable side effects when enabled are the in-memory alert store
+    populated by the admin endpoint and the ``:FleetAlert`` graph nodes
+    upserted via :func:`caretaker.fleet.alerts.upsert_fleet_alerts`.
+    """
+
+    enabled: bool = False
+    goal_health_threshold: float = 0.7
+    goal_health_n_consecutive: int = 3
+    error_spike_multiplier: float = 3.0
+    ghosted_window_days: int = 7
+
+
 class FleetConfig(StrictBaseModel):
     """M6 — fleet-tier graph + :GlobalSkill promotion.
 
@@ -703,11 +721,14 @@ class FleetConfig(StrictBaseModel):
       cross-repo skills with a ``[fleet]`` prefix. Operators can flip
       this off per-repo if a shared skill misfires — promotion itself
       is unaffected.
+    * ``alerts`` is the :FleetAlert evaluator surface (T-E4). See
+      :class:`FleetAlertConfig`.
     """
 
     share_skills: bool = False
     min_repos_for_promotion: int = 3
     include_global_in_prompts: bool = True
+    alerts: FleetAlertConfig = Field(default_factory=FleetAlertConfig)
 
 
 class GitHubAppConfig(StrictBaseModel):

--- a/src/caretaker/fleet/__init__.py
+++ b/src/caretaker/fleet/__init__.py
@@ -1,7 +1,15 @@
 """Opt-in fleet-registry heartbeat emitter, store, and HTTP surface."""
 
 from caretaker.fleet.abstraction import abstract_sop
-from caretaker.fleet.api import admin_router, public_router
+from caretaker.fleet.alerts import (
+    FleetAlert,
+    FleetAlertStore,
+    evaluate_fleet_alerts,
+    get_alert_store,
+    reset_alert_store_for_tests,
+    upsert_fleet_alerts,
+)
+from caretaker.fleet.api import admin_router, public_router, set_fleet_alert_dependencies
 from caretaker.fleet.emitter import (
     FleetHeartbeat,
     FleetOAuthClientCache,
@@ -22,6 +30,8 @@ from caretaker.fleet.store import (
 )
 
 __all__ = [
+    "FleetAlert",
+    "FleetAlertStore",
     "FleetClient",
     "FleetHeartbeat",
     "FleetOAuthClientCache",
@@ -31,10 +41,15 @@ __all__ = [
     "admin_router",
     "build_heartbeat",
     "emit_heartbeat",
+    "evaluate_fleet_alerts",
+    "get_alert_store",
     "get_store",
     "promote_global_skills",
     "public_router",
+    "reset_alert_store_for_tests",
     "reset_store_for_tests",
+    "set_fleet_alert_dependencies",
     "sign_payload",
     "sync_repos_to_graph",
+    "upsert_fleet_alerts",
 ]

--- a/src/caretaker/fleet/alerts.py
+++ b/src/caretaker/fleet/alerts.py
@@ -1,0 +1,502 @@
+""":FleetAlert evaluator + in-memory store (Phase 3 §4.4, T-E4).
+
+Fleet heartbeats (see :class:`caretaker.fleet.emitter.FleetHeartbeat`) carry
+``goal_health`` and ``error_count`` for every consumer repo. Today the admin
+UI renders them straight through. This module adds a thin alerting path on
+top: when a repo trips one of the four configured alert conditions, an
+idempotent :class:`FleetAlert` row is opened (and a ``:FleetAlert`` graph
+node is upserted). Once the underlying metric clears, the alert is
+auto-resolved — ``resolved_at`` is set and the admin ``open=true`` listing
+omits it.
+
+Four alert kinds:
+
+* ``goal_health_regression`` — last N heartbeats from a repo all below
+  ``goal_health_threshold``.
+* ``error_spike`` — most recent heartbeat's ``error_count`` is at least
+  ``error_spike_multiplier`` times the mean of the prior heartbeats'
+  ``error_count`` (with a ``mean ≥ 1`` floor so a jump from 0 → 3 still
+  trips).
+* ``ghosted`` — no heartbeat from the repo for ``ghosted_window_days`` (the
+  repo is known to the registry but has gone dark).
+* ``scope_gap`` — piggybacks on the existing scope-gap tracker via the
+  heartbeat ``summary``: when ``summary.scope_gap_open`` is truthy the
+  evaluator opens a matching FleetAlert, dedup on ``(repo, kind)``.
+
+Design notes
+------------
+
+* :func:`evaluate_fleet_alerts` is a pure function over an iterable of
+  :class:`~caretaker.fleet.emitter.FleetHeartbeat` rows. The store-side
+  history ring buffer lives in :class:`caretaker.fleet.store.FleetRegistryStore`;
+  this module never reads from it directly so the evaluator stays trivially
+  testable.
+* :class:`FleetAlertStore` dedups on ``(repo, kind)`` so calling the
+  evaluator twice on the same data doesn't double-emit. Resolution runs as
+  part of the same upsert pass: a repo that was alerting but now has a
+  heartbeat back above threshold flips ``resolved_at`` instead of
+  re-opening.
+* :func:`upsert_fleet_alerts` writes a ``:FleetAlert`` node per alert with
+  ``repo``, ``kind``, ``severity``, ``summary``, ``opened_at``, and
+  ``resolved_at``. Graph writes are best-effort; the admin API does not
+  block on graph availability.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+from pydantic import BaseModel, Field
+
+from caretaker.fleet.emitter import FleetHeartbeat
+from caretaker.graph.models import NodeType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+AlertKind = Literal[
+    "goal_health_regression",
+    "error_spike",
+    "ghosted",
+    "scope_gap",
+]
+
+AlertSeverity = Literal["warning", "critical"]
+
+
+class FleetAlert(BaseModel):
+    """One open (or recently-resolved) alert for a repo + kind pair.
+
+    ``(repo, kind)`` is the dedup key — at most one row per pair at a time.
+    ``resolved_at`` is ``None`` while the alert is active and becomes a
+    timestamp when the next evaluation pass sees the metric clear.
+    """
+
+    repo: str
+    kind: AlertKind
+    severity: AlertSeverity
+    # 240 chars is plenty for the admin list row; longer context belongs in
+    # ``details``. Also guards against a runaway summary in the graph node
+    # properties blob.
+    summary: str = Field(max_length=240)
+    opened_at: datetime
+    resolved_at: datetime | None = None
+    details: dict[str, object] = Field(default_factory=dict)
+
+    def is_open(self) -> bool:
+        return self.resolved_at is None
+
+
+# ── Evaluation ───────────────────────────────────────────────────────────
+
+
+def _coerce_heartbeat(value: FleetHeartbeat | dict[str, Any]) -> FleetHeartbeat:
+    """Accept either a :class:`FleetHeartbeat` or the raw dict stored by
+    :meth:`FleetRegistryStore.recent_heartbeats`.
+
+    Keeps the public evaluator API typed as ``list[FleetHeartbeat]`` while
+    the store's ring buffer (dicts) can feed it directly without the caller
+    hand-rolling ``FleetHeartbeat(**row)`` everywhere.
+    """
+    if isinstance(value, FleetHeartbeat):
+        return value
+    # Drop summary if it's ``None`` — pydantic accepts either, but omitting
+    # it keeps the shape clean.
+    payload = dict(value)
+    return FleetHeartbeat.model_validate(payload)
+
+
+def _group_by_repo(
+    heartbeats: Iterable[FleetHeartbeat | dict[str, Any]],
+) -> dict[str, list[FleetHeartbeat]]:
+    grouped: dict[str, list[FleetHeartbeat]] = {}
+    for raw in heartbeats:
+        try:
+            hb = _coerce_heartbeat(raw)
+        except Exception:
+            logger.debug("evaluate_fleet_alerts: skipping malformed heartbeat", exc_info=True)
+            continue
+        grouped.setdefault(hb.repo, []).append(hb)
+    for repo, rows in grouped.items():
+        rows.sort(key=lambda h: h.run_at)
+        grouped[repo] = rows
+    return grouped
+
+
+def _goal_health_alert(
+    repo: str,
+    rows: list[FleetHeartbeat],
+    *,
+    threshold: float,
+    n_consecutive: int,
+    now: datetime,
+) -> FleetAlert | None:
+    if len(rows) < n_consecutive or n_consecutive < 1:
+        return None
+    tail = rows[-n_consecutive:]
+    # ``None`` goal_health doesn't count as a failing sample — without the
+    # metric we can't make a claim either way.
+    scores = [row.goal_health for row in tail if row.goal_health is not None]
+    if len(scores) < n_consecutive:
+        return None
+    if any(score >= threshold for score in scores):
+        return None
+    opened_at = tail[0].run_at
+    severity: AlertSeverity = "critical" if scores[-1] < threshold / 2 else "warning"
+    return FleetAlert(
+        repo=repo,
+        kind="goal_health_regression",
+        severity=severity,
+        summary=(
+            f"goal_health below {threshold:.2f} for last "
+            f"{n_consecutive} heartbeats (latest={scores[-1]:.2f})"
+        ),
+        opened_at=opened_at,
+        details={
+            "threshold": threshold,
+            "n_consecutive": n_consecutive,
+            "samples": scores,
+        },
+    )
+
+
+def _error_spike_alert(
+    repo: str,
+    rows: list[FleetHeartbeat],
+    *,
+    multiplier: float,
+    now: datetime,
+) -> FleetAlert | None:
+    if len(rows) < 2:
+        return None
+    prior = rows[:-1]
+    latest = rows[-1]
+    prior_counts = [int(r.error_count or 0) for r in prior]
+    mean_prior = max(sum(prior_counts) / len(prior_counts), 1.0)
+    threshold = mean_prior * multiplier
+    if latest.error_count < threshold:
+        return None
+    severity: AlertSeverity = "critical" if latest.error_count >= threshold * 2 else "warning"
+    return FleetAlert(
+        repo=repo,
+        kind="error_spike",
+        severity=severity,
+        summary=(
+            f"error_count={latest.error_count} ≥ prior_mean({mean_prior:.1f}) × {multiplier:g}"
+        ),
+        opened_at=latest.run_at,
+        details={
+            "latest_error_count": latest.error_count,
+            "prior_mean": mean_prior,
+            "multiplier": multiplier,
+        },
+    )
+
+
+def _ghosted_alert(
+    repo: str,
+    rows: list[FleetHeartbeat],
+    *,
+    window_days: int,
+    now: datetime,
+) -> FleetAlert | None:
+    if not rows or window_days < 1:
+        return None
+    latest = rows[-1]
+    last_seen = latest.run_at if latest.run_at.tzinfo else latest.run_at.replace(tzinfo=UTC)
+    cutoff = now - timedelta(days=window_days)
+    if last_seen >= cutoff:
+        return None
+    age_days = (now - last_seen).days
+    severity: AlertSeverity = "critical" if age_days >= window_days * 2 else "warning"
+    return FleetAlert(
+        repo=repo,
+        kind="ghosted",
+        severity=severity,
+        summary=f"no heartbeat in {age_days} days (window={window_days}d)",
+        opened_at=last_seen,
+        details={
+            "last_seen": last_seen.isoformat(),
+            "window_days": window_days,
+            "age_days": age_days,
+        },
+    )
+
+
+def _scope_gap_alert(
+    repo: str,
+    rows: list[FleetHeartbeat],
+    *,
+    now: datetime,
+) -> FleetAlert | None:
+    if not rows:
+        return None
+    latest = rows[-1]
+    summary = latest.summary or {}
+    # Accept a handful of shapes the scope-gap reporter might emit:
+    #   {"scope_gap_open": true}
+    #   {"scope_gap": {"open": true, "count": 3, "scope_hint": "workflow"}}
+    #   {"scope_gap_count": 4}
+    flag = bool(summary.get("scope_gap_open"))
+    nested = summary.get("scope_gap")
+    if isinstance(nested, dict):
+        flag = flag or bool(nested.get("open")) or int(nested.get("count", 0) or 0) > 0
+    count = int(summary.get("scope_gap_count", 0) or 0)
+    if count > 0:
+        flag = True
+    if not flag:
+        return None
+    hint = ""
+    if isinstance(nested, dict):
+        hint = str(nested.get("scope_hint", "") or "")
+    hint_part = f" ({hint})" if hint else ""
+    return FleetAlert(
+        repo=repo,
+        kind="scope_gap",
+        severity="warning",
+        summary=f"scope-gap tracker reports missing token scope{hint_part}",
+        opened_at=latest.run_at,
+        details={k: v for k, v in summary.items() if str(k).startswith("scope_gap")},
+    )
+
+
+def evaluate_fleet_alerts(
+    recent_heartbeats: Iterable[FleetHeartbeat | dict[str, Any]],
+    *,
+    goal_health_threshold: float = 0.7,
+    goal_health_n_consecutive: int = 3,
+    error_spike_multiplier: float = 3.0,
+    ghosted_window_days: int = 7,
+    now: datetime | None = None,
+) -> list[FleetAlert]:
+    """Evaluate alert conditions over a batch of heartbeats.
+
+    Pure function — no graph / store writes. The caller is expected to pass
+    the cross-repo heartbeat history (see
+    :meth:`FleetRegistryStore.recent_heartbeats`) and then forward the
+    returned list to :func:`upsert_fleet_alerts` +
+    :meth:`FleetAlertStore.apply` for persistence + resolution.
+
+    ``now`` is injectable for tests; defaults to wall-clock UTC.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+
+    grouped = _group_by_repo(recent_heartbeats)
+    alerts: list[FleetAlert] = []
+    for repo, rows in grouped.items():
+        gh = _goal_health_alert(
+            repo,
+            rows,
+            threshold=goal_health_threshold,
+            n_consecutive=goal_health_n_consecutive,
+            now=now,
+        )
+        if gh is not None:
+            alerts.append(gh)
+        spike = _error_spike_alert(
+            repo,
+            rows,
+            multiplier=error_spike_multiplier,
+            now=now,
+        )
+        if spike is not None:
+            alerts.append(spike)
+        ghosted = _ghosted_alert(
+            repo,
+            rows,
+            window_days=ghosted_window_days,
+            now=now,
+        )
+        if ghosted is not None:
+            alerts.append(ghosted)
+        scope_gap = _scope_gap_alert(repo, rows, now=now)
+        if scope_gap is not None:
+            alerts.append(scope_gap)
+    alerts.sort(key=lambda a: (a.repo, a.kind))
+    return alerts
+
+
+# ── Graph sync ──────────────────────────────────────────────────────────
+
+
+class _GraphStoreProtocol(Protocol):
+    """Duck-type the subset of :class:`GraphStore` the alert sync uses."""
+
+    async def merge_node(self, label: str, node_id: str, properties: dict[str, Any]) -> None: ...
+
+
+def _alert_node_id(alert: FleetAlert) -> str:
+    # ``(repo, kind)`` is the dedup key; rolling ``opened_at`` into the id
+    # would defeat resolution tracking because a new node would be created
+    # each time the alert re-fires.
+    safe_repo = alert.repo.replace("/", "_")
+    return f"fleet_alert:{safe_repo}:{alert.kind}"
+
+
+def upsert_fleet_alerts(
+    alerts: list[FleetAlert],
+    *,
+    graph: _GraphStoreProtocol | None,
+) -> None:
+    """Mirror alerts into the graph as ``:FleetAlert`` nodes (best-effort).
+
+    Invoked synchronously from the admin evaluation pass. The graph store is
+    async-native, so we schedule a task on the running loop if one is
+    available and otherwise fall back to ``asyncio.run`` for one-shot CLI
+    contexts. Failures are logged at WARNING and swallowed — alerting must
+    not cascade into an admin outage.
+    """
+    if graph is None:
+        return
+
+    async def _run() -> None:
+        for alert in alerts:
+            props: dict[str, Any] = {
+                "repo": alert.repo,
+                "kind": alert.kind,
+                "severity": alert.severity,
+                "summary": alert.summary,
+                "opened_at": alert.opened_at.isoformat(),
+                "resolved_at": (
+                    alert.resolved_at.isoformat() if alert.resolved_at is not None else None
+                ),
+                "status": "resolved" if alert.resolved_at is not None else "open",
+            }
+            try:
+                await graph.merge_node(NodeType.FLEET_ALERT, _alert_node_id(alert), props)
+            except Exception as exc:  # best-effort: never cascade
+                logger.warning(
+                    "upsert_fleet_alerts: graph write failed for %s: %s",
+                    alert.repo,
+                    exc,
+                )
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is not None and loop.is_running():
+        # Fire-and-forget on the running loop (e.g. from an async admin
+        # handler). The resulting task is allowed to complete on its own;
+        # we don't await it because the admin request should not block on
+        # the downstream graph store.
+        loop.create_task(_run())
+    else:
+        try:
+            asyncio.run(_run())
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("upsert_fleet_alerts: asyncio.run failed: %s", exc)
+
+
+# ── In-memory alert store (admin-side) ──────────────────────────────────
+
+
+class FleetAlertStore:
+    """In-memory alert registry keyed on ``(repo, kind)``.
+
+    Lives alongside :class:`FleetRegistryStore` on the admin backend. Two
+    operations:
+
+    * :meth:`apply` — merge the output of :func:`evaluate_fleet_alerts`
+      into the store. Existing alerts with the same ``(repo, kind)`` are
+      updated in place (preserves original ``opened_at``). Alerts that are
+      no longer reported by the evaluator get their ``resolved_at`` set to
+      ``now`` (one-shot: a subsequent :meth:`apply` that doesn't include
+      them leaves ``resolved_at`` unchanged).
+    * :meth:`list` — read alerts; ``open_only=True`` filters out resolved.
+    """
+
+    def __init__(self) -> None:
+        self._alerts: dict[tuple[str, AlertKind], FleetAlert] = {}
+        self._lock = asyncio.Lock()
+
+    async def apply(
+        self,
+        evaluated: list[FleetAlert],
+        *,
+        now: datetime | None = None,
+    ) -> list[FleetAlert]:
+        """Merge evaluator output; resolve alerts that no longer fire.
+
+        Returns the resulting alert set (both open + freshly-resolved), in
+        ``(repo, kind)`` order. Deterministic.
+        """
+        current_keys = {(a.repo, a.kind) for a in evaluated}
+        stamp = now or datetime.now(UTC)
+        if stamp.tzinfo is None:
+            stamp = stamp.replace(tzinfo=UTC)
+        async with self._lock:
+            # Upsert active evaluator rows.
+            for alert in evaluated:
+                key = (alert.repo, alert.kind)
+                existing = self._alerts.get(key)
+                if existing is None or not existing.is_open():
+                    # Fresh alert, or a previously-resolved one re-firing.
+                    # Either way a new ``opened_at`` is appropriate.
+                    self._alerts[key] = FleetAlert(
+                        repo=alert.repo,
+                        kind=alert.kind,
+                        severity=alert.severity,
+                        summary=alert.summary,
+                        opened_at=alert.opened_at,
+                        resolved_at=None,
+                        details=dict(alert.details),
+                    )
+                else:
+                    # Update mutable fields but keep ``opened_at`` and
+                    # resolved_at=None so the alert's lifetime is preserved.
+                    existing.severity = alert.severity
+                    existing.summary = alert.summary
+                    existing.details = dict(alert.details)
+            # Resolve any stored alert the evaluator did not re-emit.
+            for key, alert in self._alerts.items():
+                if alert.is_open() and key not in current_keys:
+                    alert.resolved_at = stamp
+            return sorted(self._alerts.values(), key=lambda a: (a.repo, a.kind))
+
+    async def list(self, *, open_only: bool = False) -> list[FleetAlert]:
+        async with self._lock:
+            rows = list(self._alerts.values())
+        if open_only:
+            rows = [r for r in rows if r.is_open()]
+        rows.sort(key=lambda a: (a.repo, a.kind))
+        return rows
+
+    async def clear(self) -> None:
+        """Test helper — drop all stored alerts."""
+        async with self._lock:
+            self._alerts.clear()
+
+
+# Module singleton. Tests that need isolation call :func:`reset_alert_store_for_tests`.
+_ALERT_STORE = FleetAlertStore()
+
+
+def get_alert_store() -> FleetAlertStore:
+    return _ALERT_STORE
+
+
+def reset_alert_store_for_tests() -> None:
+    global _ALERT_STORE  # noqa: PLW0603
+    _ALERT_STORE = FleetAlertStore()
+
+
+__all__ = [
+    "AlertKind",
+    "AlertSeverity",
+    "FleetAlert",
+    "FleetAlertStore",
+    "evaluate_fleet_alerts",
+    "get_alert_store",
+    "reset_alert_store_for_tests",
+    "upsert_fleet_alerts",
+]

--- a/src/caretaker/fleet/api.py
+++ b/src/caretaker/fleet/api.py
@@ -22,6 +22,12 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from caretaker.fleet.alerts import (
+    FleetAlertStore,
+    evaluate_fleet_alerts,
+    get_alert_store,
+    upsert_fleet_alerts,
+)
 from caretaker.fleet.emitter import sign_payload
 from caretaker.fleet.store import FleetRegistryStore, get_store
 
@@ -30,6 +36,15 @@ logger = logging.getLogger(__name__)
 
 SECRET_ENV = "CARETAKER_FLEET_SECRET"
 SIGNATURE_HEADER = "X-Caretaker-Signature"
+
+
+# Module-level shims for the admin fleet-alerts endpoint's optional
+# dependencies. Populated by :func:`set_fleet_alert_dependencies` at admin
+# startup; left as ``None`` when the fleet routers are mounted alone. Kept
+# as globals (not FastAPI Depends) because the router is already a simple
+# mountable surface that the other fleet endpoints don't parameterize.
+_FLEET_ALERT_CONFIG: Any = None
+_FLEET_ALERT_GRAPH: Any = None
 
 
 public_router = APIRouter(prefix="/api/fleet", tags=["fleet"])
@@ -137,6 +152,83 @@ async def fleet_summary(
         "stale_threshold_days": 7,
         "version_distribution": version_counts,
     }
+
+
+@admin_router.get("/alerts")
+async def list_fleet_alerts(
+    open_only: bool = Query(
+        default=False,
+        alias="open",
+        description="Filter to open alerts only",
+    ),
+    _user: Any = _REQUIRE_SESSION,
+) -> dict[str, Any]:
+    """List fleet alerts.
+
+    Runs the alert evaluator over every registered repo's recent heartbeat
+    history, applies it to the admin-side alert store (which handles dedup
+    + resolution), and returns the resulting rows.
+
+    Set ``open=true`` to filter to alerts whose ``resolved_at`` is
+    still ``None``.
+
+    The evaluator is gated by :class:`~caretaker.config.FleetAlertConfig`
+    via dependency injection of ``app.state.maintainer_config`` when the
+    backend is configured with one; otherwise the evaluator runs with its
+    pydantic defaults so the endpoint is useful even in a bootstrap /
+    bare-registry deployment.
+    """
+    registry: FleetRegistryStore = get_store()
+    alert_store: FleetAlertStore = get_alert_store()
+
+    # Gather every repo's ring-buffer into a single list the evaluator can
+    # group by repo itself.
+    clients = await registry.list_clients()
+    batch: list[Any] = []
+    for client in clients:
+        batch.extend(await registry.recent_heartbeats(client.repo))
+
+    cfg_kwargs: dict[str, Any] = {}
+    main_cfg = _FLEET_ALERT_CONFIG
+    if main_cfg is not None:
+        alerts_cfg = main_cfg.fleet.alerts
+        if alerts_cfg.enabled:
+            cfg_kwargs = {
+                "goal_health_threshold": alerts_cfg.goal_health_threshold,
+                "goal_health_n_consecutive": alerts_cfg.goal_health_n_consecutive,
+                "error_spike_multiplier": alerts_cfg.error_spike_multiplier,
+                "ghosted_window_days": alerts_cfg.ghosted_window_days,
+            }
+        else:
+            # Feature disabled — return stored state without re-evaluating.
+            stored = await alert_store.list(open_only=open_only)
+            return {"items": [a.model_dump(mode="json") for a in stored]}
+
+    evaluated = evaluate_fleet_alerts(batch, **cfg_kwargs)
+    merged = await alert_store.apply(evaluated)
+
+    # Best-effort graph mirror — ``upsert_fleet_alerts`` is fire-and-forget.
+    upsert_fleet_alerts(merged, graph=_FLEET_ALERT_GRAPH)
+
+    rows = await alert_store.list(open_only=open_only)
+    return {"items": [a.model_dump(mode="json") for a in rows]}
+
+
+def set_fleet_alert_dependencies(
+    *,
+    maintainer_config: Any | None = None,
+    graph_store: Any | None = None,
+) -> None:
+    """Inject the admin-side config + graph store for the alert endpoint.
+
+    Called once at admin app startup. Kept as module-level globals (rather
+    than FastAPI ``Depends``) so the existing fleet routers retain their
+    simple mountable shape — the admin dashboard already drives all other
+    fleet endpoints the same way.
+    """
+    global _FLEET_ALERT_CONFIG, _FLEET_ALERT_GRAPH  # noqa: PLW0603
+    _FLEET_ALERT_CONFIG = maintainer_config
+    _FLEET_ALERT_GRAPH = graph_store
 
 
 @admin_router.get("/{owner}/{repo}")

--- a/src/caretaker/fleet/store.py
+++ b/src/caretaker/fleet/store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -53,11 +54,19 @@ class FleetClient:
         }
 
 
+#: Ring-buffer cap for per-repo heartbeat history. Alerts only ever look at the
+#: most recent handful of heartbeats (N consecutive goal-health dips, error
+#: spike vs. prior mean), so a short bounded deque is plenty and keeps the
+#: store memory O(#repos).
+_HEARTBEAT_HISTORY_MAXLEN = 32
+
+
 class FleetRegistryStore:
     """Async-safe in-memory fleet registry."""
 
     def __init__(self) -> None:
         self._clients: dict[str, FleetClient] = {}
+        self._history: dict[str, deque[dict[str, Any]]] = {}
         self._lock = asyncio.Lock()
 
     async def record_heartbeat(self, payload: dict[str, Any]) -> FleetClient:
@@ -99,7 +108,41 @@ class FleetRegistryStore:
                 heartbeats_seen=(existing.heartbeats_seen if existing else 0) + 1,
             )
             self._clients[repo] = record
+            history = self._history.setdefault(repo, deque(maxlen=_HEARTBEAT_HISTORY_MAXLEN))
+            # Keep a copy so later mutation of ``payload`` by the caller
+            # can't corrupt the history record.
+            snapshot: dict[str, Any] = {
+                "repo": repo,
+                "caretaker_version": record.caretaker_version,
+                "run_at": run_at,
+                "mode": record.last_mode,
+                "enabled_agents": list(record.enabled_agents),
+                "goal_health": record.last_goal_health,
+                "error_count": record.last_error_count,
+                "counters": dict(record.last_counters),
+                "summary": record.last_summary,
+            }
+            history.append(snapshot)
             return record
+
+    async def recent_heartbeats(
+        self, repo: str, *, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Return the bounded heartbeat ring buffer for ``repo``, oldest-first.
+
+        Each entry is a dict with the same shape the emitter sends, normalised
+        (``run_at`` is a ``datetime`` with tzinfo). Used by the alert evaluator
+        so alerts can reason about N consecutive heartbeats without touching
+        every caller that already has just the last one.
+        """
+        async with self._lock:
+            buf = self._history.get(repo)
+            if not buf:
+                return []
+            items = list(buf)
+        if limit is not None and limit >= 0:
+            items = items[-limit:]
+        return items
 
     async def list_clients(self) -> list[FleetClient]:
         async with self._lock:

--- a/src/caretaker/graph/models.py
+++ b/src/caretaker/graph/models.py
@@ -56,6 +56,13 @@ class NodeType(StrEnum):
     # :class:`~caretaker.graph.writer.GraphWriter` so agents publish the
     # fact they started a run without waiting on Neo4j.
     AGENT_CORE_MEMORY = "AgentCoreMemory"
+    # ── T-E4: fleet alerts ───────────────────────────────────────────────
+    # One ``:FleetAlert`` node per ``(repo, kind)`` tuple. The evaluator in
+    # :mod:`caretaker.fleet.alerts` opens alerts when heartbeat metrics
+    # regress and resolves them when the metric clears; both transitions
+    # are mirrored into the graph via ``merge_node`` so cypher can answer
+    # "which repos are currently alerting?" across the fleet.
+    FLEET_ALERT = "FleetAlert"
 
 
 class RelType(StrEnum):

--- a/tests/test_fleet_alerts.py
+++ b/tests/test_fleet_alerts.py
@@ -1,0 +1,480 @@
+"""Tests for the T-E4 :FleetAlert evaluator + admin endpoint.
+
+Covers:
+
+* Each alert ``kind`` trips on the right heartbeat shape.
+* Deduplication: re-running the evaluator on the same batch does not
+  double-emit. The admin-side alert store preserves ``opened_at`` across
+  re-evaluation.
+* Resolution flow: a metric that clears threshold flips ``resolved_at``
+  and drops out of the ``open=true`` listing.
+* Admin endpoint ``GET /api/admin/fleet/alerts?open=true`` behaviour.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from caretaker.config import FleetAlertConfig, FleetConfig, MaintainerConfig
+from caretaker.fleet import (
+    FleetAlert,
+    FleetAlertStore,
+    FleetHeartbeat,
+    admin_router,
+    evaluate_fleet_alerts,
+    get_alert_store,
+    public_router,
+    reset_alert_store_for_tests,
+    reset_store_for_tests,
+    set_fleet_alert_dependencies,
+    upsert_fleet_alerts,
+)
+from caretaker.graph.models import NodeType
+
+
+def _hb(
+    repo: str,
+    *,
+    run_at: datetime,
+    goal_health: float | None = None,
+    error_count: int = 0,
+    summary: dict[str, Any] | None = None,
+) -> FleetHeartbeat:
+    return FleetHeartbeat(
+        repo=repo,
+        caretaker_version="0.14.0",
+        run_at=run_at,
+        mode="full",
+        enabled_agents=["pr_agent"],
+        goal_health=goal_health,
+        error_count=error_count,
+        counters={},
+        summary=summary,
+    )
+
+
+_T0 = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+
+
+# ── Config defaults ──────────────────────────────────────────────────────
+
+
+def test_fleet_alert_config_defaults() -> None:
+    cfg = MaintainerConfig()
+    assert cfg.fleet.alerts.enabled is False
+    assert cfg.fleet.alerts.goal_health_threshold == pytest.approx(0.7)
+    assert cfg.fleet.alerts.goal_health_n_consecutive == 3
+    assert cfg.fleet.alerts.error_spike_multiplier == pytest.approx(3.0)
+    assert cfg.fleet.alerts.ghosted_window_days == 7
+
+
+def test_fleet_alert_config_round_trip(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    yaml_path = tmp_path / "config.yml"
+    yaml_path.write_text(
+        "version: v1\n"
+        "fleet:\n"
+        "  alerts:\n"
+        "    enabled: true\n"
+        "    goal_health_threshold: 0.8\n"
+        "    goal_health_n_consecutive: 2\n"
+    )
+    cfg = MaintainerConfig.from_yaml(yaml_path)
+    assert cfg.fleet.alerts.enabled is True
+    assert cfg.fleet.alerts.goal_health_threshold == pytest.approx(0.8)
+    assert cfg.fleet.alerts.goal_health_n_consecutive == 2
+
+
+# ── evaluate_fleet_alerts — per-kind tripping ───────────────────────────
+
+
+def test_goal_health_regression_trips_on_n_consecutive_low() -> None:
+    hbs = [
+        _hb("a/b", run_at=_T0 - timedelta(hours=3), goal_health=0.9),
+        _hb("a/b", run_at=_T0 - timedelta(hours=2), goal_health=0.4),
+        _hb("a/b", run_at=_T0 - timedelta(hours=1), goal_health=0.5),
+        _hb("a/b", run_at=_T0, goal_health=0.6),
+    ]
+    alerts = evaluate_fleet_alerts(
+        hbs,
+        goal_health_threshold=0.7,
+        goal_health_n_consecutive=3,
+        now=_T0,
+    )
+    kinds = [a.kind for a in alerts]
+    assert "goal_health_regression" in kinds
+    gh = next(a for a in alerts if a.kind == "goal_health_regression")
+    assert gh.repo == "a/b"
+    assert gh.details["samples"] == [0.4, 0.5, 0.6]
+
+
+def test_goal_health_regression_does_not_trip_when_any_sample_recovers() -> None:
+    hbs = [
+        _hb("a/b", run_at=_T0 - timedelta(hours=2), goal_health=0.4),
+        _hb("a/b", run_at=_T0 - timedelta(hours=1), goal_health=0.9),  # recovery
+        _hb("a/b", run_at=_T0, goal_health=0.5),
+    ]
+    alerts = evaluate_fleet_alerts(
+        hbs,
+        goal_health_threshold=0.7,
+        goal_health_n_consecutive=3,
+        now=_T0,
+    )
+    assert not any(a.kind == "goal_health_regression" for a in alerts)
+
+
+def test_error_spike_trips_on_sudden_jump() -> None:
+    hbs = [
+        _hb("a/b", run_at=_T0 - timedelta(hours=3), error_count=0),
+        _hb("a/b", run_at=_T0 - timedelta(hours=2), error_count=0),
+        _hb("a/b", run_at=_T0 - timedelta(hours=1), error_count=1),
+        _hb("a/b", run_at=_T0, error_count=10),  # big jump
+    ]
+    alerts = evaluate_fleet_alerts(hbs, error_spike_multiplier=3.0, now=_T0)
+    spike = next(a for a in alerts if a.kind == "error_spike")
+    assert spike.repo == "a/b"
+    assert spike.details["latest_error_count"] == 10
+
+
+def test_error_spike_floors_mean_at_one_so_zero_to_three_trips() -> None:
+    hbs = [
+        _hb("a/b", run_at=_T0 - timedelta(hours=2), error_count=0),
+        _hb("a/b", run_at=_T0 - timedelta(hours=1), error_count=0),
+        _hb("a/b", run_at=_T0, error_count=3),
+    ]
+    alerts = evaluate_fleet_alerts(hbs, error_spike_multiplier=3.0, now=_T0)
+    assert any(a.kind == "error_spike" for a in alerts)
+
+
+def test_ghosted_trips_when_last_seen_older_than_window() -> None:
+    hbs = [_hb("a/b", run_at=_T0 - timedelta(days=10), goal_health=0.9)]
+    alerts = evaluate_fleet_alerts(hbs, ghosted_window_days=7, now=_T0)
+    ghosted = next(a for a in alerts if a.kind == "ghosted")
+    assert ghosted.repo == "a/b"
+    assert ghosted.details["age_days"] == 10
+
+
+def test_ghosted_does_not_trip_inside_window() -> None:
+    hbs = [_hb("a/b", run_at=_T0 - timedelta(days=3), goal_health=0.9)]
+    alerts = evaluate_fleet_alerts(hbs, ghosted_window_days=7, now=_T0)
+    assert not any(a.kind == "ghosted" for a in alerts)
+
+
+def test_scope_gap_trips_on_flag_in_summary() -> None:
+    hbs = [
+        _hb(
+            "a/b",
+            run_at=_T0,
+            goal_health=0.9,
+            summary={"scope_gap_open": True, "scope_gap_count": 2},
+        )
+    ]
+    alerts = evaluate_fleet_alerts(hbs, now=_T0)
+    assert any(a.kind == "scope_gap" for a in alerts)
+
+
+def test_scope_gap_trips_on_nested_shape() -> None:
+    hbs = [
+        _hb(
+            "a/b",
+            run_at=_T0,
+            goal_health=0.9,
+            summary={"scope_gap": {"open": True, "scope_hint": "workflow", "count": 3}},
+        )
+    ]
+    alerts = evaluate_fleet_alerts(hbs, now=_T0)
+    scope_gap = next(a for a in alerts if a.kind == "scope_gap")
+    assert "workflow" in scope_gap.summary
+
+
+def test_scope_gap_quiet_when_no_flag() -> None:
+    hbs = [_hb("a/b", run_at=_T0, goal_health=0.9, summary={"other": 1})]
+    alerts = evaluate_fleet_alerts(hbs, now=_T0)
+    assert not any(a.kind == "scope_gap" for a in alerts)
+
+
+# ── Deduplication ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_evaluate_twice_yields_same_alert_set_and_store_dedups() -> None:
+    store = FleetAlertStore()
+    hbs = [
+        _hb("a/b", run_at=_T0 - timedelta(hours=2), goal_health=0.3),
+        _hb("a/b", run_at=_T0 - timedelta(hours=1), goal_health=0.4),
+        _hb("a/b", run_at=_T0, goal_health=0.5),
+    ]
+    first = evaluate_fleet_alerts(hbs, now=_T0)
+    second = evaluate_fleet_alerts(hbs, now=_T0)
+    assert [a.model_dump() for a in first] == [a.model_dump() for a in second]
+
+    merged_a = await store.apply(first)
+    merged_b = await store.apply(second, now=_T0 + timedelta(minutes=1))
+    # Same set of alerts; opened_at from the first apply is preserved,
+    # no ``resolved_at`` populated because the metric still trips.
+    assert len(merged_a) == len(merged_b) == 1
+    assert merged_a[0].opened_at == merged_b[0].opened_at
+    assert merged_b[0].resolved_at is None
+
+
+# ── Resolution flow ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolution_populates_resolved_at_and_admin_omits_when_open_only() -> None:
+    store = FleetAlertStore()
+    hbs_bad = [
+        _hb("a/b", run_at=_T0 - timedelta(hours=2), goal_health=0.3),
+        _hb("a/b", run_at=_T0 - timedelta(hours=1), goal_health=0.4),
+        _hb("a/b", run_at=_T0, goal_health=0.5),
+    ]
+    alerts_bad = evaluate_fleet_alerts(hbs_bad, now=_T0)
+    assert any(a.kind == "goal_health_regression" for a in alerts_bad)
+    await store.apply(alerts_bad, now=_T0)
+
+    # Next pass: metric recovers → evaluator emits nothing → store flips
+    # resolved_at on the previously-open alert.
+    hbs_ok = [
+        _hb("a/b", run_at=_T0, goal_health=0.5),
+        _hb("a/b", run_at=_T0 + timedelta(hours=1), goal_health=0.9),
+        _hb("a/b", run_at=_T0 + timedelta(hours=2), goal_health=0.95),
+    ]
+    alerts_ok = evaluate_fleet_alerts(hbs_ok, now=_T0 + timedelta(hours=2))
+    assert not any(a.kind == "goal_health_regression" for a in alerts_ok)
+    merged = await store.apply(alerts_ok, now=_T0 + timedelta(hours=2))
+
+    gh = next(a for a in merged if a.kind == "goal_health_regression")
+    assert gh.resolved_at is not None
+
+    open_rows = await store.list(open_only=True)
+    assert not any(a.kind == "goal_health_regression" for a in open_rows)
+    all_rows = await store.list(open_only=False)
+    assert any(a.kind == "goal_health_regression" for a in all_rows)
+
+
+# ── upsert_fleet_alerts — graph mirror ──────────────────────────────────
+
+
+class _RecordingGraph:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def merge_node(self, label: str, node_id: str, properties: dict[str, Any]) -> None:
+        self.calls.append((label, node_id, properties))
+
+
+@pytest.mark.asyncio
+async def test_upsert_fleet_alerts_writes_fleet_alert_nodes() -> None:
+    graph = _RecordingGraph()
+    alerts = [
+        FleetAlert(
+            repo="a/b",
+            kind="goal_health_regression",
+            severity="warning",
+            summary="goal_health low",
+            opened_at=_T0,
+        ),
+    ]
+    upsert_fleet_alerts(alerts, graph=graph)
+    # upsert schedules a task; wait a tick for it to run on the current loop.
+    import asyncio as _asyncio
+
+    for _ in range(10):
+        if graph.calls:
+            break
+        await _asyncio.sleep(0)
+    assert graph.calls, "merge_node was not called"
+    label, node_id, props = graph.calls[0]
+    assert label == NodeType.FLEET_ALERT
+    assert node_id == "fleet_alert:a_b:goal_health_regression"
+    assert props["status"] == "open"
+    assert props["resolved_at"] is None
+
+
+# ── Admin endpoint ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fleet_alerts_client(monkeypatch):  # type: ignore[no-untyped-def]
+    from caretaker.admin import auth as admin_auth
+
+    reset_store_for_tests()
+    reset_alert_store_for_tests()
+    monkeypatch.delenv("CARETAKER_FLEET_SECRET", raising=False)
+    # Enable the evaluator via an injected config so the endpoint exercises
+    # the full path (not the short-circuit "disabled" branch).
+    set_fleet_alert_dependencies(
+        maintainer_config=MaintainerConfig(
+            fleet=FleetConfig(alerts=FleetAlertConfig(enabled=True)),
+        ),
+        graph_store=None,
+    )
+
+    app = FastAPI()
+    app.include_router(public_router)
+    app.include_router(admin_router)
+
+    async def _fake_user():  # noqa: ANN202
+        return admin_auth.UserInfo(sub="test", email="test@example.com", name="Test", picture=None)
+
+    app.dependency_overrides[admin_auth.require_session] = _fake_user
+    yield TestClient(app)
+    set_fleet_alert_dependencies(maintainer_config=None, graph_store=None)
+
+
+def _post_heartbeat(
+    client: TestClient,
+    repo: str,
+    *,
+    run_at: datetime,
+    goal_health: float | None = None,
+    error_count: int = 0,
+    summary: dict[str, Any] | None = None,
+) -> None:
+    body = {
+        "repo": repo,
+        "caretaker_version": "0.14.0",
+        "run_at": run_at.isoformat(),
+        "mode": "full",
+        "enabled_agents": ["pr_agent"],
+        "goal_health": goal_health,
+        "error_count": error_count,
+        "counters": {},
+    }
+    if summary is not None:
+        body["summary"] = summary
+    resp = client.post("/api/fleet/heartbeat", json=body)
+    assert resp.status_code == 200, resp.text
+
+
+def test_admin_alerts_endpoint_returns_open_only_when_flag_set(  # type: ignore[no-untyped-def]
+    fleet_alerts_client,
+) -> None:
+    client = fleet_alerts_client
+    base = _T0
+    # Three consecutive low goal_health heartbeats trip the alert.
+    for i, score in enumerate([0.3, 0.4, 0.5]):
+        _post_heartbeat(
+            client,
+            "a/b",
+            run_at=base + timedelta(hours=i),
+            goal_health=score,
+        )
+
+    resp = client.get("/api/admin/fleet/alerts?open=true")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    kinds = [a["kind"] for a in items]
+    assert "goal_health_regression" in kinds
+    assert all(a["resolved_at"] is None for a in items)
+
+    # Without open=true, resolved rows would also appear — we haven't
+    # resolved anything yet so the set is identical.
+    resp_all = client.get("/api/admin/fleet/alerts")
+    assert resp_all.status_code == 200
+    assert len(resp_all.json()["items"]) == len(items)
+
+
+def test_admin_alerts_endpoint_resolution_flow(  # type: ignore[no-untyped-def]
+    fleet_alerts_client,
+) -> None:
+    client = fleet_alerts_client
+    base = _T0
+    for i, score in enumerate([0.3, 0.4, 0.5]):
+        _post_heartbeat(
+            client,
+            "a/b",
+            run_at=base + timedelta(hours=i),
+            goal_health=score,
+        )
+    # Trigger one evaluation so the alert is recorded in the store.
+    first = client.get("/api/admin/fleet/alerts?open=true").json()
+    assert any(a["kind"] == "goal_health_regression" for a in first["items"])
+
+    # Now send three healthy heartbeats — this pushes the bad ones out of
+    # the last-N window AND adds fresh high-score samples so the evaluator
+    # no longer trips. The store flips resolved_at.
+    for i, score in enumerate([0.9, 0.95, 0.92]):
+        _post_heartbeat(
+            client,
+            "a/b",
+            run_at=base + timedelta(hours=10 + i),
+            goal_health=score,
+        )
+
+    resolved = client.get("/api/admin/fleet/alerts?open=true").json()
+    assert not any(a["kind"] == "goal_health_regression" for a in resolved["items"])
+
+    all_rows = client.get("/api/admin/fleet/alerts").json()
+    gh = next(a for a in all_rows["items"] if a["kind"] == "goal_health_regression")
+    assert gh["resolved_at"] is not None
+
+
+def test_admin_alerts_endpoint_disabled_returns_stored_state_only(  # type: ignore[no-untyped-def]
+    monkeypatch,
+) -> None:
+    """When config.fleet.alerts.enabled is False the endpoint must not
+    re-evaluate — it just returns whatever the alert store already has.
+    This is the default posture for the feature."""
+    from caretaker.admin import auth as admin_auth
+
+    reset_store_for_tests()
+    reset_alert_store_for_tests()
+    monkeypatch.delenv("CARETAKER_FLEET_SECRET", raising=False)
+    set_fleet_alert_dependencies(
+        maintainer_config=MaintainerConfig(),  # default: alerts disabled
+        graph_store=None,
+    )
+    app = FastAPI()
+    app.include_router(public_router)
+    app.include_router(admin_router)
+
+    async def _fake_user():  # noqa: ANN202
+        return admin_auth.UserInfo(sub="test", email="test@example.com", name="Test", picture=None)
+
+    app.dependency_overrides[admin_auth.require_session] = _fake_user
+    with TestClient(app) as client:
+        for i, score in enumerate([0.3, 0.4, 0.5]):
+            _post_heartbeat(
+                client,
+                "a/b",
+                run_at=_T0 + timedelta(hours=i),
+                goal_health=score,
+            )
+        # Alerts disabled → evaluator does not run → store is empty.
+        resp = client.get("/api/admin/fleet/alerts")
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+
+    set_fleet_alert_dependencies(maintainer_config=None, graph_store=None)
+
+
+# ── FleetAlert model ────────────────────────────────────────────────────
+
+
+def test_fleet_alert_summary_max_length() -> None:
+    with pytest.raises(ValueError):
+        FleetAlert(
+            repo="a/b",
+            kind="ghosted",
+            severity="warning",
+            summary="x" * 241,
+            opened_at=_T0,
+        )
+
+
+def test_fleet_alert_is_open() -> None:
+    a = FleetAlert(repo="a/b", kind="ghosted", severity="warning", summary="x", opened_at=_T0)
+    assert a.is_open()
+    a.resolved_at = _T0
+    assert not a.is_open()
+
+
+def test_get_alert_store_singleton_survives_test_reset() -> None:
+    store = get_alert_store()
+    reset_alert_store_for_tests()
+    assert get_alert_store() is not store


### PR DESCRIPTION
## Summary

- Add a thin alerting path on top of existing fleet heartbeats. `evaluate_fleet_alerts` is a pure function over a batch of `FleetHeartbeat` rows that emits `FleetAlert` entries for four kinds:
  - `goal_health_regression` — last N heartbeats all below threshold.
  - `error_spike` — latest `error_count` ≥ `prior_mean × multiplier` (prior_mean floored at 1 so 0→3 still trips).
  - `ghosted` — no heartbeat in the configured window.
  - `scope_gap` — piggybacks on the existing tracker via `summary.scope_gap_open` / nested shapes.
- `FleetAlertStore` dedups on `(repo, kind)`, preserves `opened_at` across re-evaluation, and flips `resolved_at` when a previously-open alert is no longer emitted.
- `upsert_fleet_alerts` mirrors every alert to the graph as a `:FleetAlert` node (best-effort, fire-and-forget) using a new `NodeType.FLEET_ALERT`.
- New admin endpoint `GET /api/admin/fleet/alerts?open=true` runs the evaluator over every repo's bounded heartbeat ring buffer (new `FleetRegistryStore.recent_heartbeats`) and returns merged / resolved alerts.
- New `FleetAlertConfig` attached to `FleetConfig.alerts` holds the thresholds. `enabled: false` by default — when disabled, the endpoint returns stored state without re-evaluating so existing deployments are byte-identical.

## Test plan

- [x] `PYTHONPATH="$PWD/src" pytest -q` — 1579 passed, 1 skipped
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src/caretaker` — no new errors introduced (pre-existing `k8s_worker/launcher.py` errors unrelated)
- [x] Each alert `kind` has a dedicated test that trips it
- [x] Deduplication test: two evaluator passes on identical data produce one stored alert with a preserved `opened_at`
- [x] Resolution test: healthy heartbeats after a regression flip `resolved_at` and drop the alert from `open=true`
- [x] Admin endpoint tests for `open=true` filtering, resolution flow, and the disabled-feature short-circuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)