### PR TITLE
feat(dependency_agent): grouped-dependabot bisector

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -279,12 +279,24 @@ class SecurityAgentConfig(StrictBaseModel):
     include_secret_scanning: bool = True
 
 
+class DependencyBisectorConfig(StrictBaseModel):
+    """Configuration for the grouped-Dependabot PR bisector."""
+
+    enabled: bool = False
+    max_runs: int = 6
+    # Label that marks PRs Caretaker has claimed. The bisector only
+    # fires on grouped PRs that carry this label to avoid acting on
+    # third-party-owned PRs.
+    owned_label: str = "caretaker:owned"
+
+
 class DependencyAgentConfig(StrictBaseModel):
     enabled: bool = True
     auto_merge_patch: bool = True
     auto_merge_minor: bool = True
     merge_method: Literal["squash", "merge", "rebase"] = "squash"
     post_digest: bool = True
+    bisector: DependencyBisectorConfig = Field(default_factory=DependencyBisectorConfig)
 
 
 class DocsAgentConfig(StrictBaseModel):

--- a/src/caretaker/dependency_agent/adapter.py
+++ b/src/caretaker/dependency_agent/adapter.py
@@ -35,6 +35,9 @@ class DependencyAgentAdapter(BaseAgent):
             auto_merge_minor=cfg.auto_merge_minor,
             merge_method=cfg.merge_method,
             post_digest=cfg.post_digest,
+            bisector_enabled=cfg.bisector.enabled,
+            bisector_max_runs=cfg.bisector.max_runs,
+            bisector_owned_label=cfg.bisector.owned_label,
         )
         report = await agent.run()
         return AgentResult(
@@ -43,6 +46,7 @@ class DependencyAgentAdapter(BaseAgent):
             extra={
                 "prs_auto_merged": report.prs_auto_merged,
                 "major_issues_created": report.major_issues_created,
+                "bisector_plans_posted": report.bisector_plans_posted,
             },
         )
 

--- a/src/caretaker/dependency_agent/agent.py
+++ b/src/caretaker/dependency_agent/agent.py
@@ -8,12 +8,19 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
+from caretaker.dependency_agent.bisector import (
+    BISECTOR_COMMENT_MARKER,
+    BisectResult,
+    bisect_grouped_dependabot_pr,
+    format_bisect_comment,
+)
 from caretaker.identity import classify_identity
 from caretaker.tools.github import GitHubIssueTools
 
 if TYPE_CHECKING:
+    from caretaker.dependency_agent.bisector import CIProbe
     from caretaker.github_client.api import GitHubClient
-    from caretaker.github_client.models import Issue
+    from caretaker.github_client.models import Issue, PullRequest
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +57,8 @@ class DependencyReport:
     major_issues_created: list[int] = field(default_factory=list)
     digest_issue_number: int | None = None
     errors: list[str] = field(default_factory=list)
+    # PR numbers where the bisector posted an advisory merge plan.
+    bisector_plans_posted: list[int] = field(default_factory=list)
 
 
 class DependencyAgent:
@@ -69,6 +78,9 @@ class DependencyAgent:
         auto_merge_minor: bool = True,
         merge_method: str = "squash",
         post_digest: bool = True,
+        bisector_enabled: bool = False,
+        bisector_max_runs: int = 6,
+        bisector_owned_label: str = "caretaker:owned",
     ) -> None:
         self._github = github
         self._owner = owner
@@ -77,6 +89,9 @@ class DependencyAgent:
         self._auto_merge_minor = auto_merge_minor
         self._merge_method = merge_method
         self._post_digest = post_digest
+        self._bisector_enabled = bisector_enabled
+        self._bisector_max_runs = bisector_max_runs
+        self._bisector_owned_label = bisector_owned_label
         self._issues = GitHubIssueTools(github, owner, repo)
 
     async def run(self) -> DependencyReport:
@@ -153,6 +168,28 @@ class DependencyAgent:
                     )
                     report.errors.append(str(e))
 
+        # Bisector hook: for each Dependabot PR that is grouped
+        # (i.e. has no parseable single-bump title) AND carries the
+        # ``caretaker:owned`` label AND is mergeable-but-unstable,
+        # post an advisory plan comment. Gated behind an explicit
+        # config knob; default off.
+        if self._bisector_enabled:
+            unparsed_prs = [
+                pr for pr, bump in zip(dep_prs, bumps_raw, strict=False) if bump is None
+            ]
+            for pr in unparsed_prs:
+                try:
+                    posted = await self._maybe_run_bisector(pr)
+                    if posted:
+                        report.bisector_plans_posted.append(pr.number)
+                except Exception as e:
+                    logger.warning(
+                        "Dependency agent: bisector failed for PR#%d: %s",
+                        pr.number,
+                        e,
+                    )
+                    report.errors.append(str(e))
+
         # Post weekly digest
         if self._post_digest and bumps:
             try:
@@ -163,6 +200,88 @@ class DependencyAgent:
                 report.errors.append(str(e))
 
         return report
+
+    async def _maybe_run_bisector(
+        self,
+        pr: PullRequest,
+        *,
+        ci_probe: CIProbe | None = None,
+    ) -> bool:
+        """Run the grouped-dependabot bisector against ``pr`` if applicable.
+
+        Returns ``True`` when an advisory plan comment was posted.
+
+        Firing conditions:
+        * PR carries the configured ``owned_label`` (default
+          ``caretaker:owned``). Without this label Caretaker has not
+          claimed ownership and must not act.
+        * PR is ``MERGEABLE UNSTABLE`` (mergeable=True AND latest CI
+          verdict is not ``success``). Green PRs and conflicted PRs
+          are skipped; conflicted PRs are the Dependabot-rebase
+          agent's problem.
+        * The PR body contains a grouped-update preamble (parser
+          returns ≥ 2 updates). Non-grouped PRs fall through to the
+          per-package bump flow.
+        * No prior bisector comment exists on the PR (idempotent —
+          we don't spam on every poll).
+        """
+        if not pr.has_label(self._bisector_owned_label):
+            return False
+
+        mergeable = getattr(pr, "mergeable", None)
+        if mergeable is False:
+            return False
+
+        # CI must be non-green for there to be anything to bisect.
+        try:
+            ci_status = await self._github.get_combined_status(
+                self._owner, self._repo, str(pr.number)
+            )
+        except Exception as e:
+            logger.warning(
+                "Dependency agent: could not read CI status for PR#%d: %s",
+                pr.number,
+                e,
+            )
+            return False
+        if ci_status == "success":
+            return False
+
+        # Idempotency check: skip if we've already posted a plan.
+        try:
+            existing = await self._github.get_pr_comments(self._owner, self._repo, pr.number)
+        except Exception:
+            existing = []
+        if any(BISECTOR_COMMENT_MARKER in (c.body or "") for c in existing):
+            logger.info("Dependency agent: bisect comment already present on PR#%d", pr.number)
+            return False
+
+        result: BisectResult = await bisect_grouped_dependabot_pr(
+            pr,
+            github=self._github,
+            max_runs=self._bisector_max_runs,
+            ci_probe=ci_probe,
+        )
+        if result.outcome == "inconclusive" and result.reason == "not_grouped":
+            return False
+
+        body = format_bisect_comment(result)
+        try:
+            await self._github.add_issue_comment(self._owner, self._repo, pr.number, body)
+        except Exception as e:
+            logger.warning(
+                "Dependency agent: failed to post bisect comment on PR#%d: %s",
+                pr.number,
+                e,
+            )
+            return False
+        logger.info(
+            "Dependency agent: posted bisect plan on PR#%d (%s, runs=%d)",
+            pr.number,
+            result.outcome,
+            result.runs_consumed,
+        )
+        return True
 
     async def _get_existing_major_issue_prs(self) -> set[int]:
         """Return PR numbers that already have open major-upgrade tracking issues."""

