### PR TITLE
feat(eval): per-shadow-site model overrides for A/B model comparison

### DIFF
--- a/docs/plans/2026-Q2-agentic-migration.md
+++ b/docs/plans/2026-Q2-agentic-migration.md
@@ -169,3 +169,46 @@ The supervisor itself is a reasonable candidate for its own sub-agent in a follo
 - **Prompt-cache TTL (R2).** Tool loops regularly exceed 5 min; cache wins may be smaller than expected on long-running Foundry runs. Measure before claiming savings.
 - **M4 + M5 are simple code fixes but each unblocks large fleet-wide silences.** Do not save them for Phase 2.
 - **S6 is self-inflicted** — shipped in v0.12.0 this morning. Patch in Phase 1 W1 or mark the v0.12.0 docs.
+
+### Per-site model overrides (2026-04-22)
+
+`agentic.<site>.model_override` (and its sibling `max_tokens_override`)
+lets the nightly-eval harness A/B different LLM models against the same
+legacy heuristic on a single decision site. When the override is set,
+the candidate leg of `@shadow_decision` receives a `model=` kwarg that
+propagates into `ClaudeClient.structured_complete` /
+`ClaudeClient.complete`; the legacy leg, and every LLM call outside
+shadow decisions, continues to use `llm.default_model`. Leave the
+override at `None` to inherit the router default.
+
+**Two-model A/B pattern (recommended rollout):**
+
+1. Site already running in `mode: shadow` on `llm.default_model` (call
+   it *model A*) for at least 7 days; baseline agreement-rate
+   established in the Braintrust dashboard.
+2. Set `agentic.<site>.model_override: "<model B>"`. Leave the site in
+   `mode: shadow` for another 7 days. The candidate leg now runs on
+   model B; the legacy leg is unchanged; every `:ShadowDecision` row
+   stamps `candidate_model = "<model B>"`.
+3. Compare the two windows in Braintrust. The harness surfaces
+   `per_model_reports` in the nightly JSON report and logs an
+   `eval site=... candidate_model=... agreement_rate=...` line per
+   model when the window is mixed, so the split shows up both in the
+   CI comment and in the admin dashboard.
+4. If model B's agreement rate ≥ model A's (and the disagreement
+   samples look qualitatively better), clear `model_override` — model A
+   is now the router default so the enforce-mode flip will use it —
+   OR promote model B to `llm.default_model` and clear the override.
+   Either way, the override is removed once the A/B concludes so the
+   site returns to a single-model shadow stream.
+
+**Known follow-up:** the enforce-gate's `min_agreement_rate` check
+(see `AgenticEnforceGateConfig.min_agreement_rate`) applies per-site
+and does *not* distinguish candidate models. If model B is winning in
+the A/B but the site-wide rolling mean is dragged down by model A's
+earlier samples, the gate may refuse to unlock until the window rolls
+far enough forward. A future refinement is a per-model
+`min_agreement_rate` map (e.g. `{"azure_ai/gpt-5": 0.93}`) so the
+enforce flip can be gated specifically on the model about to become
+authoritative. Not in scope for this change — tracked as a separate
+follow-up on the 2026-Q2 migration plan.

--- a/src/caretaker/admin/shadow_api.py
+++ b/src/caretaker/admin/shadow_api.py
@@ -68,6 +68,12 @@ class ShadowDecisionRow(BaseModel):
     candidate_verdict_json: str | None
     disagreement_reason: str | None
     context_json: str
+    # Per-PR #503 follow-up: expose model attribution to the admin UI so
+    # operators can tell at a glance whether a disagreement row was
+    # produced by a model swap or a prompt change. Defaults to ``None``
+    # so rows persisted before the field existed deserialise cleanly.
+    legacy_model: str | None = None
+    candidate_model: str | None = None
 
     @classmethod
     def from_record(cls, rec: ShadowDecisionRecord) -> ShadowDecisionRow:
@@ -82,6 +88,8 @@ class ShadowDecisionRow(BaseModel):
             candidate_verdict_json=rec.candidate_verdict_json,
             disagreement_reason=rec.disagreement_reason,
             context_json=rec.context_json,
+            legacy_model=rec.legacy_model,
+            candidate_model=rec.candidate_model,
         )
 
 
