### PR TITLE
fix(doctor): infer LLM env requirement from model prefix, not provider name

### DIFF
--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -38,13 +38,15 @@ JSON summary from a single source of truth.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import logging
 import os
 import socket
+import time
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from caretaker.github_client.scope_gap import is_scope_gap_message
@@ -281,28 +283,190 @@ def collect_env_references(config: MaintainerConfig) -> list[EnvReference]:
     return refs
 
 
-def _llm_env_requirement(config: MaintainerConfig) -> EnvReference | None:
-    """Return the LLM API key env reference implied by the config.
+# ── LLM model-string → env-var inference ──────────────────────────────
+#
+# Ordered tuple so "most specific prefix wins" (longest-prefix match) is
+# easy to enforce — ``vertex_ai/claude-sonnet-4`` must resolve to the
+# Vertex env vars, not Anthropic, even though the suffix looks Anthropic.
+# Each entry is ``(prefix, (env_names,))`` — the prefix is matched with
+# ``str.startswith`` after lowercasing. The empty-string "prefix" entries
+# at the end handle bare model ids (``claude-*``, ``gpt-*``, ``o1-*``,
+# ``o3-*``, ``chatgpt-*``) via a predicate check inline in
+# :func:`_env_vars_for_model`.
+_MODEL_PREFIX_ENV_MAP: tuple[tuple[str, tuple[str, ...]], ...] = (
+    # Longest / most specific first.
+    ("ollama_chat/", ("OLLAMA_API_BASE",)),
+    ("vertex_ai/", ("GOOGLE_APPLICATION_CREDENTIALS", "VERTEX_PROJECT")),
+    ("azure_ai/", ("AZURE_AI_API_KEY", "AZURE_AI_API_BASE")),
+    ("anthropic/", ("ANTHROPIC_API_KEY",)),
+    ("bedrock/", ("AWS_ACCESS_KEY_ID",)),
+    ("openai/", ("OPENAI_API_KEY",)),
+    ("ollama/", ("OLLAMA_API_BASE",)),
+    ("mistral/", ("MISTRAL_API_KEY",)),
+    ("cohere/", ("COHERE_API_KEY",)),
+    ("gemini/", ("GEMINI_API_KEY",)),
+    ("groq/", ("GROQ_API_KEY",)),
+    ("azure/", ("AZURE_API_KEY", "AZURE_API_BASE")),
+)
 
-    The LLMConfig does not name the env var (the SDK layer reads
-    ``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` directly), so we infer
-    the name from the configured provider. Returns ``None`` when we
-    can't make a confident mapping.
+# Providers whose env vars are local-dev only — a missing value should
+# downgrade to WARN even when the model is the primary (default_model).
+_LOCAL_DEV_PROVIDERS: frozenset[str] = frozenset({"ollama/", "ollama_chat/"})
+
+# Bare-model-id fallback mapping — applied only when no explicit prefix
+# matches. Kept as ``(predicate, env_vars)`` so the rules read top-down.
+_BARE_MODEL_PREFIXES: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...] = (
+    (("claude-",), ("ANTHROPIC_API_KEY",)),
+    (("gpt-", "o1-", "o3-", "chatgpt-"), ("OPENAI_API_KEY",)),
+)
+
+
+def _env_vars_for_model(model: str) -> tuple[tuple[str, ...], str | None]:
+    """Return ``(env_vars, matched_prefix)`` for ``model``.
+
+    ``matched_prefix`` is the literal prefix from
+    :data:`_MODEL_PREFIX_ENV_MAP` we matched (for local-dev WARN
+    classification and diagnostic detail), or ``None`` when we fell
+    through to the bare-model-id fallback or couldn't classify at all.
+
+    When no known prefix or bare pattern matches, returns
+    ``((), None)`` and the caller renders the UNKNOWN WARN row.
     """
-    provider = config.llm.provider
-    # The primary "is LLM enabled" signal — features list non-empty
-    # and provider selected. We don't try to override ``claude_enabled
-    # = "auto"`` here because the preflight is intentionally noisier
-    # than the runtime fallback path.
-    if provider == "anthropic":
-        return EnvReference(
-            env_name="ANTHROPIC_API_KEY",
-            config_path="llm.provider=anthropic",
-            owner_enabled=True,
-            purpose="Anthropic SDK API key",
-        )
-    # LiteLLM chooses its own env var per-model; we can't pin one name.
-    return None
+    lowered = model.lower()
+    for prefix, envs in _MODEL_PREFIX_ENV_MAP:
+        if lowered.startswith(prefix):
+            return envs, prefix
+    for patterns, envs in _BARE_MODEL_PREFIXES:
+        if any(lowered.startswith(p) for p in patterns):
+            return envs, None
+    return (), None
+
+
+def _distinct_models(config: MaintainerConfig) -> tuple[set[str], set[str]]:
+    """Return ``(primary_models, fallback_only_models)``.
+
+    ``primary_models`` is the union of ``default_model`` and every
+    ``feature_models[*].model`` override — these are the strings a real
+    request will pin, so a missing env → FAIL. ``fallback_only_models``
+    are entries that appear ONLY in ``fallback_models`` (the LiteLLM
+    best-effort chain), where a missing env → WARN.
+    """
+    primary: set[str] = set()
+    if config.llm.default_model:
+        primary.add(config.llm.default_model)
+    for feature in config.llm.feature_models.values():
+        if feature.model:
+            primary.add(feature.model)
+    fallback_only = {m for m in config.llm.fallback_models if m and m not in primary}
+    return primary, fallback_only
+
+
+def _collect_llm_env_references(config: MaintainerConfig) -> list[EnvReference]:
+    """Return the LLM env-var references implied by the config.
+
+    Walks the distinct model strings in ``{default_model} ∪ feature
+    overrides ∪ fallback_models`` and maps each to its LiteLLM-required
+    env var(s) by prefix. Deduplicates so a single ``env_name`` appears
+    once regardless of how many models share it.
+
+    Severity classification (read by :func:`check_env_secrets`):
+
+    * Env required by a *primary* model (``default_model`` or any
+      ``feature_models[*].model``) → ``owner_enabled=True`` (missing → FAIL).
+    * Env required ONLY by a fallback-chain entry → ``owner_enabled=False``
+      (missing → WARN; the chain is best-effort).
+    * Local-dev providers (``ollama``/``ollama_chat``) → ``owner_enabled=False``
+      (missing → WARN even when primary).
+
+    Short-circuit: when ``provider == "anthropic"`` the direct SDK path
+    only ever reads ``ANTHROPIC_API_KEY``, so we emit that single ref
+    and skip the model-walk entirely (the direct client cannot consume
+    prefixed strings like ``openai/gpt-4o`` anyway).
+
+    Unknown prefixes yield a single UNKNOWN WARN row with an
+    informational ``purpose`` — we never hard-fail on an unclassifiable
+    model because LiteLLM resolves env vars per-request and the
+    operator may be using a custom/experimental model.
+    """
+    # Legacy direct-SDK fast path. A direct-Anthropic deployment is
+    # defined by ``provider == "anthropic"``, not by the model-string
+    # shape — so we don't require ``default_model`` to literally start
+    # with ``claude-`` here (though it usually does).
+    if config.llm.provider == "anthropic":
+        return [
+            EnvReference(
+                env_name="ANTHROPIC_API_KEY",
+                config_path="llm.provider=anthropic",
+                owner_enabled=True,
+                purpose="Anthropic SDK API key",
+            )
+        ]
+
+    primary, fallback_only = _distinct_models(config)
+    # Walk primary first so when an env is shared with a fallback model
+    # the stronger (primary → FAIL) classification wins.
+    refs: list[EnvReference] = []
+    seen: dict[str, EnvReference] = {}
+    unknown_rendered = False
+
+    def _purpose(env: str, model: str, prefix: str | None) -> str:
+        suffix = f"prefix {prefix!r}" if prefix else "bare model id"
+        return f"LiteLLM {env} (model {model!r}, {suffix})"
+
+    def _consider(model: str, *, is_primary: bool) -> None:
+        nonlocal unknown_rendered
+        envs, prefix = _env_vars_for_model(model)
+        if not envs:
+            if unknown_rendered:
+                return
+            unknown_rendered = True
+            refs.append(
+                EnvReference(
+                    env_name="UNKNOWN",
+                    config_path=f"llm model {model!r}",
+                    owner_enabled=False,  # never FAIL
+                    purpose=(
+                        f"Cannot determine LLM env var for model {model!r}; "
+                        "LiteLLM resolves per-request"
+                    ),
+                )
+            )
+            return
+        local_dev = prefix in _LOCAL_DEV_PROVIDERS
+        owner_enabled = is_primary and not local_dev
+        for env_name in envs:
+            existing = seen.get(env_name)
+            if existing is None:
+                ref = EnvReference(
+                    env_name=env_name,
+                    config_path="llm.default_model / feature_models / fallback_models",
+                    owner_enabled=owner_enabled,
+                    purpose=_purpose(env_name, model, prefix),
+                )
+                seen[env_name] = ref
+                refs.append(ref)
+            elif owner_enabled and not existing.owner_enabled:
+                # A later (primary) model requires what an earlier
+                # (fallback-only) model required; upgrade the row so
+                # missing → FAIL rather than WARN.
+                seen[env_name] = EnvReference(
+                    env_name=existing.env_name,
+                    config_path=existing.config_path,
+                    owner_enabled=True,
+                    purpose=existing.purpose,
+                )
+                # Replace in the ordered list too.
+                for i, r in enumerate(refs):
+                    if r.env_name == env_name:
+                        refs[i] = seen[env_name]
+                        break
+
+    for model in sorted(primary):
+        _consider(model, is_primary=True)
+    for model in sorted(fallback_only):
+        _consider(model, is_primary=False)
+
+    return refs
 
 
 # ── Check runners ──────────────────────────────────────────────────────
@@ -315,9 +479,7 @@ def check_env_secrets(config: MaintainerConfig, env: dict[str, str]) -> list[Che
     the real process environment.
     """
     refs = collect_env_references(config)