--- a/src/caretaker/dependency_agent/bisector.py
+++ b/src/caretaker/dependency_agent/bisector.py
@@ -1,0 +1,626 @@
+"""Grouped-dependabot PR bisector.
+
+When Dependabot ships a grouped PR that bundles many package updates
+together (for example ``npm_and_yarn across 4 directories, 19 updates``)
+the PR can land with ``MERGEABLE UNSTABLE``: one update in the bundle
+broke CI but Caretaker has no way to tell which. Merging the whole
+bundle is not safe; closing it loses every safe update.
+
+This module parses the Dependabot PR body into a structured list of
+``PackageUpdate`` rows and narrows the failing bundle down to a short
+``suggested_merge_plan`` that a maintainer (or a follow-up agent) can
+execute. The default integration is advisory: a comment is posted on
+the PR summarising the plan. The actual CI-driven branch-bisect loop
+(create-branch / push / wait-for-CI / narrow) is documented as a
+follow-up and gated behind
+``DependencyAgentConfig.bisector.enabled``.
+
+Scope notes
+-----------
+* The parser understands Dependabot's ``Bumps the <ecosystem> group
+  with N updates in the <dir> directory`` preamble plus the per-row
+  "Updates <name> from X to Y" statements. Multi-directory and
+  single-update blocks (``Bumps the npm_and_yarn group with 1 update
+  in the /embed directory: [vite]...``) are both handled.
+* ``bisect_grouped_dependabot_pr`` is **async**; when no
+  ``ci_probe`` is supplied it falls back to a pure planner that
+  emits an advisory merge plan and reports ``outcome="inconclusive"``
+  with reason ``no_probe_configured``. Callers that want the real
+  bisect loop can pass a coroutine that creates a probe branch
+  applying the subset, waits for CI, and returns the outcome.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from caretaker.github_client.api import GitHubClient
+    from caretaker.github_client.models import PullRequest
+
+logger = logging.getLogger(__name__)
+
+# Marker so caretaker can recognise its own bisect comments on subsequent
+# runs and avoid duplicate-posting them.
+BISECTOR_COMMENT_MARKER = "<!-- caretaker:dependency-bisect -->"
+
+Ecosystem = Literal["npm", "pip", "cargo", "gomod", "bundler", "other"]
+
+# "Bumps the npm_and_yarn group with 10 updates in the /backend directory:"
+# "Bumps the npm_and_yarn group with 1 update in the /embed directory: [vite]..."
+_GROUP_HEADER_RE = re.compile(
+    r"Bumps?\s+the\s+(?P<ecosystem>[A-Za-z0-9_.\-]+)\s+group\s+with\s+"
+    r"(?P<count>\d+)\s+updates?\s+in\s+the\s+(?P<directory>\S+)\s+directory",
+    re.IGNORECASE,
+)
+
+# Matches a Dependabot markdown table row listing one update:
+# "| [express-rate-limit](https://…) | `8.2.1` | `8.3.2` |"
+# Also matches rows without the link form: "| minimatch | `3.1.2` | `3.1.5` |"
+_TABLE_ROW_RE = re.compile(
+    r"^\|\s*"
+    r"(?:\[(?P<name_linked>[^\]]+)\]\([^)]+\)|(?P<name_plain>[^|`\[\]]+?))"
+    r"\s*\|\s*"
+    r"`(?P<from_version>[^`]+)`"
+    r"\s*\|\s*"
+    r"`(?P<to_version>[^`]+)`"
+    r"\s*\|\s*$",
+    re.MULTILINE,
+)
+
+# Fallback per-update paragraph form:
+# "Updates `express-rate-limit` from 8.2.1 to 8.3.2"
+# Version chars: digits, letters, dots, dashes, plus, underscore (covers
+# semver, pre-releases like 8.0.0a1, and build metadata).
+_UPDATES_LINE_RE = re.compile(
+    r"Updates?\s+`(?P<name>[^`]+)`\s+from\s+"
+    r"(?P<from_version>[\w.\-+]+)\s+to\s+(?P<to_version>[\w.\-+]+)",
+    re.IGNORECASE,
+)
+
+# "Bumps the npm_and_yarn group with 1 update in the /embed directory:
+#   [vite](https://…)." — single update with package baked into header line.
+# Also matches the 2-update "inline" variant dependabot sometimes uses:
+# "...with 2 updates in the /web directory: [vite](...) and [vitest](...)."
+_INLINE_HEADER_RE = re.compile(
+    r"Bumps?\s+the\s+(?P<ecosystem>[A-Za-z0-9_.\-]+)\s+group\s+with\s+"
+    r"(?P<count>\d+)\s+updates?\s+in\s+the\s+(?P<directory>\S+)\s+directory:\s+"
+    r"(?P<tail>.+)$",
+    re.IGNORECASE,
+)
+
+# Extracts "[name](url)" link targets used as a package list inside
+# inline headers.
+_LINK_NAME_RE = re.compile(r"\[([^\]]+)\]\(")
+
+_ECOSYSTEM_NORMALISE: dict[str, Ecosystem] = {
+    "npm_and_yarn": "npm",
+    "npm": "npm",
+    "yarn": "npm",
+    "pip": "pip",
+    "pip_and_poetry": "pip",
+    "cargo": "cargo",
+    "gomod": "gomod",
+    "go_modules": "gomod",
+    "bundler": "bundler",
+}
+
+
+def _normalise_ecosystem(raw: str) -> Ecosystem:
+    return _ECOSYSTEM_NORMALISE.get(raw.lower(), "other")
+
+
+class PackageUpdate(BaseModel):
+    """One package update row inside a grouped Dependabot PR."""
+
+    ecosystem: Ecosystem
+    name: str
+    from_version: str
+    to_version: str
+    directory: str = "/"
+
+    @property
+    def slug(self) -> str:
+        """Short human identifier used in merge-plan strings."""
+        return f"{self.name} {self.from_version}->{self.to_version}"
+
+
+# Result of running a single CI probe against a subset of updates.
+# Callers wire a coroutine matching this signature when they want to
+# drive the real CI-backed bisect loop. The subset is the list of
+# updates the probe branch should apply; the implementation is
+# responsible for creating and pushing the branch, waiting for CI,
+# and returning a verdict.
+CIProbe = Callable[[list[PackageUpdate]], Awaitable["ProbeOutcome"]]
+
+
+class ProbeOutcome(BaseModel):
+    """Result of running CI on a subset of the grouped PR."""
+
+    passed: bool
+    reason: str = ""
+
+
+class BisectResult(BaseModel):
+    """Structured outcome of a bisect attempt on a grouped PR."""
+
+    outcome: Literal["all_green", "guilty_identified", "inconclusive", "error"]
+    guilty_updates: list[PackageUpdate] = Field(default_factory=list)
+    safe_updates: list[PackageUpdate] = Field(default_factory=list)
+    suggested_merge_plan: list[str] = Field(default_factory=list)
+    runs_consumed: int = 0
+    reason: str = ""
+
+
+# ────────────────────────────────────────────────────────────────────
+# Parser
+# ────────────────────────────────────────────────────────────────────
+
+
+def parse_grouped_pr_body(body: str) -> list[PackageUpdate]:
+    """Extract a ``list[PackageUpdate]`` from a Dependabot PR body.
+
+    The parser is permissive: it looks at the structured header blocks
+    ("Bumps the <ecosystem> group with N updates in the <dir>
+    directory: ...") to assign ecosystem and directory, then harvests
+    package rows from the markdown tables that follow (and, as a
+    fallback, from "Updates <foo> from X to Y" lines). Duplicate
+    ``(name, directory)`` pairs are de-duplicated to handle Dependabot
+    occasionally repeating a row in the "Updates" detail section.
+    """
+    if not body:
+        return []
+
+    # Pass 1: walk the header blocks and record (ecosystem, name,
+    # directory) tuples. Table rows carry their own version range;
+    # inline header lines list package names but defer version info
+    # to the global detail section.
+    pending: list[tuple[Ecosystem, str, str, str | None, str | None]] = []
+    seen_keys: set[tuple[str, str]] = set()
+
+    def _remember(
+        ecosystem: Ecosystem,
+        name: str,
+        directory: str,
+        from_version: str | None,
+        to_version: str | None,
+    ) -> None:
+        key = (name, directory)
+        if key in seen_keys:
+            return
+        seen_keys.add(key)
+        pending.append((ecosystem, name, directory, from_version, to_version))
+
+    current_ecosystem: Ecosystem = "other"
+    current_directory = "/"
+    in_header_block = False
+    in_table = False
+    details_started = False
+
+    for line in body.splitlines():
+        if line.startswith("Updates `") or line.startswith("Updates ["):
+            # Entering the per-package detail section; header blocks
+            # have all been consumed by this point.
+            details_started = True
+            in_header_block = False
+            in_table = False
+
+        if details_started:
+            continue
+
+        inline = _INLINE_HEADER_RE.search(line)
+        if inline:
+            current_ecosystem = _normalise_ecosystem(inline.group("ecosystem"))
+            current_directory = inline.group("directory")
+            in_header_block = True
+            in_table = False
+            for name in _LINK_NAME_RE.findall(inline.group("tail")):
+                cleaned = name.strip()
+                if cleaned:
+                    _remember(current_ecosystem, cleaned, current_directory, None, None)
+            continue
+
+        header = _GROUP_HEADER_RE.search(line)
+        if header:
+            current_ecosystem = _normalise_ecosystem(header.group("ecosystem"))
+            current_directory = header.group("directory")
+            in_header_block = True
+            in_table = False
+            continue
+
+        if in_header_block:
+            row = _TABLE_ROW_RE.match(line)
+            if row:
+                in_table = True
+                name = (row.group("name_linked") or row.group("name_plain") or "").strip()
+                if name and name.lower() not in {"package", "---"}:
+                    _remember(
+                        current_ecosystem,
+                        name,
+                        current_directory,
+                        row.group("from_version"),
+                        row.group("to_version"),
+                    )
+                continue
+            # A blank line after a table ends the header block's
+            # scope so a trailing per-update paragraph doesn't get
+            # mis-attributed to the last seen directory.
+            if in_table and not line.strip():
+                in_header_block = False
+                in_table = False
+
+    # Pass 2: collect global "Updates `x` from Y to Z" version ranges
+    # for names we recorded without versions (inline-single-update
+    # groups and the like). First occurrence wins.
+    detail_versions: dict[str, tuple[str, str]] = {}
+    for match in _UPDATES_LINE_RE.finditer(body):
+        name = match.group("name").strip()
+        if name in detail_versions:
+            continue
+        detail_versions[name] = (
+            match.group("from_version"),
+            match.group("to_version"),
+        )
+
+    result: list[PackageUpdate] = []
+    for ecosystem, name, directory, from_v, to_v in pending:
+        if from_v is None or to_v is None:
+            versions = detail_versions.get(name)
+            if versions is None:
+                # No version info anywhere in the PR body; drop the
+                # row rather than emitting a half-populated update.
+                continue
+            from_v, to_v = versions
+        result.append(
+            PackageUpdate(
+                ecosystem=ecosystem,
+                name=name,
+                from_version=from_v,
+                to_version=to_v,
+                directory=directory,
+            )
+        )
+
+    # Defensive fallback: no header blocks parsed but the body does
+    # contain "Updates `x` from Y to Z" lines. Preserve the original
+    # lenient behaviour so unusual PR shapes still produce
+    # ``PackageUpdate`` rows.
+    if not result and detail_versions:
+        for name, (from_v, to_v) in detail_versions.items():
+            result.append(
+                PackageUpdate(
+                    ecosystem="other",
+                    name=name,
+                    from_version=from_v,
+                    to_version=to_v,
+                    directory="/",
+                )
+            )
+
+    return result
+
+
+# ────────────────────────────────────────────────────────────────────
+# Plan synthesis
+# ────────────────────────────────────────────────────────────────────
+
+
+def synthesize_merge_plan(
+    *,
+    safe: list[PackageUpdate],
+    guilty: list[PackageUpdate],
+    inconclusive: list[PackageUpdate] | None = None,
+    budget_exhausted: bool = False,
+) -> list[str]:
+    """Turn bisect results into a human-readable merge plan.
+
+    The plan is an ordered list of short imperative strings ready to be
+    pasted into a PR comment. Examples:
+
+    * ``"Merge: react-dom 18.3.1"``
+    * ``"Hold: typescript 5.4.5 (breaks CI)"``
+    * ``"Open followup issue: typescript upgrade"``
+    """
+    plan: list[str] = []
+    for update in safe:
+        plan.append(f"Merge: {update.slug} ({update.directory})")
+    for update in guilty:
+        plan.append(f"Hold: {update.slug} ({update.directory}) — breaks CI")
+        plan.append(f"Open followup issue: {update.name} upgrade")
+    if inconclusive:
+        joined = ", ".join(u.slug for u in inconclusive)
+        if budget_exhausted:
+            plan.append(
+                f"Needs human review: bisect budget exhausted with {len(inconclusive)} "
+                f"candidate(s) remaining ({joined})"
+            )
+        else:
+            plan.append(f"Needs human review: unable to narrow ({joined})")
+    return plan
+
+
+# ────────────────────────────────────────────────────────────────────
+# Bisect loop
+# ────────────────────────────────────────────────────────────────────
+
+
+async def _run_bisect(
+    updates: list[PackageUpdate],
+    probe: CIProbe,
+    *,
+    max_runs: int,
+) -> tuple[list[PackageUpdate], list[PackageUpdate], list[PackageUpdate], int]:
+    """Classic bisect: partition the input into guilty / safe / undetermined.
+
+    Strategy:
+    1. Probe the full bundle. If it passes, everything is safe.
+    2. Otherwise split in half; probe each half.
+    3. If only one half fails, recurse into that half. If both fail,
+       recurse into each (two independent culprits). If neither
+       fails individually the failure was an interaction — record
+       the whole bundle as undetermined.
+    4. Stop when a subset of size 1 fails (that update is guilty) or
+       the run budget is spent.
+    """
+    safe: list[PackageUpdate] = []
+    guilty: list[PackageUpdate] = []
+    undetermined: list[PackageUpdate] = []
+    runs = 0
+
+    async def _probe(subset: list[PackageUpdate]) -> bool:
+        nonlocal runs
+        if runs >= max_runs:
+            return False
+        runs += 1
+        outcome = await probe(subset)
+        logger.info(
+            "bisect probe: subset_size=%d run=%d passed=%s reason=%s",
+            len(subset),
+            runs,
+            outcome.passed,
+            outcome.reason,
+        )
+        return outcome.passed
+
+    async def _narrow(subset: list[PackageUpdate], *, known_fails: bool = True) -> None:
+        """Recursively narrow ``subset`` to guilty / safe updates.
+
+        Precondition: ``subset`` is known to fail CI when ``known_fails``
+        is True. The initial call from ``_run_bisect`` always satisfies
+        this (we only recurse once the full-bundle probe has failed).
+        """
+        if len(subset) == 0:
+            return
+        if runs >= max_runs:
+            undetermined.extend(subset)
+            return
+        if len(subset) == 1:
+            # A single-element failing subset is guilty by elimination;
+            # no need to burn another probe.
+            if known_fails:
+                guilty.append(subset[0])
+            else:
+                undetermined.append(subset[0])
+            return
+
+        # Special-case 2-element subsets: one probe suffices to
+        # identify the guilty element. We probe the left half; if it
+        # fails, the right half is safe by elimination. If the left
+        # passes, the right element must be guilty (we know the pair
+        # fails together).
+        if len(subset) == 2:
+            left_single = [subset[0]]
+            left_passes = await _probe(left_single)
+            if left_passes:
+                # Left safe, right must be the culprit.
+                safe.extend(left_single)
+                guilty.append(subset[1])
+            else:
+                # Left is guilty; right is safe by elimination.
+                guilty.extend(left_single)
+                safe.append(subset[1])
+            return
+
+        mid = len(subset) // 2
+        left = subset[:mid]
+        right = subset[mid:]
+
+        left_passes = await _probe(left)
+
+        if runs >= max_runs:
+            # We know left's verdict but can't test right; leave right
+            # undetermined and record what we do know.
+            if left_passes:
+                safe.extend(left)
+                undetermined.extend(right)
+            else:
+                undetermined.extend(subset)
+            return
+
+        if left_passes:
+            # Pair known to fail, left half passes → right half fails.
+            safe.extend(left)
+            await _narrow(right, known_fails=True)
+            return
+
+        # Left half fails. Probe right half to distinguish
+        # single-culprit (right safe) from two-culprit (right fails)
+        # scenarios.
+        right_passes = await _probe(right)
+        if right_passes:
+            safe.extend(right)
+            await _narrow(left, known_fails=True)
+            return
+        # Both halves fail independently → recurse into both.
+        await _narrow(left, known_fails=True)
+        await _narrow(right, known_fails=True)
+
+    # Step 1: full-bundle probe.
+    full_passes = await _probe(updates)
+    if full_passes:
+        safe.extend(updates)
+    else:
+        await _narrow(updates)
+
+    return safe, guilty, undetermined, runs
+
+
+async def bisect_grouped_dependabot_pr(
+    pr: PullRequest,
+    *,
+    github: GitHubClient,  # noqa: ARG001 — reserved for future CI-driven bisect
+    max_runs: int = 6,
+    ci_probe: CIProbe | None = None,
+) -> BisectResult:
+    """Identify the guilty update(s) inside a grouped Dependabot PR.
+
+    Behaviour:
+
+    1. Parse ``pr.body`` for the grouped-update table. Fewer than 2
+       updates → ``outcome="inconclusive"`` with
+       ``reason="not_grouped"``.
+    2. If ``ci_probe`` is None the function operates in advisory mode:
+       it returns ``outcome="inconclusive"`` with
+       ``reason="no_probe_configured"`` and a plan that lists every
+       parsed update as a "needs human review" entry. Callers wire the
+       probe in when they're ready to drive the real CI loop.
+    3. Otherwise run the bisect up to ``max_runs`` probes. If the
+       budget is exhausted while the guilty set is still ambiguous
+       return ``outcome="inconclusive"`` with a partial plan; never
+       merge on behalf of the user inside this function.
+
+    The function never mutates the PR; it returns a ``BisectResult``
+    that the caller posts as a comment (or hands to a follow-up
+    agent).
+    """
+    updates = parse_grouped_pr_body(pr.body or "")
+    if len(updates) < 2:
+        return BisectResult(
+            outcome="inconclusive",
+            suggested_merge_plan=[],
+            runs_consumed=0,
+            reason="not_grouped",
+        )
+
+    if ci_probe is None:
+        plan = synthesize_merge_plan(
+            safe=[],
+            guilty=[],
+            inconclusive=updates,
+            budget_exhausted=False,
+        )
+        return BisectResult(
+            outcome="inconclusive",
+            guilty_updates=[],
+            safe_updates=[],
+            suggested_merge_plan=plan,
+            runs_consumed=0,
+            reason="no_probe_configured",
+        )
+
+    try:
+        safe, guilty, undetermined, runs = await _run_bisect(updates, ci_probe, max_runs=max_runs)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("bisect: probe raised")
+        return BisectResult(
+            outcome="error",
+            suggested_merge_plan=[f"Bisect aborted: {exc}"],
+            runs_consumed=0,
+            reason=str(exc),
+        )
+
+    budget_exhausted = runs >= max_runs and bool(undetermined)
+
+    if not guilty and not undetermined:
+        # Full bundle passed — no-op recommendation. The grouped PR is
+        # safe to merge as-is.
+        return BisectResult(
+            outcome="all_green",
+            safe_updates=safe,
+            suggested_merge_plan=[
+                f"Merge: {len(safe)} updates in grouped PR (all subsets passed CI)"
+            ],
+            runs_consumed=runs,
+        )
+
+    plan = synthesize_merge_plan(
+        safe=safe,
+        guilty=guilty,
+        inconclusive=undetermined,
+        budget_exhausted=budget_exhausted,
+    )
+
+    if guilty and not undetermined:
+        outcome: Literal["all_green", "guilty_identified", "inconclusive", "error"] = (
+            "guilty_identified"
+        )
+    else:
+        outcome = "inconclusive"
+
+    reason = ""
+    if budget_exhausted:
+        reason = "budget_exhausted"
+    elif undetermined and not guilty:
+        reason = "interaction_failure"
+
+    return BisectResult(
+        outcome=outcome,
+        safe_updates=safe,
+        guilty_updates=guilty,
+        suggested_merge_plan=plan,
+        runs_consumed=runs,
+        reason=reason,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────
+# Comment formatter (used by the agent integration hook)
+# ────────────────────────────────────────────────────────────────────
+
+
+def format_bisect_comment(result: BisectResult) -> str:
+    """Render a ``BisectResult`` as a PR comment body."""
+    lines = [
+        "## Caretaker dependency bisect",
+        "",
+        f"**Outcome:** `{result.outcome}`  ",
+        f"**CI runs consumed:** {result.runs_consumed}",
+    ]
+    if result.reason:
+        lines.append(f"**Reason:** `{result.reason}`")
+    lines.append("")
+
+    if result.outcome == "inconclusive" and result.reason == "not_grouped":
+        lines.append(
+            "This PR does not look like a grouped Dependabot bundle "
+            "(fewer than 2 updates parsed); nothing to bisect."
+        )
+        lines.append("")
+        lines.append(BISECTOR_COMMENT_MARKER)
+        return "\n".join(lines)
+
+    if result.safe_updates:
+        lines.append("### Safe to merge")
+        for u in result.safe_updates:
+            lines.append(f"- `{u.name}` {u.from_version} → {u.to_version} ({u.directory})")
+        lines.append("")
+
+    if result.guilty_updates:
+        lines.append("### Blocking CI")
+        for u in result.guilty_updates:
+            lines.append(f"- `{u.name}` {u.from_version} → {u.to_version} ({u.directory})")
+        lines.append("")
+
+    if result.suggested_merge_plan:
+        lines.append("### Suggested plan")
+        for step in result.suggested_merge_plan:
+            lines.append(f"1. {step}")
+        lines.append("")
+
+    lines.append(BISECTOR_COMMENT_MARKER)
+    return "\n".join(lines)

--- a/tests/fixtures/dependency_agent/grouped_pr_195_body.md
+++ b/tests/fixtures/dependency_agent/grouped_pr_195_body.md
@@ -1,0 +1,778 @@
+Bumps the npm_and_yarn group with 10 updates in the /backend directory:
+
+| Package | From | To |
+| --- | --- | --- |
+| [express-rate-limit](https://github.com/express-rate-limit/express-rate-limit) | `8.2.1` | `8.3.2` |
+| [brace-expansion](https://github.com/juliangruber/brace-expansion) | `1.1.12` | `1.1.14` |
+| [minimatch](https://github.com/isaacs/minimatch) | `3.1.2` | `3.1.5` |
+| [basic-ftp](https://github.com/patrickjuchli/basic-ftp) | `5.0.5` | `5.3.0` |
+| [flatted](https://github.com/WebReflection/flatted) | `3.3.3` | `3.4.2` |
+| [path-to-regexp](https://github.com/pillarjs/path-to-regexp) | `8.2.0` | `8.4.2` |
+| [picomatch](https://github.com/micromatch/picomatch) | `2.3.1` | `2.3.2` |
+| [protobufjs](https://github.com/protobufjs/protobuf.js) | `7.5.3` | `7.5.5` |
+| [socket.io-parser](https://github.com/socketio/socket.io) | `4.2.4` | `4.2.6` |
+| [undici](https://github.com/nodejs/undici) | `7.16.0` | `7.25.0` |
+
+Bumps the npm_and_yarn group with 1 update in the /embed directory: [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite).
+Bumps the npm_and_yarn group with 12 updates in the /frontend directory:
+
+| Package | From | To |
+| --- | --- | --- |
+| [brace-expansion](https://github.com/juliangruber/brace-expansion) | `1.1.12` | `1.1.14` |
+| [minimatch](https://github.com/isaacs/minimatch) | `3.1.2` | `3.1.5` |
+| [flatted](https://github.com/WebReflection/flatted) | `3.3.3` | `3.4.2` |
+| [picomatch](https://github.com/micromatch/picomatch) | `2.3.1` | `2.3.2` |
+| [socket.io-parser](https://github.com/socketio/socket.io) | `4.2.4` | `4.2.6` |
+| [undici](https://github.com/nodejs/undici) | `6.21.3` | `6.25.0` |
+| [@xmldom/xmldom](https://github.com/xmldom/xmldom) | `0.8.10` | `0.8.13` |
+| [handlebars](https://github.com/handlebars-lang/handlebars.js) | `4.7.8` | `4.7.9` |
+| [lodash](https://github.com/lodash/lodash) | `4.17.21` | `4.18.1` |
+| [node-forge](https://github.com/digitalbazaar/forge) | `1.3.1` | `1.4.0` |
+| [serialize-javascript](https://github.com/yahoo/serialize-javascript) | `6.0.2` | `removed` |
+| [tar](https://github.com/isaacs/node-tar) | `7.4.3` | `7.5.13` |
+
+Bumps the npm_and_yarn group with 2 updates in the /web directory: [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) and [vitest](https://github.com/vitest-dev/vitest/tree/HEAD/packages/vitest).
+
+Updates `express-rate-limit` from 8.2.1 to 8.3.2
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/express-rate-limit/express-rate-limit/releases">express-rate-limit's releases</a>.</em></p>
+<blockquote>
+<h2>v8.3.2</h2>
+<p>You can view the changelog <a href="https://express-rate-limit.mintlify.app/reference/changelog">here</a>.</p>
+<h2>v8.3.1</h2>
+<p>You can view the changelog <a href="https://express-rate-limit.mintlify.app/reference/changelog">here</a>.</p>
+<h2>v8.3.0</h2>
+<p>You can view the changelog <a href="https://express-rate-limit.mintlify.app/reference/changelog">here</a>.</p>
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/c4dbb42c1b4891056545e30a9187a64c8bfeb8bc"><code>c4dbb42</code></a> 8.3.2</li>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/8f1cc6639a430d6409e600c8e5434c1bc1e572bf"><code>8f1cc66</code></a> v8.3.2 changelog</li>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/601b87f5d171487ed035ccdfee17ec75f5b22f2d"><code>601b87f</code></a> Fix skipFailedRequests for for connections that close very early (<a href="https://redirect.github.com/express-rate-limit/express-rate-limit/issues/611">#611</a>)</li>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/014c2f32708c0fdb5544834c3e77043e041ae38a"><code>014c2f3</code></a> chore(deps-dev): bump the development-dependencies group with 6 updates (<a href="https://redirect.github.com/express-rate-limit/express-rate-limit/issues/612">#612</a>)</li>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/4e8b18bf972eff2890ed67bd11d8a08a2c6502d5"><code>4e8b18b</code></a> Remove Zuplo sponsorship details from README (<a href="https://redirect.github.com/express-rate-limit/express-rate-limit/issues/613">#613</a>)</li>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/31dab192a3798984b89e78bfacf755f361f29660"><code>31dab19</code></a> test: use numeric range for reset timestamp assertion (<a href="https://redirect.github.com/express-rate-limit/express-rate-limit/issues/610">#610</a>)</li>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/f82ad139611ed69c451f113913f0347ee78d19ec"><code>f82ad13</code></a> chore(deps-dev): bump the development-dependencies group with 2 updates (<a href="https://redirect.github.com/express-rate-limit/express-rate-limit/issues/609">#609</a>)</li>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/fa0b0982049814870faf9d57b7588a0b9acd107f"><code>fa0b098</code></a> docs: fix broken link</li>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/47e5b2952fe697ac0a5f8a6aa86f050f6f2c0ce5"><code>47e5b29</code></a> 8.3.1</li>
+<li><a href="https://github.com/express-rate-limit/express-rate-limit/commit/eb61179a49064c7e86f6f8688be742343b1f1b8e"><code>eb61179</code></a> v8.3.1 changelog</li>
+<li>Additional commits viewable in <a href="https://github.com/express-rate-limit/express-rate-limit/compare/v8.2.1...v8.3.2">compare view</a></li>
+</ul>
+</details>
+<details>
+<summary>Maintainer changes</summary>
+<p>This version was pushed to npm by <a href="https://www.npmjs.com/~GitHub%20Actions">GitHub Actions</a>, a new releaser for express-rate-limit since your current version.</p>
+</details>
+<br />
+
+Updates `brace-expansion` from 1.1.12 to 1.1.14
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/10c05fcf3699b1a29ef5e611c011af3d3c97e6e3"><code>10c05fc</code></a> 1.1.14</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/1afa1b22ead12f6a7a02f25bf0f7d64c2439b007"><code>1afa1b2</code></a> Add opt-in { max } mitigation to v1 legacy line (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/103">#103</a>)</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/2fbb6a2aa0f984bb2fb5f60252ca6cba3e1368ec"><code>2fbb6a2</code></a> Revert &quot;Backport fix for GHSA-7h2j-956f-4vf2 to v1 (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/101">#101</a>)&quot; (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/102">#102</a>)</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/0d7652e3093d3273151729812f9b0b79a17ecba6"><code>0d7652e</code></a> Backport fix for GHSA-7h2j-956f-4vf2 to v1 (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/101">#101</a>)</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/6c353caf23beb9644f858eb3fe38d43a68b82898"><code>6c353ca</code></a> 1.1.13</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/7fd684f89fdde3549563d0a6522226a9189472a2"><code>7fd684f</code></a> Backport fix for GHSA-f886-m6hf-6m8v (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/95">#95</a>)</li>
+<li>See full diff in <a href="https://github.com/juliangruber/brace-expansion/compare/v1.1.12...v1.1.14">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates `minimatch` from 3.1.2 to 3.1.5
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/isaacs/minimatch/commit/7bba97888a27a6162983056bcce2a6e28f668712"><code>7bba978</code></a> 3.1.5</li>
+<li><a href="https://github.com/isaacs/minimatch/commit/bd259425b2ca17b42897997f93e890314155522d"><code>bd25942</code></a> docs: add warning about ReDoS</li>
+<li><a href="https://github.com/isaacs/minimatch/commit/1a9c27c75725474dbde57db2995b6281b267756d"><code>1a9c27c</code></a> fix partial matching of globstar patterns</li>
+<li><a href="https://github.com/isaacs/minimatch/commit/1a2e084af579731af66c221214e3ca8222c9bf23"><code>1a2e084</code></a> 3.1.4</li>
+<li><a href="https://github.com/isaacs/minimatch/commit/ae24656237c3d58067442f790ce17eff84463a47"><code>ae24656</code></a> update lockfile</li>
+<li><a href="https://github.com/isaacs/minimatch/commit/b1003749228b2a79e1f237963a0d559ef7a0941e"><code>b100374</code></a> limit recursion for **, improve perf considerably</li>
+<li><a href="https://github.com/isaacs/minimatch/commit/26ffeaa091b9f660833e23f42e07165b33e85c13"><code>26ffeaa</code></a> lockfile update</li>
+<li><a href="https://github.com/isaacs/minimatch/commit/9eca892a4e5dbb20534f9f30483b85cdeee6c2eb"><code>9eca892</code></a> lock node version to 14</li>
+<li><a href="https://github.com/isaacs/minimatch/commit/00c323b188b704e5d4bc534ecec2268cfa70a32a"><code>00c323b</code></a> 3.1.3</li>
+<li><a href="https://github.com/isaacs/minimatch/commit/30486b2048929264f44d18822891cfffa02af78b"><code>30486b2</code></a> update CI matrix and actions</li>
+<li>Additional commits viewable in <a href="https://github.com/isaacs/minimatch/compare/v3.1.2...v3.1.5">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates `basic-ftp` from 5.0.5 to 5.3.0
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/patrickjuchli/basic-ftp/releases">basic-ftp's releases</a>.</em></p>
+<blockquote>
+<h2>5.3.0</h2>
+<ul>
+<li>Changed: Introduced an upper bound for total bytes of directory listing, fixes <a href="https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-rp42-5vxx-qpwr">https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-rp42-5vxx-qpwr</a>.</li>
+<li>Added: Option to increase the upper bound for total bytes of directory listing in Client constructor.</li>
+</ul>
+<h2>5.2.2</h2>
+<ul>
+<li>Fixed: Improve control character rejection, fixes <a href="https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-6v7q-wjvx-w8wg">https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-6v7q-wjvx-w8wg</a>.</li>
+</ul>
+<h2>5.2.1</h2>
+<ul>
+<li>Fixed: Reject control character injection attempts using paths. See <a href="https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-chqc-8p9q-pq6q">https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-chqc-8p9q-pq6q</a>.</li>
+</ul>
+<h2>5.2.0</h2>
+<ul>
+<li>Changed: Skip files with invalid name in downloadToDir.</li>
+</ul>
+<h2>5.1.0</h2>
+<ul>
+<li>Added: Add the option to prevent the use of separate transfer host IPs when using PASV. (<a href="https://redirect.github.com/patrickjuchli/basic-ftp/issues/259">#259</a>)</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Changelog</summary>
+<p><em>Sourced from <a href="https://github.com/patrickjuchli/basic-ftp/blob/master/CHANGELOG.md">basic-ftp's changelog</a>.</em></p>
+<blockquote>
+<h2>5.3.0</h2>
+<ul>
+<li>Changed: Introduced an upper bound for total bytes of directory listing, fixes <a href="https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-rp42-5vxx-qpwr">https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-rp42-5vxx-qpwr</a>.</li>
+<li>Added: Option to increase the upper bound for total bytes of directory listing in Client constructor.</li>
+</ul>
+<h2>5.2.2</h2>
+<ul>
+<li>Fixed: Improve control character rejection, fixes <a href="https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-6v7q-wjvx-w8wg">https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-6v7q-wjvx-w8wg</a>.</li>
+</ul>
+<h2>5.2.1</h2>
+<ul>
+<li>Fixed: Reject control character injection attempts using paths. See <a href="https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-chqc-8p9q-pq6q">https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-chqc-8p9q-pq6q</a>.</li>
+</ul>
+<h2>5.2.0</h2>
+<ul>
+<li>Changed: Skip files with invalid name in downloadToDir. Fixes security vulnerability CVE-2026-27699, see <a href="https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-5rq4-664w-9x2c">https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-5rq4-664w-9x2c</a>.</li>
+</ul>
+<h2>5.1.0</h2>
+<ul>
+<li>Added: Add the option to prevent the use of separate transfer host IPs when using PASV. (<a href="https://redirect.github.com/patrickjuchli/basic-ftp/issues/259">#259</a>)</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/c9378a8ff73b96e89f17525266d648ce495286a6"><code>c9378a8</code></a> Fix test</li>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/22abe4356782f499d97418f0a7a2c3bb02db72b7"><code>22abe43</code></a> Update Github Actions</li>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/0feaaec3d4394bb3470edd006df933d2b6e64689"><code>0feaaec</code></a> Fix test</li>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/6629d7d7abe9169543a8ff60a6dc32e6fe7cf91c"><code>6629d7d</code></a> Improve error message</li>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/9c3bf4f893470cd2418b54862eb9b609efc3d335"><code>9c3bf4f</code></a> Set higher default value for max size of directory listing</li>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/acd3942c81ac27caf998b0ed13f3ce85c0fc6320"><code>acd3942</code></a> Bump version</li>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/130442932b1ef27a550c915f231c07eae01e665a"><code>1304429</code></a> Offer maxListingBytes as an option</li>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/5cb5367e86d8a2991224fb2b82e4933d27c07904"><code>5cb5367</code></a> Add bounded StringWriter</li>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/07e9fc5e48ecef4b807d47bb3b5f1aa93e6e67dd"><code>07e9fc5</code></a> Update dev dependencies</li>
+<li><a href="https://github.com/patrickjuchli/basic-ftp/commit/e9d09d6815b300b73e1297cdcf91786a979ef212"><code>e9d09d6</code></a> Bump version</li>
+<li>Additional commits viewable in <a href="https://github.com/patrickjuchli/basic-ftp/compare/v5.0.5...v5.3.0">compare view</a></li>
+</ul>
+</details>
+<details>
+<summary>Maintainer changes</summary>
+<p>This version was pushed to npm by <a href="https://www.npmjs.com/~patrickjuchli">patrickjuchli</a>, a new releaser for basic-ftp since your current version.</p>
+</details>
+<details>
+<summary>Install script changes</summary>
+<p>This version adds <code>prepare</code> script that runs during installation. Review the package contents before updating.</p>
+</details>
+<br />
+
+Updates `flatted` from 3.3.3 to 3.4.2
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/WebReflection/flatted/commit/3bf09091c3562e17a0647bc06710dd6097079cf7"><code>3bf0909</code></a> 3.4.2</li>
+<li><a href="https://github.com/WebReflection/flatted/commit/885ddcc33cf9657caf38c57c7be45ae1c5272802"><code>885ddcc</code></a> fix CWE-1321</li>
+<li><a href="https://github.com/WebReflection/flatted/commit/0bdba705d130f00892b1b8fcc80cf4cdea0631e3"><code>0bdba70</code></a> added flatted-view to the benchmark</li>
+<li><a href="https://github.com/WebReflection/flatted/commit/2a02dce7c641dec31194c67663f9b0b12e62da20"><code>2a02dce</code></a> 3.4.1</li>
+<li><a href="https://github.com/WebReflection/flatted/commit/fba4e8f2e113665da275b19cd0f695f3d98e9416"><code>fba4e8f</code></a> Merge pull request <a href="https://redirect.github.com/WebReflection/flatted/issues/89">#89</a> from WebReflection/python-fix</li>
+<li><a href="https://github.com/WebReflection/flatted/commit/5fe86485e6df7f7f34a07a2a85498bd3e17384e7"><code>5fe8648</code></a> added &quot;when in Rome&quot; also a test for PHP</li>
+<li><a href="https://github.com/WebReflection/flatted/commit/53517adbefe724fe472b2f9ebcdb01910d0ae3f0"><code>53517ad</code></a> some minor improvement</li>
+<li><a href="https://github.com/WebReflection/flatted/commit/b3e2a0c387bf446435fec45ad7f05299f012346f"><code>b3e2a0c</code></a> Fixing recursion issue in Python too</li>
+<li><a href="https://github.com/WebReflection/flatted/commit/c4b46dbcbf782326e54ea1b65d3ebb1dc7a23fad"><code>c4b46db</code></a> Add SECURITY.md for security policy and reporting</li>
+<li><a href="https://github.com/WebReflection/flatted/commit/f86d071e0f70de5a7d8200198824a3f07fc9c988"><code>f86d071</code></a> Create dependabot.yml for version updates</li>
+<li>Additional commits viewable in <a href="https://github.com/WebReflection/flatted/compare/v3.3.3...v3.4.2">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates `path-to-regexp` from 8.2.0 to 8.4.2
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/pillarjs/path-to-regexp/releases">path-to-regexp's releases</a>.</em></p>
+<blockquote>
+<h2>v8.4.2</h2>
+<p><strong>Fixed</strong></p>
+<ul>
+<li>Error on trailing backslash (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/434">#434</a>)  9a78879</li>
+</ul>
+<p><strong>Performance</strong></p>
+<ul>
+<li>Minimize array allocations (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/437">#437</a>)  937c02d</li>
+<li>Improve compile performance (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/436">#436</a>)  57247e6
+<ul>
+<li>Should improve compilation performance by ~25%</li>
+</ul>
+</li>
+<li>Remove internal tokenization during parse (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/435">#435</a>)  5844988
+<ul>
+<li>Should improve parse performance by ~20%</li>
+</ul>
+</li>
+</ul>
+<p><strong>Bundle size</strong> to 1.93 kB, from 1.97 kB.</p>
+<hr />
+<p><a href="https://github.com/pillarjs/path-to-regexp/compare/v8.4.1...v8.4.2">https://github.com/pillarjs/path-to-regexp/compare/v8.4.1...v8.4.2</a></p>
+<h2>v8.4.1</h2>
+<p><strong>Fixed</strong></p>
+<ul>
+<li>Remove trie deduplication (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/431">#431</a>)  6bc8e84
+<ul>
+<li>Using a trie required non-greedy matching, which regressed wildcards in non-ending mode by matching them up until the first match. For example:
+<ul>
+<li><code>/*foo</code> with <code>/a/b</code> = <code>/a</code></li>
+<li><code>/*foo.html</code>with <code>/a/b.html/c.html</code> = <code>/a/b.html</code></li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Allow backtrack handling to match itself (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/427">#427</a>)  5bcd30b
+<ul>
+<li>When backtracking was introduced, it rejected matching things like <code>/:&quot;a&quot;_:&quot;b&quot;</code> against <code>/foo__</code>. This makes intuitive sense because the second parameter is not going to backtrack on <code>_</code> anymore, but it's somewhat unexpected since there's no reason it shouldn't match the second <code>_</code>.</li>
+</ul>
+</li>
+</ul>
+<hr />
+<p><a href="https://github.com/pillarjs/path-to-regexp/compare/v8.4.0...v8.4.1">https://github.com/pillarjs/path-to-regexp/compare/v8.4.0...v8.4.1</a></p>
+<h2>v8.4.0</h2>
+<p><strong>Important</strong></p>
+<ul>
+<li>Fix <a href="https://www.cve.org/CVERecord?id=CVE-2026-4926">CVE-2026-4926</a> (<a href="https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-j3q9-mxjg-w52f">GHSA-j3q9-mxjg-w52f</a>)</li>
+<li>Fix <a href="https://www.cve.org/CVERecord?id=CVE-2026-4923">CVE-2026-4923</a> (<a href="https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-27v5-c462-wpq7">GHSA-27v5-c462-wpq7</a>)</li>
+</ul>
+<p><strong>Fixed</strong></p>
+<ul>
+<li>Restricts wildcard backtracking when using more than 1 in a path (<a href="https://redirect.github.com/pillarjs/path-to-regexp/pull/421">pillarjs/path-to-regexp#421</a>)</li>
+</ul>
+<p><strong>Changed</strong></p>
+<ul>
+<li>Dedupes regex prefixes (<a href="https://redirect.github.com/pillarjs/path-to-regexp/pull/422">pillarjs/path-to-regexp#422</a>)
+<ul>
+<li>This will result in shorter regular expressions for some cases using optional groups</li>
+</ul>
+</li>
+<li>Rejects large optional route combinations (<a href="https://redirect.github.com/pillarjs/path-to-regexp/pull/424">pillarjs/path-to-regexp#424</a>)
+<ul>
+<li>When using groups such as <code>/users{/delete}</code> it will restrict the number of generated combinations to &lt; 256, equivalent to 8 top-level optional groups and unlikely to occur in a real world application, but avoids exploding the regex size for applications that accept user created routes</li>
+</ul>
+</li>
+</ul>
+<!-- raw HTML omitted -->
+</blockquote>
+<p>... (truncated)</p>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/cbf30259e6d34d6135f9e7dbaa3371e7188f9936"><code>cbf3025</code></a> 8.4.2</li>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/937c02df571aef02832610100859efab21995320"><code>937c02d</code></a> Minimize array allocations (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/437">#437</a>)</li>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/57247e63fd061aa17b9f75c87712c680b223ee04"><code>57247e6</code></a> Improve compile performance (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/436">#436</a>)</li>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/58449883539022c9ac36ea3e9abb0fc7b9d84223"><code>5844988</code></a> Remove internal tokenization during parse (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/435">#435</a>)</li>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/9a788793e7eeb0ccf9c53c1cb54d297b5badfcc3"><code>9a78879</code></a> Error on trailing backslash (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/434">#434</a>)</li>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/7f058760ae0867fdd75e5ed07d7096f782c1f752"><code>7f05876</code></a> 8.4.1</li>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/6bc8e84677caa52de6db7b2b17a6729ec155b070"><code>6bc8e84</code></a> Remove trie deduplication (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/431">#431</a>)</li>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/5bcd30b790fecfd4798521af28a57214996c4139"><code>5bcd30b</code></a> Allow backtrack handling to match itself (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/427">#427</a>)</li>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/9f9c6c501f6d015db3df224d2479475d59cac0a5"><code>9f9c6c5</code></a> Add parsing to benchmarks (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/418">#418</a>)</li>
+<li><a href="https://github.com/pillarjs/path-to-regexp/commit/9fd31e0cde4f35b5f15f1676eabe3484618038ad"><code>9fd31e0</code></a> Add <code>trailing: false</code> tests (<a href="https://redirect.github.com/pillarjs/path-to-regexp/issues/428">#428</a>)</li>
+<li>Additional commits viewable in <a href="https://github.com/pillarjs/path-to-regexp/compare/v8.2.0...v8.4.2">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates `picomatch` from 2.3.1 to 2.3.2
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/micromatch/picomatch/releases">picomatch's releases</a>.</em></p>
+<blockquote>
+<h2>2.3.2</h2>
+<p>This is a security release fixing several security relevant issues.</p>
+<h2>What's Changed</h2>
+<ul>
+<li>fix: exception when glob pattern contains constructor by <a href="https://github.com/Jason3S"><code>@​Jason3S</code></a> in <a href="https://redirect.github.com/micromatch/picomatch/pull/144">micromatch/picomatch#144</a></li>
+<li>Fix for <a href="https://github.com/micromatch/picomatch/security/advisories/GHSA-c2c7-rcm5-vvqj">CVE-2026-33671</a></li>
+<li>Fix for <a href="https://github.com/micromatch/picomatch/security/advisories/GHSA-3v7f-55p6-f55p">CVE-2026-33672</a></li>
+</ul>
+<p><strong>Full Changelog</strong>: <a href="https://github.com/micromatch/picomatch/compare/2.3.1...2.3.2">https://github.com/micromatch/picomatch/compare/2.3.1...2.3.2</a></p>
+</blockquote>
+</details>
+<details>
+<summary>Changelog</summary>
+<p><em>Sourced from <a href="https://github.com/micromatch/picomatch/blob/master/CHANGELOG.md">picomatch's changelog</a>.</em></p>
+<blockquote>
+<h1>Release history</h1>
+<p><strong>All notable changes to this project will be documented in this file.</strong></p>
+<p>The format is based on <a href="http://keepachangelog.com/en/1.0.0/">Keep a Changelog</a>
+and this project adheres to <a href="http://semver.org/spec/v2.0.0.html">Semantic Versioning</a>.</p>
+<!-- raw HTML omitted -->
+<ul>
+<li>Changelogs are for humans, not machines.</li>
+<li>There should be an entry for every single version.</li>
+<li>The same types of changes should be grouped.</li>
+<li>Versions and sections should be linkable.</li>
+<li>The latest version comes first.</li>
+<li>The release date of each versions is displayed.</li>
+<li>Mention whether you follow Semantic Versioning.</li>
+</ul>
+<!-- raw HTML omitted -->
+<!-- raw HTML omitted -->
+<p>Changelog entries are classified using the following labels <em>(from <a href="http://keepachangelog.com/">keep-a-changelog</a></em>):</p>
+<ul>
+<li><code>Added</code> for new features.</li>
+<li><code>Changed</code> for changes in existing functionality.</li>
+<li><code>Deprecated</code> for soon-to-be removed features.</li>
+<li><code>Removed</code> for now removed features.</li>
+<li><code>Fixed</code> for any bug fixes.</li>
+<li><code>Security</code> in case of vulnerabilities.</li>
+</ul>
+<!-- raw HTML omitted -->
+<h2>4.0.0 (2024-02-07)</h2>
+<h3>Fixes</h3>
+<ul>
+<li>Fix bad text values in parse <a href="https://redirect.github.com/micromatch/picomatch/issues/126">#126</a>, thanks to <a href="https://github.com/connor4312"><code>@​connor4312</code></a></li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>Remove process global to work outside of node <a href="https://redirect.github.com/micromatch/picomatch/issues/129">#129</a>, thanks to <a href="https://github.com/styfle"><code>@​styfle</code></a></li>
+<li>Add sideEffects to package.json <a href="https://redirect.github.com/micromatch/picomatch/issues/128">#128</a>, thanks to <a href="https://github.com/frandiox"><code>@​frandiox</code></a></li>
+<li>Removed <code>os</code>, make compatible browser environment. See <a href="https://redirect.github.com/micromatch/picomatch/issues/124">#124</a>, thanks to <a href="https://github.com/gwsbhqt"><code>@​gwsbhqt</code></a></li>
+</ul>
+<h2>3.0.1</h2>
+<h3>Fixes</h3>
+<!-- raw HTML omitted -->
+</blockquote>
+<p>... (truncated)</p>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/micromatch/picomatch/commit/81cba8d4b767cab3cb29d26eb4f691eed75b73b2"><code>81cba8d</code></a> Publish 2.3.2</li>
+<li><a href="https://github.com/micromatch/picomatch/commit/fc1f6b69006e9435caf8fb40d8aff378bc0b7bce"><code>fc1f6b6</code></a> Merge commit from fork</li>
+<li><a href="https://github.com/micromatch/picomatch/commit/eec17aee5428a7249e9ca5adbb8a0d28fa29619b"><code>eec17ae</code></a> Merge commit from fork</li>
+<li><a href="https://github.com/micromatch/picomatch/commit/78f8ca4362d9e66cadea97b93e292f10096452ed"><code>78f8ca4</code></a> Merge pull request <a href="https://redirect.github.com/micromatch/picomatch/issues/156">#156</a> from micromatch/backport-144</li>
+<li><a href="https://github.com/micromatch/picomatch/commit/3f4f10eaa65bf3a52e8f2999674cd27e11fa3c9b"><code>3f4f10e</code></a> Merge pull request <a href="https://redirect.github.com/micromatch/picomatch/issues/144">#144</a> from Jason3S/jdent-object-properties</li>
+<li>See full diff in <a href="https://github.com/micromatch/picomatch/compare/2.3.1...2.3.2">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates `protobufjs` from 7.5.3 to 7.5.5
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/protobufjs/protobuf.js/releases">protobufjs's releases</a>.</em></p>
+<blockquote>
+<h2>v7.5.5</h2>
+<p>This release backports two reported security issues to 7.x branch.</p>
+<ul>
+<li>fix: do not allow setting <code>__proto__</code> in Message constructor (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2126">#2126</a>)</li>
+<li>fix: filter invalid characters from the type name (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2127">#2127</a>)</li>
+</ul>
+<p><strong>Full Changelog</strong>: <a href="https://github.com/protobufjs/protobuf.js/compare/protobufjs-v7.5.4...protobufjs-v7.5.5">https://github.com/protobufjs/protobuf.js/compare/protobufjs-v7.5.4...protobufjs-v7.5.5</a></p>
+<h2>protobufjs: v7.5.4</h2>
+<h2><a href="https://github.com/protobufjs/protobuf.js/compare/protobufjs-v7.5.3...protobufjs-v7.5.4">7.5.4</a> (2025-08-15)</h2>
+<h3>Bug Fixes</h3>
+<ul>
+<li>invalid syntax in descriptor.proto (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2092">#2092</a>) (<a href="https://github.com/protobufjs/protobuf.js/commit/5a3769a465fead089a533ad55c21d069299df760">5a3769a</a>)</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Changelog</summary>
+<p><em>Sourced from <a href="https://github.com/protobufjs/protobuf.js/blob/master/CHANGELOG.md">protobufjs's changelog</a>.</em></p>
+<blockquote>
+<h1>Changelog</h1>
+<h2><a href="https://github.com/protobufjs/protobuf.js/compare/protobufjs-v8.0.0...protobufjs-v8.0.1">8.0.1</a> (2026-03-11)</h2>
+<h3>Bug Fixes</h3>
+<ul>
+<li>bump protobufjs dependency version for cli package (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2128">#2128</a>) (<a href="https://github.com/protobufjs/protobuf.js/commit/549b05ecd95e23da40fa1a36a9336c57946b8377">549b05e</a>)</li>
+<li>correct json syntax in tsconfig.json (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2120">#2120</a>) (<a href="https://github.com/protobufjs/protobuf.js/commit/80656255c75000f3e954e036cdfcb5bfd0a8c687">8065625</a>)</li>
+<li><strong>descriptor:</strong> guard oneof index for non-Type parents (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2122">#2122</a>) (<a href="https://github.com/protobufjs/protobuf.js/commit/1cac5cf811d0855b27dcde73a3a04d15efde3728">1cac5cf</a>)</li>
+<li>do not allow setting <strong>proto</strong> in Message constructor (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2126">#2126</a>) (<a href="https://github.com/protobufjs/protobuf.js/commit/f05e3c3bdd0b3c2cddbf8540bb5bd4d394a693ad">f05e3c3</a>)</li>
+<li>filter invalid characters from the type name (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2127">#2127</a>) (<a href="https://github.com/protobufjs/protobuf.js/commit/535df444ac060243722ac5d672db205e5c531d75">535df44</a>)</li>
+</ul>
+<h2><a href="https://github.com/protobufjs/protobuf.js/compare/protobufjs-v7.5.4...protobufjs-v8.0.0">8.0.0</a> (2025-12-16)</h2>
+<h3>⚠ BREAKING CHANGES</h3>
+<ul>
+<li>add Edition 2024 Support (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2060">#2060</a>)</li>
+</ul>
+<h3>Features</h3>
+<ul>
+<li>add Edition 2024 Support (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2060">#2060</a>) (<a href="https://github.com/protobufjs/protobuf.js/commit/53e8492cbaae2c741801fa50b5f908ff5129c3d7">53e8492</a>)</li>
+</ul>
+<h2><a href="https://github.com/protobufjs/protobuf.js/compare/protobufjs-v7.5.3...protobufjs-v7.5.4">7.5.4</a> (2025-08-15)</h2>
+<h3>Bug Fixes</h3>
+<ul>
+<li>invalid syntax in descriptor.proto (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2092">#2092</a>) (<a href="https://github.com/protobufjs/protobuf.js/commit/5a3769a465fead089a533ad55c21d069299df760">5a3769a</a>)</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/protobufjs/protobuf.js/commit/b7bdfaf91d7bf279326f2d043b633da0a2dbfe47"><code>b7bdfaf</code></a> chore: release 7.5.5</li>
+<li><a href="https://github.com/protobufjs/protobuf.js/commit/ff7b2afef8754837cc6dc64c864cd111ab477956"><code>ff7b2af</code></a> fix: filter invalid characters from the type name (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2127">#2127</a>)</li>
+<li><a href="https://github.com/protobufjs/protobuf.js/commit/086b19d00d1d01e801d6ccc2ae3f207bb1b06482"><code>086b19d</code></a> fix: do not allow setting <strong>proto</strong> in Message constructor (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2126">#2126</a>)</li>
+<li><a href="https://github.com/protobufjs/protobuf.js/commit/827ff8e48253e9041f19ac81168aa046dbdfb041"><code>827ff8e</code></a> chore: release master (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2093">#2093</a>)</li>
+<li><a href="https://github.com/protobufjs/protobuf.js/commit/5a3769a465fead089a533ad55c21d069299df760"><code>5a3769a</code></a> fix: invalid syntax in descriptor.proto (<a href="https://redirect.github.com/protobufjs/protobuf.js/issues/2092">#2092</a>)</li>
+<li>See full diff in <a href="https://github.com/protobufjs/protobuf.js/compare/protobufjs-v7.5.3...protobufjs-v7.5.5">compare view</a></li>
+</ul>
+</details>
+<details>
+<summary>Maintainer changes</summary>
+<p>This version was pushed to npm by <a href="https://www.npmjs.com/~fenster">fenster</a>, a new releaser for protobufjs since your current version.</p>
+</details>
+<br />
+
+Updates `socket.io-parser` from 4.2.4 to 4.2.6
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/socketio/socket.io/releases">socket.io-parser's releases</a>.</em></p>
+<blockquote>
+<h2>socket.io-parser@4.2.6</h2>
+<p>This release includes a fix for <a href="https://github.com/socketio/socket.io/security/advisories/GHSA-677m-j7p3-52f9">CVE-2026-33151</a>. Please upgrade as soon as possible.</p>
+<h3>Bug Fixes</h3>
+<ul>
+<li>add a limit to the number of binary attachments (<a href="https://github.com/socketio/socket.io/commit/b25738c416c4e32fbff62ee182afa8f6d0dacf78">b25738c</a>)</li>
+</ul>
+<h2>socket.io-parser@4.2.5</h2>
+<p>This release contains a bump of <code>debug</code> from <code>~4.3.1</code> to <code>~4.4.1</code>.</p>
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/socketio/socket.io/commit/522edcdbb89da5eb647abb93c73229d1e91c304f"><code>522edcd</code></a> chore(release): socket.io-parser@4.2.6</li>
+<li><a href="https://github.com/socketio/socket.io/commit/3fff7cafa98f1ba5840475b6917c651fe841a943"><code>3fff7ca</code></a> fix(parser): add a limit to the number of binary attachments</li>
+<li><a href="https://github.com/socketio/socket.io/commit/37aad11417d1020cf51d27a0cf90fa367efd5dc1"><code>37aad11</code></a> fix: cleanup pending acks on timeout to prevent memory leak</li>
+<li><a href="https://github.com/socketio/socket.io/commit/ba9cd6900d0d84678623cd8e3a42165e922f3fbd"><code>ba9cd69</code></a> revert: fix: cleanup pending acks on timeout to prevent memory leak</li>
+<li><a href="https://github.com/socketio/socket.io/commit/84c2fb78217b6375b38e0b47e0d59d7b1b8431d7"><code>84c2fb7</code></a> chore(release): engine.io@6.6.6</li>
+<li><a href="https://github.com/socketio/socket.io/commit/07cbe1510ded7e5460cb82e026e2533e50e30eaf"><code>07cbe15</code></a> fix(eio): add <code>@​types/ws</code> as dependency (<a href="https://redirect.github.com/socketio/socket.io/issues/5458">#5458</a>)</li>
+<li><a href="https://github.com/socketio/socket.io/commit/44ed73f53995d35ef0c8d10df6806d5687238282"><code>44ed73f</code></a> fix(eio): emit initial_headers and headers events in uServer (<a href="https://redirect.github.com/socketio/socket.io/issues/5460">#5460</a>)</li>
+<li><a href="https://github.com/socketio/socket.io/commit/da04267ffc7b0903ca91f2fccb80e56246d13328"><code>da04267</code></a> fix: cleanup pending acks on timeout to prevent memory leak (<a href="https://redirect.github.com/socketio/socket.io/issues/5442">#5442</a>)</li>
+<li><a href="https://github.com/socketio/socket.io/commit/74599a6b9e3dbeff1a9efe46c305d5d25d6e3dd8"><code>74599a6</code></a> fix(types): properly import http module</li>
+<li><a href="https://github.com/socketio/socket.io/commit/d48718cb675721fc1252775115592ebd1b255899"><code>d48718c</code></a> ci: use actions/checkout@v6 and actions/setup-node@v6 (<a href="https://redirect.github.com/socketio/socket.io/issues/5449">#5449</a>)</li>
+<li>Additional commits viewable in <a href="https://github.com/socketio/socket.io/compare/socket.io-parser@4.2.4...socket.io-parser@4.2.6">compare view</a></li>
+</ul>
+</details>
+<details>
+<summary>Maintainer changes</summary>
+<p>This version was pushed to npm by <a href="https://www.npmjs.com/~GitHub%20Actions">GitHub Actions</a>, a new releaser for socket.io-parser since your current version.</p>
+</details>
+<br />
+
+Updates `undici` from 7.16.0 to 7.25.0
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/nodejs/undici/releases">undici's releases</a>.</em></p>
+<blockquote>
+<h2>v7.25.0</h2>
+<h2>What's Changed</h2>
+<p><strong>Full Changelog</strong>: <a href="https://github.com/nodejs/undici/compare/v7.24.8...v7.25.0">https://github.com/nodejs/undici/compare/v7.24.8...v7.25.0</a></p>
+<h2>v7.24.8</h2>
+<h2>What's Changed</h2>
+<ul>
+<li>fix: backport 401 stream-backed body fix to v7.x by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/5006">nodejs/undici#5006</a></li>
+</ul>
+<p><strong>Full Changelog</strong>: <a href="https://github.com/nodejs/undici/compare/v7.24.7...v7.24.8">https://github.com/nodejs/undici/compare/v7.24.7...v7.24.8</a></p>
+<h2>v7.24.7</h2>
+<h2>What's Changed</h2>
+<ul>
+<li>docs: update broken links in file &quot;Dispatcher.md&quot; by <a href="https://github.com/samuel871211"><code>@​samuel871211</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4924">nodejs/undici#4924</a></li>
+<li>doc: remove unused parameter <code>redirectionLimitReached</code> by <a href="https://github.com/samuel871211"><code>@​samuel871211</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4933">nodejs/undici#4933</a></li>
+<li>test: skip flaky macOS Node 20 cookie fetch cases by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4932">nodejs/undici#4932</a></li>
+<li>fix(types): align Response with DOM fetch types by <a href="https://github.com/theamodhshetty"><code>@​theamodhshetty</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4867">nodejs/undici#4867</a></li>
+<li>fix(types): Fix clone method type declaration to be an instance method rather than instance property by <a href="https://github.com/mistval"><code>@​mistval</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4925">nodejs/undici#4925</a></li>
+<li>test: skip IPv6 tests when IPv6 is not available by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4939">nodejs/undici#4939</a></li>
+<li>fix: correctly handle multi-value rawHeaders in fetch by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4938">nodejs/undici#4938</a></li>
+<li>ignore AGENTS.md by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4942">nodejs/undici#4942</a></li>
+</ul>
+<h2>New Contributors</h2>
+<ul>
+<li><a href="https://github.com/samuel871211"><code>@​samuel871211</code></a> made their first contribution in <a href="https://redirect.github.com/nodejs/undici/pull/4924">nodejs/undici#4924</a></li>
+<li><a href="https://github.com/mistval"><code>@​mistval</code></a> made their first contribution in <a href="https://redirect.github.com/nodejs/undici/pull/4925">nodejs/undici#4925</a></li>
+</ul>
+<p><strong>Full Changelog</strong>: <a href="https://github.com/nodejs/undici/compare/v7.24.6...v7.24.7">https://github.com/nodejs/undici/compare/v7.24.6...v7.24.7</a></p>
+<h2>v7.24.6</h2>
+<h2>What's Changed</h2>
+<ul>
+<li>fix(test): client wasm compatible with clang 22 by <a href="https://github.com/rozzilla"><code>@​rozzilla</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4909">nodejs/undici#4909</a></li>
+<li>fix(mock): improve error message when intercepts are exhausted by <a href="https://github.com/travisbreaks"><code>@​travisbreaks</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4912">nodejs/undici#4912</a></li>
+<li>fix(websocket): support open diagnostics over h2 by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4921">nodejs/undici#4921</a></li>
+<li>fix: assume http/https scheme for scheme-less proxy env vars by <a href="https://github.com/travisbreaks"><code>@​travisbreaks</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4914">nodejs/undici#4914</a></li>
+<li>fix(cache): check Authorization on request headers per RFC 9111 §3.5 by <a href="https://github.com/metalix2"><code>@​metalix2</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4911">nodejs/undici#4911</a></li>
+<li>fix: wrap kConnector call in try/catch to prevent client hang by <a href="https://github.com/veeceey"><code>@​veeceey</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4834">nodejs/undici#4834</a></li>
+<li>docs: clarify fetch and FormData pairing by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4922">nodejs/undici#4922</a></li>
+<li>fix: support Connection header with connection-specific header names per RFC 7230 by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4775">nodejs/undici#4775</a></li>
+<li>fix: avoid prototype collisions in parseHeaders by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4923">nodejs/undici#4923</a></li>
+<li>build(deps-dev): bump typescript from 5.9.3 to 6.0.2 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/nodejs/undici/pull/4926">nodejs/undici#4926</a></li>
+<li>test: auto-init WPT submodule by <a href="https://github.com/mcollina"><code>@​mcollina</code></a> in <a href="https://redirect.github.com/nodejs/undici/pull/4930">nodejs/undici#4930</a></li>
+</ul>
+<h2>New Contributors</h2>
+<ul>
+<li><a href="https://github.com/rozzilla"><code>@​rozzilla</code></a> made their first contribution in <a href="https://redirect.github.com/nodejs/undici/pull/4909">nodejs/undici#4909</a></li>
+<li><a href="https://github.com/veeceey"><code>@​veeceey</code></a> made their first contribution in <a href="https://redirect.github.com/nodejs/undici/pull/4834">nodejs/undici#4834</a></li>
+</ul>
+<p><strong>Full Changelog</strong>: <a href="https://github.com/nodejs/undici/compare/v7.24.5...v7.24.6">https://github.com/nodejs/undici/compare/v7.24.5...v7.24.6</a></p>
+<!-- raw HTML omitted -->
+</blockquote>
+<p>... (truncated)</p>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/nodejs/undici/commit/12d9045923b7caebb1ae6975ef34c29dbcfd95d0"><code>12d9045</code></a> Bumped v7.25.0 (<a href="https://redirect.github.com/nodejs/undici/issues/5025">#5025</a>)</li>
+<li><a href="https://github.com/nodejs/undici/commit/7a6f7febb30a30748a04f38c21e3641c77d21b0e"><code>7a6f7fe</code></a> Bumped v7.24.8 (<a href="https://redirect.github.com/nodejs/undici/issues/5020">#5020</a>)</li>
+<li><a href="https://github.com/nodejs/undici/commit/1f85ae4b27ed6401e7ccc35eb546ad2e5976121f"><code>1f85ae4</code></a> fix: avoid 401 failures for stream-backed request bodies (<a href="https://redirect.github.com/nodejs/undici/issues/4941">#4941</a>) (<a href="https://redirect.github.com/nodejs/undici/issues/5006">#5006</a>)</li>
+<li><a href="https://github.com/nodejs/undici/commit/c6610674dfad7c205ddf0f27831133973ad7894e"><code>c661067</code></a> chore: update v7.x maintenance release flow</li>
+<li><a href="https://github.com/nodejs/undici/commit/84f23e2a19cd0f585579c4257d801e4ec2d65dbd"><code>84f23e2</code></a> Bumped v7.24.7 (<a href="https://redirect.github.com/nodejs/undici/issues/4947">#4947</a>)</li>
+<li><a href="https://github.com/nodejs/undici/commit/a770b1033201984b9e8082a9bf955414bff5dc2e"><code>a770b10</code></a> ignore AGENTS.md (<a href="https://redirect.github.com/nodejs/undici/issues/4942">#4942</a>)</li>
+<li><a href="https://github.com/nodejs/undici/commit/6acd19beaf67c1a2d07bcd38f40d0b751a81e7cc"><code>6acd19b</code></a> fix: correctly handle multi-value rawHeaders in fetch (<a href="https://redirect.github.com/nodejs/undici/issues/4938">#4938</a>)</li>
+<li><a href="https://github.com/nodejs/undici/commit/1da1c747c7d6e01b93ab295e0efb86623f3c8e06"><code>1da1c74</code></a> test: skip IPv6 tests when IPv6 is not available (<a href="https://redirect.github.com/nodejs/undici/issues/4939">#4939</a>)</li>
+<li><a href="https://github.com/nodejs/undici/commit/04cb77327f7ada95c2e5b67424cddcb22d7bf882"><code>04cb773</code></a> fix(types): Fix clone method type declaration to be an instance method rather...</li>
+<li><a href="https://github.com/nodejs/undici/commit/5145a7c47080d1715b2723591def3a75b0c3ba63"><code>5145a7c</code></a> fix(types): align Response with DOM fetch types (<a href="https://redirect.github.com/nodejs/undici/issues/4867">#4867</a>)</li>
+<li>Additional commits viewable in <a href="https://github.com/nodejs/undici/compare/v7.16.0...v7.25.0">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates `vite` from 5.4.21 to 6.4.2
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/vitejs/vite/releases">vite's releases</a>.</em></p>
+<blockquote>
+<h2>v6.4.2</h2>
+<p>Please refer to <a href="https://github.com/vitejs/vite/blob/v6.4.2/packages/vite/CHANGELOG.md">CHANGELOG.md</a> for details.</p>
+<h2>v6.4.1</h2>
+<p>Please refer to <a href="https://github.com/vitejs/vite/blob/v6.4.1/packages/vite/CHANGELOG.md">CHANGELOG.md</a> for details.</p>
+<h2>v6.4.0</h2>
+<p>Please refer to <a href="https://github.com/vitejs/vite/blob/v6.4.0/packages/vite/CHANGELOG.md">CHANGELOG.md</a> for details.</p>
+<h2>v6.3.7</h2>
+<p>Please refer to <a href="https://github.com/vitejs/vite/blob/v6.3.7/packages/vite/CHANGELOG.md">CHANGELOG.md</a> for details.</p>
+<h2>v6.3.6</h2>
+<p>Please refer to <a href="https://github.com/vitejs/vite/blob/v6.3.6/packages/vite/CHANGELOG.md">CHANGELOG.md</a> for details.</p>
+</blockquote>
+</details>
+<details>
+<summary>Changelog</summary>
+<p><em>Sourced from <a href="https://github.com/vitejs/vite/blob/v6.4.2/packages/vite/CHANGELOG.md">vite's changelog</a>.</em></p>
+<blockquote>
+<h2><!-- raw HTML omitted -->6.4.2 (2026-04-06)<!-- raw HTML omitted --></h2>
+<ul>
+<li>fix: apply server.fs check to env transport (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/22159">#22159</a>) (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/22163">#22163</a>) (<a href="https://github.com/vitejs/vite/commit/fe28e47e9463e4c9619f94bfa06d2f8f1411b44b">fe28e47</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/22159">#22159</a> <a href="https://redirect.github.com/vitejs/vite/issues/22163">#22163</a></li>
+<li>fix: avoid path traversal with optimize deps sourcemap handler (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/22161">#22161</a>) (<a href="https://github.com/vitejs/vite/commit/ca4da5d1fb45c9cfdce606aa30825095791b164b">ca4da5d</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/22161">#22161</a></li>
+</ul>
+<h2><!-- raw HTML omitted -->6.4.1 (2025-10-20)<!-- raw HTML omitted --></h2>
+<ul>
+<li>fix(dev): trim trailing slash before <code>server.fs.deny</code> check (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20968">#20968</a>) (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20969">#20969</a>) (<a href="https://github.com/vitejs/vite/commit/1114b5d7ea03e26572708715343bec69db4536e8">1114b5d</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/20968">#20968</a> <a href="https://redirect.github.com/vitejs/vite/issues/20969">#20969</a></li>
+</ul>
+<h2>6.4.0 (2025-10-15)</h2>
+<ul>
+<li>feat: allow passing down resolved config to vite's createServer (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20932">#20932</a>) (<a href="https://github.com/vitejs/vite/commit/ca6455ee9eb6111a9caa9810506a1b9ac96a520a">ca6455e</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/20932">#20932</a></li>
+</ul>
+<h2><!-- raw HTML omitted -->6.3.7 (2025-10-14)<!-- raw HTML omitted --></h2>
+<ul>
+<li>fix(esbuild): inject esbuild helpers correctly for esbuild 0.25.9+ (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20940">#20940</a>) (<a href="https://github.com/vitejs/vite/commit/c59a222aa584c087cfe710173de1b9ecb597a3ff">c59a222</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/20940">#20940</a></li>
+</ul>
+<h2><!-- raw HTML omitted -->6.3.6 (2025-09-08)<!-- raw HTML omitted --></h2>
+<ul>
+<li>fix: apply <code>fs.strict</code> check to HTML files (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20736">#20736</a>) (<a href="https://github.com/vitejs/vite/commit/0ab19ea9fcb66f544328f442cf6e70f7c0528d5f">0ab19ea</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/20736">#20736</a></li>
+<li>fix: upgrade sirv to 3.0.2 (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20735">#20735</a>) (<a href="https://github.com/vitejs/vite/commit/e11d24008b97d4ca731ecc1a3b95260a6d12e7e0">e11d240</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/20735">#20735</a></li>
+<li>test: detect ts support via <code>process.features</code> (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20544">#20544</a>) (<a href="https://github.com/vitejs/vite/commit/7d9922972b62329d37a71d4da5a4a382d0bf8a79">7d99229</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/20544">#20544</a></li>
+</ul>
+<h2><!-- raw HTML omitted -->6.3.5 (2025-05-05)<!-- raw HTML omitted --></h2>
+<ul>
+<li>fix(ssr): handle uninitialized export access as undefined (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/19959">#19959</a>) (<a href="https://github.com/vitejs/vite/commit/fd38d076fe2455aac1e00a7b15cd51159bf12bb5">fd38d07</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/19959">#19959</a></li>
+</ul>
+<h2><!-- raw HTML omitted -->6.3.4 (2025-04-30)<!-- raw HTML omitted --></h2>
+<ul>
+<li>fix: check static serve file inside sirv (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/19965">#19965</a>) (<a href="https://github.com/vitejs/vite/commit/c22c43de612eebb6c182dd67850c24e4fab8cacb">c22c43d</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/19965">#19965</a></li>
+<li>fix(optimizer): return plain object when using <code>require</code> to import externals in optimized dependenci (<a href="https://github.com/vitejs/vite/commit/efc5eab253419fde0a6a48b8d2f233063d6a9643">efc5eab</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/19940">#19940</a></li>
+<li>refactor: remove duplicate plugin context type (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/19935">#19935</a>) (<a href="https://github.com/vitejs/vite/commit/d6d01c2292fa4f9603e05b95d81c8724314c20e0">d6d01c2</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/19935">#19935</a></li>
+</ul>
+<h2><!-- raw HTML omitted -->6.3.3 (2025-04-24)<!-- raw HTML omitted --></h2>
+<ul>
+<li>fix: ignore malformed uris in tranform middleware (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/19853">#19853</a>) (<a href="https://github.com/vitejs/vite/commit/e4d520141bcd83ad61f16767348b4a813bf9340a">e4d5201</a>), closes <a href="https://redirect.github.com/vitejs/vite/issues/19853">#19853</a></li>
+</ul>
+<!-- raw HTML omitted -->
+</blockquote>
+<p>... (truncated)</p>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/vitejs/vite/commit/6b3fad02abd550bd7b79934ff92c58dbd7f33045"><code>6b3fad0</code></a> release: v6.4.2</li>
+<li><a href="https://github.com/vitejs/vite/commit/ca4da5d1fb45c9cfdce606aa30825095791b164b"><code>ca4da5d</code></a> fix: avoid path traversal with optimize deps sourcemap handler (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/22161">#22161</a>)</li>
+<li><a href="https://github.com/vitejs/vite/commit/fe28e47e9463e4c9619f94bfa06d2f8f1411b44b"><code>fe28e47</code></a> fix: apply server.fs check to env transport (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/22159">#22159</a>) (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/22163">#22163</a>)</li>
+<li><a href="https://github.com/vitejs/vite/commit/5487f4f641f70c47ea05fd101a4319897df048b3"><code>5487f4f</code></a> release: v6.4.1</li>
+<li><a href="https://github.com/vitejs/vite/commit/1114b5d7ea03e26572708715343bec69db4536e8"><code>1114b5d</code></a> fix(dev): trim trailing slash before <code>server.fs.deny</code> check (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20968">#20968</a>) (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20969">#20969</a>)</li>
+<li><a href="https://github.com/vitejs/vite/commit/f12697c0f64b9a37196b9ab218a0911829d5b103"><code>f12697c</code></a> release: v6.4.0</li>
+<li><a href="https://github.com/vitejs/vite/commit/ca6455ee9eb6111a9caa9810506a1b9ac96a520a"><code>ca6455e</code></a> feat: allow passing down resolved config to vite's createServer (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20932">#20932</a>)</li>
+<li><a href="https://github.com/vitejs/vite/commit/0e173d83681daa31be10fa8a62d56b1ec84690af"><code>0e173d8</code></a> release: v6.3.7</li>
+<li><a href="https://github.com/vitejs/vite/commit/c59a222aa584c087cfe710173de1b9ecb597a3ff"><code>c59a222</code></a> fix(esbuild): inject esbuild helpers correctly for esbuild 0.25.9+ (<a href="https://github.com/vitejs/vite/tree/HEAD/packages/vite/issues/20940">#20940</a>)</li>
+<li><a href="https://github.com/vitejs/vite/commit/3f337c5e24504e51188d29c970de1416ee523dbb"><code>3f337c5</code></a> release: v6.3.6</li>
+<li>Additional commits viewable in <a href="https://github.com/vitejs/vite/commits/v6.4.2/packages/vite">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates `esbuild` from 0.21.5 to 0.25.12
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/evanw/esbuild/releases">esbuild's releases</a>.</em></p>
+<blockquote>
+<h2>v0.25.12</h2>
+<ul>
+<li>
+<p>Fix a minification regression with CSS media queries (<a href="https://redirect.github.com/evanw/esbuild/issues/4315">#4315</a>)</p>
+<p>The previous release introduced support for parsing media queries which unintentionally introduced a regression with the removal of duplicate media rules during minification. Specifically the grammar for <code>@media &lt;media-type&gt; and &lt;media-condition-without-or&gt; { ... }</code> was missing an equality check for the <code>&lt;media-condition-without-or&gt;</code> part, so rules with different suffix clauses in this position would incorrectly compare equal and be deduplicated. This release fixes the regression.</p>
+</li>
+<li>
+<p>Update the list of known JavaScript globals (<a href="https://redirect.github.com/evanw/esbuild/issues/4310">#4310</a>)</p>
+<p>This release updates esbuild's internal list of known JavaScript globals. These are globals that are known to not have side-effects when the property is accessed. For example, accessing the global <code>Array</code> property is considered to be side-effect free but accessing the global <code>scrollY</code> property can trigger a layout, which is a side-effect. This is used by esbuild's tree-shaking to safely remove unused code that is known to be side-effect free. This update adds the following global properties:</p>
+<p>From <a href="https://tc39.es/ecma262/2017/">ES2017</a>:</p>
+<ul>
+<li><code>Atomics</code></li>
+<li><code>SharedArrayBuffer</code></li>
+</ul>
+<p>From <a href="https://tc39.es/ecma262/2020/">ES2020</a>:</p>
+<ul>
+<li><code>BigInt64Array</code></li>
+<li><code>BigUint64Array</code></li>
+</ul>
+<p>From <a href="https://tc39.es/ecma262/2021/">ES2021</a>:</p>
+<ul>
+<li><code>FinalizationRegistry</code></li>
+<li><code>WeakRef</code></li>
+</ul>
+<p>From <a href="https://tc39.es/ecma262/2025/">ES2025</a>:</p>
+<ul>
+<li><code>Float16Array</code></li>
+<li><code>Iterator</code></li>
+</ul>
+<p>Note that this does not indicate that constructing any of these objects is side-effect free, just that accessing the identifier is side-effect free. For example, this now allows esbuild to tree-shake classes that extend from <code>Iterator</code>:</p>
+<pre lang="js"><code>// This can now be tree-shaken by esbuild:
+class ExampleIterator extends Iterator {}
+</code></pre>
+</li>
+<li>
+<p>Add support for the new <code>@view-transition</code> CSS rule (<a href="https://redirect.github.com/evanw/esbuild/pull/4313">#4313</a>)</p>
+<p>With this release, esbuild now has improved support for pretty-printing and minifying the new <code>@view-transition</code> rule (which esbuild was previously unaware of):</p>
+<pre lang="css"><code>/* Original code */
+@view-transition {
+  navigation: auto;
+  types: check;
+}
+<p>/* Old output */<br />
+<a href="https://github.com/view-transition"><code>@​view-transition</code></a> { navigation: auto; types: check; }</p>
+<p>/* New output */<br />
+<a href="https://github.com/view-transition"><code>@​view-transition</code></a> {<br />
+navigation: auto;<br />
+types: check;<br />
+</code></pre></p>
+</li>
+</ul>
+<!-- raw HTML omitted -->
+</blockquote>
+<p>... (truncated)</p>
+</details>
+<details>
+<summary>Changelog</summary>
+<p><em>Sourced from <a href="https://github.com/evanw/esbuild/blob/main/CHANGELOG-2024.md">esbuild's changelog</a>.</em></p>
+<blockquote>
+<h1>Changelog: 2024</h1>
+<p>This changelog documents all esbuild versions published in the year 2024 (versions 0.19.12 through 0.24.2).</p>
+<h2>0.24.2</h2>
+<ul>
+<li>
+<p>Fix regression with <code>--define</code> and <code>import.meta</code> (<a href="https://redirect.github.com/evanw/esbuild/issues/4010">#4010</a>, <a href="https://redirect.github.com/evanw/esbuild/issues/4012">#4012</a>, <a href="https://redirect.github.com/evanw/esbuild/pull/4013">#4013</a>)</p>
+<p>The previous change in version 0.24.1 to use a more expression-like parser for <code>define</code> values to allow quoted property names introduced a regression that removed the ability to use <code>--define:import.meta=...</code>. Even though <code>import</code> is normally a keyword that can't be used as an identifier, ES modules special-case the <code>import.meta</code> expression to behave like an identifier anyway. This change fixes the regression.</p>
+<p>This fix was contributed by <a href="https://github.com/sapphi-red"><code>@​sapphi-red</code></a>.</p>
+</li>
+</ul>
+<h2>0.24.1</h2>
+<ul>
+<li>
+<p>Allow <code>es2024</code> as a target in <code>tsconfig.json</code> (<a href="https://redirect.github.com/evanw/esbuild/issues/4004">#4004</a>)</p>
+<p>TypeScript recently <a href="https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#support-for---target-es2024-and---lib-es2024">added <code>es2024</code></a> as a compilation target, so esbuild now supports this in the <code>target</code> field of <code>tsconfig.json</code> files, such as in the following configuration file:</p>
+<pre lang="json"><code>{
+  &quot;compilerOptions&quot;: {
+    &quot;target&quot;: &quot;ES2024&quot;
+  }
+}
+</code></pre>
+<p>As a reminder, the only thing that esbuild uses this field for is determining whether or not to use legacy TypeScript behavior for class fields. You can read more in <a href="https://esbuild.github.io/content-types/#tsconfig-json">the documentation</a>.</p>
+<p>This fix was contributed by <a href="https://github.com/billyjanitsch"><code>@​billyjanitsch</code></a>.</p>
+</li>
+<li>
+<p>Allow automatic semicolon insertion after <code>get</code>/<code>set</code></p>
+<p>This change fixes a grammar bug in the parser that incorrectly treated the following code as a syntax error:</p>
+<pre lang="ts"><code>class Foo {
+  get
+  *x() {}
+  set
+  *y() {}
+}
+</code></pre>
+<p>The above code will be considered valid starting with this release. This change to esbuild follows a <a href="https://redirect.github.com/microsoft/TypeScript/pull/60225">similar change to TypeScript</a> which will allow this syntax starting with TypeScript 5.7.</p>
+</li>
+<li>
+<p>Allow quoted property names in <code>--define</code> and <code>--pure</code> (<a href="https://redirect.github.com/evanw/esbuild/issues/4008">#4008</a>)</p>
+<p>The <code>define</code> and <code>pure</code> API options now accept identifier expressions containing quoted property names. Previously all identifiers in the identifier expression had to be bare identifiers. This change now makes <code>--define</code> and <code>--pure</code> consistent with <code>--global-name</code>, which already supported quoted property names. For example, the following is now possible:</p>
+<pre lang="js"><code></code></pre>
+</li>
+</ul>
+<!-- raw HTML omitted -->
+</blockquote>
+<p>... (truncated)</p>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/evanw/esbuild/commit/208f539945b145e7c9d6d844290f81c3fe5af320"><code>208f539</code></a> publish 0.25.12 to npm</li>
+<li><a href="https://github.com/evanw/esbuild/commit/5f03afdd007f6626d4300afc7cbb5bf7c9554393"><code>5f03afd</code></a> update release notes</li>
+<li><a href="https://github.com/evanw/esbuild/commit/6b2ee78d7f273d7ed4c4bb08b516939b373bcd67"><code>6b2ee78</code></a> minify: remove css rules containing empty <code>:is()</code></li>
+<li><a href="https://github.com/evanw/esbuild/commit/f361debd61ffa0ae2d810fbe0e4c9d39183ed4c6"><code>f361deb</code></a> add some additional known static methods</li>
+<li><a href="https://github.com/evanw/esbuild/commit/07aa646bb2fd9c5eb1de804edf9eae5bd1617637"><code>07aa646</code></a> automatically mark &quot;RegExp.escape()&quot; calls as pure</li>
+<li><a href="https://github.com/evanw/esbuild/commit/9039c468258fd9a19eeaf5e05fd6a3d582b46d3a"><code>9039c46</code></a> simplify some call expression checks</li>
+<li><a href="https://github.com/evanw/esbuild/commit/188944dd946dd54d50bbe844dc22969b604589d0"><code>188944d</code></a> add some additional known static methods</li>
+<li><a href="https://github.com/evanw/esbuild/commit/d3c67f9e94267d06337d2e2e0d837844d2cac6bd"><code>d3c67f9</code></a> fix <a href="https://redirect.github.com/evanw/esbuild/issues/4310">#4310</a>: add <code>Iterator</code> and other known globals</li>
+<li><a href="https://github.com/evanw/esbuild/commit/4a51f0b24d343d7ae5b7d5a3e5c3afce3f96a0f8"><code>4a51f0b</code></a> fix: escape dev server breadcrumb hrefs properly (<a href="https://redirect.github.com/evanw/esbuild/issues/4316">#4316</a>)</li>
+<li><a href="https://github.com/evanw/esbuild/commit/26b29ed51ffe20730ffaf69921dbb53e27de464a"><code>26b29ed</code></a> fix <a href="https://redirect.github.com/evanw/esbuild/issues/4315">#4315</a>: <code>@media</code> deduplication bug edge case</li>
+<li>Additional commits viewable in <a href="https://github.com/evanw/esbuild/compare/v0.21.5...v0.25.12">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates `brace-expansion` from 1.1.12 to 1.1.14
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/10c05fcf3699b1a29ef5e611c011af3d3c97e6e3"><code>10c05fc</code></a> 1.1.14</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/1afa1b22ead12f6a7a02f25bf0f7d64c2439b007"><code>1afa1b2</code></a> Add opt-in { max } mitigation to v1 legacy line (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/103">#103</a>)</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/2fbb6a2aa0f984bb2fb5f60252ca6cba3e1368ec"><code>2fbb6a2</code></a> Revert &quot;Backport fix for GHSA-7h2j-956f-4vf2 to v1 (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/101">#101</a>)&quot; (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/102">#102</a>)</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/0d7652e3093d3273151729812f9b0b79a17ecba6"><code>0d7652e</code></a> Backport fix for GHSA-7h2j-956f-4vf2 to v1 (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/101">#101</a>)</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/6c353caf23beb9644f858eb3fe38d43a68b82898"><code>6c353ca</code></a> 1.1.13</li>
+<li><a href="https://github.com/juliangruber/brace-expansion/commit/7fd684f89fdde3549563d0a6522226a9189472a2"><code>7fd684f</code></a> Backport fix for GHSA-f886-m6hf-6m8v (<a href="https://redirect.github.com/juliangruber/brace-expansion/issues/95">#95</a>)</li>
+<li>See full diff in <a href="https://github.com/juliangruber/brace-expansion/compare/v1.1.12...v1.1.14">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates ...
+
+_Description has been truncated_

--- a/tests/test_dependency_bisector.py
+++ b/tests/test_dependency_bisector.py
@@ -1,0 +1,478 @@
+"""Tests for the grouped-Dependabot PR bisector."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from caretaker.dependency_agent.agent import DependencyAgent
+from caretaker.dependency_agent.bisector import (
+    BISECTOR_COMMENT_MARKER,
+    PackageUpdate,
+    ProbeOutcome,
+    bisect_grouped_dependabot_pr,
+    format_bisect_comment,
+    parse_grouped_pr_body,
+    synthesize_merge_plan,
+)
+from caretaker.github_client.models import Comment, Label, PullRequest, User
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "dependency_agent"
+
+
+# ────────────────────────────────────────────────────────────────────
+# Parser
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestParseGroupedPrBody:
+    def test_empty_body_returns_empty(self) -> None:
+        assert parse_grouped_pr_body("") == []
+        assert parse_grouped_pr_body("Some unrelated text") == []
+
+    def test_single_header_table(self) -> None:
+        body = (
+            "Bumps the npm_and_yarn group with 2 updates in the /backend directory:\n\n"
+            "| Package | From | To |\n"
+            "| --- | --- | --- |\n"
+            "| [lodash](https://github.com/lodash/lodash) | `4.17.20` | `4.17.21` |\n"
+            "| minimatch | `3.1.2` | `3.1.5` |\n"
+        )
+        updates = parse_grouped_pr_body(body)
+        assert len(updates) == 2
+        assert updates[0].name == "lodash"
+        assert updates[0].ecosystem == "npm"
+        assert updates[0].directory == "/backend"
+        assert updates[0].from_version == "4.17.20"
+        assert updates[0].to_version == "4.17.21"
+        assert updates[1].name == "minimatch"
+
+    def test_multi_directory_grouped(self) -> None:
+        body = (
+            "Bumps the npm_and_yarn group with 1 update in the /a directory:\n\n"
+            "| Package | From | To |\n"
+            "| --- | --- | --- |\n"
+            "| [lodash](https://example.com/lodash) | `4.17.20` | `4.17.21` |\n"
+            "\n"
+            "Bumps the pip group with 1 update in the /b directory:\n\n"
+            "| Package | From | To |\n"
+            "| --- | --- | --- |\n"
+            "| [requests](https://example.com/requests) | `2.28.0` | `2.29.0` |\n"
+        )
+        updates = parse_grouped_pr_body(body)
+        assert len(updates) == 2
+        directories = {u.directory for u in updates}
+        ecosystems = {u.ecosystem for u in updates}
+        assert directories == {"/a", "/b"}
+        assert ecosystems == {"npm", "pip"}
+
+    def test_inline_single_update_group(self) -> None:
+        body = (
+            "Bumps the npm_and_yarn group with 1 update in the /embed directory: "
+            "[vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite).\n\n"
+            "Updates `vite` from 4.5.0 to 4.5.3\n"
+        )
+        updates = parse_grouped_pr_body(body)
+        assert len(updates) == 1
+        assert updates[0].name == "vite"
+        assert updates[0].ecosystem == "npm"
+        assert updates[0].directory == "/embed"
+        assert updates[0].from_version == "4.5.0"
+        assert updates[0].to_version == "4.5.3"
+
+    def test_dedupes_repeated_rows(self) -> None:
+        # Dependabot occasionally duplicates a row between summary and
+        # details sections; the parser must not count it twice.
+        body = (
+            "Bumps the pip group with 1 update in the / directory:\n\n"
+            "| Package | From | To |\n"
+            "| --- | --- | --- |\n"
+            "| requests | `2.28.0` | `2.29.0` |\n"
+            "\n"
+            "Updates `requests` from 2.28.0 to 2.29.0\n"
+        )
+        updates = parse_grouped_pr_body(body)
+        assert len(updates) == 1
+
+    def test_real_dependabot_fixture(self) -> None:
+        """Golden test against a real Dependabot grouped-PR body.
+
+        Fixture is the body of Example-React-AI-Chat-App#195:
+        npm_and_yarn across 4 directories, 25 updates total
+        (10 /backend + 1 /embed + 12 /frontend + 2 /web).
+        """
+        body = (FIXTURE_DIR / "grouped_pr_195_body.md").read_text()
+        updates = parse_grouped_pr_body(body)
+
+        assert len(updates) >= 20, (
+            f"parser pulled only {len(updates)} updates out of a PR listing 25"
+        )
+        names = {u.name for u in updates}
+        # Sampling of well-known packages from the fixture.
+        for expected in (
+            "express-rate-limit",
+            "brace-expansion",
+            "minimatch",
+            "undici",
+            "vite",
+        ):
+            assert expected in names, f"missing {expected}"
+        directories = {u.directory for u in updates}
+        assert directories == {"/backend", "/embed", "/frontend", "/web"}
+        for u in updates:
+            assert u.ecosystem == "npm"
+
+
+# ────────────────────────────────────────────────────────────────────
+# Plan synthesizer
+# ────────────────────────────────────────────────────────────────────
+
+
+def _mk(name: str, *, directory: str = "/") -> PackageUpdate:
+    return PackageUpdate(
+        ecosystem="npm",
+        name=name,
+        from_version="1.0.0",
+        to_version="1.0.1",
+        directory=directory,
+    )
+
+
+class TestSynthesizeMergePlan:
+    def test_all_safe(self) -> None:
+        plan = synthesize_merge_plan(safe=[_mk("a"), _mk("b")], guilty=[])
+        assert len(plan) == 2
+        assert all(step.startswith("Merge: ") for step in plan)
+
+    def test_guilty_produces_hold_and_followup(self) -> None:
+        plan = synthesize_merge_plan(safe=[_mk("a")], guilty=[_mk("bad")])
+        assert any("Merge: a" in s for s in plan)
+        assert any("Hold: bad" in s for s in plan)
+        assert any("Open followup issue: bad upgrade" in s for s in plan)
+
+    def test_budget_exhausted_flags_human_review(self) -> None:
+        plan = synthesize_merge_plan(
+            safe=[_mk("a")],
+            guilty=[],
+            inconclusive=[_mk("x"), _mk("y")],
+            budget_exhausted=True,
+        )
+        assert any("budget exhausted" in s for s in plan)
+
+
+# ────────────────────────────────────────────────────────────────────
+# Bisect loop
+# ────────────────────────────────────────────────────────────────────
+
+
+def _mk_grouped_pr(body: str, *, number: int = 1, labels: list[Label] | None = None) -> PullRequest:
+    return PullRequest(
+        number=number,
+        title="Bump the npm_and_yarn group across 1 directory with 8 updates",
+        body=body,
+        state="open",
+        user=User(login="dependabot[bot]", id=2),
+        head_ref="dependabot/npm_and_yarn/group-8",
+        base_ref="main",
+        mergeable=True,
+        merged=False,
+        draft=False,
+        labels=labels or [],
+        html_url=f"https://github.com/o/r/pull/{number}",
+    )
+
+
+def _body_with(packages: list[str]) -> str:
+    """Render a synthetic grouped-PR body for the given package names."""
+    rows = "\n".join(f"| {name} | `1.0.0` | `1.0.1` |" for name in packages)
+    return (
+        f"Bumps the npm_and_yarn group with {len(packages)} updates in the / directory:\n\n"
+        "| Package | From | To |\n"
+        "| --- | --- | --- |\n"
+        f"{rows}\n"
+    )
+
+
+class _ScriptedProbe:
+    """CI probe stub: fails whenever any package in ``guilty_names`` is present."""
+
+    def __init__(self, guilty_names: set[str]) -> None:
+        self.guilty_names = guilty_names
+        self.calls: list[list[str]] = []
+
+    async def __call__(self, subset: list[PackageUpdate]) -> ProbeOutcome:
+        names = [u.name for u in subset]
+        self.calls.append(names)
+        if any(n in self.guilty_names for n in names):
+            return ProbeOutcome(passed=False, reason="simulated failure")
+        return ProbeOutcome(passed=True)
+
+
+class TestBisectLoop:
+    @pytest.mark.asyncio
+    async def test_returns_inconclusive_for_non_grouped(self) -> None:
+        pr = _mk_grouped_pr("just prose, no table")
+        result = await bisect_grouped_dependabot_pr(pr, github=MagicMock())
+        assert result.outcome == "inconclusive"
+        assert result.reason == "not_grouped"
+        assert result.suggested_merge_plan == []
+
+    @pytest.mark.asyncio
+    async def test_advisory_mode_without_probe(self) -> None:
+        pr = _mk_grouped_pr(_body_with(["a", "b", "c"]))
+        result = await bisect_grouped_dependabot_pr(pr, github=MagicMock())
+        assert result.outcome == "inconclusive"
+        assert result.reason == "no_probe_configured"
+        assert result.runs_consumed == 0
+        assert len(result.suggested_merge_plan) >= 1
+        assert any("human review" in s for s in result.suggested_merge_plan)
+
+    @pytest.mark.asyncio
+    async def test_full_bundle_green(self) -> None:
+        pr = _mk_grouped_pr(_body_with(["a", "b", "c"]))
+        probe = _ScriptedProbe(guilty_names=set())
+        result = await bisect_grouped_dependabot_pr(pr, github=MagicMock(), ci_probe=probe)
+        assert result.outcome == "all_green"
+        assert len(result.safe_updates) == 3
+        # One probe of the full bundle — never split.
+        assert result.runs_consumed == 1
+
+    @pytest.mark.asyncio
+    async def test_converges_on_single_guilty_in_logarithmic_probes(self) -> None:
+        # 8 updates, 1 guilty → expect ceil(log2(8)) + 1 ≈ 4 or fewer probes.
+        names = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        pr = _mk_grouped_pr(_body_with(names))
+        probe = _ScriptedProbe(guilty_names={"e"})
+
+        result = await bisect_grouped_dependabot_pr(
+            pr, github=MagicMock(), ci_probe=probe, max_runs=6
+        )
+
+        assert result.outcome == "guilty_identified"
+        assert [u.name for u in result.guilty_updates] == ["e"]
+        assert {u.name for u in result.safe_updates} == {n for n in names if n != "e"}
+        # Full bundle probe + at most log2(n)=3 narrowing rounds of 2
+        # probes each; we easily fit in 6.
+        assert result.runs_consumed <= 6
+        # And strictly fewer than a linear scan.
+        assert result.runs_consumed < len(names)
+        assert any("Hold: e" in s for s in result.suggested_merge_plan)
+        assert any("Merge: a" in s for s in result.suggested_merge_plan)
+
+    @pytest.mark.asyncio
+    async def test_budget_exhausted_returns_partial(self) -> None:
+        # 16 updates + 1 guilty + tight budget → bisect can't converge.
+        names = [f"pkg{i}" for i in range(16)]
+        pr = _mk_grouped_pr(_body_with(names))
+        probe = _ScriptedProbe(guilty_names={"pkg9"})
+
+        result = await bisect_grouped_dependabot_pr(
+            pr, github=MagicMock(), ci_probe=probe, max_runs=2
+        )
+
+        assert result.outcome == "inconclusive"
+        assert result.reason == "budget_exhausted"
+        assert result.runs_consumed == 2
+        # Some narrowing should still have happened: half the bundle
+        # got confirmed safe.
+        assert len(result.safe_updates) > 0
+        assert any("budget exhausted" in step.lower() for step in result.suggested_merge_plan)
+
+    @pytest.mark.asyncio
+    async def test_handles_two_independent_culprits(self) -> None:
+        names = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        pr = _mk_grouped_pr(_body_with(names))
+        # Put one guilty in each half so both halves fail individually.
+        probe = _ScriptedProbe(guilty_names={"b", "g"})
+
+        result = await bisect_grouped_dependabot_pr(
+            pr, github=MagicMock(), ci_probe=probe, max_runs=6
+        )
+
+        # With 6 runs we may not fully converge on both; we accept
+        # either ``guilty_identified`` with both found, or
+        # ``inconclusive`` with at least one confirmed guilty.
+        assert result.outcome in {"guilty_identified", "inconclusive"}
+        guilty_names = {u.name for u in result.guilty_updates}
+        assert "b" in guilty_names or "g" in guilty_names
+
+
+# ────────────────────────────────────────────────────────────────────
+# Comment formatter
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestFormatBisectComment:
+    def test_comment_contains_marker(self) -> None:
+        from caretaker.dependency_agent.bisector import BisectResult
+
+        result = BisectResult(
+            outcome="guilty_identified",
+            safe_updates=[_mk("safe-pkg")],
+            guilty_updates=[_mk("bad-pkg")],
+            suggested_merge_plan=["Merge: safe-pkg 1.0.0->1.0.1 (/)"],
+            runs_consumed=3,
+        )
+        body = format_bisect_comment(result)
+        assert BISECTOR_COMMENT_MARKER in body
+        assert "safe-pkg" in body
+        assert "bad-pkg" in body
+        assert "CI runs consumed:** 3" in body
+
+
+# ────────────────────────────────────────────────────────────────────
+# Agent integration hook
+# ────────────────────────────────────────────────────────────────────
+
+
+def _make_agent_github(
+    prs: list[PullRequest],
+    *,
+    ci_status: str = "failure",
+    existing_comments: list[Comment] | None = None,
+) -> AsyncMock:
+    from caretaker.github_client.models import Issue
+
+    gh = AsyncMock()
+    gh.list_pull_requests.return_value = prs
+    gh.get_combined_status.return_value = ci_status
+    gh.get_pr_comments.return_value = existing_comments or []
+    gh.add_issue_comment.return_value = None
+    gh.list_issues.return_value = []
+    gh.create_issue.return_value = Issue(
+        number=99,
+        title="",
+        body="",
+        state="open",
+        user=User(login="bot", id=1),
+        labels=[],
+        assignees=[],
+        html_url="",
+    )
+    gh.ensure_label.return_value = None
+    return gh
+
+
+class TestAgentBisectorIntegration:
+    @pytest.mark.asyncio
+    async def test_fires_when_owned_and_unstable(self) -> None:
+        grouped = _mk_grouped_pr(
+            _body_with(["a", "b", "c"]),
+            number=42,
+            labels=[Label(name="caretaker:owned")],
+        )
+        # Title is the generic "group" form so _parse_bump() returns None
+        # → the grouped PR is picked up by the bisector path.
+        grouped.title = "chore(deps): bump the npm_and_yarn group with 3 updates"
+        gh = _make_agent_github([grouped], ci_status="failure")
+
+        agent = DependencyAgent(
+            github=gh,
+            owner="o",
+            repo="r",
+            post_digest=False,
+            bisector_enabled=True,
+        )
+        report = await agent.run()
+
+        assert 42 in report.bisector_plans_posted
+        gh.add_issue_comment.assert_awaited_once()
+        comment_body = gh.add_issue_comment.call_args.args[3]
+        assert BISECTOR_COMMENT_MARKER in comment_body
+
+    @pytest.mark.asyncio
+    async def test_noop_without_owned_label(self) -> None:
+        grouped = _mk_grouped_pr(_body_with(["a", "b"]), number=42, labels=[])
+        grouped.title = "chore(deps): bump the npm_and_yarn group with 2 updates"
+        gh = _make_agent_github([grouped], ci_status="failure")
+
+        agent = DependencyAgent(
+            github=gh,
+            owner="o",
+            repo="r",
+            post_digest=False,
+            bisector_enabled=True,
+        )
+        report = await agent.run()
+
+        assert report.bisector_plans_posted == []
+        gh.add_issue_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_feature_disabled(self) -> None:
+        grouped = _mk_grouped_pr(
+            _body_with(["a", "b"]),
+            number=42,
+            labels=[Label(name="caretaker:owned")],
+        )
+        grouped.title = "chore(deps): bump the npm_and_yarn group with 2 updates"
+        gh = _make_agent_github([grouped], ci_status="failure")
+
+        agent = DependencyAgent(
+            github=gh,
+            owner="o",
+            repo="r",
+            post_digest=False,
+            bisector_enabled=False,
+        )
+        report = await agent.run()
+
+        assert report.bisector_plans_posted == []
+        gh.add_issue_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_ci_green(self) -> None:
+        grouped = _mk_grouped_pr(
+            _body_with(["a", "b"]),
+            number=42,
+            labels=[Label(name="caretaker:owned")],
+        )
+        grouped.title = "chore(deps): bump the npm_and_yarn group with 2 updates"
+        gh = _make_agent_github([grouped], ci_status="success")
+
+        agent = DependencyAgent(
+            github=gh,
+            owner="o",
+            repo="r",
+            post_digest=False,
+            bisector_enabled=True,
+        )
+        await agent.run()
+
+        gh.add_issue_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_on_existing_comment(self) -> None:
+        import datetime as dt
+
+        from caretaker.github_client.models import Comment, User
+
+        existing = [
+            Comment(
+                id=7,
+                user=User(login="caretaker[bot]", id=1),
+                body=f"prior plan\n\n{BISECTOR_COMMENT_MARKER}",
+                created_at=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+            )
+        ]
+        grouped = _mk_grouped_pr(
+            _body_with(["a", "b"]),
+            number=42,
+            labels=[Label(name="caretaker:owned")],
+        )
+        grouped.title = "chore(deps): bump the npm_and_yarn group with 2 updates"
+        gh = _make_agent_github([grouped], ci_status="failure", existing_comments=existing)
+
+        agent = DependencyAgent(
+            github=gh,
+            owner="o",
+            repo="r",
+            post_digest=False,
+            bisector_enabled=True,
+        )
+        report = await agent.run()
+
+        assert report.bisector_plans_posted == []
+        gh.add_issue_comment.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Parses grouped Dependabot PR bodies (e.g. `npm_and_yarn across 4 directories, 25 updates`) into structured `PackageUpdate` rows — handles table-style headers, inline-list headers, multi-directory bundles, and the global "Updates \`pkg\` from X to Y" detail section. Tested against a real fixture (Example-React-AI-Chat-App#195).
- Adds `bisect_grouped_dependabot_pr`, a budget-capped classic-bisect loop that accepts a pluggable `CIProbe` callable. Converges on a single guilty update in <= log2(n) rounds; surfaces two-culprit scenarios; emits `outcome="inconclusive"` with partial plan when the budget is exhausted.
- Adds `synthesize_merge_plan` / `format_bisect_comment` so results render as a short, copy-pastable plan (`Merge: X`, `Hold: Y (breaks CI)`, `Open followup issue: Y upgrade`).
- Wires a `DependencyAgent` hook gated behind `dependency_agent.bisector.enabled` (default `false`). Hook fires only on Dependabot PRs that (a) carry the `caretaker:owned` label, (b) are not conflicted, (c) have non-green CI, and (d) don't already have a prior bisect comment (idempotent).

## Scope: Part 1 only
Per the M10 brief, this PR ships the **parser + plan synthesizer + advisory comment hook**. Without a `ci_probe` wired in the bisector runs in **advisory mode**: it emits `outcome="inconclusive"` with `reason="no_probe_configured"` and a plan that lists the parsed updates for human review. The CI-driven branch-bisect driver (create branch → apply subset → push → wait for CI → recurse) is left as a **follow-up** because it needs branch-push permissions and CI-minute budget that this repo is not yet configured to grant to the dependency agent. The `CIProbe` protocol is in place so the follow-up is purely additive.

## Design notes
- **Parsing:** two-pass approach. Pass 1 walks header blocks and records `(name, directory)` tuples with whatever version info the summary table provides. Pass 2 fills in missing versions from the global per-package detail section. This fixes the naive "track the current directory" approach, which over-attributes every detail line to the last-seen header.
- **Bisect loop:** classic binary search, special-cased for 2-element subsets so a single probe identifies the guilty element by elimination (saves half the CI runs in the common single-culprit case). Budget is hard-capped via `max_runs` (default 6). Interaction-failure case (both halves pass individually but together fail) is recorded as `undetermined` and surfaced in the plan as "needs human review".
- **Config:** new `DependencyBisectorConfig` under `DependencyAgentConfig.bisector` with `enabled: false`, `max_runs: 6`, `owned_label: "caretaker:owned"`. Default-off keeps the feature dormant until explicitly opted in.

## Test plan
- [x] `pytest -q tests/test_dependency_agent.py tests/test_dependency_bisector.py` — 39 passed
- [x] `pytest -q` — 1580 passed, 1 skipped (full suite)
- [x] `ruff check src tests` — all checks passed
- [x] `ruff format --check src tests` — 309 files already formatted
- [x] `mypy src/caretaker` — only pre-existing `k8s_worker/launcher.py` warnings unrelated to this change
- [x] Parser golden-tested against the real Dependabot grouped PR body (fixture: `tests/fixtures/dependency_agent/grouped_pr_195_body.md`)

## Follow-up
- Implement the `CIProbe` driver that creates a probe branch, applies the subset of Dependabot commits, pushes, waits for CI, and returns a `ProbeOutcome`. Flip `enabled` to `true` (or keep behind a per-repo toggle) once the CI-minute budget story is settled.
- Consider promoting `bisector_plans_posted` into the `RunSummary` for observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)