@@ -155,6 +163,13 @@ async def _read_from_neo4j(
                 continue
             candidate = props.get("candidate_verdict_json") or None
             reason = props.get("disagreement_reason") or None
+            # Models are stored as empty-string-for-None in Neo4j (see the
+            # write path in :func:`caretaker.evolution.shadow.write_shadow_decision`);
+            # normalise back to ``None`` so the admin UI / tests don't
+            # have to know about the storage-layer quirk. Missing keys
+            # (pre-field rows) also land at ``None`` here.
+            legacy_model = props.get("legacy_model") or None
+            candidate_model = props.get("candidate_model") or None
             rows.append(
                 ShadowDecisionRow(
                     id=str(props.get("id", "")),
@@ -167,6 +182,8 @@ async def _read_from_neo4j(
                     candidate_verdict_json=candidate,
                     disagreement_reason=reason,
                     context_json=str(props.get("context_json", "{}")),
+                    legacy_model=legacy_model,
+                    candidate_model=candidate_model,
                 )
             )
         return rows

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -1026,6 +1026,15 @@ class AgenticDomainConfig(StrictBaseModel):
 
     mode: Literal["off", "shadow", "enforce"] = "off"
     enforce_gate: AgenticEnforceGateConfig = Field(default_factory=AgenticEnforceGateConfig)
+    # Optional per-site model override. When set, the candidate leg of
+    # @shadow_decision uses this model instead of llm.default_model, enabling
+    # A/B comparison of two models against the legacy heuristic via the
+    # nightly-eval harness. Example: set to "azure_ai/claude-sonnet-4" while
+    # the legacy leg (and LLM calls outside shadow decisions) continues to
+    # use llm.default_model. Leave None to inherit.
+    model_override: str | None = None
+    # Optional per-site max-tokens override; only consumed when model_override is set.
+    max_tokens_override: int | None = None
 
 
 class IssueTriageAgenticConfig(AgenticDomainConfig):

--- a/src/caretaker/eval/harness.py
+++ b/src/caretaker/eval/harness.py
@@ -77,13 +77,29 @@ class ScorerSummary:
 
 @dataclass(frozen=True)
 class SiteReport:
-    """Per-decision-site results for one nightly run."""
+    """Per-decision-site results for one nightly run.
+
+    When :class:`ShadowDecisionRecord.candidate_model` varies across the
+    records in the window (because an operator set
+    ``agentic.<site>.model_override`` to run an A/B between two models),
+    this report aggregates across *all* models — see
+    :attr:`per_model_reports` for the per-model break-out.
+    """
 
     site: str
     record_count: int
     scorer_summaries: list[ScorerSummary]
     experiment_url: str | None
     braintrust_logged: bool
+    # Per-``candidate_model`` break-out when the window contains records
+    # produced by more than one model. Empty when every record shares a
+    # single model (the common case). Populated by :func:`_score_records`
+    # via :func:`_group_by_model`.
+    per_model_reports: list[PerModelReport] = field(default_factory=list)
+    # The single ``candidate_model`` for the whole window when the set
+    # reduces to one; ``None`` when the window is empty or contains
+    # multiple models (use :attr:`per_model_reports` for that case).
+    candidate_model: str | None = None
 
     def agreement_rate(self) -> float:
         """Mean across all scorer means; 1.0 when no records scored."""
@@ -99,6 +115,37 @@ class SiteReport:
             "scorer_summaries": [s.to_dict() for s in self.scorer_summaries],
             "experiment_url": self.experiment_url,
             "braintrust_logged": self.braintrust_logged,
+            "candidate_model": self.candidate_model,
+            "per_model_reports": [m.to_dict() for m in self.per_model_reports],
+        }
+
+
+@dataclass(frozen=True)
+class PerModelReport:
+    """Break-out of one ``candidate_model`` inside a :class:`SiteReport`.
+
+    Exists so the nightly harness can surface A/B comparisons when an
+    operator sets :attr:`AgenticDomainConfig.model_override` and lets
+    two models accumulate shadow decisions against the same legacy
+    heuristic in one window. Consumed by the report JSON and the
+    agreement-rate log line in :func:`run_nightly_eval`.
+    """
+
+    candidate_model: str | None
+    record_count: int
+    scorer_summaries: list[ScorerSummary]
+
+    def agreement_rate(self) -> float:
+        if not self.scorer_summaries:
+            return 1.0
+        return statistics.fmean(s.mean for s in self.scorer_summaries)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_model": self.candidate_model,
+            "record_count": self.record_count,
+            "agreement_rate": self.agreement_rate(),
+            "scorer_summaries": [s.to_dict() for s in self.scorer_summaries],
         }
 
 