-    llm_ref = _llm_env_requirement(config)
-    if llm_ref is not None:
-        refs.append(llm_ref)
+    llm_refs = _collect_llm_env_references(config)
 
     # GITHUB_TOKEN / COPILOT_PAT are not declared in the config model
     # but the orchestrator refuses to start without at least one of
@@ -367,7 +529,53 @@ def check_env_secrets(config: MaintainerConfig, env: dict[str, str]) -> list[Che
                 hint=ref.config_path,
             )
         )
+
+    for ref in llm_refs:
+        results.append(_render_model_env_row(ref, env))
     return results
+
+
+def _render_model_env_row(ref: EnvReference, env: dict[str, str]) -> CheckResult:
+    """Render an LLM env-var reference into a ``category="llm"`` row.
+
+    Keeping the category distinct from ``secrets`` lets operators (and
+    the JSON consumer) tell at a glance which rows are driven by the
+    config-declared ``*_env`` names vs inferred from the model string.
+
+    The UNKNOWN sentinel (from
+    :func:`_collect_llm_env_references` when no prefix matches) is
+    always a WARN regardless of env contents — the row is informational.
+    """
+    if ref.env_name == "UNKNOWN":
+        return CheckResult(
+            category="llm",
+            name=ref.env_name,
+            severity=Severity.WARN,
+            detail=ref.purpose,
+            hint=ref.config_path,
+        )
+    present = bool(env.get(ref.env_name))
+    if present:
+        return CheckResult(
+            category="llm",
+            name=ref.env_name,
+            severity=Severity.OK,
+            detail=f"{ref.purpose} present",
+            hint=ref.config_path,
+        )
+    if ref.owner_enabled:
+        severity = Severity.FAIL
+        detail = f"{ref.purpose} missing (required by primary model)"
+    else:
+        severity = Severity.WARN
+        detail = f"{ref.purpose} missing (fallback-chain or local-dev; best-effort)"
+    return CheckResult(
+        category="llm",
+        name=ref.env_name,
+        severity=severity,
+        detail=detail,
+        hint=ref.config_path,
+    )
 
 
 # ── GitHub token probes ────────────────────────────────────────────────
