### PR TITLE
feat(workflow): pass GitHub App credentials to caretaker process for self-mint tokens

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -268,6 +268,12 @@ jobs:
         id: doctor
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # GitHub App raw credentials — lets caretaker self-mint tokens via
+          # GitHubAppCredentialsProvider instead of consuming the pre-minted
+          # GITHUB_TOKEN (which can't auto-refresh on long runs).
+          CARETAKER_GITHUB_APP_ID: ${{ vars.CARETAKER_APP_ID }}
+          CARETAKER_GITHUB_APP_INSTALLATION_ID: "124850811"
+          CARETAKER_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CARETAKER_APP_PRIVATE_KEY }}
           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
           # LLM credentials — Azure AI Foundry is the primary path.
           # ANTHROPIC_API_KEY is intentionally absent: provider=litellm
@@ -336,6 +342,12 @@ jobs:
         id: caretaker_run
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # GitHub App raw credentials — lets caretaker self-mint tokens via
+          # GitHubAppCredentialsProvider instead of consuming the pre-minted
+          # GITHUB_TOKEN (which can't auto-refresh on long runs).
+          CARETAKER_GITHUB_APP_ID: ${{ vars.CARETAKER_APP_ID }}
+          CARETAKER_GITHUB_APP_INSTALLATION_ID: "124850811"
+          CARETAKER_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CARETAKER_APP_PRIVATE_KEY }}
           # Fine-grained PAT for a real write-capable user or machine user.
           # Caretaker uses this for Copilot issue assignment and @copilot comments
           # that must not be authored as github-actions[bot].
@@ -425,6 +437,12 @@ jobs:
       - name: Self-heal — analyse own failure
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # GitHub App raw credentials — lets caretaker self-mint tokens via
+          # GitHubAppCredentialsProvider instead of consuming the pre-minted
+          # GITHUB_TOKEN (which can't auto-refresh on long runs).
+          CARETAKER_GITHUB_APP_ID: ${{ vars.CARETAKER_APP_ID }}
+          CARETAKER_GITHUB_APP_INSTALLATION_ID: "124850811"
+          CARETAKER_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CARETAKER_APP_PRIVATE_KEY }}
           # Fine-grained PAT for a real write-capable user or machine user.
           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/setup-templates/templates/workflows/maintainer.yml
+++ b/setup-templates/templates/workflows/maintainer.yml
@@ -124,10 +124,17 @@ jobs:
       # enabled agent fails loudly with an actionable row instead of
       # getting swallowed by a later 403 / import error. See the
       # 2026-04-22 audio_engineer outage post-mortem.
-      - name: Caretaker bootstrap-check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
+       - name: Caretaker bootstrap-check
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           # Preferred: pass GitHub App credentials so caretaker self-mints
+           # tokens via GitHubAppCredentialsProvider (auto-refresh, no expiry).
+           # Set CARETAKER_APP_ID (var) + CARETAKER_APP_PRIVATE_KEY (secret)
+           # and un-comment these three lines:
+           # CARETAKER_GITHUB_APP_ID: ${{ vars.CARETAKER_APP_ID }}
+           # CARETAKER_GITHUB_APP_INSTALLATION_ID: ${{ vars.CARETAKER_APP_INSTALLATION_ID }}
+           # CARETAKER_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CARETAKER_APP_PRIVATE_KEY }}
+           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
           # Add your LLM provider credentials here. Examples:
           # Azure AI Foundry (recommended):
           AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
@@ -142,13 +149,17 @@ jobs:
             --config .github/maintainer/config.yml \
             --bootstrap-check
 
-      - name: Run
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Fine-grained PAT for a real write-capable user or machine user.
-          # Caretaker uses this for Copilot issue assignment and @copilot comments
-          # that must not be authored as github-actions[bot].
-          COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
+       - name: Run
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           # Preferred: GitHub App self-mint credentials (see bootstrap-check above).
+           # CARETAKER_GITHUB_APP_ID: ${{ vars.CARETAKER_APP_ID }}
+           # CARETAKER_GITHUB_APP_INSTALLATION_ID: ${{ vars.CARETAKER_APP_INSTALLATION_ID }}
+           # CARETAKER_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CARETAKER_APP_PRIVATE_KEY }}
+           # Fine-grained PAT for a real write-capable user or machine user.
+           # Caretaker uses this for Copilot issue assignment and @copilot comments
+           # that must not be authored as github-actions[bot].
+           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
           # LLM provider credentials — add whichever your config uses:
           AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
           AZURE_AI_API_BASE: ${{ secrets.AZURE_AI_API_BASE }}
@@ -205,11 +216,15 @@ jobs:
           # custom coding agent (see docs/custom-coding-agent-plan.md).
           pip install "litellm>=1.50,<2"
 
-      - name: Self-heal — analyse own failure
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Fine-grained PAT for a real write-capable user or machine user.
-          COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
+       - name: Self-heal — analyse own failure
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           # Preferred: GitHub App self-mint credentials.
+           # CARETAKER_GITHUB_APP_ID: ${{ vars.CARETAKER_APP_ID }}
+           # CARETAKER_GITHUB_APP_INSTALLATION_ID: ${{ vars.CARETAKER_APP_INSTALLATION_ID }}
+           # CARETAKER_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CARETAKER_APP_PRIVATE_KEY }}
+           # Fine-grained PAT for a real write-capable user or machine user.
+           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
           AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
           AZURE_AI_API_BASE: ${{ secrets.AZURE_AI_API_BASE }}
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Problem

The workflow minted a token via `create-github-app-token@v2` and passed it as `GITHUB_TOKEN` (pre-minted, static). The caretaker process therefore used `EnvCredentialsProvider` — not `GitHubAppCredentialsProvider` — and could not auto-refresh when the token expired mid-run.

## Fix

Pass `CARETAKER_GITHUB_APP_ID`, `CARETAKER_GITHUB_APP_INSTALLATION_ID=124850811`, and `CARETAKER_GITHUB_APP_PRIVATE_KEY` to the caretaker process env in all three jobs (`doctor`, `maintain`, `self-heal-on-failure`).

`GitHubAppCredentialsProvider` activates when all three are set, self-mints installation tokens via `InstallationTokenMinter`, and auto-refreshes before expiry. The pre-minted `GITHUB_TOKEN` remains as a fallback via `ChainCredentialsProvider`.

## setup-templates

Add opt-in comment block for new consumer repos documenting the GitHub App self-mint path with `CARETAKER_APP_ID` (var) + `CARETAKER_APP_PRIVATE_KEY` (secret) + `CARETAKER_APP_INSTALLATION_ID` (var).

No tests needed — this is a workflow/env-wiring change only.