### PR TITLE
feat(attribution): caretaker_touched/merged/operator_intervened telemetry + admin endpoint

### DIFF
--- a/src/caretaker/admin/api.py
+++ b/src/caretaker/admin/api.py
@@ -121,6 +121,44 @@ async def latest_run(
     return result
 
 
+@router.get("/attribution/weekly")
+async def attribution_weekly(
+    repo: str | None = Query(
+        default=None,
+        description=(
+            "Repo slug (owner/name). Currently ignored — "
+            "the admin data is scoped to one repo per deployment."
+        ),
+    ),
+    since: str | None = Query(
+        default=None,
+        description="ISO-8601 cutoff. Defaults to 7 days ago.",
+    ),
+    _user: UserInfo = Depends(require_session),
+) -> dict[str, Any]:
+    """Weekly attribution rollup.
+
+    Returns the count of PRs caretaker touched / merged / rescued /
+    abandoned since ``since``, plus the average
+    ``avg_time_to_merge_hours`` for PRs caretaker closed as merged. The
+    ``repo`` query parameter is accepted for forward-compatibility with
+    the fleet-aggregated admin tier — the single-repo admin dashboard
+    ignores it and serves data for the repo the orchestrator is scoped
+    to.
+    """
+    from datetime import datetime  # local import to keep module footprint small
+
+    since_dt: datetime | None = None
+    if since is not None:
+        try:
+            since_dt = datetime.fromisoformat(since)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail=f"invalid ISO-8601 datetime: {since!r}"
+            ) from exc
+    return _get_data().get_attribution_weekly(since=since_dt)
+
+
 @router.get("/metrics/fanout")
 async def fanout_metrics(
     high_cycle_threshold: int = Query(default=2, ge=1, le=100),

--- a/src/caretaker/admin/data.py
+++ b/src/caretaker/admin/data.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import asdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from pydantic import BaseModel
@@ -272,6 +272,85 @@ class AdminDataAccess:
                 }
                 for p in hot_sorted
             ],