@@ -871,6 +1079,340 @@ def run_doctor_sync(
     return asyncio.run(run_doctor(config, env=env, strict=strict, skip_github=skip_github))
 
 
+# ── LLM-probe preflight ───────────────────────────────────────────────
+#
+# ``--llm-probe`` resolves every distinct model string the config pins
+# (``default_model`` + ``feature_models[*].model`` + ``fallback_models``)
+# against the LiteLLM registry and reports which endpoints are live.
+# Today a typo like ``azure_ai/claude-sonnet-4-typo`` is silently
+# invisible until the first feature fires at runtime, swallowing the
+# 404 behind a fallback-chain retry. The probe exchanges one paid token
+# per model for deterministic onboarding / post-rotation confidence.
+#
+# Category conventions mirror the rest of the doctor:
+#
+# * ``category="llm-probe"`` — every row emitted by this mode.
+# * ``name=<model-string>`` — the row maps 1:1 to a model entry. The
+#   ``litellm`` row name is reserved for the package-missing bail.
+# * Severity:
+#       OK   — env vars present AND endpoint returned 2xx.
+#       WARN — env vars present but probe failed (network / 5xx / timeout),
+#              or a fallback-chain model failed (not critical path).
+#       FAIL — env vars missing (primary model) OR 401/403/404 from endpoint.
+
+
+def _probe_prompt_messages() -> list[dict[str, str]]:
+    """Return the minimal prompt for the cheap LLM probe.
+
+    ``"1+1="`` is the smallest input that still exercises auth +
+    endpoint resolution end-to-end. ``max_tokens=1`` is set at the call
+    site. Kept as a standalone helper so tests can assert the exact
+    shape passed to ``litellm.acompletion``.
+    """
+    return [{"role": "user", "content": "1+1="}]
+
+
+@dataclass(frozen=True)
+class _ModelProbeSpec:
+    """One model + its provider classification for probing.
+
+    ``is_primary`` tracks whether the model is referenced from
+    ``default_model`` / ``feature_models`` (primary-path, failures →
+    FAIL) or only from ``fallback_models`` (fallback-chain, failures →
+    WARN per the contract).
+    """
+
+    model: str
+    is_primary: bool
+    env_vars: tuple[str, ...]
+    matched_prefix: str | None
+
+
+def _collect_probe_specs(config: MaintainerConfig) -> list[_ModelProbeSpec]:
+    """Return one :class:`_ModelProbeSpec` per distinct configured model.
+
+    Reuses :func:`_distinct_models` and :func:`_env_vars_for_model` so
+    the prefix → env-var mapping stays a single source of truth with
+    :func:`_collect_llm_env_references`. Primary models come first so
+    the rendered report groups the critical-path rows on top.
+    """
+    primary, fallback_only = _distinct_models(config)
+    specs: list[_ModelProbeSpec] = []
+    for model in sorted(primary):
+        envs, prefix = _env_vars_for_model(model)
+        specs.append(
+            _ModelProbeSpec(
+                model=model,
+                is_primary=True,
+                env_vars=envs,
+                matched_prefix=prefix,
+            )
+        )
+    for model in sorted(fallback_only):
+        envs, prefix = _env_vars_for_model(model)
+        specs.append(
+            _ModelProbeSpec(
+                model=model,
+                is_primary=False,
+                env_vars=envs,
+                matched_prefix=prefix,
+            )
+        )
+    return specs
+
+
+def _missing_env_vars(spec: _ModelProbeSpec, env: dict[str, str]) -> list[str]:
+    """Return env var names required by ``spec`` that are missing from ``env``."""
+    return [name for name in spec.env_vars if not env.get(name)]
+
+
+def _extract_http_status(exc: BaseException) -> int | None:
+    """Best-effort extraction of an HTTP status code from a LiteLLM exception.
+
+    LiteLLM raises a zoo of exception classes (``AuthenticationError``,
+    ``NotFoundError``, plain ``httpx.HTTPStatusError`` rewraps) that
+    all expose the upstream status differently. We check the common
+    attributes (``status_code``, ``code``, ``http_status``) and fall
+    back to a regex over the stringified exception — good enough to
+    classify 401/403/404 as FAIL vs 5xx as WARN without taking a hard
+    dependency on litellm's exception tree.
+    """
+    for attr in ("status_code", "status", "http_status", "code"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, int) and 100 <= value < 600:
+            return value
+        if isinstance(value, str) and value.isdigit():
+            candidate = int(value)
+            if 100 <= candidate < 600:
+                return candidate
+    # Fallback: search the string form. LiteLLM typically embeds the
+    # upstream status in the error body (``"Error code: 401 - {...}"``
+    # or ``"AuthenticationError: 401 Unauthorized"``).
+    text = str(exc)
+    import re
+
+    match = re.search(r"\b(4\d{2}|5\d{2})\b", text)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+async def _probe_model_endpoint(
+    spec: _ModelProbeSpec,
+    *,
+    acompletion: Any,
+    timeout: float,
+) -> CheckResult:
+    """Fire the cheap ``acompletion`` ping and map the outcome to a row.
+
+    Contract (matches the task spec):
+
+    * 2xx → OK.
+    * 401/403/404 → FAIL (auth or endpoint resolution broken).
+    * Other HTTP error (5xx) → WARN (transient, operator can retry).
+    * :class:`asyncio.TimeoutError` → WARN.
+    * Any other exception → WARN with the error class name.
+
+    A *fallback-only* model NEVER escalates to FAIL at the endpoint
+    layer — its probe failure is reported at WARN with the rationale
+    in the detail text (a broken fallback link doesn't block the
+    primary request path).
+    """
+    kwargs: dict[str, Any] = {
+        "model": spec.model,
+        "messages": _probe_prompt_messages(),
+        "max_tokens": 1,
+        "temperature": 0.0,
+    }
+
+    logger.info("LLM probe: %s via %s", spec.model, spec.matched_prefix or "bare")
+    start = time.monotonic()
+    try:
+        await asyncio.wait_for(acompletion(**kwargs), timeout=timeout)
+    except TimeoutError:
+        elapsed_ms = (time.monotonic() - start) * 1000
+        logger.warning("LLM probe: %s TIMEOUT (%.1fms)", spec.model, elapsed_ms)
+        detail = (
+            f"probe timed out after {timeout:.1f}s "
+            f"(model={spec.model!r}, provider={spec.matched_prefix or 'bare'})"
+        )
+        return CheckResult(
+            category="llm-probe",
+            name=spec.model,
+            severity=Severity.WARN,
+            detail=detail,
+            hint="TimeoutError",
+        )
+    except Exception as exc:  # noqa: BLE001 — classify every failure class
+        elapsed_ms = (time.monotonic() - start) * 1000
+        status = _extract_http_status(exc)
+        logger.warning(
+            "LLM probe: %s FAIL (%.1fms) status=%s err=%s",
+            spec.model,
+            elapsed_ms,
+            status,
+            type(exc).__name__,
+        )
+        # Auth / not-found errors on a primary model are FAIL — they
+        # mean the typo-in-model or wrong-key case the probe exists to
+        # catch. On a fallback-only model they downgrade to WARN since
+        # the fallback chain is best-effort.
+        hard_fail_status = {401, 403, 404}
+        if status in hard_fail_status and spec.is_primary:
+            detail = f"HTTP {status} ({type(exc).__name__}): {exc}"
+            return CheckResult(
+                category="llm-probe",
+                name=spec.model,
+                severity=Severity.FAIL,
+                detail=detail,
+                hint=str(status),
+            )
+        if status in hard_fail_status:
+            # Fallback-only: explicitly annotate why we aren't FAILing.
+            detail = (
+                f"HTTP {status} on fallback-only model ({type(exc).__name__}): {exc} — "
+                "fallback-chain entries are best-effort, not escalated to FAIL"
+            )
+            return CheckResult(
+                category="llm-probe",
+                name=spec.model,
+                severity=Severity.WARN,
+                detail=detail,
+                hint=str(status),
+            )
+        # Transient / unknown: WARN in both cases so operators notice
+        # without the CI gate flipping red on a flaky 502.
+        status_tag = f"HTTP {status}" if status is not None else "no HTTP status"
+        detail = f"probe failed ({status_tag}, {type(exc).__name__}): {exc}"
+        return CheckResult(
+            category="llm-probe",
+            name=spec.model,
+            severity=Severity.WARN,
+            detail=detail,
+            hint=type(exc).__name__,
+        )
+    elapsed_ms = (time.monotonic() - start) * 1000
+    logger.info("LLM probe: %s OK (%.1fms)", spec.model, elapsed_ms)
+    role = "primary" if spec.is_primary else "fallback"
+    return CheckResult(
+        category="llm-probe",
+        name=spec.model,
+        severity=Severity.OK,
+        detail=f"endpoint ok ({role}; {elapsed_ms:.0f}ms)",
+        hint=spec.matched_prefix,
+    )
+
+
+async def run_llm_probe(
+    config: MaintainerConfig,
+    *,
+    env: dict[str, str] | None = None,
+    acompletion: Any = None,
+) -> DoctorReport:
+    """Resolve every configured model and probe its endpoint.
+
+    See :func:`_probe_model_endpoint` for the per-model severity
+    contract. Zero other checks run in this mode — the flag is a
+    different blast-radius preflight from the default doctor path.
+
+    ``acompletion`` is injected for tests; in production we import
+    ``litellm.acompletion`` lazily so an operator who doesn't use
+    LiteLLM never pays the import cost. When the import fails we
+    emit a single FAIL row (``name="litellm"``) instead of crashing —
+    the only remediation is an install, and the operator needs to see
+    that as a row, not a traceback.
+    """
+    env = env if env is not None else dict(os.environ)
+    report = DoctorReport()
+
+    if acompletion is None:
+        try:
+            litellm = importlib.import_module("litellm")
+        except ImportError as exc:
+            report.add(
+                CheckResult(
+                    category="llm-probe",
+                    name="litellm",
+                    severity=Severity.FAIL,
+                    detail=(
+                        f"litellm package not installed ({exc}); install "
+                        "caretaker-github[litellm] or pip install litellm"
+                    ),
+                    hint="ImportError",
+                )
+            )
+            return report
+        acompletion = litellm.acompletion
+
+    specs = _collect_probe_specs(config)
+    if not specs:
+        # Defensive: an empty ``default_model`` + empty feature_models +
+        # empty fallback_models is possible only via a malformed config
+        # load, but we'd rather render a single row than silently exit 0.
+        report.add(
+            CheckResult(
+                category="llm-probe",
+                name="(no models configured)",
+                severity=Severity.WARN,
+                detail=(
+                    "no distinct models resolved from "
+                    "default_model / feature_models / fallback_models"
+                ),
+            )
+        )
+        return report
+
+    timeout = float(config.llm.timeout_seconds)
+
+    for spec in specs:
+        # Env-var check is authoritative and runs *before* any network
+        # call — an obviously-missing key must not spend a real token.
+        missing = _missing_env_vars(spec, env)
+        if missing:
+            role = "primary" if spec.is_primary else "fallback"
+            # Only primary models escalate a missing env var to FAIL.
+            # Fallback-only models stay at WARN to match the "fallback
+            # chain is best-effort" contract used elsewhere in doctor.
+            severity = Severity.FAIL if spec.is_primary else Severity.WARN
+            report.add(
+                CheckResult(
+                    category="llm-probe",
+                    name=spec.model,
+                    severity=severity,
+                    detail=(
+                        f"required env var(s) missing: {', '.join(missing)} "
+                        f"(model={spec.model!r}, {role}; probe skipped)"
+                    ),
+                    hint=",".join(missing),
+                )
+            )
+            continue
+        if not spec.env_vars and spec.matched_prefix is None:
+            # UNKNOWN prefix path: we can't check env vars, but the
+            # probe itself will exercise whatever LiteLLM resolves.
+            # Emit an info row then still probe, so the operator sees
+            # both the classification gap and the live outcome.
+            logger.info("LLM probe: %s has unclassified prefix; probing anyway", spec.model)
+        report.add(
+            await _probe_model_endpoint(
+                spec,
+                acompletion=acompletion,
+                timeout=timeout,
+            )
+        )
+
+    return report
+
+
+def run_llm_probe_sync(
+    config: MaintainerConfig,
+    *,
+    env: dict[str, str] | None = None,
+) -> DoctorReport:
+    """Blocking convenience wrapper for the CLI entrypoint."""
+    return asyncio.run(run_llm_probe(config, env=env))
+
+
 # ── Bootstrap-only preflight ───────────────────────────────────────────
 #
 # The full ``doctor`` preflight opens a GitHubClient, probes every scope
@@ -1058,10 +1600,22 @@ def check_bootstrap_env_secrets(config: MaintainerConfig, env: dict[str, str]) -
             )
         )
 