@@ -218,6 +265,29 @@ def run_nightly_eval(
         for summary in summaries:
             EVAL_AGREEMENT_RATE.labels(site=site, scorer=summary.scorer).set(summary.mean)
 
+        # Per-``candidate_model`` breakout — empty when the window is
+        # uniform (the common case: operator hasn't set ``model_override``
+        # yet). We compute the breakout ONLY when the record set has
+        # more than one distinct model, because scoring each bucket
+        # re-invokes the scorers (which include the LLM judge on
+        # ``readiness``) and we don't want to double the judge's API
+        # cost for the common single-model window.
+        distinct_models = {r.candidate_model for r in records}
+        single_model: str | None = None
+        if len(distinct_models) == 1:
+            single_model = next(iter(distinct_models))
+        breakout: list[PerModelReport] = []
+        if len(distinct_models) > 1:
+            breakout = _group_by_model(records, scorers, site=site)
+            for pm in breakout:
+                logger.info(
+                    "eval site=%s candidate_model=%s agreement_rate=%.3f records=%d",
+                    site,
+                    pm.candidate_model,
+                    pm.agreement_rate(),
+                    pm.record_count,
+                )
+
         site_reports.append(
             SiteReport(
                 site=site,
@@ -225,6 +295,8 @@ def run_nightly_eval(
                 scorer_summaries=summaries,
                 experiment_url=experiment_result.experiment_url,
                 braintrust_logged=experiment_result.logged,
+                per_model_reports=breakout,
+                candidate_model=single_model,
             )
         )
 
@@ -309,6 +381,46 @@ def _score_records(
     return summaries, cases
 
 
+def _group_by_model(
+    records: Sequence[ShadowDecisionRecord],
+    scorers: Sequence[Scorer],
+    *,
+    site: str,
+) -> list[PerModelReport]:
+    """Group ``records`` by ``candidate_model`` and score each bucket.
+
+    The top-level site report already aggregates across every record in
+    the window; this helper produces the same scorer summaries for each
+    individual ``candidate_model`` so the nightly report can surface A/B
+    splits cleanly. Buckets with zero records are dropped. Ordering is
+    stable: ``None`` last, then the remaining models sorted alphabetically
+    so successive nightly runs render predictably in diffs.
+    """
+    buckets: dict[str | None, list[ShadowDecisionRecord]] = {}
+    for record in records:
+        buckets.setdefault(record.candidate_model, []).append(record)
+    if not buckets:
+        return []
+
+    def _sort_key(model: str | None) -> tuple[int, str]:
+        return (1 if model is None else 0, model or "")
+
+    reports: list[PerModelReport] = []
+    for model in sorted(buckets.keys(), key=_sort_key):
+        bucket = buckets[model]
+        if not bucket:
+            continue
+        summaries, _ = _score_records(bucket, scorers, site=site)
+        reports.append(
+            PerModelReport(
+                candidate_model=model,
+                record_count=len(bucket),
+                scorer_summaries=summaries,
+            )
+        )
+    return reports
+
+
 def _maybe_log_experiment(
     *,
     site: str,
@@ -343,6 +455,7 @@ def _maybe_log_experiment(
 __all__ = [
     "EVAL_AGREEMENT_RATE",
     "NightlyReport",
+    "PerModelReport",
     "RecordLoader",
     "ScorerSummary",
     "SiteReport",

--- a/src/caretaker/evolution/shadow.py
+++ b/src/caretaker/evolution/shadow.py
@@ -162,6 +162,30 @@ class ShadowDecisionRecord(BaseModel):
         default="{}",
         description="JSON-serialised caller context (repo, pr number, etc.).",
     )
+    # Per-PR #503 (nightly-eval harness): capture which model produced the
+    # legacy vs candidate verdict so paired Braintrust experiments can
+    # disambiguate a prompt-change regression from a model-swap regression.
+    # Both default to ``None`` so rows written before these fields existed
+    # load cleanly — Neo4j nodes persisted pre-field lack the property and
+    # pydantic's ``extra='forbid'`` on StrictBaseModel doesn't apply here.
+    legacy_model: str | None = Field(
+        default=None,
+        description=(
+            "Model used by the legacy leg, if any. ``None`` when the legacy "
+            "leg is a pure heuristic (the usual case) — most sites only set "
+            "``candidate_model`` because only the candidate leg calls an LLM."
+        ),
+    )
+    candidate_model: str | None = Field(
+        default=None,
+        description=(
+            "Model used by the candidate leg. Equals the site's "
+            "``AgenticDomainConfig.model_override`` when set, else the "
+            "router's ``llm.default_model`` at the time of the call. "
+            "``None`` when the decorator was unable to determine a model "
+            "(e.g. candidate errored before issuing an LLM request)."
+        ),
+    )
 
 
 # ── Graph-store write helper ─────────────────────────────────────────────
@@ -199,6 +223,11 @@ def write_shadow_decision(record: ShadowDecisionRecord) -> None:
         "candidate_verdict_json": record.candidate_verdict_json or "",
         "disagreement_reason": record.disagreement_reason or "",
         "context_json": record.context_json,
+        # Empty string rather than None so the Neo4j storage layer doesn't
+        # have to special-case ``NULL`` property values; the admin API
+        # normalises the empty-string back to ``None`` on read.
+        "legacy_model": record.legacy_model or "",
+        "candidate_model": record.candidate_model or "",
     }
     stats = writer.stats()
     if stats.get("enabled"):
@@ -292,6 +321,55 @@ def _resolve_mode(name: str) -> ShadowMode:
     return cast("ShadowMode", mode)
 
 
+def _resolve_model_overrides(name: str) -> tuple[str | None, int | None]:
+    """Return ``(model_override, max_tokens_override)`` for ``name``.
+
+    Both are ``None`` when no :class:`~caretaker.config.AgenticConfig` is
+    installed or the domain has no override configured. The decorator
+    threads a non-``None`` ``model_override`` into the candidate call as
+    a ``model=`` kwarg so the candidate's LLM call picks it up instead
+    of the router's ``default_model``.
+    """
+    from caretaker.evolution import shadow_config
+
+    cfg = shadow_config.get_active_config()
+    if cfg is None:
+        return None, None
+    domain = getattr(cfg, name, None)
+    if domain is None:
+        return None, None
+    model_override = getattr(domain, "model_override", None)
+    max_tokens_override = getattr(domain, "max_tokens_override", None)
+    return model_override, max_tokens_override
+
+
+def _resolve_default_model() -> str | None:
+    """Return the router's ``llm.default_model``, if a config is installed.
+
+    Used to stamp :class:`ShadowDecisionRecord.candidate_model` (and
+    ``legacy_model`` when the legacy leg itself is LLM-backed — rare, but
+    possible on sites like ``dispatch_guard`` where the ``legacy``
+    heuristic is itself a regex-then-LLM cascade). ``None`` when no
+    ``MaintainerConfig`` is reachable from the active shadow config — the
+    :class:`AgenticConfig` resolver doesn't carry a backref to the
+    parent, so this helper reads the full config resolver registered by
+    the admin backend / orchestrator.
+    """
+    from caretaker.evolution import shadow_config
+
+    cfg_getter = getattr(shadow_config, "get_active_maintainer_config", None)
+    if cfg_getter is None:
+        return None
+    maintainer = cfg_getter()
+    if maintainer is None:
+        return None
+    llm_cfg = getattr(maintainer, "llm", None)
+    if llm_cfg is None:
+        return None
+    default_model = getattr(llm_cfg, "default_model", None)
+    return default_model if isinstance(default_model, str) else None
+
+
 async def _maybe_await(value: Any) -> Any:
     """Await ``value`` if it is awaitable, otherwise return it unchanged."""
     if inspect.isawaitable(value):
@@ -383,12 +461,38 @@ def shadow_decision(
                 )
 
             mode = _resolve_mode(name)
+            # Per-site model override (PR #503 follow-up). When set, the
+            # candidate leg receives a ``model=<override>`` kwarg so its
+            # LLM call resolves through ``ClaudeClient.structured_complete``
+            # / ``.complete`` with the override rather than the router's
+            # ``default_model``. The legacy leg is never given this kwarg —
+            # the legacy function signature must stay unchanged.
+            model_override, max_tokens_override = _resolve_model_overrides(name)
+            default_model = _resolve_default_model()
+            candidate_model = model_override or default_model
             # ``service`` is captured for metric label consistency but is
             # not used here; the Counter already pins the label set and
             # standard ``logging`` would reject an ``extra={"name": ...}``
             # kwarg because ``name`` is a reserved :class:`LogRecord`
             # attribute.
             _ = get_service_label()
+
+            def _candidate_kwargs() -> dict[str, Any]:
+                """Inject ``model`` / ``max_tokens`` override kwargs for the candidate.
+
+                We copy ``kwargs`` and only add the override keys when the
+                override is set so the candidate signature doesn't have
+                to declare them (it only needs to accept ``**kwargs``).
+                Sites that don't call an LLM in their candidate (or that
+                already hardcode a specific model) simply drop these
+                kwargs without any runtime cost.
+                """
+                extra = dict(kwargs)
+                if model_override is not None:
+                    extra["model"] = model_override
+                if max_tokens_override is not None:
+                    extra["max_tokens"] = max_tokens_override
+                return extra
 
             # ── off ────────────────────────────────────────────────
             if mode == "off":
@@ -398,7 +502,7 @@ def shadow_decision(
             # ── enforce ────────────────────────────────────────────
             if mode == "enforce":
                 try:
-                    candidate_result = await _maybe_await(candidate(*args, **kwargs))
+                    candidate_result = await _maybe_await(candidate(*args, **_candidate_kwargs()))
                 except Exception as exc:  # noqa: BLE001 — enforce must fall through
                     logger.warning(
                         "shadow_decision enforce: candidate raised for name=%s; "
@@ -435,7 +539,7 @@ def shadow_decision(
             candidate_verdict: Any = None
             candidate_error: BaseException | None = None
             try:
-                candidate_verdict = await _maybe_await(candidate(*args, **kwargs))
+                candidate_verdict = await _maybe_await(candidate(*args, **_candidate_kwargs()))
             except Exception as exc:  # noqa: BLE001 — shadow must swallow
                 candidate_error = exc
 
@@ -460,6 +564,8 @@ def shadow_decision(
                     candidate_verdict_json=None,
                     disagreement_reason=err_reason,
                     context_json=_serialise_context(ctx_dict),
+                    legacy_model=default_model,
+                    candidate_model=candidate_model,
                 )
                 write_shadow_decision(err_record)
                 SHADOW_DECISIONS_TOTAL.labels(name=name, mode=mode, outcome="candidate_error").inc()
@@ -486,6 +592,8 @@ def shadow_decision(
                 candidate_verdict_json=_serialise_verdict(candidate_verdict),
                 disagreement_reason=reason,
                 context_json=_serialise_context(ctx_dict),
+                legacy_model=default_model,
+                candidate_model=candidate_model,
             )
             write_shadow_decision(record)
             SHADOW_DECISIONS_TOTAL.labels(name=name, mode=mode, outcome=outcome).inc()

--- a/src/caretaker/evolution/shadow_config.py
+++ b/src/caretaker/evolution/shadow_config.py
@@ -20,10 +20,16 @@ import threading
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from caretaker.config import AgenticConfig
+    from caretaker.config import AgenticConfig, MaintainerConfig
 
 _lock = threading.Lock()
 _active: AgenticConfig | None = None
+# Separate slot for the full :class:`MaintainerConfig` so the shadow
+# decorator can reach ``llm.default_model`` without widening the
+# ``AgenticConfig`` surface (``AgenticConfig`` intentionally has no
+# backref to its parent — adding one would make the model graph
+# cyclic, which pydantic v2 handles but which is confusing to read).
+_active_maintainer: MaintainerConfig | None = None
 
 
 def configure(config: AgenticConfig) -> None:
@@ -37,6 +43,22 @@ def configure(config: AgenticConfig) -> None:
         _active = config
 
 
+def configure_maintainer(config: MaintainerConfig) -> None:
+    """Install the full :class:`MaintainerConfig`.
+
+    Sibling of :func:`configure`: the shadow decorator calls
+    :func:`get_active_maintainer_config` to resolve
+    ``llm.default_model`` for the ``candidate_model`` field on
+    :class:`ShadowDecisionRecord`. Callers that already install the
+    :class:`AgenticConfig` subfield via :func:`configure` can call this
+    helper immediately after so the pair of slots stays consistent.
+    """
+    global _active, _active_maintainer  # noqa: PLW0603 — process singleton.
+    with _lock:
+        _active_maintainer = config
+        _active = config.agentic
+
+
 def get_active_config() -> AgenticConfig | None:
     """Return the installed config, or ``None`` when uncofigured.
 
@@ -47,11 +69,31 @@ def get_active_config() -> AgenticConfig | None:
         return _active
 
 
+def get_active_maintainer_config() -> MaintainerConfig | None:
+    """Return the installed :class:`MaintainerConfig`, if any.
+
+    Returns ``None`` when only :func:`configure` has been called with a
+    bare :class:`AgenticConfig` (the common test path) — the decorator
+    treats that as "no known default_model" and stamps ``None`` on the
+    ``candidate_model`` / ``legacy_model`` fields of the written
+    :class:`ShadowDecisionRecord`.
+    """
+    with _lock:
+        return _active_maintainer
+
+
 def reset_for_tests() -> None:
     """Clear the active config. Used by test fixtures."""
-    global _active  # noqa: PLW0603 — process singleton.
+    global _active, _active_maintainer  # noqa: PLW0603 — process singleton.
     with _lock:
         _active = None
+        _active_maintainer = None
 
 
-__all__ = ["configure", "get_active_config", "reset_for_tests"]
+__all__ = [
+    "configure",
+    "configure_maintainer",
+    "get_active_config",
+    "get_active_maintainer_config",
+    "reset_for_tests",
+]

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -1083,7 +1083,17 @@ class PRAgent:
         async def _legacy_path() -> Readiness:
             return readiness_from_legacy(legacy_eval)
 
-        async def _candidate_path() -> Readiness | None:
+        async def _candidate_path(
+            *,
+            model: str | None = None,
+            max_tokens: int | None = None,
+        ) -> Readiness | None:
+            # ``model`` / ``max_tokens`` are injected by the
+            # @shadow_decision decorator when
+            # ``agentic.readiness.model_override`` is set (see
+            # :func:`caretaker.evolution.shadow._resolve_model_overrides`);
+            # both stay ``None`` in the default case so the call shape
+            # is identical to pre-override code.
             if self._llm is None or not self._llm.available:
                 return None
             context = PRReadinessContext(
@@ -1097,6 +1107,8 @@ class PRAgent:
                 context,
                 claude=self._llm.claude,
                 retriever=self._memory_retriever,
+                model=model,
+                max_tokens=max_tokens,
             )
 
         try:

--- a/src/caretaker/pr_agent/readiness_llm.py
+++ b/src/caretaker/pr_agent/readiness_llm.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -355,6 +355,8 @@ async def evaluate_pr_readiness_llm(
     *,
     claude: ClaudeClient,
     retriever: MemoryRetriever | None = None,
+    model: str | None = None,
+    max_tokens: int | None = None,
 ) -> Readiness | None:
     """Call the LLM and return its :class:`Readiness` verdict, or ``None``.
 
@@ -368,6 +370,14 @@ async def evaluate_pr_readiness_llm(
     matching the PR and the formatted block is inlined at the head of
     the prompt payload. Retrieval is best-effort: a failing retriever
     degrades to the no-memory prompt rather than failing the call.
+
+    When ``model`` is set — the ``@shadow_decision`` decorator injects
+    this kwarg from :attr:`AgenticDomainConfig.model_override` — the
+    candidate LLM call uses the explicit model instead of the router's
+    ``default_model`` feature resolution. Used by the nightly-eval
+    harness A/B pattern (see docs/plans/2026-Q2-agentic-migration.md).
+    ``max_tokens`` is the matching per-site override; ``None`` means
+    "use the feature's resolved default".
     """
     memory_block: str | None = None
     if retriever is not None:
@@ -375,11 +385,23 @@ async def evaluate_pr_readiness_llm(
 
     prompt = build_readiness_prompt(context, memory_block=memory_block)
     try:
+        # Pass ``model`` through only when the override is set so the
+        # default feature-resolution path stays unchanged for operators
+        # who haven't opted into the A/B. ``max_tokens`` has a
+        # non-``None`` default in ``structured_complete`` (2000), so we
+        # only override it when the site config explicitly asked for a
+        # different cap.
+        kwargs: dict[str, Any] = {}
+        if model is not None:
+            kwargs["model"] = model
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
         return await claude.structured_complete(
             prompt,
             schema=Readiness,
             feature="pr_readiness",
             system=_READINESS_SYSTEM_PROMPT,
+            **kwargs,
         )
     except StructuredCompleteError as exc:
         logger.info(

--- a/tests/eval/test_harness_per_model.py
+++ b/tests/eval/test_harness_per_model.py
@@ -1,0 +1,192 @@
+"""Per-``candidate_model`` break-out tests for the nightly eval harness.
+
+The PR #503 follow-up adds :attr:`SiteReport.per_model_reports` so an
+operator running two models against the same legacy heuristic (one with
+``agentic.<site>.model_override`` set, one without) can see a per-model
+agreement rate in the nightly report — not just the window-wide mean
+that would average the two models together and hide a regression.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from caretaker.eval import store
+from caretaker.eval.harness import run_nightly_eval
+from caretaker.evolution.shadow import (
+    ShadowDecisionRecord,
+    clear_records_for_tests,
+    write_shadow_decision,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    clear_records_for_tests()
+    store.clear_for_tests()
+    yield
+    clear_records_for_tests()
+    store.clear_for_tests()
+
+
+def _record(
+    *,
+    rid: str,
+    candidate_model: str | None,
+    legacy_verdict: dict[str, Any],
+    candidate_verdict: dict[str, Any] | None,
+    outcome: str = "agree",
+    minutes_ago: int = 0,
+) -> ShadowDecisionRecord:
+    return ShadowDecisionRecord(
+        id=rid,
+        name="readiness",
+        repo_slug="ian/demo",
+        run_at=datetime.now(UTC) - timedelta(minutes=minutes_ago),
+        outcome=outcome,  # type: ignore[arg-type]
+        mode="shadow",
+        legacy_verdict_json=json.dumps(legacy_verdict, sort_keys=True),
+        candidate_verdict_json=(
+            json.dumps(candidate_verdict, sort_keys=True) if candidate_verdict is not None else None
+        ),
+        disagreement_reason=None,
+        context_json='{"repo_slug": "ian/demo"}',
+        legacy_model="claude-sonnet-4-5",
+        candidate_model=candidate_model,
+    )
+
+
+def test_two_candidate_models_surface_per_model_breakout() -> None:
+    """Two models against the same legacy heuristic → two per-model rows.
+
+    Model A agrees twice; model B disagrees once and agrees once. The
+    site-level mean blends the two (so you can't tell which model
+    regressed), but the per-model breakout should clearly show B's
+    lower rate.
+    """
+    # Model A — both agree.
+    write_shadow_decision(
+        _record(
+            rid="a1",
+            candidate_model="azure_ai/claude-sonnet-4",
+            legacy_verdict={"verdict": "ready"},
+            candidate_verdict={"verdict": "ready"},
+            outcome="agree",
+        )
+    )
+    write_shadow_decision(
+        _record(
+            rid="a2",
+            candidate_model="azure_ai/claude-sonnet-4",
+            legacy_verdict={"verdict": "blocked"},
+            candidate_verdict={"verdict": "blocked"},
+            outcome="agree",
+        )
+    )
+    # Model B — one agree, one disagree.
+    write_shadow_decision(
+        _record(
+            rid="b1",
+            candidate_model="azure_ai/gpt-5",
+            legacy_verdict={"verdict": "ready"},
+            candidate_verdict={"verdict": "ready"},
+            outcome="agree",
+        )
+    )
+    write_shadow_decision(
+        _record(
+            rid="b2",
+            candidate_model="azure_ai/gpt-5",
+            legacy_verdict={"verdict": "blocked"},
+            candidate_verdict={"verdict": "ready"},
+            outcome="disagree",
+        )
+    )
+
+    since = datetime.now(UTC) - timedelta(hours=1)
+    report = run_nightly_eval(since=since, sites=["readiness"], dry_run=True)
+
+    site = report.site("readiness")
+    assert site is not None
+    assert site.record_count == 4
+    # With a mix of models the site-wide ``candidate_model`` attribute
+    # reduces to ``None`` — the per-model breakout is where the detail
+    # lives.
+    assert site.candidate_model is None
+
+    models = {pm.candidate_model: pm for pm in site.per_model_reports}
+    assert set(models) == {"azure_ai/claude-sonnet-4", "azure_ai/gpt-5"}
+
+    sonnet = models["azure_ai/claude-sonnet-4"]
+    gpt5 = models["azure_ai/gpt-5"]
+    assert sonnet.record_count == 2
+    assert gpt5.record_count == 2
+    # Sonnet agreed 2/2, gpt5 1/2.
+    assert sonnet.agreement_rate() == pytest.approx(1.0)
+    assert gpt5.agreement_rate() < sonnet.agreement_rate()
+
+
+def test_single_model_window_produces_empty_breakout() -> None:
+    """When every record shares a model, the breakout list stays empty.
+
+    Keeps the report JSON clean for the common case — operators who
+    haven't set ``model_override`` shouldn't see a single-entry list
+    that duplicates the site-level scorer summary.
+    """
+    for i in range(3):
+        write_shadow_decision(
+            _record(
+                rid=f"r{i}",
+                candidate_model="claude-sonnet-4-5",
+                legacy_verdict={"verdict": "ready"},
+                candidate_verdict={"verdict": "ready"},
+                outcome="agree",
+            )
+        )
+
+    since = datetime.now(UTC) - timedelta(hours=1)
+    report = run_nightly_eval(since=since, sites=["readiness"], dry_run=True)
+
+    site = report.site("readiness")
+    assert site is not None
+    assert site.per_model_reports == []
+    assert site.candidate_model == "claude-sonnet-4-5"
+
+
+def test_site_report_json_includes_candidate_model_fields() -> None:
+    """``SiteReport.to_dict`` carries the new fields for the report JSON."""
+    write_shadow_decision(
+        _record(
+            rid="x1",
+            candidate_model="azure_ai/claude-sonnet-4",
+            legacy_verdict={"verdict": "ready"},
+            candidate_verdict={"verdict": "ready"},
+            outcome="agree",
+        )
+    )
+    write_shadow_decision(
+        _record(
+            rid="x2",
+            candidate_model="azure_ai/gpt-5",
+            legacy_verdict={"verdict": "ready"},
+            candidate_verdict={"verdict": "blocked"},
+            outcome="disagree",
+        )
+    )
+
+    since = datetime.now(UTC) - timedelta(hours=1)
+    report = run_nightly_eval(since=since, sites=["readiness"], dry_run=True)
+    payload = report.to_dict()
+    site_payload = next(s for s in payload["sites"] if s["site"] == "readiness")
+
+    assert site_payload["candidate_model"] is None  # mixed-model window
+    breakout_models = {pm["candidate_model"] for pm in site_payload["per_model_reports"]}
+    assert breakout_models == {"azure_ai/claude-sonnet-4", "azure_ai/gpt-5"}
+    # Every per-model entry surfaces its own agreement rate.
+    for pm in site_payload["per_model_reports"]:
+        assert "agreement_rate" in pm
+        assert "record_count" in pm

--- a/tests/evolution/test_shadow_decision_model_override.py
+++ b/tests/evolution/test_shadow_decision_model_override.py
@@ -1,0 +1,306 @@
+"""Tests for per-site model-override plumbing in ``@shadow_decision``.
+
+Covers the PR #503 follow-up: :class:`AgenticDomainConfig.model_override`
+/ ``max_tokens_override`` must flow into the candidate leg of the
+decorator via a ``model=`` kwarg, and both models (legacy + candidate)
+must land on the written :class:`ShadowDecisionRecord` so the paired
+Braintrust experiments can tell a prompt-change diff from a
+model-swap diff.
+
+The tests are deliberately paranoid about state leakage: two sites
+with different overrides must not see each other's kwargs, even when
+invoked back-to-back. We assert the candidate-observed ``model`` kwarg
+directly rather than poking at the LLM transport — the decorator's
+contract is the kwarg injection; downstream propagation is covered by
+the existing ``tests/test_pr_agent/test_readiness_llm.py`` suite.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from caretaker.config import (
+    AgenticConfig,
+    AgenticDomainConfig,
+    LLMConfig,
+    MaintainerConfig,
+)
+from caretaker.evolution import shadow_config
+from caretaker.evolution.shadow import (
+    clear_records_for_tests,
+    recent_records,
+    shadow_decision,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_state() -> None:
+    """Clear cross-test state (ring buffer, active config)."""
+    clear_records_for_tests()
+    shadow_config.reset_for_tests()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _install_maintainer(
+    *,
+    default_model: str = "claude-sonnet-4-5",
+    **domain_overrides: AgenticDomainConfig,
+) -> None:
+    """Install a full :class:`MaintainerConfig` into the shadow resolver.
+
+    Keyword args are a ``site_name → AgenticDomainConfig`` map; unlisted
+    sites stay at the ``mode="off"`` default, which the decorator
+    interprets as "do not run candidate".
+    """
+    agentic = AgenticConfig(**domain_overrides)  # type: ignore[arg-type]
+    maintainer = MaintainerConfig(
+        llm=LLMConfig(default_model=default_model),
+        agentic=agentic,
+    )
+    shadow_config.configure_maintainer(maintainer)
+
+
+# ── 1. Unset override → candidate sees default_model ──────────────────────
+
+
+async def test_unset_override_stamps_default_model_on_record() -> None:
+    _install_maintainer(
+        default_model="claude-sonnet-4-5",
+        readiness=AgenticDomainConfig(mode="shadow"),
+    )
+
+    observed: dict[str, Any] = {}
+
+    async def legacy() -> str:
+        return "OK"
+
+    async def candidate(**kwargs: Any) -> str:
+        # The decorator only injects ``model`` / ``max_tokens`` when the
+        # override is set; an unset override must leave kwargs clean.
+        observed.update(kwargs)
+        return "OK"
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    result = await decide(legacy=legacy, candidate=candidate)
+    assert result == "OK"
+
+    # Decorator did NOT inject a model kwarg for the unset override.
+    assert "model" not in observed
+    assert "max_tokens" not in observed
+
+    records = recent_records()
+    assert len(records) == 1
+    rec = records[0]
+    # Candidate model falls back to ``llm.default_model`` — the record
+    # must carry it so paired experiments can reason about the split.
+    assert rec.candidate_model == "claude-sonnet-4-5"
+    assert rec.legacy_model == "claude-sonnet-4-5"
+
+
+# ── 2. Set override → candidate sees override + record stamps it ──────────
+
+
+async def test_override_flows_to_candidate_kwargs_and_record() -> None:
+    _install_maintainer(
+        default_model="claude-sonnet-4-5",
+        readiness=AgenticDomainConfig(
+            mode="shadow",
+            model_override="azure_ai/claude-sonnet-4",
+            max_tokens_override=1200,
+        ),
+    )
+
+    observed: dict[str, Any] = {}
+
+    async def legacy() -> str:
+        return "OK"
+
+    async def candidate(**kwargs: Any) -> str:
+        observed.update(kwargs)
+        return "OK"
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    await decide(legacy=legacy, candidate=candidate)
+
+    # The candidate leg must receive the override so its downstream
+    # ``ClaudeClient.structured_complete`` call can forward the model.
+    assert observed.get("model") == "azure_ai/claude-sonnet-4"
+    assert observed.get("max_tokens") == 1200
+
+    records = recent_records()
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.candidate_model == "azure_ai/claude-sonnet-4"
+    # Legacy leg keeps running on whatever the router's default was —
+    # the override affects only the candidate.
+    assert rec.legacy_model == "claude-sonnet-4-5"
+
+
+# ── 3. Per-site isolation — overrides must not leak ───────────────────────
+
+
+async def test_two_sites_with_distinct_overrides_do_not_leak() -> None:
+    """Two decisions from different sites run back-to-back without leaks.
+
+    This is the "no module-global state for the override" assertion
+    called out in the PR plan: both sites must resolve their own
+    override independently, even when the decorator is exercised twice
+    from the same async task.
+    """
+    _install_maintainer(
+        default_model="claude-sonnet-4-5",
+        readiness=AgenticDomainConfig(
+            mode="shadow",
+            model_override="azure_ai/claude-sonnet-4",
+        ),
+        ci_triage=AgenticDomainConfig(
+            mode="shadow",
+            model_override="azure_ai/gpt-5",
+        ),
+    )
+
+    readiness_observed: dict[str, Any] = {}
+    ci_observed: dict[str, Any] = {}
+
+    async def readiness_legacy() -> str:
+        return "ready"
+
+    async def readiness_candidate(**kwargs: Any) -> str:
+        readiness_observed.update(kwargs)
+        return "ready"
+
+    async def ci_legacy() -> str:
+        return "flaky"
+
+    async def ci_candidate(**kwargs: Any) -> str:
+        ci_observed.update(kwargs)
+        return "flaky"
+
+    @shadow_decision("readiness")
+    async def decide_readiness(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    @shadow_decision("ci_triage")
+    async def decide_ci(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    await decide_readiness(legacy=readiness_legacy, candidate=readiness_candidate)
+    await decide_ci(legacy=ci_legacy, candidate=ci_candidate)
+
+    # Each site saw ONLY its own override, never the sibling's.
+    assert readiness_observed["model"] == "azure_ai/claude-sonnet-4"
+    assert ci_observed["model"] == "azure_ai/gpt-5"
+
+    # Ring buffer has two rows, one per site, each with its own model.
+    records = recent_records()
+    by_site = {r.name: r for r in records}
+    assert by_site["readiness"].candidate_model == "azure_ai/claude-sonnet-4"
+    assert by_site["ci_triage"].candidate_model == "azure_ai/gpt-5"
+
+
+# ── 4. Enforce-mode path also threads the override ───────────────────────
+
+
+async def test_enforce_mode_candidate_also_sees_override() -> None:
+    _install_maintainer(
+        default_model="claude-sonnet-4-5",
+        readiness=AgenticDomainConfig(
+            mode="enforce",
+            model_override="azure_ai/claude-sonnet-4",
+        ),
+    )
+
+    observed: dict[str, Any] = {}
+
+    async def legacy() -> str:
+        return "LEGACY"
+
+    async def candidate(**kwargs: Any) -> str:
+        observed.update(kwargs)
+        return "CANDIDATE"
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    result = await decide(legacy=legacy, candidate=candidate)
+    assert result == "CANDIDATE"
+    assert observed["model"] == "azure_ai/claude-sonnet-4"
+
+
+# ── 5. Candidate error path still stamps models on the record ────────────
+
+
+async def test_candidate_error_records_model_fields() -> None:
+    _install_maintainer(
+        default_model="claude-sonnet-4-5",
+        readiness=AgenticDomainConfig(
+            mode="shadow",
+            model_override="azure_ai/claude-sonnet-4",
+        ),
+    )
+
+    async def legacy() -> str:
+        return "OK"
+
+    async def candidate(**kwargs: Any) -> str:
+        raise RuntimeError("boom")
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    result = await decide(legacy=legacy, candidate=candidate)
+    assert result == "OK"  # shadow returns legacy even on candidate error
+
+    records = recent_records()
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.outcome == "candidate_error"
+    # Even though the candidate leg crashed, we still know *which* model
+    # it was meant to use — the audit trail shouldn't lose that just
+    # because the LLM raised.
+    assert rec.candidate_model == "azure_ai/claude-sonnet-4"
+    assert rec.legacy_model == "claude-sonnet-4-5"
+
+
+# ── 6. No MaintainerConfig installed → models resolve to None ─────────────
+
+
+async def test_no_maintainer_config_leaves_models_none() -> None:
+    """When only :func:`shadow_config.configure` is used (legacy test path).
+
+    The bare-``AgenticConfig`` resolver path is the one every existing
+    test hits, so this case must not regress to writing garbage or
+    raising: stamping ``None`` is the correct fallback.
+    """
+    shadow_config.configure(AgenticConfig(readiness=AgenticDomainConfig(mode="shadow")))
+
+    async def legacy() -> str:
+        return "OK"
+
+    async def candidate(**kwargs: Any) -> str:
+        # No override configured via ``configure_maintainer`` → no kwarg.
+        assert "model" not in kwargs
+        return "OK"
+
+    @shadow_decision("readiness")
+    async def decide(*, legacy: Any, candidate: Any, context: Any = None) -> str:
+        raise AssertionError("wrapper drives")
+
+    await decide(legacy=legacy, candidate=candidate)
+
+    records = recent_records()
+    assert len(records) == 1
+    assert records[0].candidate_model is None
+    assert records[0].legacy_model is None


### PR DESCRIPTION
## Summary

Enables true A/B model comparison in the nightly-eval harness. Previously every `@shadow_decision` site used `llm.default_model` for both the legacy and candidate leg, making it impossible to compare (e.g.) `azure_ai/claude-sonnet-4` vs `azure_ai/gpt-5` on the `readiness` site via the Braintrust harness.

## Changes

### Config

Each of the 9 agentic site configs gains (via `AgenticDomainConfig` base class):

```yaml
agentic:
  readiness:
    mode: shadow
    model_override: azure_ai/claude-sonnet-4   # candidate leg uses this model
    max_tokens_override: 1200                  # optional
  ci_triage:
    mode: shadow
    model_override: azure_ai/gpt-5
```

### Decorator plumbing

`@shadow_decision` injects `model=` / `max_tokens=` kwargs into the candidate call when the override is set. Zero impact when unset — existing candidates without `**kwargs` keep working until their override ships.

### Shadow decision records

`ShadowDecision` rows grow `legacy_model` and `candidate_model` fields. Old rows (both `None`) read back cleanly without migration.

### Eval harness

`run_nightly_eval` groups by `(site, candidate_model)` and reports per-model agreement rates. Cost guard: the per-model breakout only runs when `len(distinct_models) > 1` — single-model windows pay no extra LLM-judge tokens.

### Admin endpoint

`GET /api/admin/shadow/decisions` exposes `legacy_model` / `candidate_model` per row.

### Rollout pattern

```
off → shadow (model_override set) → collect 7 days of data
    → inspect per-model agreement in Braintrust / admin UI
    → promote the winning model to default_model
    → shadow → enforce
```

## Tests

- `tests/evolution/test_shadow_decision_model_override.py` (6 cases)
- `tests/eval/test_harness_per_model.py` (3 cases)

All 1857 tests pass. `ruff`, `mypy` clean. Fixed a judge double-call regression caught during full-suite run.