### PR TITLE
chore(triage): flip TriageAgent live — remove dry_run override

### DIFF
--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -122,10 +122,3 @@ executor:
       - LINT_FAILURE
       - REVIEW_COMMENT
     route_same_repo_only: true
-
-# Triage subsystem (v0.11.0) — start in dry-run so the next scheduled run
-# emits the "[DRY RUN]" plan-summary log line without closing anything.
-# Flip dry_run to false (or remove the block to use defaults) once a run
-# confirms the planner's choices look correct.
-triage:
-  dry_run: true


### PR DESCRIPTION
## Summary
- Remove the `triage: dry_run: true` block from `.github/maintainer/config.yml`
- Defaults kick in (`TriageConfig.dry_run = False`), so the next scheduled Caretaker run executes triage live
- Plan-summary log line added in #467 remains in place for ongoing observability

## Smoke test
Two back-to-back runs produced identical empty plans:

| Run | Marker | Plan |
|-----|--------|------|
| 24759725094 | (live, pre-fix) | `pr(empty=0 duplicate=0 conflicted=0) issue(empty=0 duplicate=0 stale=0 resolved=0) cascade(planned=0 applied=0 skipped=0)` |
| 24759922866 | `[DRY RUN]` | same |

The accidental live run proved zero destructive actions would fire on current repo state. Further dry-run iterations add no information.

## Test plan
- [x] `uv run caretaker validate-config --config .github/maintainer/config.yml` — ✅ valid
- [ ] Next scheduled Caretaker run logs `Triage agent: pr(…) issue(…) cascade(…)` (no `[DRY RUN]` prefix) and produces zero or expected closures

## Rollback
If a future plan looks wrong, re-add:
```yaml
triage:
  dry_run: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)