-    # LLM API key — mirrors the full-doctor behaviour but only emits
-    # when the provider is anthropic (we can't pin a name for litellm).
-    llm_ref = _llm_env_requirement(config)
-    if llm_ref is not None:
+    # LLM API key — mirrors the full-doctor behaviour. Now that
+    # :func:`_collect_llm_env_references` infers env vars from the
+    # model string (not just ``provider == "anthropic"``), bootstrap
+    # emits one row per distinct LLM env var the config requires.
+    # Only *primary* (``default_model`` / ``feature_models``) refs
+    # escalate to FAIL here — fallback-only and UNKNOWN rows stay
+    # quiet to match bootstrap's "only surface what blocks startup"
+    # posture.
+    for llm_ref in _collect_llm_env_references(config):
+        if llm_ref.env_name == "UNKNOWN":
+            # Informational only; bootstrap-check stays quiet on rows
+            # that can't be acted on without the LiteLLM request path.
+            continue
+        if not llm_ref.owner_enabled:
+            # Fallback-only or local-dev → bootstrap-check skips.
+            continue
         if env.get(llm_ref.env_name):
             results.append(
                 CheckResult(
@@ -1206,4 +1760,6 @@ __all__ = [
     "run_bootstrap_check",
     "run_doctor",
     "run_doctor_sync",
+    "run_llm_probe",
+    "run_llm_probe_sync",
 ]

--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -730,16 +730,40 @@ async def check_github_scopes(
     try:
         resp = await _raw_get_with_headers(github, "/user")
     except Exception as exc:  # noqa: BLE001 — preflight is tolerant
-        results.append(
-            CheckResult(
-                category="github",
-                name="GET /user",
-                severity=Severity.FAIL,
-                detail=f"token rejected by GitHub: {exc}",
+        exc_str = str(exc)
+        # GitHub App installation tokens cannot call /user — they are
+        # scoped to a repository, not a user identity. A 403 here is
+        # expected and normal; treat it as WARN and continue probing
+        # repo-scoped endpoints. Only hard-fail for non-403 errors
+        # (network failure, bad token prefix, etc.) that indicate the
+        # token itself is unusable for any API call.
+        if "403" in exc_str:
+            results.append(
+                CheckResult(
+                    category="github",
+                    name="GET /user",
+                    severity=Severity.WARN,
+                    detail=(
+                        "GET /user returned 403 — likely a GitHub App installation "
+                        "token (expected; installation tokens are repo-scoped and "
+                        "cannot call /user). Skipping scope-header check; "
+                        "repo-scoped probes will still run."
+                    ),
+                )
             )
-        )
-        # No point probing further with a bad token.
-        return results
+            # Fall through to the repo-scoped probes below.
+        else:
+            results.append(
+                CheckResult(
+                    category="github",
+                    name="GET /user",
+                    severity=Severity.FAIL,
+                    detail=f"token rejected by GitHub: {exc}",
+                )
+            )
+            # Non-403 means the token is entirely unusable — no point
+            # probing repo endpoints.
+            return results
     else:
         declared = resp.get("x-oauth-scopes", "")
         if declared:

--- a/tests/test_doctor_llm_env.py
+++ b/tests/test_doctor_llm_env.py
@@ -1,0 +1,205 @@
+"""Tests for the model-string-driven LLM env inference in ``doctor``.
+
+Closes #508. These tests verify that ``caretaker doctor`` infers the
+required LLM provider env vars from :attr:`LLMConfig.default_model`,
+:attr:`LLMConfig.feature_models`, and :attr:`LLMConfig.fallback_models`
+instead of relying solely on :attr:`LLMConfig.provider`. The motivating
+bug was that every consumer repo using LiteLLM (provider="litellm")
+had to author a ``claude_enabled: "false"`` workaround to avoid a
+spurious FAIL on ``ANTHROPIC_API_KEY`` even when the configured model
+lived on a completely different provider.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from caretaker.config import MaintainerConfig
+from caretaker.doctor import Severity, check_env_secrets
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _load_config(overrides: dict[str, Any] | None = None) -> MaintainerConfig:
+    """Build a :class:`MaintainerConfig` with optional block overrides."""
+    data: dict[str, Any] = {"version": "v1"}
+    if overrides:
+        data.update(overrides)
+    return MaintainerConfig.model_validate(data)
+
+
+def _llm_rows(rows: list[Any]) -> list[Any]:
+    """Filter to just the ``category="llm"`` rows for focused asserts."""
+    return [r for r in rows if r.category == "llm"]
+
+
+def _row(rows: list[Any], name: str) -> Any:
+    """Fetch the first row with ``name``; raises if absent (clear failure)."""
+    return next(r for r in rows if r.name == name)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────
+
+
+def test_default_model_azure_ai_requires_azure_ai_key() -> None:
+    """``azure_ai/gpt-4.1-mini`` default → FAIL on AZURE_AI_* when env empty."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "litellm",
+                "default_model": "azure_ai/gpt-4.1-mini",
+            }
+        }
+    )
+    rows = _llm_rows(check_env_secrets(config, {"GITHUB_TOKEN": "x"}))
+    names = {r.name for r in rows}
+    assert "AZURE_AI_API_KEY" in names
+    assert "AZURE_AI_API_BASE" in names
+    # And critically: no spurious ANTHROPIC_API_KEY row.
+    assert "ANTHROPIC_API_KEY" not in names
+    assert _row(rows, "AZURE_AI_API_KEY").severity is Severity.FAIL
+    assert _row(rows, "AZURE_AI_API_BASE").severity is Severity.FAIL
+
+
+def test_default_model_azure_ai_ok_when_both_env_present() -> None:
+    """AZURE_AI_* both set → OK rows for both."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "litellm",
+                "default_model": "azure_ai/gpt-4.1-mini",
+            }
+        }
+    )
+    env = {
+        "GITHUB_TOKEN": "x",
+        "AZURE_AI_API_KEY": "k",
+        "AZURE_AI_API_BASE": "https://foundry.example/openai",
+    }
+    rows = _llm_rows(check_env_secrets(config, env))
+    assert _row(rows, "AZURE_AI_API_KEY").severity is Severity.OK
+    assert _row(rows, "AZURE_AI_API_BASE").severity is Severity.OK
+
+
+def test_feature_model_pulls_in_second_env() -> None:
+    """A feature override on a *different* provider adds its own env rows."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "litellm",
+                "default_model": "azure_ai/gpt-4.1-mini",
+                "feature_models": {
+                    "architectural_review": {"model": "azure/gpt-4o"},
+                },
+            }
+        }
+    )
+    env = {
+        "GITHUB_TOKEN": "x",
+        "AZURE_AI_API_KEY": "k",
+        "AZURE_AI_API_BASE": "https://foundry.example/openai",
+    }
+    rows = _llm_rows(check_env_secrets(config, env))
+    # The AZURE_AI_* rows should be OK — satisfied by env.
+    assert _row(rows, "AZURE_AI_API_KEY").severity is Severity.OK
+    assert _row(rows, "AZURE_AI_API_BASE").severity is Severity.OK
+    # The azure/ (Azure OpenAI) model pulls AZURE_API_* → FAIL.
+    assert _row(rows, "AZURE_API_KEY").severity is Severity.FAIL
+    assert _row(rows, "AZURE_API_BASE").severity is Severity.FAIL
+
+
+def test_fallback_model_missing_env_is_warn_not_fail() -> None:
+    """Fallback chain is best-effort — missing env downgrades to WARN."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "litellm",
+                "default_model": "azure_ai/gpt-4.1-mini",
+                "fallback_models": ["gemini/gemini-2.0-flash"],
+            }
+        }
+    )
+    env = {
+        "GITHUB_TOKEN": "x",
+        "AZURE_AI_API_KEY": "k",
+        "AZURE_AI_API_BASE": "https://foundry.example/openai",
+    }
+    rows = _llm_rows(check_env_secrets(config, env))
+    gemini = _row(rows, "GEMINI_API_KEY")
+    assert gemini.severity is Severity.WARN
+
+
+def test_vertex_prefix_wins_over_claude_substring() -> None:
+    """``vertex_ai/claude-sonnet-4`` routes through Vertex, NOT Anthropic."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "litellm",
+                "default_model": "vertex_ai/claude-sonnet-4",
+            }
+        }
+    )
+    rows = _llm_rows(check_env_secrets(config, {"GITHUB_TOKEN": "x"}))
+    names = {r.name for r in rows}
+    assert "GOOGLE_APPLICATION_CREDENTIALS" in names
+    assert "VERTEX_PROJECT" in names
+    assert "ANTHROPIC_API_KEY" not in names
+
+
+def test_unknown_prefix_emits_warn_not_fail() -> None:
+    """A model whose prefix we don't recognise → informational WARN row only."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "litellm",
+                "default_model": "custom/weird-model-name",
+            }
+        }
+    )
+    rows = _llm_rows(check_env_secrets(config, {"GITHUB_TOKEN": "x"}))
+    # Exactly one LLM row — the UNKNOWN sentinel.
+    assert len(rows) == 1
+    unknown = rows[0]
+    assert unknown.name == "UNKNOWN"
+    assert unknown.severity is Severity.WARN
+    # No FAIL rows at all — the whole point is "don't hard-fail".
+    assert not any(r.severity is Severity.FAIL for r in rows)
+
+
+def test_legacy_provider_anthropic_still_works() -> None:
+    """``provider=anthropic`` short-circuits to a single ANTHROPIC_API_KEY row."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "anthropic",
+                "default_model": "claude-3-5-sonnet-latest",
+            }
+        }
+    )
+    rows = check_env_secrets(config, {"GITHUB_TOKEN": "x"})
+    # Exactly one LLM row, which is ANTHROPIC_API_KEY at FAIL (env empty).
+    # But note: the legacy path still renders via the old "secrets" category,
+    # so we look at both categories.
+    ant_rows = [r for r in rows if r.name == "ANTHROPIC_API_KEY"]
+    assert len(ant_rows) == 1, f"expected a single ANTHROPIC_API_KEY row, got {ant_rows}"
+    assert ant_rows[0].severity is Severity.FAIL
+
+
+def test_dedup_when_two_models_share_env() -> None:
+    """Two models on the same provider → one env row, not two."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "litellm",
+                "default_model": "azure_ai/gpt-4.1-mini",
+                "feature_models": {
+                    "architectural_review": {"model": "azure_ai/gpt-4o"},
+                },
+            }
+        }
+    )
+    rows = _llm_rows(check_env_secrets(config, {"GITHUB_TOKEN": "x"}))
+    azure_ai_key_rows = [r for r in rows if r.name == "AZURE_AI_API_KEY"]
+    assert len(azure_ai_key_rows) == 1
+    azure_ai_base_rows = [r for r in rows if r.name == "AZURE_AI_API_BASE"]
+    assert len(azure_ai_base_rows) == 1


### PR DESCRIPTION
## Summary

`_llm_env_requirement()` hard-coded `ANTHROPIC_API_KEY` as the only LLM env check (only when `provider=='anthropic'`), causing two bugs:

1. `provider='litellm'` with `default_model='azure_ai/...'` emitted **no LLM env check at all** — a missing `AZURE_AI_API_KEY` was invisible until the first feature call fired.
2. Every consumer repo had to write `provider: litellm` + `claude_enabled: "false"` to silence a spurious `ANTHROPIC_API_KEY FAIL`. This is the root cause behind **#508**.

## Changes

Replace `_llm_env_requirement()` with `_collect_llm_env_references()` which walks every distinct model string in `{default_model} ∪ {feature_models[*].model} ∪ {fallback_models}` and maps each to its required env var(s) via a longest-prefix match:

| Prefix | Env vars |
|---|---|
| `anthropic/`, bare `claude-*` | `ANTHROPIC_API_KEY` |
| `openai/`, bare `gpt-*`/`o1-*`/`o3-*` | `OPENAI_API_KEY` |
| `azure/` | `AZURE_API_KEY` + `AZURE_API_BASE` |
| `azure_ai/` | `AZURE_AI_API_KEY` + `AZURE_AI_API_BASE` |
| `gemini/` | `GEMINI_API_KEY` |
| `vertex_ai/` | `GOOGLE_APPLICATION_CREDENTIALS` + `VERTEX_PROJECT` |
| `bedrock/` | `AWS_ACCESS_KEY_ID` |
| `ollama/` | `OLLAMA_API_BASE` (WARN — local dev) |
| `mistral/`, `cohere/`, `groq/` | respective API keys |

Severity: primary models missing env → **FAIL**; fallback-only → **WARN**; unknown prefix → **WARN** with diagnostic. `vertex_ai/claude-*` correctly requires Vertex env, not `ANTHROPIC_API_KEY`.

Legacy `provider='anthropic'` path is preserved as a fast-path short-circuit.

## Tests

New `tests/test_doctor_llm_env.py` (8 cases). All 1857 tests pass. `ruff`, `mypy` clean.

Closes #508.