+        }
+
+    # ── Attribution telemetry ─────────────────────────────────────────────
+
+    def get_attribution_weekly(
+        self,
+        *,
+        since: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Weekly attribution rollup for the configured repo.
+
+        Returns the count of PRs caretaker touched / merged / rescued /
+        abandoned since ``since``, plus the average
+        ``avg_time_to_merge_hours`` for PRs caretaker closed as merged.
+        ``since`` is inclusive and defaults to seven days ago. PRs
+        without a ``merged_at`` never contribute to the time-to-merge
+        average (it's ``None`` when no caretaker merges landed).
+
+        The implementation is intentionally stateless: it walks the
+        in-memory ``OrchestratorState.tracked_prs`` rather than talking
+        to Neo4j so the dashboard renders under typical single-repo
+        pressure. Multi-repo aggregation happens at the fleet tier via
+        the heartbeat payload.
+        """
+        cutoff = since if since is not None else datetime.now(UTC) - timedelta(days=7)
+        if cutoff.tzinfo is None:
+            cutoff = cutoff.replace(tzinfo=UTC)
+        prs = list(self._state.tracked_prs.values())
+
+        # ``merged_at`` is the closest proxy we have for "activity window."
+        # For PRs caretaker never merged, fall back to ``last_checked`` so
+        # abandoned / rescued PRs still show up in the rollup for the
+        # window they were last observed in.
+        def _window_stamp(pr: Any) -> datetime | None:
+            stamp = pr.merged_at or pr.last_checked or pr.first_seen_at
+            if stamp is None:
+                return None
+            if stamp.tzinfo is None:
+                stamp = stamp.replace(tzinfo=UTC)
+            return stamp  # type: ignore[no-any-return]
+
+        in_window = [pr for pr in prs if (s := _window_stamp(pr)) is not None and s >= cutoff]
+
+        touched = sum(1 for pr in in_window if pr.caretaker_touched)
+        merged = sum(1 for pr in in_window if pr.caretaker_merged)
+        rescued = sum(1 for pr in in_window if pr.operator_intervened)
+        # "Abandoned" mirrors the metrics classifier — escalated without
+        # a rescue. We compute it here rather than importing the
+        # classifier to keep the admin surface insulated from the
+        # in-process metrics module's side-effects.
+        abandoned = sum(
+            1 for pr in in_window if pr.state.value == "escalated" and not pr.operator_intervened
+        )
+
+        merged_prs = [
+            pr for pr in in_window if pr.caretaker_merged and pr.merged_at and pr.first_seen_at
+        ]
+        ttm_hours: float | None = None
+        if merged_prs:
+            total = 0.0
+            for pr in merged_prs:
+                first = pr.first_seen_at
+                merged_at = pr.merged_at
+                if first is None or merged_at is None:
+                    continue
+                if first.tzinfo is None:
+                    first = first.replace(tzinfo=UTC)
+                if merged_at.tzinfo is None:
+                    merged_at = merged_at.replace(tzinfo=UTC)
+                total += (merged_at - first).total_seconds() / 3600.0
+            ttm_hours = round(total / len(merged_prs), 2) if merged_prs else None
+
+        return {
+            "since": cutoff.isoformat(),
+            "touched": touched,
+            "merged": merged,
+            "operator_rescued": rescued,
+            "abandoned": abandoned,
+            "avg_time_to_merge_hours": ttm_hours,
         }
 
     # ── Memory Store ──────────────────────────────────────────────────────

--- a/src/caretaker/cli.py
+++ b/src/caretaker/cli.py
@@ -298,29 +298,34 @@ def eval_group() -> None:
 
 
 def _parse_since(value: str) -> datetime:
-    """Parse ``--since`` as either ``<N>[smhd]`` or an ISO-8601 timestamp.
+    """Parse ``--since`` as ``<N>[smhdw]`` or an ISO-8601 timestamp.
 
     Kept module-local (not a Click type) because the duration grammar is
     tiny and reusing click's DateTime type would lose the ``7d`` case.
+    Shared by the eval harness (``caretaker eval run``) and the
+    attribution backfill (``caretaker backfill-attribution``).
     """
+    import re
     from datetime import UTC, datetime, timedelta
 
     stripped = value.strip()
-    if stripped and stripped[-1] in {"s", "m", "h", "d"} and stripped[:-1].isdigit():
-        amount = int(stripped[:-1])
-        unit = stripped[-1]
+    match = re.fullmatch(r"(\d+)([smhdw])", stripped)
+    if match:
+        amount = int(match.group(1))
+        unit = match.group(2)
         delta = {
             "s": timedelta(seconds=amount),
             "m": timedelta(minutes=amount),
             "h": timedelta(hours=amount),
             "d": timedelta(days=amount),
+            "w": timedelta(weeks=amount),
         }[unit]
         return datetime.now(UTC) - delta
     try:
         parsed = datetime.fromisoformat(stripped)
     except ValueError as exc:
         raise click.BadParameter(
-            f"--since must be a duration like '24h' or an ISO-8601 timestamp; got {value!r}"
+            f"--since must be a duration like '24h' / '4w' or an ISO-8601 timestamp; got {value!r}"
         ) from exc
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
@@ -446,6 +451,157 @@ def backfill_embeddings(
     click.echo(json.dumps(result, indent=2, sort_keys=True))
     if result.get("errors"):
         raise SystemExit(1)
+
+
+# ── attribution backfill ──────────────────────────────────────────────────
+
+# Local shims so ``backfill_attribution`` stays readable without pulling
+# every model symbol into the top of the file.
+_PR_MERGED = "merged"
+_PR_ESCALATED = "escalated"
+_PR_CLOSED = "closed"
+_ISSUE_STALE = "stale"
+_ISSUE_CLOSED = "closed"
+
+
+def _row_active_since(row: object, cutoff: datetime) -> bool:
+    """Return True if the tracked row has any activity on or after ``cutoff``.
+
+    Uses ``last_checked`` first (updated on every cycle), then
+    ``merged_at`` / ``first_seen_at`` as fallbacks. Rows with no
+    timestamps at all are included — they're the most-suspect candidates
+    for backfill, and filtering them out would leave the weekly
+    dashboard permanently blind on them.
+    """
+    from datetime import UTC
+
+    stamp = (
+        getattr(row, "last_checked", None)
+        or getattr(row, "merged_at", None)
+        or getattr(row, "first_seen_at", None)
+    )
+    if stamp is None:
+        return True
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=UTC)
+    if cutoff.tzinfo is None:
+        cutoff = cutoff.replace(tzinfo=UTC)
+    return bool(stamp >= cutoff)
+
+
+@main.command("backfill-attribution")
+@click.option(
+    "--config",
+    default=DEFAULT_DOCTOR_CONFIG,
+    show_default=True,
+    type=click.Path(),
+    help="Path to config.yml. Defaults to .github/maintainer/config.yml.",
+)
+@click.option(
+    "--since",
+    default="30d",
+    show_default=True,
+    help=(
+        "Look back window. Accepts 'Nd' / 'Nw' / 'Nh' or an ISO-8601 datetime. "
+        "Rows older than this are skipped."
+    ),
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print what would change without mutating persisted state.",
+)
+def backfill_attribution(config: str, since: str, dry_run: bool) -> None:
+    """Backfill attribution telemetry on existing tracked state.
+
+    Walks every PR / issue in the orchestrator state store and reconciles
+    the attribution fields (``caretaker_touched`` / ``caretaker_merged``
+    / ``caretaker_closed``) against what can be inferred from the
+    existing history. Best-effort: any field that can't be reconstructed
+    is left at its default, which renders as "unknown" in the dashboard.
+
+    This is a one-shot. Running it more than once on the same state is
+    a no-op for rows that are already coherent.
+    """
+    import asyncio as _asyncio
+    import json as _json
+    from datetime import UTC, datetime, timedelta
+
+    from caretaker.orchestrator import Orchestrator
+    from caretaker.state.intervention_detector import backfill_missing_fields
+
+    _configure_logging(None, debug=False)
+
+    try:
+        loaded = MaintainerConfig.from_yaml(config)
+    except FileNotFoundError as exc:
+        click.echo(f"backfill-attribution: config file not found: {exc}", err=True)
+        raise SystemExit(2) from exc
+
+    cutoff = _parse_since(since)
+    del loaded
+    orch = Orchestrator.from_config_path(config)
+
+    async def _run() -> tuple[int, int, int]:
+        await orch._state_tracker.load()
+        state = orch._state_tracker.state
+        filtered_prs = {
+            n: pr for n, pr in state.tracked_prs.items() if _row_active_since(pr, cutoff)
+        }
+        filtered_issues = {
+            n: issue
+            for n, issue in state.tracked_issues.items()
+            if _row_active_since(issue, cutoff)
+        }
+        pr_inferred = 0
+        for pr in filtered_prs.values():
+            if pr.state == _PR_MERGED and not pr.caretaker_merged:
+                pr.caretaker_merged = True
+                pr.caretaker_touched = True
+                pr_inferred += 1
+            elif pr.state == _PR_ESCALATED and not pr.caretaker_touched:
+                pr.caretaker_touched = True
+                pr_inferred += 1
+        issue_inferred = 0
+        for issue in filtered_issues.values():
+            if issue.state in (_ISSUE_STALE, _ISSUE_CLOSED) and not issue.caretaker_touched:
+                issue.caretaker_touched = True
+                if issue.state == _ISSUE_STALE:
+                    issue.caretaker_closed = True
+                issue_inferred += 1
+        reconciled = backfill_missing_fields(state.tracked_prs, state.tracked_issues)
+        if dry_run:
+            click.echo(
+                _json.dumps(
+                    {
+                        "dry_run": True,
+                        "since": cutoff.isoformat(),
+                        "prs_in_window": len(filtered_prs),
+                        "issues_in_window": len(filtered_issues),
+                        "prs_inferred": pr_inferred,
+                        "issues_inferred": issue_inferred,
+                        "invariant_reconciliations": reconciled,
+                    },
+                    indent=2,
+                )
+            )
+            return pr_inferred, issue_inferred, reconciled
+        if pr_inferred or issue_inferred or reconciled:
+            await orch._state_tracker.save()
+        return pr_inferred, issue_inferred, reconciled
+
+    try:
+        pr_inferred, issue_inferred, reconciled = _asyncio.run(_run())
+    except Exception as exc:  # pragma: no cover - surfaced to CLI user
+        click.echo(f"backfill-attribution: internal error: {exc}", err=True)
+        raise SystemExit(2) from exc
+
+    click.echo(
+        f"Backfill complete: PRs updated={pr_inferred} Issues updated={issue_inferred} "
+        f"Invariant fixes={reconciled}"
+    )
+    _ = datetime.now(UTC) - timedelta(days=1)
 
 
 if __name__ == "__main__":

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -641,6 +641,37 @@ class AdminDashboardConfig(StrictBaseModel):
     public_base_url: str = ""
 
 
+class AttributionConfig(StrictBaseModel):
+    """Attribution telemetry knobs (R&D workstream A2).
+
+    The telemetry fields themselves (``caretaker_touched`` / ``merged`` /
+    ``operator_intervened`` on :class:`~caretaker.state.models.TrackedPR`
+    and :class:`~caretaker.state.models.TrackedIssue`) round-trip through
+    Pydantic JSON with defaults, so existing Mongo/SQLite rows load cleanly
+    without a destructive schema migration. What this knob governs is
+    *when* those defaults get materialised back into the persisted state:
+
+    * ``lazy`` (default) — populate on next write. Existing rows keep
+      their missing fields until the next run causes ``save()`` to serialise
+      them fresh. Zero runtime cost; the only caveat is that the weekly
+      attribution rollup will count under-reported values for repos that
+      haven't run since the feature shipped.
+    * ``eager`` — the orchestrator runs a one-pass
+      :func:`caretaker.state.intervention_detector.backfill_missing_fields`
+      on load() so every tracked row has the attribution fields set before
+      the first action of the run. Costs one extra pass over the tracked
+      state; useful for operators who want the weekly dashboard accurate
+      from the first run post-upgrade.
+
+    Lazy is the safe default: the worst case is a few days of partial
+    attribution data for repos that run infrequently. Eager is the
+    preferred mode for high-value repos where the dashboard needs to be
+    correct immediately.
+    """
+
+    migration_strategy: Literal["eager", "lazy"] = "lazy"
+
+
 class GraphStoreConfig(StrictBaseModel):
     """Configuration for the Neo4j graph store."""
 
@@ -1074,6 +1105,7 @@ class MaintainerConfig(StrictBaseModel):
     admin_dashboard: AdminDashboardConfig = Field(default_factory=AdminDashboardConfig)
     graph_store: GraphStoreConfig = Field(default_factory=GraphStoreConfig)
     agentic: AgenticConfig = Field(default_factory=AgenticConfig)
+    attribution: AttributionConfig = Field(default_factory=AttributionConfig)
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> MaintainerConfig:

--- a/src/caretaker/fleet/__init__.py
+++ b/src/caretaker/fleet/__init__.py
@@ -11,6 +11,7 @@ from caretaker.fleet.alerts import (
 )
 from caretaker.fleet.api import admin_router, public_router, set_fleet_alert_dependencies
 from caretaker.fleet.emitter import (
+    AttributionSummary,
     FleetHeartbeat,
     FleetOAuthClientCache,
     build_heartbeat,
@@ -30,6 +31,7 @@ from caretaker.fleet.store import (
 )
 
 __all__ = [
+    "AttributionSummary",
     "FleetAlert",
     "FleetAlertStore",
     "FleetClient",

--- a/src/caretaker/fleet/emitter.py
+++ b/src/caretaker/fleet/emitter.py
@@ -174,6 +174,33 @@ def _enabled_agents(config: MaintainerConfig) -> list[str]:
     return names
 
 
+class AttributionSummary(BaseModel):
+    """Per-heartbeat attribution rollup (R&D workstream A2).
+
+    Optional block on :class:`FleetHeartbeat` so the central registry can
+    aggregate cross-repo counts without having to scrape each repo's
+    orchestrator state directly. Mirrors the shape of the admin
+    ``GET /api/admin/attribution/weekly`` response so the backend can
+    use a single DTO end-to-end.
+
+    All counts are scoped to the heartbeat's *reporting window* — for
+    the full-repo scheduled run that's whatever the orchestrator
+    observed in this cycle, for a single-PR event run that's typically
+    just the touched PR. The registry is expected to sum these over the
+    last N heartbeats per repo to get a weekly rollup, not to trust a
+    single heartbeat as canonical. Every field defaults to 0 / None so
+    older caretakers that don't emit this block still validate.
+    """
+
+    touched: int = 0
+    merged: int = 0
+    operator_rescued: int = 0
+    abandoned: int = 0
+    # ``None`` when no caretaker merges landed in the window so the
+    # dashboard can render "unknown" instead of a misleading zero.
+    avg_time_to_merge_hours: float | None = None
+
+
 class FleetHeartbeat(BaseModel):
     """Canonical heartbeat payload.
 
@@ -192,6 +219,61 @@ class FleetHeartbeat(BaseModel):
     error_count: int = 0
     counters: dict[str, int] = Field(default_factory=dict)
     summary: dict[str, Any] | None = None
+    # Optional attribution rollup. ``None`` keeps the payload byte-
+    # identical to pre-A2 for older emitters; the current emitter
+    # always populates this block even when everything is zero, so the
+    # backend can distinguish "no data" from "zero activity."
+    attribution: AttributionSummary | None = None
+
+
+def _build_attribution_summary(state: Any | None) -> AttributionSummary | None:
+    """Roll tracked-PR attribution into an :class:`AttributionSummary`.
+
+    Returns ``None`` when no state is supplied — the heartbeat field is
+    optional and older callers that never passed a state should keep
+    their payload byte-identical. When state is supplied we always
+    return a summary, even if every counter is zero, so the backend can
+    tell "zero activity this window" from "older caretaker that doesn't
+    report attribution yet."
+    """
+    if state is None:
+        return None
+    prs = list(getattr(state, "tracked_prs", {}).values())
+    touched = sum(1 for pr in prs if getattr(pr, "caretaker_touched", False))
+    merged = sum(1 for pr in prs if getattr(pr, "caretaker_merged", False))
+    rescued = sum(1 for pr in prs if getattr(pr, "operator_intervened", False))
+    abandoned = sum(
+        1
+        for pr in prs
+        if getattr(getattr(pr, "state", None), "value", None) == "escalated"
+        and not getattr(pr, "operator_intervened", False)
+    )
+    merged_prs = [
+        pr
+        for pr in prs
+        if getattr(pr, "caretaker_merged", False)
+        and getattr(pr, "merged_at", None) is not None
+        and getattr(pr, "first_seen_at", None) is not None
+    ]
+    ttm: float | None = None
+    if merged_prs:
+        total = 0.0
+        for pr in merged_prs:
+            first = pr.first_seen_at
+            merged_at = pr.merged_at
+            if first.tzinfo is None:
+                first = first.replace(tzinfo=UTC)
+            if merged_at.tzinfo is None:
+                merged_at = merged_at.replace(tzinfo=UTC)
+            total += (merged_at - first).total_seconds() / 3600.0
+        ttm = round(total / len(merged_prs), 2)
+    return AttributionSummary(
+        touched=touched,
+        merged=merged,
+        operator_rescued=rescued,
+        abandoned=abandoned,
+        avg_time_to_merge_hours=ttm,
+    )
 
 
 def build_heartbeat(
@@ -200,8 +282,17 @@ def build_heartbeat(
     *,
     repo: str | None = None,
     include_full_summary: bool | None = None,
+    state: Any | None = None,
 ) -> FleetHeartbeat:
-    """Assemble the heartbeat payload from a finished run."""
+    """Assemble the heartbeat payload from a finished run.
+
+    ``state`` is the orchestrator's ``OrchestratorState`` snapshot; when
+    supplied the heartbeat carries an :class:`AttributionSummary` block
+    so the fleet registry can aggregate cross-repo attribution counts
+    without scraping each consumer. Kept optional for backward
+    compatibility and for legacy test fixtures that never constructed
+    state.
+    """
     slug = repo or os.environ.get("GITHUB_REPOSITORY") or "unknown/unknown"
     counters = {k: int(getattr(summary, k, 0) or 0) for k in _COUNTERS}
     want_full = (
@@ -220,6 +311,7 @@ def build_heartbeat(
         error_count=len(summary.errors or []),
         counters=counters,
         summary=full,
+        attribution=_build_attribution_summary(state),
     )
 
 
@@ -234,6 +326,7 @@ async def emit_heartbeat(
     *,
     client: httpx.AsyncClient | None = None,
     oauth_cache: FleetOAuthClientCache | None = None,
+    state: Any | None = None,
 ) -> bool:
     """POST a heartbeat to the configured fleet endpoint.
 
@@ -255,7 +348,7 @@ async def emit_heartbeat(
         return False
 
     try:
-        heartbeat = build_heartbeat(config, summary)
+        heartbeat = build_heartbeat(config, summary, state=state)
     except Exception as exc:  # defensive: never break the run loop
         logger.warning("fleet heartbeat: failed to build payload: %s", exc)
         return False

--- a/src/caretaker/issue_agent/agent.py
+++ b/src/caretaker/issue_agent/agent.py
@@ -42,6 +42,19 @@ class IssueAgentReport:
     errors: list[str] = field(default_factory=list)
 
 
+def _mark_caretaker_touched(tracking: TrackedIssue) -> None:
+    """Stamp the attribution fields on a tracked issue after a write action.
+
+    Called after any comment / label / close / escalation on the issue
+    via the GitHub client. Keeps ``last_caretaker_action_at`` aligned
+    with the latest write so the intervention detector can tell human
+    activity that landed *after* caretaker's touch apart from activity
+    that landed between caretaker actions.
+    """
+    tracking.caretaker_touched = True
+    tracking.last_caretaker_action_at = datetime.now(UTC)
+
+
 def _compare_triage_tuple(
     legacy_v: tuple[IssueClassification, IssueTriage] | IssueClassification,
     candidate_v: tuple[IssueClassification, IssueTriage] | IssueClassification,
@@ -276,6 +289,7 @@ class IssueAgent:
                     result = await self._dispatcher.dispatch(issue, classification)
                     if result:
                         tracking.state = IssueTrackingState.ASSIGNED
+                        _mark_caretaker_touched(tracking)
                         report.assigned.append(issue.number)
 
             case IssueClassification.BUG_COMPLEX:
@@ -289,6 +303,7 @@ class IssueAgent:
                     result = await self._dispatcher.dispatch(issue, classification)
                     if result:
                         tracking.state = IssueTrackingState.ASSIGNED
+                        _mark_caretaker_touched(tracking)
                         report.assigned.append(issue.number)
                 else:
                     if tracking.state in (
@@ -304,6 +319,7 @@ class IssueAgent:
                     debug_data={"classification": classification.value},
                 )
                 tracking.state = IssueTrackingState.ESCALATED
+                _mark_caretaker_touched(tracking)
                 report.escalated.append(issue.number)
 
             case IssueClassification.QUESTION:
@@ -316,6 +332,8 @@ class IssueAgent:
                     )
                     await self._issues.update(issue.number, state="closed")
                     tracking.state = IssueTrackingState.CLOSED
+                    _mark_caretaker_touched(tracking)
+                    tracking.caretaker_closed = True
                     report.closed.append(issue.number)
 
             case IssueClassification.DUPLICATE:
@@ -326,6 +344,8 @@ class IssueAgent:
                 )
                 await self._issues.update(issue.number, state="closed")
                 tracking.state = IssueTrackingState.CLOSED
+                _mark_caretaker_touched(tracking)
+                tracking.caretaker_closed = True
                 report.closed.append(issue.number)
 
             case IssueClassification.STALE:
@@ -335,6 +355,8 @@ class IssueAgent:
                 )
                 await self._issues.update(issue.number, state="closed")
                 tracking.state = IssueTrackingState.STALE
+                _mark_caretaker_touched(tracking)
+                tracking.caretaker_closed = True
                 report.closed.append(issue.number)
 
             case IssueClassification.INFRA_OR_CONFIG:
@@ -344,6 +366,7 @@ class IssueAgent:
                     debug_data={"classification": classification.value},
                 )
                 tracking.state = IssueTrackingState.ESCALATED
+                _mark_caretaker_touched(tracking)
                 report.escalated.append(issue.number)
 
             case _:

--- a/src/caretaker/observability/metrics.py
+++ b/src/caretaker/observability/metrics.py
@@ -216,6 +216,58 @@ GITHUB_SCOPE_GAP_TOTAL = Counter(
     registry=REGISTRY,
 )
 
+# ── Attribution telemetry (R&D workstream A2) ───────────────────────
+#
+# Answers "did caretaker actually save human toil this week?" The three
+# counters below aggregate the per-PR / per-issue booleans stored on
+# :class:`~caretaker.state.models.TrackedPR` /
+# :class:`~caretaker.state.models.TrackedIssue` into rolling totals the
+# admin dashboard can graph. Cardinality is bounded by a small fixed
+# enum of ``outcome`` / ``reason`` labels and the set of repos caretaker
+# runs in.
+#
+# The ``repo`` label is the ``owner/repo`` slug. We intentionally do not
+# include per-PR numbers — that would blow up cardinality to something
+# like one series per open PR, and Prometheus would start evicting
+# series at scale. The per-PR state lives in the graph store instead.
+
+CARETAKER_PR_OUTCOME_TOTAL = Counter(
+    "caretaker_pr_outcome_total",
+    "PR outcomes classified by attribution status (touched / merged / "
+    "closed_unmerged / operator_rescued / abandoned).",
+    ["service", "repo", "outcome"],
+    registry=REGISTRY,
+)
+
+CARETAKER_ISSUE_OUTCOME_TOTAL = Counter(
+    "caretaker_issue_outcome_total",
+    "Issue outcomes classified by attribution status (triaged / "
+    "closed_by_caretaker / closed_by_operator / stale_closed).",
+    ["service", "repo", "outcome"],
+    registry=REGISTRY,
+)
+
+CARETAKER_OPERATOR_INTERVENTION_TOTAL = Counter(
+    "caretaker_operator_intervention_total",
+    "Human interventions that superseded a caretaker action, by reason.",
+    ["service", "repo", "reason"],
+    registry=REGISTRY,
+)
+
+# Bounded enums for the ``outcome`` / ``reason`` labels. Re-exported so
+# callers don't fat-finger label values (which would silently create new
+# series and break the cardinality budget).
+PR_OUTCOMES: frozenset[str] = frozenset(
+    {"touched", "merged", "closed_unmerged", "operator_rescued", "abandoned"}
+)
+ISSUE_OUTCOMES: frozenset[str] = frozenset(
+    {"triaged", "closed_by_caretaker", "closed_by_operator", "stale_closed"}
+)
+INTERVENTION_REASONS: frozenset[str] = frozenset(
+    {"manual_merge", "manual_close", "label_changed", "force_push", "commit_added"}
+)
+
+
 # ── LLM prompt-cache telemetry ───────────────────────────────────────
 #
 # Emitted by :mod:`caretaker.llm.provider` on every completion.  Together
@@ -632,6 +684,39 @@ def record_github_scope_gap(scope: str) -> None:
     GITHUB_SCOPE_GAP_TOTAL.labels(service=_SERVICE_LABEL, scope=scope).inc()
 
 
+def record_pr_outcome(repo: str, outcome: str) -> None:
+    """Increment the ``caretaker_pr_outcome_total`` counter.
+
+    ``outcome`` must be one of :data:`PR_OUTCOMES` — unknown values are
+    silently dropped so a typo in the caller can never expand cardinality.
+    """
+    if outcome not in PR_OUTCOMES:
+        logger.warning("record_pr_outcome called with unknown outcome=%r; dropping", outcome)
+        return
+    CARETAKER_PR_OUTCOME_TOTAL.labels(service=_SERVICE_LABEL, repo=repo, outcome=outcome).inc()
+
+
+def record_issue_outcome(repo: str, outcome: str) -> None:
+    """Increment the ``caretaker_issue_outcome_total`` counter."""
+    if outcome not in ISSUE_OUTCOMES:
+        logger.warning("record_issue_outcome called with unknown outcome=%r; dropping", outcome)
+        return
+    CARETAKER_ISSUE_OUTCOME_TOTAL.labels(service=_SERVICE_LABEL, repo=repo, outcome=outcome).inc()
+
+
+def record_operator_intervention(repo: str, reason: str) -> None:
+    """Increment the ``caretaker_operator_intervention_total`` counter."""
+    if reason not in INTERVENTION_REASONS:
+        logger.warning(
+            "record_operator_intervention called with unknown reason=%r; dropping",
+            reason,
+        )
+        return
+    CARETAKER_OPERATOR_INTERVENTION_TOTAL.labels(
+        service=_SERVICE_LABEL, repo=repo, reason=reason
+    ).inc()
+
+
 def record_llm_cache_usage(
     *,
     provider: str,
@@ -661,7 +746,9 @@ def record_llm_cache_usage(
 __all__ = [
     "APP_INFO",
     "CARETAKER_ERRORS_TOTAL",
-    "ORCHESTRATOR_SOFT_FAIL_TOTAL",
+    "CARETAKER_ISSUE_OUTCOME_TOTAL",
+    "CARETAKER_OPERATOR_INTERVENTION_TOTAL",
+    "CARETAKER_PR_OUTCOME_TOTAL",
     "DB_CLIENT_OPERATIONS_TOTAL",
     "DB_CLIENT_OPERATION_DURATION_SECONDS",
     "GITHUB_SCOPE_GAP_TOTAL",
@@ -669,9 +756,13 @@ __all__ = [
     "HTTP_CLIENT_REQUEST_DURATION_SECONDS",
     "HTTP_SERVER_REQUESTS_TOTAL",
     "HTTP_SERVER_REQUEST_DURATION_SECONDS",
+    "INTERVENTION_REASONS",
+    "ISSUE_OUTCOMES",
     "LATENCY_BUCKETS",
     "LLM_CACHE_CREATION_TOKENS_TOTAL",
     "LLM_CACHE_READ_TOKENS_TOTAL",
+    "ORCHESTRATOR_SOFT_FAIL_TOTAL",
+    "PR_OUTCOMES",
     "RATE_LIMIT_COOLDOWN_SECONDS",
     "RATE_LIMIT_REMAINING",
     "REGISTRY",
@@ -684,8 +775,11 @@ __all__ = [
     "record_error",
     "record_github_scope_gap",
     "record_http_client",
+    "record_issue_outcome",
     "record_llm_cache_usage",
+    "record_operator_intervention",
     "record_orchestrator_soft_fail",
+    "record_pr_outcome",
     "record_worker_job",
     "set_rate_limit_cooldown",
     "set_rate_limit_remaining",

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -719,6 +719,7 @@ class Orchestrator:
                     self._config,
                     summary,
                     oauth_cache=self._fleet_oauth_cache,
+                    state=self._state_tracker.state,
                 )
             except Exception as e:
                 logger.warning("Fleet heartbeat failed: %s", e)

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -117,6 +117,21 @@ class PRAgentReport:
     errors: list[str] = field(default_factory=list)
 
 
+def _mark_caretaker_touched(tracking: TrackedPR) -> None:
+    """Flip the attribution booleans on a PR when caretaker takes a write action.
+
+    Called immediately after any non-read-only GitHub operation (comment,
+    label, approve, merge, close). ``last_caretaker_action_at`` is the
+    anchor used by
+    :func:`caretaker.state.intervention_detector.detect_pr_intervention`
+    to decide whether a later human action qualifies as an operator
+    rescue. We stamp the *latest* write so consecutive caretaker actions
+    in the same cycle don't accidentally claim an earlier timestamp.
+    """
+    tracking.caretaker_touched = True
+    tracking.last_caretaker_action_at = datetime.now(UTC)
+
+
 class PRAgent:
     """Monitors and manages pull requests through their lifecycle."""
 
@@ -491,6 +506,7 @@ class PRAgent:
                 )
                 tracking.state = PRTrackingState.ESCALATED
                 tracking.escalated = True
+                _mark_caretaker_touched(tracking)
                 report.escalated.append(pr.number)
                 # Still flow through ownership handling so the status
                 # comment transitions to "released — escalated" cleanly.
@@ -568,6 +584,7 @@ class PRAgent:
                             run.name,
                         )
                         approved_any = True
+                        _mark_caretaker_touched(tracking)
                     else:
                         message = f"PR #{pr.number}: Failed to approve workflow run {run_id}"
                         logger.warning(message)
@@ -627,6 +644,12 @@ class PRAgent:
                 logger.info("PR #%d merged via %s", pr.number, merge_decision.method)
                 tracking.state = PRTrackingState.MERGED
                 tracking.merged_at = datetime.now(UTC)
+                # Attribution: caretaker's merge authority closed this PR.
+                # `caretaker_merged` implies `caretaker_touched`; we set
+                # both through the shared helper so the
+                # ``last_caretaker_action_at`` cutoff moves forward.
+                _mark_caretaker_touched(tracking)
+                tracking.caretaker_merged = True
                 report.merged.append(pr.number)
             else:
                 logger.warning("PR #%d merge failed", pr.number)
@@ -753,6 +776,7 @@ class PRAgent:
             )
             tracking.state = PRTrackingState.ESCALATED
             tracking.escalated = True
+            _mark_caretaker_touched(tracking)
             report.escalated.append(pr.number)
             return tracking
 
@@ -811,6 +835,7 @@ class PRAgent:
             tracking.state = PRTrackingState.FIX_REQUESTED
             tracking.last_state_change_at = datetime.now(UTC)
             tracking.last_copilot_attempt_at = datetime.now(UTC)
+            _mark_caretaker_touched(tracking)
             report.fix_requested.append(pr.number)
             logger.info(
                 "PR #%d: CI fix requested (attempt %d/%d)",
@@ -873,6 +898,7 @@ class PRAgent:
             await self._github.update_issue(self._owner, self._repo, pr.number, state="closed")
             tracking.state = PRTrackingState.CLOSED
             tracking.notes = "closed:ci_backlog_guard"
+            _mark_caretaker_touched(tracking)
             logger.info("PR #%d: closed due to CI backlog guard", pr.number)
             return tracking
 
@@ -909,6 +935,7 @@ class PRAgent:
             )
             tracking.state = PRTrackingState.ESCALATED
             tracking.escalated = True
+            _mark_caretaker_touched(tracking)
             report.escalated.append(pr.number)
         else:
             report.waiting.append(pr.number)
@@ -948,6 +975,7 @@ class PRAgent:
             )
             tracking.state = PRTrackingState.ESCALATED
             tracking.escalated = True
+            _mark_caretaker_touched(tracking)
             report.escalated.append(pr.number)
             return tracking
 
@@ -968,6 +996,7 @@ class PRAgent:
         tracking.last_task_comment_id = result.comment_id
         tracking.last_copilot_attempt_at = datetime.now(UTC)
         tracking.state = PRTrackingState.FIX_REQUESTED
+        _mark_caretaker_touched(tracking)
         report.fix_requested.append(pr.number)
 
         return tracking
@@ -1219,7 +1248,8 @@ class PRAgent:
         tracking.readiness_blockers = evaluation.readiness.blockers
         tracking.readiness_summary = evaluation.readiness.summary
 
-        # Handle ownership state transitions
+        # Handle ownership state transitions. Each branch that calls out
+        # to GitHub counts as a write action for attribution telemetry.
         if should_release_ownership(pr, tracking, "merged"):
             await release_ownership(
                 self._github,
@@ -1230,6 +1260,7 @@ class PRAgent:
                 self._config.ownership,
                 reason="PR merged",
             )
+            _mark_caretaker_touched(tracking)
         elif should_release_ownership(pr, tracking, "closed"):
             await release_ownership(
                 self._github,
@@ -1240,6 +1271,7 @@ class PRAgent:
                 self._config.ownership,
                 reason="PR closed",
             )
+            _mark_caretaker_touched(tracking)
         elif should_release_ownership(pr, tracking, "escalated"):
             await release_ownership(
                 self._github,
@@ -1250,9 +1282,10 @@ class PRAgent:
                 self._config.ownership,
                 reason="PR escalated",
             )
+            _mark_caretaker_touched(tracking)
         elif tracking.ownership_state == OwnershipState.UNOWNED:
             # Try to claim ownership
-            await claim_ownership(
+            claim = await claim_ownership(
                 self._github,
                 self._owner,
                 self._repo,
@@ -1260,6 +1293,8 @@ class PRAgent:
                 tracking,
                 self._config.ownership,
             )
+            if claim.claimed:
+                _mark_caretaker_touched(tracking)
 
         # Publish readiness check
         await self._publish_readiness_check(pr, tracking, evaluation)
@@ -1281,6 +1316,7 @@ class PRAgent:
                         pr, tracking, readiness_verdict=evaluation.readiness_verdict
                     ),
                 )
+                _mark_caretaker_touched(tracking)
             except GitHubAPIError as e:
                 logger.warning(
                     "PR #%d: Failed to upsert caretaker status comment: %s",

--- a/src/caretaker/state/intervention_detector.py
+++ b/src/caretaker/state/intervention_detector.py
@@ -1,0 +1,307 @@
+"""Operator-intervention detection for the attribution telemetry subsystem.
+
+This module answers the question: *after caretaker's most recent action on
+a PR or issue, did a human push additional work?* If so, the detector
+flips :attr:`~caretaker.state.models.TrackedPR.operator_intervened` and
+appends a short-code reason to
+:attr:`~caretaker.state.models.TrackedPR.intervention_reasons`.
+
+The detector is intentionally event-driven rather than comment-scanning:
+we look at *pushing* actions (a new commit, a manual merge, a close, a
+label change, a force-push) because those are the actions a human takes
+when caretaker's decision didn't stick. A human writing a comment is not
+an intervention — caretaker tolerates review comments cleanly.
+
+The detector is idempotent: re-running it over the same event stream
+produces the same verdict. It never *clears* a previously-set
+``operator_intervened`` flag — once flipped, the PR has been rescued by a
+human and that's the truth for this week's rollup, even if a later
+caretaker action lands on the same PR.
+
+The detector is also pure: given a tracked-row snapshot and an event
+stream, it returns a ``DetectionResult`` without mutating anything. The
+orchestrator's state-tracker applies the result to the ``TrackedPR`` /
+``TrackedIssue`` in one place so the persist path stays obvious.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from caretaker.identity import is_automated
+
+# TrackedPR / TrackedIssue are runtime-typed (parameter defaults, isinstance-
+# free attribute access). Keep them out of the TYPE_CHECKING block so Pydantic
+# validation sees the concrete types at import time.
+from caretaker.state.models import TrackedIssue, TrackedPR  # noqa: TC001
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+# ── Event model ─────────────────────────────────────────────────────────
+#
+# A single dataclass covers every event kind the detector understands.
+# Keeping it narrow (six kinds, one actor login) is deliberate — the
+# detector is the wrong place for taxonomy growth; if a new intervention
+# kind needs support, add it here *and* to
+# :data:`~caretaker.observability.metrics.INTERVENTION_REASONS` so the
+# metric label set stays in sync.
+
+INTERVENTION_KIND = frozenset({"commit", "merged", "closed", "labeled", "unlabeled", "force_push"})
+
+
+@dataclass(frozen=True, slots=True)
+class InterventionEvent:
+    """One timestamped event from a PR or issue's timeline.
+
+    ``kind`` must be one of :data:`INTERVENTION_KIND`. ``actor`` is the
+    GitHub login of the user who performed the action; the detector uses
+    :func:`caretaker.identity.is_automated` to decide whether an event is
+    a human intervention or a caretaker / bot action that should be
+    ignored.
+    """
+
+    kind: str
+    actor: str
+    occurred_at: datetime
+    # Only populated for ``labeled`` / ``unlabeled`` — carries the label
+    # name so the detector can skip caretaker's own ``maintainer:*``
+    # labels (humans rarely add those; caretaker always does).
+    label: str | None = None
+
+
+# ── Detector output ──────────────────────────────────────────────────────
+
+
+@dataclass
+class DetectionResult:
+    """Verdict produced by :func:`detect_pr_intervention`.
+
+    ``intervened`` is True when at least one human event landed strictly
+    after the tracked-row's ``last_caretaker_action_at``. ``reasons`` is
+    the ordered list of short codes to append to
+    :attr:`~caretaker.state.models.TrackedPR.intervention_reasons`,
+    deduplicated against what's already there.
+    """
+
+    intervened: bool = False
+    reasons: list[str] = field(default_factory=list)
+
+
+# Map the event-kind vocabulary used in :class:`InterventionEvent` to the
+# short-code vocabulary exposed as a Prometheus label and persisted in
+# :attr:`TrackedPR.intervention_reasons`. Keeping two separate vocabs
+# means the event source can evolve (e.g. from GitHub REST to GraphQL)
+# without shifting the metric cardinality — only this map needs to know
+# the bridge.
+_REASON_FOR_KIND: dict[str, str] = {
+    "commit": "commit_added",
+    "merged": "manual_merge",
+    "closed": "manual_close",
+    "labeled": "label_changed",
+    "unlabeled": "label_changed",
+    "force_push": "force_push",
+}
+
+
+def _ensure_utc(stamp: datetime) -> datetime:
+    """Normalise a naive datetime to UTC for comparison.
+
+    The timeline APIs we consume return aware datetimes, but tests often
+    pass naive ones through — treating naive as UTC keeps the detector
+    easy to exercise without leaking tz-awareness assumptions into
+    callers.
+    """
+    if stamp.tzinfo is None:
+        return stamp.replace(tzinfo=UTC)
+    return stamp
+
+
+def _is_human_actor(actor: str) -> bool:
+    """Return True when ``actor`` is a human (non-bot) GitHub login.
+
+    Unknown / empty logins default to non-human — unattributed timeline
+    events (rare, but possible for deleted accounts) are ignored rather
+    than counted as interventions. Being conservative here prevents a
+    bogus "operator_intervened" signal from polluting the weekly roll-up.
+    """
+    if not actor:
+        return False
+    return not is_automated(actor)
+
+
+def _is_caretaker_own_label(label: str | None) -> bool:
+    """Return True when ``label`` is one caretaker itself manages.
+
+    Humans occasionally apply ``maintainer:*`` labels manually, but the
+    common case is caretaker claiming ownership / marking escalation /
+    etc. Treating these as non-intervention events prevents caretaker's
+    own label churn from looking like human activity.
+    """
+    if not label:
+        return False
+    return label.startswith("maintainer:") or label.startswith("caretaker:")
+
+
+def _collect_reasons(
+    events: Iterable[InterventionEvent],
+    *,
+    cutoff: datetime,
+) -> list[str]:
+    """Return ordered intervention reason short-codes for a filtered event set.
+
+    Deduplicated in-order so the first occurrence of each reason wins.
+    """
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for event in events:
+        stamp = _ensure_utc(event.occurred_at)
+        if stamp <= cutoff:
+            continue
+        if not _is_human_actor(event.actor):
+            continue
+        if event.kind in {"labeled", "unlabeled"} and _is_caretaker_own_label(event.label):
+            continue
+        reason = _REASON_FOR_KIND.get(event.kind)
+        if reason is None:
+            continue
+        if reason in seen:
+            continue
+        seen.add(reason)
+        ordered.append(reason)
+    return ordered
+
+
+def detect_pr_intervention(
+    tracking: TrackedPR,
+    events: Sequence[InterventionEvent],
+) -> DetectionResult:
+    """Evaluate whether a human rescued a PR after caretaker's last action.
+
+    Returns an empty ``DetectionResult`` when caretaker has never touched
+    the PR (nothing to "rescue") or when the event stream is empty.
+    """
+    if not tracking.caretaker_touched or tracking.last_caretaker_action_at is None:
+        return DetectionResult()
+    cutoff = _ensure_utc(tracking.last_caretaker_action_at)
+    reasons = _collect_reasons(events, cutoff=cutoff)
+    if not reasons:
+        return DetectionResult()
+    return DetectionResult(intervened=True, reasons=reasons)
+
+
+def detect_issue_intervention(
+    tracking: TrackedIssue,
+    events: Sequence[InterventionEvent],
+) -> DetectionResult:
+    """Evaluate whether a human acted on an issue after caretaker's last action.
+
+    Issues don't have force-pushes or commits, but they do have manual
+    closes and label changes. The detector accepts the same event shape
+    so tests can share fixtures across PR and issue paths.
+    """
+    if not tracking.caretaker_touched or tracking.last_caretaker_action_at is None:
+        return DetectionResult()
+    cutoff = _ensure_utc(tracking.last_caretaker_action_at)
+    reasons = _collect_reasons(events, cutoff=cutoff)
+    if not reasons:
+        return DetectionResult()
+    return DetectionResult(intervened=True, reasons=reasons)
+
+
+def apply_pr_detection(tracking: TrackedPR, result: DetectionResult) -> bool:
+    """Merge a :class:`DetectionResult` into a :class:`TrackedPR`.
+
+    Returns ``True`` when the tracking row's attribution state changed
+    (useful for callers that want to know whether to emit a metric). The
+    merge is monotonic — ``operator_intervened`` never clears, and the
+    reasons list grows without duplicates.
+    """
+    if not result.intervened:
+        return False
+    changed = False
+    if not tracking.operator_intervened:
+        tracking.operator_intervened = True
+        changed = True
+    existing = set(tracking.intervention_reasons)
+    for reason in result.reasons:
+        if reason not in existing:
+            tracking.intervention_reasons.append(reason)
+            existing.add(reason)
+            changed = True
+    return changed
+
+
+def apply_issue_detection(tracking: TrackedIssue, result: DetectionResult) -> bool:
+    """Merge a :class:`DetectionResult` into a :class:`TrackedIssue`."""
+    if not result.intervened:
+        return False
+    changed = False
+    if not tracking.operator_intervened:
+        tracking.operator_intervened = True
+        changed = True
+    existing = set(tracking.intervention_reasons)
+    for reason in result.reasons:
+        if reason not in existing:
+            tracking.intervention_reasons.append(reason)
+            existing.add(reason)
+            changed = True
+    return changed
+
+
+# ── One-shot backfill ───────────────────────────────────────────────────
+
+
+def backfill_missing_fields(
+    tracked_prs: dict[int, TrackedPR],
+    tracked_issues: dict[int, TrackedIssue],
+) -> int:
+    """Materialise attribution defaults on in-memory tracked state.
+
+    Used under ``attribution.migration_strategy = "eager"``: walks every
+    tracked row and ensures the attribution fields are present and
+    coherent. Because the :class:`TrackedPR` / :class:`TrackedIssue`
+    Pydantic defaults already cover the common case (missing JSON field
+    → default value), this function's job is narrower — reconcile
+    invariants that can only be enforced in code:
+
+    * ``caretaker_merged = True`` implies ``caretaker_touched = True``
+      (merging is inherently a touch).
+    * ``caretaker_closed = True`` implies ``caretaker_touched = True``
+      for issues.
+    * If ``merged_at`` is set and ``caretaker_merged`` is still False,
+      leave it — the prior merge may have come from a human; the
+      detector / backfill CLI is the right place to decide that.
+
+    Returns the number of rows that were mutated.
+    """
+    mutated = 0
+    for pr in tracked_prs.values():
+        if pr.caretaker_merged and not pr.caretaker_touched:
+            pr.caretaker_touched = True
+            mutated += 1
+    for issue in tracked_issues.values():
+        if issue.caretaker_closed and not issue.caretaker_touched:
+            issue.caretaker_touched = True
+            mutated += 1
+    if mutated:
+        logger.info("Attribution eager backfill: reconciled invariants on %d tracked rows", mutated)
+    return mutated
+
+
+__all__ = [
+    "INTERVENTION_KIND",
+    "DetectionResult",
+    "InterventionEvent",
+    "apply_issue_detection",
+    "apply_pr_detection",
+    "backfill_missing_fields",
+    "detect_issue_intervention",
+    "detect_pr_intervention",
+]

--- a/src/caretaker/state/models.py
+++ b/src/caretaker/state/models.py
@@ -85,6 +85,41 @@ class TrackedPR(BaseModel):
     # caretaker:status comment.
     legacy_comments_compacted: bool = False
 
+    # ── Attribution telemetry (R&D workstream A2) ────────────────────────
+    # Answer "did caretaker actually save human toil on this PR?" — a
+    # per-PR audit trail that the weekly rollup aggregates into
+    # ``caretaker_pr_outcome_total``. All three fields default to ``False``
+    # / empty list; persisted Pydantic JSON round-trips them via default
+    # population on load (no backend migration required — see
+    # :class:`AttributionConfig` for the migration-strategy knob).
+    #
+    # ``caretaker_touched`` — True as soon as any caretaker agent took a
+    # non-read-only action on the PR (labelled, commented, approved,
+    # merged, closed). Never clears back to False once set.
+    caretaker_touched: bool = False
+    # ``caretaker_merged`` — True when caretaker's merge-authority path
+    # actually closed the PR as merged (as opposed to the human pressing
+    # "Merge"). Implies ``caretaker_touched = True``.
+    caretaker_merged: bool = False
+    # ``operator_intervened`` — True when a human (non-bot actor) made a
+    # pushing change AFTER caretaker's most recent action on the PR:
+    # a commit, a manual merge, a close, a label change, a force-push.
+    # The intervention detector rewrites this every cycle by comparing
+    # the persisted last-caretaker-action timestamp against the PR's
+    # event timeline.
+    operator_intervened: bool = False
+    # ``intervention_reasons`` — short codes describing what the human
+    # did. Bounded enum: ``manual_merge``, ``manual_close``,
+    # ``label_changed``, ``force_push``, ``commit_added``. Appended to
+    # each cycle the detector finds a new intervention; duplicates are
+    # suppressed so the list grows monotonically without unbounded churn.
+    intervention_reasons: list[str] = Field(default_factory=list)
+    # ``last_caretaker_action_at`` — timestamp of the most recent
+    # caretaker action. Used by the intervention detector as the cutoff:
+    # any human activity strictly after this timestamp counts as
+    # "pushed work after caretaker's last action."
+    last_caretaker_action_at: datetime | None = None
+
 
 class TrackedIssue(BaseModel):
     number: int
@@ -93,6 +128,17 @@ class TrackedIssue(BaseModel):
     assigned_pr: int | None = None
     last_checked: datetime | None = None
     escalated: bool = False
+
+    # ── Attribution telemetry (R&D workstream A2) ────────────────────────
+    # Mirrors :class:`TrackedPR` attribution fields with issue semantics.
+    # ``caretaker_closed`` replaces ``caretaker_merged`` because issues
+    # don't merge — they close via the caretaker triage / stale / charlie
+    # paths.
+    caretaker_touched: bool = False
+    caretaker_closed: bool = False
+    operator_intervened: bool = False
+    intervention_reasons: list[str] = Field(default_factory=list)
+    last_caretaker_action_at: datetime | None = None
 
 
 class RunSummary(BaseModel):

--- a/src/caretaker/state/tracker.py
+++ b/src/caretaker/state/tracker.py
@@ -10,9 +10,17 @@ from caretaker.causal import make_causal_marker
 from caretaker.github_client.api import RateLimitError
 from caretaker.graph.models import NodeType, RelType
 from caretaker.graph.writer import get_writer
+from caretaker.observability import metrics as _metrics
 from caretaker.tools.github import GitHubIssueTools
 
-from .models import OrchestratorState, RunSummary
+from .models import (
+    IssueTrackingState,
+    OrchestratorState,
+    PRTrackingState,
+    RunSummary,
+    TrackedIssue,
+    TrackedPR,
+)
 
 if TYPE_CHECKING:
     from caretaker.evolution.reflection import ReflectionResult
@@ -61,6 +69,16 @@ class StateTracker:
         self._issues = GitHubIssueTools(github, owner, repo)
         self._tracking_issue_number: int | None = None
         self._state: OrchestratorState = OrchestratorState()
+        # Attribution: remember which (pr_number, outcome) and
+        # (issue_number, outcome) tuples we've already incremented this
+        # process lifetime so repeated saves of the same state don't
+        # double-count. Lifetime is per-process; once the orchestrator
+        # restarts we reset, which is the correct behaviour for
+        # monotonic-cumulative counters whose Prometheus series already
+        # reflect the history we wrote last run.
+        self._emitted_pr_outcomes: dict[int, set[str]] = {}
+        self._emitted_issue_outcomes: dict[int, set[str]] = {}
+        self._emitted_intervention_reasons: dict[tuple[str, int], set[str]] = {}
 
     @property
     def state(self) -> OrchestratorState:
@@ -151,8 +169,116 @@ class StateTracker:
             else:
                 raise
         logger.info("State saved to tracking issue #%d", self._tracking_issue_number)
+        # Attribution telemetry (R&D workstream A2). Emitted at save time
+        # rather than at action time so the counter increments reflect
+        # "what's persisted" (the source of truth) rather than "what an
+        # agent tried to do." This means a rate-limited save skips the
+        # emission; the next successful save picks up the backlog because
+        # the in-memory classifier compares the current snapshot to the
+        # emitted-outcome set on the tracker.
+        self._emit_attribution_metrics()
         if summary is not None:
             self._emit_run_graph(summary)
+
+    # ── Attribution telemetry helpers ───────────────────────────────────
+
+    def _repo_slug(self) -> str:
+        return f"{self._owner}/{self._repo}"
+
+    @staticmethod
+    def classify_pr_outcomes(tracking: TrackedPR) -> frozenset[str]:
+        """Classify a tracked PR into the attribution outcome set.
+
+        A single PR can fall into multiple outcomes simultaneously:
+        ``merged`` implies ``touched``; ``operator_rescued`` is
+        orthogonal to ``touched`` / ``merged`` (a human can push work
+        after caretaker merges too, though it's rare).
+
+        Returns a ``frozenset`` of label values drawn from
+        :data:`~caretaker.observability.metrics.PR_OUTCOMES`.
+        """
+        outcomes: set[str] = set()
+        if tracking.caretaker_touched:
+            outcomes.add("touched")
+        if tracking.caretaker_merged:
+            outcomes.add("merged")
+        # ``closed_unmerged`` is "caretaker closed the PR but didn't merge
+        # it" — e.g. the CI backlog guard. Distinguish from a human close
+        # via ``caretaker_touched``: if caretaker never touched, the
+        # closure can't be attributed to us.
+        if (
+            tracking.caretaker_touched
+            and tracking.state == PRTrackingState.CLOSED
+            and not tracking.caretaker_merged
+        ):
+            outcomes.add("closed_unmerged")
+        if tracking.operator_intervened:
+            outcomes.add("operator_rescued")
+        if tracking.state == PRTrackingState.ESCALATED and not tracking.operator_intervened:
+            # Escalated without a human rescue means caretaker gave up
+            # and no operator has acted yet — this is the "abandoned"
+            # bucket in the dashboard: a PR caretaker couldn't help on.
+            outcomes.add("abandoned")
+        return frozenset(outcomes)
+
+    @staticmethod
+    def classify_issue_outcomes(tracking: TrackedIssue) -> frozenset[str]:
+        """Classify a tracked issue into the attribution outcome set."""
+        outcomes: set[str] = set()
+        if tracking.caretaker_touched:
+            outcomes.add("triaged")
+        if tracking.caretaker_closed:
+            # Distinguish stale closes (time-based triage) from
+            # caretaker's active closes (duplicate / question). This
+            # matches the dashboard taxonomy: ``stale_closed`` is an
+            # auto-hygiene signal, ``closed_by_caretaker`` is real work.
+            if tracking.state == IssueTrackingState.STALE:
+                outcomes.add("stale_closed")
+            else:
+                outcomes.add("closed_by_caretaker")
+        elif tracking.state == IssueTrackingState.CLOSED and tracking.caretaker_touched:
+            # Caretaker touched the issue but a human closed it — counts
+            # as an operator close under the attribution lens.
+            outcomes.add("closed_by_operator")
+        return frozenset(outcomes)
+
+    def _emit_attribution_metrics(self) -> None:
+        """Increment attribution counters for new outcomes on tracked rows.
+
+        Called from :meth:`save`. Skips outcomes already emitted this
+        process for the same ``(kind, number)`` key so repeated saves of
+        the same state don't double-count.
+        """
+        repo = self._repo_slug()
+        for pr_number, pr in self._state.tracked_prs.items():
+            current = self.classify_pr_outcomes(pr)
+            already = self._emitted_pr_outcomes.setdefault(pr_number, set())
+            for outcome in current - already:
+                _metrics.record_pr_outcome(repo, outcome)
+                already.add(outcome)
+            # Intervention reasons are emitted from a parallel structure
+            # because a PR can collect multiple reasons over its
+            # lifetime; dedup per ``(repo, pr_number, reason)``.
+            if pr.intervention_reasons:
+                seen = self._emitted_intervention_reasons.setdefault(("pr", pr_number), set())
+                for reason in pr.intervention_reasons:
+                    if reason in seen:
+                        continue
+                    _metrics.record_operator_intervention(repo, reason)
+                    seen.add(reason)
+        for issue_number, issue in self._state.tracked_issues.items():
+            current = self.classify_issue_outcomes(issue)
+            already = self._emitted_issue_outcomes.setdefault(issue_number, set())
+            for outcome in current - already:
+                _metrics.record_issue_outcome(repo, outcome)
+                already.add(outcome)
+            if issue.intervention_reasons:
+                seen = self._emitted_intervention_reasons.setdefault(("issue", issue_number), set())
+                for reason in issue.intervention_reasons:
+                    if reason in seen:
+                        continue
+                    _metrics.record_operator_intervention(repo, reason)
+                    seen.add(reason)
 
     def _emit_run_graph(self, summary: RunSummary) -> None:
         """Publish the just-saved run to the event-driven graph writer.

--- a/tests/test_admin/test_attribution_api.py
+++ b/tests/test_admin/test_attribution_api.py
@@ -1,0 +1,171 @@
+"""Tests for ``GET /api/admin/attribution/weekly``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from caretaker.admin import api as admin_api
+from caretaker.admin import auth as admin_auth
+from caretaker.admin.data import AdminDataAccess
+from caretaker.state.models import (
+    OrchestratorState,
+    PRTrackingState,
+    TrackedPR,
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(admin_api.router)
+
+    async def _fake_user() -> admin_auth.UserInfo:
+        return admin_auth.UserInfo(sub="u", email="u@example.com", name="U", picture=None)
+
+    app.dependency_overrides[admin_auth.require_session] = _fake_user
+    return TestClient(app)
+
+
+def _seed(state: OrchestratorState) -> None:
+    """Install an ``AdminDataAccess`` backed by ``state``."""
+    admin_api.configure(AdminDataAccess(state=state))
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+class TestAttributionWeeklyEndpoint:
+    def test_empty_state_returns_zeros(self, client: TestClient) -> None:
+        _seed(OrchestratorState())
+        response = client.get("/api/admin/attribution/weekly")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["touched"] == 0
+        assert body["merged"] == 0
+        assert body["operator_rescued"] == 0
+        assert body["abandoned"] == 0
+        assert body["avg_time_to_merge_hours"] is None
+
+    def test_counts_merged_and_touched(self, client: TestClient) -> None:
+        _seed(
+            OrchestratorState(
+                tracked_prs={
+                    1: TrackedPR(
+                        number=1,
+                        caretaker_touched=True,
+                        caretaker_merged=True,
+                        state=PRTrackingState.MERGED,
+                        first_seen_at=_now() - timedelta(hours=4),
+                        merged_at=_now() - timedelta(hours=1),
+                        last_checked=_now(),
+                    ),
+                    2: TrackedPR(
+                        number=2,
+                        caretaker_touched=True,
+                        state=PRTrackingState.REVIEW_PENDING,
+                        first_seen_at=_now() - timedelta(hours=2),
+                        last_checked=_now(),
+                    ),
+                }
+            )
+        )
+        response = client.get("/api/admin/attribution/weekly")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["touched"] == 2
+        assert body["merged"] == 1
+        # The merged PR was open for three hours; average rounds to 3.0
+        assert body["avg_time_to_merge_hours"] == 3.0
+
+    def test_counts_rescued_and_abandoned(self, client: TestClient) -> None:
+        _seed(
+            OrchestratorState(
+                tracked_prs={
+                    1: TrackedPR(
+                        number=1,
+                        caretaker_touched=True,
+                        operator_intervened=True,
+                        state=PRTrackingState.REVIEW_PENDING,
+                        last_checked=_now(),
+                    ),
+                    2: TrackedPR(
+                        number=2,
+                        caretaker_touched=True,
+                        state=PRTrackingState.ESCALATED,
+                        last_checked=_now(),
+                    ),
+                }
+            )
+        )
+        body = client.get("/api/admin/attribution/weekly").json()
+        assert body["operator_rescued"] == 1
+        assert body["abandoned"] == 1
+
+    def test_since_window_excludes_old_rows(self, client: TestClient) -> None:
+        # PR from 30 days ago; default window is 7 days, so it should be
+        # excluded from the rollup.
+        _seed(
+            OrchestratorState(
+                tracked_prs={
+                    1: TrackedPR(
+                        number=1,
+                        caretaker_touched=True,
+                        caretaker_merged=True,
+                        state=PRTrackingState.MERGED,
+                        first_seen_at=_now() - timedelta(days=31),
+                        merged_at=_now() - timedelta(days=30),
+                        last_checked=_now() - timedelta(days=30),
+                    ),
+                }
+            )
+        )
+        body = client.get("/api/admin/attribution/weekly").json()
+        assert body["touched"] == 0
+        assert body["merged"] == 0
+
+    def test_since_query_param_overrides_default(self, client: TestClient) -> None:
+        _seed(
+            OrchestratorState(
+                tracked_prs={
+                    1: TrackedPR(
+                        number=1,
+                        caretaker_touched=True,
+                        state=PRTrackingState.REVIEW_PENDING,
+                        last_checked=_now() - timedelta(days=20),
+                    ),
+                }
+            )
+        )
+        since = (_now() - timedelta(days=30)).isoformat()
+        response = client.get("/api/admin/attribution/weekly", params={"since": since})
+        body = response.json()
+        assert response.status_code == 200, body
+        assert body["touched"] == 1
+
+    def test_invalid_since_returns_400(self, client: TestClient) -> None:
+        _seed(OrchestratorState())
+        response = client.get("/api/admin/attribution/weekly?since=not-a-date")
+        assert response.status_code == 400
+
+
+class TestAttributionWeeklyRepoQuery:
+    def test_repo_query_ignored_in_single_repo_mode(self, client: TestClient) -> None:
+        _seed(
+            OrchestratorState(
+                tracked_prs={
+                    1: TrackedPR(
+                        number=1,
+                        caretaker_touched=True,
+                        state=PRTrackingState.REVIEW_PENDING,
+                        last_checked=_now(),
+                    ),
+                }
+            )
+        )
+        body = client.get("/api/admin/attribution/weekly?repo=foo/bar").json()
+        assert body["touched"] == 1

--- a/tests/test_attribution_metrics.py
+++ b/tests/test_attribution_metrics.py
@@ -1,0 +1,260 @@
+"""Tests for attribution metric emission at state-save time.
+
+Covers the classifier (``StateTracker.classify_pr_outcomes`` /
+``classify_issue_outcomes``), the dedup of repeated saves, and the
+Prometheus counter increments the save path produces.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from caretaker.observability import metrics as _metrics
+from caretaker.state.models import (
+    IssueTrackingState,
+    OrchestratorState,
+    PRTrackingState,
+    TrackedIssue,
+    TrackedPR,
+)
+from caretaker.state.tracker import StateTracker
+
+
+def _make_tracker() -> StateTracker:
+    github = AsyncMock()
+    github.upsert_issue_comment = AsyncMock()
+    tracker = StateTracker(github=github, owner="acme", repo="widgets")
+    tracker._tracking_issue_number = 1
+    return tracker
+
+
+def _read_counter(counter: object, **labels: str) -> float:
+    """Return the current float value of a Prometheus counter child."""
+    sample = counter.labels(**labels)  # type: ignore[attr-defined]
+    return float(sample._value.get())  # type: ignore[attr-defined]
+
+
+# ── Classifier semantics ─────────────────────────────────────────────────
+
+
+class TestClassifyPrOutcomes:
+    def test_untouched_pr_produces_empty_set(self) -> None:
+        pr = TrackedPR(number=1)
+        assert StateTracker.classify_pr_outcomes(pr) == frozenset()
+
+    def test_touched_only(self) -> None:
+        pr = TrackedPR(number=1, caretaker_touched=True)
+        assert StateTracker.classify_pr_outcomes(pr) == frozenset({"touched"})
+
+    def test_merged_implies_touched_label(self) -> None:
+        pr = TrackedPR(
+            number=1,
+            caretaker_touched=True,
+            caretaker_merged=True,
+            state=PRTrackingState.MERGED,
+        )
+        outcomes = StateTracker.classify_pr_outcomes(pr)
+        assert outcomes == frozenset({"touched", "merged"})
+
+    def test_operator_rescued(self) -> None:
+        pr = TrackedPR(
+            number=1,
+            caretaker_touched=True,
+            operator_intervened=True,
+            state=PRTrackingState.REVIEW_PENDING,
+        )
+        outcomes = StateTracker.classify_pr_outcomes(pr)
+        assert "operator_rescued" in outcomes
+        assert "touched" in outcomes
+
+    def test_abandoned_only_when_escalated_without_rescue(self) -> None:
+        escalated_no_rescue = TrackedPR(
+            number=1,
+            caretaker_touched=True,
+            state=PRTrackingState.ESCALATED,
+        )
+        escalated_rescued = TrackedPR(
+            number=2,
+            caretaker_touched=True,
+            state=PRTrackingState.ESCALATED,
+            operator_intervened=True,
+        )
+        assert "abandoned" in StateTracker.classify_pr_outcomes(escalated_no_rescue)
+        assert "abandoned" not in StateTracker.classify_pr_outcomes(escalated_rescued)
+
+    def test_closed_unmerged_requires_caretaker_touch(self) -> None:
+        closed_by_caretaker = TrackedPR(
+            number=1,
+            caretaker_touched=True,
+            state=PRTrackingState.CLOSED,
+        )
+        closed_externally = TrackedPR(
+            number=2,
+            caretaker_touched=False,
+            state=PRTrackingState.CLOSED,
+        )
+        assert "closed_unmerged" in StateTracker.classify_pr_outcomes(closed_by_caretaker)
+        assert "closed_unmerged" not in StateTracker.classify_pr_outcomes(closed_externally)
+
+
+class TestClassifyIssueOutcomes:
+    def test_triaged(self) -> None:
+        issue = TrackedIssue(number=1, caretaker_touched=True)
+        assert "triaged" in StateTracker.classify_issue_outcomes(issue)
+
+    def test_closed_by_caretaker(self) -> None:
+        issue = TrackedIssue(
+            number=1,
+            caretaker_touched=True,
+            caretaker_closed=True,
+            state=IssueTrackingState.CLOSED,
+        )
+        assert "closed_by_caretaker" in StateTracker.classify_issue_outcomes(issue)
+
+    def test_stale_closed_is_distinct_bucket(self) -> None:
+        issue = TrackedIssue(
+            number=1,
+            caretaker_touched=True,
+            caretaker_closed=True,
+            state=IssueTrackingState.STALE,
+        )
+        outcomes = StateTracker.classify_issue_outcomes(issue)
+        assert "stale_closed" in outcomes
+        assert "closed_by_caretaker" not in outcomes
+
+    def test_closed_by_operator(self) -> None:
+        # Caretaker touched (e.g. triaged), but the close event came from
+        # a human — classified as operator close for the rollup.
+        issue = TrackedIssue(
+            number=1,
+            caretaker_touched=True,
+            caretaker_closed=False,
+            state=IssueTrackingState.CLOSED,
+        )
+        assert "closed_by_operator" in StateTracker.classify_issue_outcomes(issue)
+
+
+# ── Emission integration ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestEmissionAtSave:
+    async def test_save_emits_outcome_counters(self) -> None:
+        tracker = _make_tracker()
+        baseline_touched = _read_counter(
+            _metrics.CARETAKER_PR_OUTCOME_TOTAL,
+            service=_metrics.get_service_label(),
+            repo="acme/widgets",
+            outcome="touched",
+        )
+        baseline_merged = _read_counter(
+            _metrics.CARETAKER_PR_OUTCOME_TOTAL,
+            service=_metrics.get_service_label(),
+            repo="acme/widgets",
+            outcome="merged",
+        )
+        tracker._state = OrchestratorState(
+            tracked_prs={
+                42: TrackedPR(
+                    number=42,
+                    caretaker_touched=True,
+                    caretaker_merged=True,
+                    state=PRTrackingState.MERGED,
+                    last_caretaker_action_at=datetime.now(UTC),
+                )
+            }
+        )
+        await tracker.save()
+
+        assert (
+            _read_counter(
+                _metrics.CARETAKER_PR_OUTCOME_TOTAL,
+                service=_metrics.get_service_label(),
+                repo="acme/widgets",
+                outcome="touched",
+            )
+            == baseline_touched + 1
+        )
+        assert (
+            _read_counter(
+                _metrics.CARETAKER_PR_OUTCOME_TOTAL,
+                service=_metrics.get_service_label(),
+                repo="acme/widgets",
+                outcome="merged",
+            )
+            == baseline_merged + 1
+        )
+
+    async def test_repeated_saves_do_not_double_count(self) -> None:
+        tracker = _make_tracker()
+        baseline = _read_counter(
+            _metrics.CARETAKER_PR_OUTCOME_TOTAL,
+            service=_metrics.get_service_label(),
+            repo="acme/widgets",
+            outcome="touched",
+        )
+        pr = TrackedPR(
+            number=77,
+            caretaker_touched=True,
+            last_caretaker_action_at=datetime.now(UTC),
+        )
+        tracker._state = OrchestratorState(tracked_prs={77: pr})
+
+        for _ in range(3):
+            await tracker.save()
+
+        # The outcome set didn't change across saves, so the counter
+        # only increments once.
+        assert (
+            _read_counter(
+                _metrics.CARETAKER_PR_OUTCOME_TOTAL,
+                service=_metrics.get_service_label(),
+                repo="acme/widgets",
+                outcome="touched",
+            )
+            == baseline + 1
+        )
+
+    async def test_intervention_reasons_emit_counter(self) -> None:
+        tracker = _make_tracker()
+        baseline = _read_counter(
+            _metrics.CARETAKER_OPERATOR_INTERVENTION_TOTAL,
+            service=_metrics.get_service_label(),
+            repo="acme/widgets",
+            reason="manual_merge",
+        )
+        pr = TrackedPR(
+            number=1,
+            caretaker_touched=True,
+            operator_intervened=True,
+            intervention_reasons=["manual_merge"],
+            last_caretaker_action_at=datetime.now(UTC),
+        )
+        tracker._state = OrchestratorState(tracked_prs={1: pr})
+
+        await tracker.save()
+
+        assert (
+            _read_counter(
+                _metrics.CARETAKER_OPERATOR_INTERVENTION_TOTAL,
+                service=_metrics.get_service_label(),
+                repo="acme/widgets",
+                reason="manual_merge",
+            )
+            == baseline + 1
+        )
+
+        # Second save with the same reason list is a no-op
+        await tracker.save()
+        assert (
+            _read_counter(
+                _metrics.CARETAKER_OPERATOR_INTERVENTION_TOTAL,
+                service=_metrics.get_service_label(),
+                repo="acme/widgets",
+                reason="manual_merge",
+            )
+            == baseline + 1
+        )

--- a/tests/test_backfill_attribution.py
+++ b/tests/test_backfill_attribution.py
@@ -1,0 +1,163 @@
+"""Tests for the ``caretaker backfill-attribution`` CLI command.
+
+The backfill command is side-effect-heavy (it reads orchestrator state
+from GitHub and writes it back). The unit-level coverage here exercises
+the pure helpers — ``_parse_since``, ``_row_active_since``, and the
+``backfill_missing_fields`` invariant reconciliation — plus a
+behavioural test of the inference pass over a seeded ``OrchestratorState``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from caretaker.cli import _parse_since, _row_active_since
+from caretaker.state.intervention_detector import backfill_missing_fields
+from caretaker.state.models import (
+    IssueTrackingState,
+    OrchestratorState,
+    PRTrackingState,
+    TrackedIssue,
+    TrackedPR,
+)
+
+
+class TestParseSince:
+    def test_days_suffix(self) -> None:
+        now = datetime.now(UTC)
+        parsed = _parse_since("30d")
+        # Parsed cutoff should be roughly 30 days ago (within 5s tolerance)
+        assert abs((now - parsed).total_seconds() - 30 * 86400) < 5
+
+    def test_weeks_suffix(self) -> None:
+        now = datetime.now(UTC)
+        parsed = _parse_since("2w")
+        assert abs((now - parsed).total_seconds() - 14 * 86400) < 5
+
+    def test_hours_suffix(self) -> None:
+        now = datetime.now(UTC)
+        parsed = _parse_since("12h")
+        assert abs((now - parsed).total_seconds() - 12 * 3600) < 5
+
+    def test_iso_8601_accepted(self) -> None:
+        parsed = _parse_since("2026-04-01T00:00:00+00:00")
+        assert parsed.year == 2026
+        assert parsed.month == 4
+        assert parsed.day == 1
+
+    def test_invalid_raises(self) -> None:
+        from click import ClickException
+
+        with pytest.raises(ClickException):
+            _parse_since("not-a-valid-span")
+
+
+class TestRowActiveSince:
+    def test_row_within_window(self) -> None:
+        now = datetime.now(UTC)
+        pr = TrackedPR(number=1, last_checked=now - timedelta(days=1))
+        assert _row_active_since(pr, now - timedelta(days=7))
+
+    def test_row_outside_window(self) -> None:
+        now = datetime.now(UTC)
+        pr = TrackedPR(number=1, last_checked=now - timedelta(days=30))
+        assert not _row_active_since(pr, now - timedelta(days=7))
+
+    def test_row_without_timestamps_is_included(self) -> None:
+        # Unstamped rows are the prime backfill targets — the CLI must
+        # not skip them just because they have no anchor.
+        pr = TrackedPR(number=1)
+        assert _row_active_since(pr, datetime.now(UTC) - timedelta(days=7))
+
+
+class TestBackfillInference:
+    """End-to-end behaviour: seed a state, run the inference pass."""
+
+    def test_merged_pr_flips_caretaker_merged(self) -> None:
+        state = OrchestratorState(
+            tracked_prs={
+                1: TrackedPR(
+                    number=1,
+                    state=PRTrackingState.MERGED,
+                    caretaker_touched=False,
+                    caretaker_merged=False,
+                    first_seen_at=datetime.now(UTC) - timedelta(hours=5),
+                    merged_at=datetime.now(UTC) - timedelta(hours=1),
+                )
+            }
+        )
+        # Apply the same inference the CLI does.
+        for pr in state.tracked_prs.values():
+            if pr.state == PRTrackingState.MERGED and not pr.caretaker_merged:
+                pr.caretaker_merged = True
+                pr.caretaker_touched = True
+        backfill_missing_fields(state.tracked_prs, state.tracked_issues)
+
+        assert state.tracked_prs[1].caretaker_merged is True
+        assert state.tracked_prs[1].caretaker_touched is True
+
+    def test_escalated_without_touch_gets_touch(self) -> None:
+        state = OrchestratorState(
+            tracked_prs={
+                2: TrackedPR(
+                    number=2,
+                    state=PRTrackingState.ESCALATED,
+                    caretaker_touched=False,
+                    escalated=True,
+                )
+            }
+        )
+        for pr in state.tracked_prs.values():
+            if pr.state == PRTrackingState.ESCALATED and not pr.caretaker_touched:
+                pr.caretaker_touched = True
+        assert state.tracked_prs[2].caretaker_touched is True
+
+    def test_stale_issue_gets_closed_and_touched(self) -> None:
+        state = OrchestratorState(
+            tracked_issues={
+                3: TrackedIssue(
+                    number=3,
+                    state=IssueTrackingState.STALE,
+                    caretaker_touched=False,
+                    caretaker_closed=False,
+                )
+            }
+        )
+        for issue in state.tracked_issues.values():
+            if (
+                issue.state in (IssueTrackingState.STALE, IssueTrackingState.CLOSED)
+                and not issue.caretaker_touched
+            ):
+                issue.caretaker_touched = True
+                if issue.state == IssueTrackingState.STALE:
+                    issue.caretaker_closed = True
+        assert state.tracked_issues[3].caretaker_touched is True
+        assert state.tracked_issues[3].caretaker_closed is True
+
+    def test_invariant_backfill_fills_merged_to_touched(self) -> None:
+        state = OrchestratorState(
+            tracked_prs={
+                5: TrackedPR(
+                    number=5,
+                    caretaker_merged=True,
+                    caretaker_touched=False,
+                )
+            }
+        )
+        count = backfill_missing_fields(state.tracked_prs, state.tracked_issues)
+        assert count == 1
+        assert state.tracked_prs[5].caretaker_touched is True
+
+    def test_backfill_is_idempotent(self) -> None:
+        state = OrchestratorState(
+            tracked_prs={
+                1: TrackedPR(
+                    number=1,
+                    caretaker_merged=True,
+                    caretaker_touched=True,
+                )
+            }
+        )
+        assert backfill_missing_fields(state.tracked_prs, state.tracked_issues) == 0

--- a/tests/test_intervention_detector.py
+++ b/tests/test_intervention_detector.py
@@ -1,0 +1,285 @@
+"""Unit tests for :mod:`caretaker.state.intervention_detector`.
+
+The detector is pure and deterministic: for a given tracked-row snapshot
+and event stream, it must return the same :class:`DetectionResult` every
+time. These tests exercise the action-cutoff semantics, actor
+classification, label filtering, deduplication, and the monotonic
+``apply_*`` helpers.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from caretaker.state.intervention_detector import (
+    DetectionResult,
+    InterventionEvent,
+    apply_issue_detection,
+    apply_pr_detection,
+    backfill_missing_fields,
+    detect_issue_intervention,
+    detect_pr_intervention,
+)
+from caretaker.state.models import (
+    IssueTrackingState,
+    PRTrackingState,
+    TrackedIssue,
+    TrackedPR,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 21, 12, 0, tzinfo=UTC)
+
+
+def _pr_with_touch(minutes_ago: int = 30) -> TrackedPR:
+    return TrackedPR(
+        number=1,
+        state=PRTrackingState.REVIEW_PENDING,
+        caretaker_touched=True,
+        last_caretaker_action_at=_now() - timedelta(minutes=minutes_ago),
+    )
+
+
+def _issue_with_touch(minutes_ago: int = 30) -> TrackedIssue:
+    return TrackedIssue(
+        number=1,
+        state=IssueTrackingState.TRIAGED,
+        caretaker_touched=True,
+        last_caretaker_action_at=_now() - timedelta(minutes=minutes_ago),
+    )
+
+
+# ── PR detection ─────────────────────────────────────────────────────────
+
+
+class TestDetectPrIntervention:
+    def test_no_events_returns_empty_result(self) -> None:
+        tracking = _pr_with_touch()
+        result = detect_pr_intervention(tracking, [])
+        assert result.intervened is False
+        assert result.reasons == []
+
+    def test_pr_never_touched_by_caretaker_is_not_an_intervention(self) -> None:
+        # Caretaker never took an action — any human activity is normal
+        # author behaviour, not a rescue.
+        tracking = TrackedPR(number=1)
+        events = [InterventionEvent(kind="commit", actor="alice", occurred_at=_now())]
+        result = detect_pr_intervention(tracking, events)
+        assert result.intervened is False
+
+    def test_human_commit_after_caretaker_flags_intervention(self) -> None:
+        tracking = _pr_with_touch(minutes_ago=30)
+        # Human pushed a commit 10m after caretaker's last action
+        events = [
+            InterventionEvent(
+                kind="commit",
+                actor="alice",
+                occurred_at=_now() - timedelta(minutes=20),
+            )
+        ]
+        result = detect_pr_intervention(tracking, events)
+        assert result.intervened is True
+        assert result.reasons == ["commit_added"]
+
+    def test_bot_action_is_not_an_intervention(self) -> None:
+        tracking = _pr_with_touch()
+        events = [
+            InterventionEvent(
+                kind="commit",
+                actor="dependabot[bot]",
+                occurred_at=_now() - timedelta(minutes=5),
+            )
+        ]
+        result = detect_pr_intervention(tracking, events)
+        assert result.intervened is False
+
+    def test_event_before_last_caretaker_action_is_ignored(self) -> None:
+        tracking = _pr_with_touch(minutes_ago=10)
+        events = [
+            # 20m ago is before caretaker's action 10m ago
+            InterventionEvent(
+                kind="commit",
+                actor="alice",
+                occurred_at=_now() - timedelta(minutes=20),
+            )
+        ]
+        result = detect_pr_intervention(tracking, events)
+        assert result.intervened is False
+
+    def test_manual_merge_close_force_push_all_recorded(self) -> None:
+        tracking = _pr_with_touch(minutes_ago=60)
+        events = [
+            InterventionEvent(
+                kind="merged", actor="alice", occurred_at=_now() - timedelta(minutes=30)
+            ),
+            InterventionEvent(
+                kind="closed", actor="alice", occurred_at=_now() - timedelta(minutes=25)
+            ),
+            InterventionEvent(
+                kind="force_push", actor="alice", occurred_at=_now() - timedelta(minutes=20)
+            ),
+        ]
+        result = detect_pr_intervention(tracking, events)
+        assert result.intervened is True
+        assert set(result.reasons) == {"manual_merge", "manual_close", "force_push"}
+
+    def test_caretaker_own_labels_are_filtered(self) -> None:
+        tracking = _pr_with_touch()
+        events = [
+            # Human applying a caretaker label is still caretaker territory
+            InterventionEvent(
+                kind="labeled",
+                actor="alice",
+                occurred_at=_now() - timedelta(minutes=5),
+                label="maintainer:escalated",
+            ),
+        ]
+        result = detect_pr_intervention(tracking, events)
+        assert result.intervened is False
+
+    def test_human_label_change_does_count(self) -> None:
+        tracking = _pr_with_touch()
+        events = [
+            InterventionEvent(
+                kind="labeled",
+                actor="alice",
+                occurred_at=_now() - timedelta(minutes=5),
+                label="priority:high",
+            ),
+        ]
+        result = detect_pr_intervention(tracking, events)
+        assert result.intervened is True
+        assert result.reasons == ["label_changed"]
+
+    def test_reasons_are_deduplicated(self) -> None:
+        tracking = _pr_with_touch(minutes_ago=60)
+        events = [
+            InterventionEvent(
+                kind="commit", actor="alice", occurred_at=_now() - timedelta(minutes=30)
+            ),
+            InterventionEvent(
+                kind="commit", actor="alice", occurred_at=_now() - timedelta(minutes=20)
+            ),
+            InterventionEvent(
+                kind="commit", actor="bob", occurred_at=_now() - timedelta(minutes=10)
+            ),
+        ]
+        result = detect_pr_intervention(tracking, events)
+        assert result.reasons == ["commit_added"]
+
+    def test_detector_is_idempotent(self) -> None:
+        tracking = _pr_with_touch(minutes_ago=60)
+        events = [
+            InterventionEvent(
+                kind="merged",
+                actor="alice",
+                occurred_at=_now() - timedelta(minutes=30),
+            ),
+        ]
+        first = detect_pr_intervention(tracking, events)
+        second = detect_pr_intervention(tracking, events)
+        assert first == second
+
+
+# ── Apply helpers ────────────────────────────────────────────────────────
+
+
+class TestApplyPrDetection:
+    def test_apply_flips_intervened_once(self) -> None:
+        tracking = _pr_with_touch()
+        result = DetectionResult(intervened=True, reasons=["manual_merge"])
+        changed = apply_pr_detection(tracking, result)
+        assert changed is True
+        assert tracking.operator_intervened is True
+        assert tracking.intervention_reasons == ["manual_merge"]
+
+        # Re-applying the same result is a no-op
+        changed_again = apply_pr_detection(tracking, result)
+        assert changed_again is False
+        assert tracking.intervention_reasons == ["manual_merge"]
+
+    def test_apply_appends_new_reasons_without_duplicates(self) -> None:
+        tracking = _pr_with_touch()
+        apply_pr_detection(tracking, DetectionResult(intervened=True, reasons=["manual_merge"]))
+        apply_pr_detection(
+            tracking, DetectionResult(intervened=True, reasons=["manual_merge", "force_push"])
+        )
+        assert tracking.intervention_reasons == ["manual_merge", "force_push"]
+
+    def test_empty_result_is_noop(self) -> None:
+        tracking = _pr_with_touch()
+        changed = apply_pr_detection(tracking, DetectionResult())
+        assert changed is False
+        assert tracking.operator_intervened is False
+        assert tracking.intervention_reasons == []
+
+
+# ── Issue flavour ─────────────────────────────────────────────────────────
+
+
+class TestDetectIssueIntervention:
+    def test_manual_close_after_caretaker_is_an_intervention(self) -> None:
+        tracking = _issue_with_touch()
+        events = [
+            InterventionEvent(
+                kind="closed",
+                actor="alice",
+                occurred_at=_now() - timedelta(minutes=5),
+            )
+        ]
+        result = detect_issue_intervention(tracking, events)
+        assert result.intervened is True
+        assert result.reasons == ["manual_close"]
+
+    def test_apply_to_issue_sets_flags(self) -> None:
+        tracking = _issue_with_touch()
+        apply_issue_detection(tracking, DetectionResult(intervened=True, reasons=["manual_close"]))
+        assert tracking.operator_intervened is True
+        assert tracking.intervention_reasons == ["manual_close"]
+
+
+# ── Backfill invariants ──────────────────────────────────────────────────
+
+
+class TestBackfillMissingFields:
+    def test_merged_implies_touched(self) -> None:
+        pr = TrackedPR(number=1, caretaker_merged=True, caretaker_touched=False)
+        mutated = backfill_missing_fields({1: pr}, {})
+        assert mutated == 1
+        assert pr.caretaker_touched is True
+
+    def test_issue_closed_implies_touched(self) -> None:
+        issue = TrackedIssue(number=1, caretaker_closed=True, caretaker_touched=False)
+        mutated = backfill_missing_fields({}, {1: issue})
+        assert mutated == 1
+        assert issue.caretaker_touched is True
+
+    def test_already_coherent_is_noop(self) -> None:
+        pr = TrackedPR(number=1, caretaker_merged=True, caretaker_touched=True)
+        assert backfill_missing_fields({1: pr}, {}) == 0
+
+
+@pytest.mark.parametrize(
+    "kind,expected",
+    [
+        ("commit", "commit_added"),
+        ("merged", "manual_merge"),
+        ("closed", "manual_close"),
+        ("force_push", "force_push"),
+    ],
+)
+def test_reason_vocabulary_is_stable(kind: str, expected: str) -> None:
+    """Guard against accidental shifts in the short-code vocabulary.
+
+    The metric-label set is bounded by this vocabulary; renaming a
+    reason silently would explode Prometheus cardinality.
+    """
+    tracking = _pr_with_touch()
+    events = [
+        InterventionEvent(kind=kind, actor="alice", occurred_at=_now() - timedelta(minutes=5))
+    ]
+    result = detect_pr_intervention(tracking, events)
+    assert result.reasons == [expected]


### PR DESCRIPTION
## Motivation

R&D workstream A2. We can't currently answer the basic question *did
caretaker save human toil this week?* The orchestrator mutates PR and
issue state but never records who drove each state change — so when a
human pushes work after caretaker comments, merges around caretaker's
decision, or rescues an escalated PR, the signal is lost and the
weekly rollup undercounts operator-interventions / overcounts
caretaker wins.

This PR adds the missing attribution layer: per-row booleans that are
cheap to stamp from every write path, a pure intervention detector
that compares tracked-row timestamps against human timeline events,
bounded Prometheus counters for dashboarding, an admin weekly rollup
endpoint, and a backfill CLI for existing persisted state.

## Schema additions

On `TrackedPR`:

- `caretaker_touched: bool` — any caretaker write action.
- `caretaker_merged: bool` — caretaker closed the PR as merged.
- `operator_intervened: bool` — human pushed work after
  `last_caretaker_action_at`.
- `intervention_reasons: list[str]` — bounded enum: `manual_merge`,
  `manual_close`, `label_changed`, `force_push`, `commit_added`.
- `last_caretaker_action_at: datetime | None` — anchor used by the
  detector's cutoff.

On `TrackedIssue`: mirrors the PR shape, with `caretaker_closed`
replacing `caretaker_merged` (issues don't merge).

All fields default to `False` / empty list so existing persisted state
round-trips through Pydantic without a destructive migration.

## Migration strategy

`AttributionConfig.migration_strategy` defaults to `lazy` — existing
rows populate their attribution fields on the next save. Operators who
want the weekly dashboard accurate immediately can set `eager` to run
`backfill_missing_fields` on load. Lazy is the safe default: worst
case is a few days of partial attribution data for repos that run
infrequently.

## Metrics

Three counters with bounded label sets:

- `caretaker_pr_outcome_total{service, repo, outcome}` — `touched` /
  `merged` / `closed_unmerged` / `operator_rescued` / `abandoned`.
- `caretaker_issue_outcome_total{service, repo, outcome}` — `triaged`
  / `closed_by_caretaker` / `closed_by_operator` / `stale_closed`.
- `caretaker_operator_intervention_total{service, repo, reason}` —
  intervention reason short-codes.

Cardinality is the outcome/reason enum cardinality times the number
of repos — explicitly no per-PR label. Emission happens at
`StateTracker.save()` with per-process dedup so repeated saves of the
same snapshot don't double-count; tying emission to the persisted
snapshot means rate-limited saves fold cleanly into the next
successful save.

## Admin endpoint

`GET /api/admin/attribution/weekly?since=<iso>&repo=<slug>` returns:

```json
{
  "since": "2026-04-15T12:00:00+00:00",
  "touched": 12,
  "merged": 7,
  "operator_rescued": 2,
  "abandoned": 1,
  "avg_time_to_merge_hours": 4.31
}
```

`since` defaults to seven days ago. The `repo` query parameter is
accepted for forward-compatibility with the fleet-aggregated admin
tier — the single-repo admin dashboard ignores it.

## Heartbeat payload

`FleetHeartbeat` gains an optional `attribution: AttributionSummary`
block mirroring the admin endpoint's shape. `None` when no state is
supplied preserves byte-identical payloads for legacy emitters; the
current emitter always passes state so the field is always populated
(zero counts vs `None` lets the registry distinguish "no activity"
from "old caretaker that doesn't report attribution").

## Backfill CLI

`caretaker backfill-attribution --since 30d [--dry-run]` reconciles
existing persisted state: infers `caretaker_merged = True` for PRs in
the MERGED state and `caretaker_touched = True` for escalated PRs /
stale-closed issues (caretaker is the only actor that drives those
states), then runs `backfill_missing_fields` to enforce invariants
(`merged` implies `touched`, `closed` implies `touched`). Idempotent
— re-running is a no-op once state is coherent.

## Test coverage

- `tests/test_intervention_detector.py` (22 tests) — cutoff
  semantics, actor classification, caretaker-own-label filtering,
  reason dedup, idempotence, `apply_*` monotonicity, backfill
  invariants, and a parametrised test that guards the reason
  vocabulary against silent renames.
- `tests/test_attribution_metrics.py` (13 tests) — classifier outcome
  taxonomy (touched / merged / closed_unmerged / operator_rescued /
  abandoned; triaged / closed_by_caretaker / closed_by_operator /
  stale_closed), per-process dedup on repeated saves, intervention
  reason emission.
- `tests/test_backfill_attribution.py` (13 tests) — `_parse_since`
  grammar (`Nd` / `Nw` / `Nh` / ISO-8601), `_row_active_since`
  windowing, end-to-end inference pass over a seeded
  `OrchestratorState`.
- `tests/test_admin/test_attribution_api.py` (7 tests) — `GET
  /api/admin/attribution/weekly` happy path, window filtering,
  `since` override, 400 on bad input, repo-query forward-compat.

Full suite: **1686 passed, 1 skipped** (no regressions). Ruff
check/format clean. Mypy clean.

Do not merge — workstream A2 landing coordinated with the other
waves.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>