### PR TITLE
fix: three QA gaps — qa-scenario suppression, empty PR body close, Copilot action_required escalation guard

### DIFF
--- a/src/caretaker/issue_agent/agent.py
+++ b/src/caretaker/issue_agent/agent.py
@@ -12,6 +12,7 @@ from caretaker.evolution.shadow import shadow_decision
 from caretaker.evolution.shadow_config import get_active_config
 from caretaker.issue_agent.classifier import IssueClassification, classify_issue
 from caretaker.issue_agent.dispatcher import IssueDispatcher
+from caretaker.issue_agent.issue_triage import is_qa_scenario_issue
 from caretaker.issue_agent.triage_llm import (
     IssueTriage,
     classify_issue_llm,
@@ -139,6 +140,14 @@ class IssueAgent:
                     continue
 
                 tracking = self._reconcile_issue_progress(issue, pull_requests, tracking)
+
+                # Skip QA-scenario issues — they are synthetic test fixtures and
+                # must never be triaged, dispatched, labelled, or escalated.
+                if is_qa_scenario_issue(issue):
+                    logger.debug("Issue #%d: QA-scenario marker — skipping", issue.number)
+                    tracking.last_checked = datetime.now(UTC)
+                    tracked_issues[issue.number] = tracking
+                    continue
 
                 # Skip issues that are already actioned or in-flight
                 if tracking.state in (

--- a/src/caretaker/issue_agent/issue_triage.py
+++ b/src/caretaker/issue_agent/issue_triage.py
@@ -77,6 +77,20 @@ async def _close_issue(
         return False
 
 
+_QA_SCENARIO_MARKER = "<!-- caretaker:qa-scenario -->"
+
+
+def is_qa_scenario_issue(issue: Issue) -> bool:
+    """Return True when the issue body contains the QA-scenario suppression marker.
+
+    Issues created by caretaker-qa embed this marker to prevent caretaker from
+    triaging, dispatching, or escalating them. The marker is checked in both
+    the issue body and (for belt-and-suspenders safety) issue title.
+    """
+    haystack = f"{issue.title}\n{issue.body or ''}"
+    return _QA_SCENARIO_MARKER in haystack
+
+
 async def close_empty_issues(
     github: GitHubClient,
     owner: str,
@@ -92,6 +106,9 @@ async def close_empty_issues(
             continue
         # Protect human-authored issues with labels — only bot/empty stubs.
         if issue.has_label("pinned") or issue.has_label("keep-open"):
+            continue
+        # Never close QA-scenario issues — they are synthetic test fixtures.
+        if is_qa_scenario_issue(issue):
             continue
         reason = "issue body is empty or contains only boilerplate; no actionable content."
         if dry_run:
@@ -118,6 +135,8 @@ async def close_duplicate_issues(
 
     groups: dict[str, list[Issue]] = {}
     for issue in open_issues:
+        if is_qa_scenario_issue(issue):
+            continue
         key = _group_key(issue)
         if key is None:
             continue
@@ -164,6 +183,8 @@ async def mark_stale_issues(
 
     for issue in open_issues:
         if issue.has_label("pinned") or issue.has_label("keep-open"):
+            continue
+        if is_qa_scenario_issue(issue):
             continue
         last_touched = issue.updated_at or issue.created_at
         if last_touched is None:

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -481,10 +481,22 @@ class PRAgent:
         # / merge_queue / solo_repo_no_reviewer and picks a matching
         # action. Skipped if already escalated (terminal) or the PR is
         # closed/merged.
-        if not tracking.escalated and tracking.state not in (
-            PRTrackingState.ESCALATED,
-            PRTrackingState.MERGED,
-            PRTrackingState.CLOSED,
+        #
+        # Exception: Copilot-authored PRs with ``action_required`` CI runs
+        # are waiting for owner workflow approval — this is normal expected
+        # behaviour, not a stall. Suppress the stuck gate so caretaker
+        # does not escalate while the owner has simply not yet clicked
+        # "Approve and run" in the Actions tab.
+        _copilot_awaiting_approval = pr.is_copilot_pr and bool(evaluation.ci.action_required_runs)
+        if (
+            not tracking.escalated
+            and tracking.state
+            not in (
+                PRTrackingState.ESCALATED,
+                PRTrackingState.MERGED,
+                PRTrackingState.CLOSED,
+            )
+            and not _copilot_awaiting_approval
         ):
             stuck_verdict = await self._evaluate_stuck_verdict(
                 pr, check_runs, reviews, evaluation.readiness_verdict

--- a/src/caretaker/pr_agent/pr_triage.py
+++ b/src/caretaker/pr_agent/pr_triage.py
@@ -49,6 +49,22 @@ def _is_binary_only_diff(files: list[dict[str, object]], binary_paths: list[str]
     return True
 
 
+def _is_empty_pr_body(pr: PullRequest) -> bool:
+    """Return True when the PR has no substantive description.
+
+    A PR body is considered empty when it is blank, shorter than 20 characters,
+    or contains only checklist / boilerplate markup with no real text.
+    """
+    body = (pr.body or "").strip()
+    if len(body) < 20:
+        return True
+    # Body composed only of checklist markers, whitespace, or common placeholders.
+    meaningful = re.sub(
+        r"[-*\[\]\s`]|(?:TODO|N/A|<!--.*?-->)", "", body, flags=re.IGNORECASE | re.DOTALL
+    )
+    return len(meaningful) < 10
+
+
 def _extract_group_key(pr: PullRequest) -> str | None:
     """Return a grouping key for duplicate detection — CVE id or bumped package."""
     haystack = f"{pr.title}\n{pr.body}"
@@ -112,6 +128,39 @@ async def close_empty_prs(
             closed.append(pr.number)
         except Exception as exc:
             logger.warning("Failed to close empty PR #%d: %s", pr.number, exc)
+    return closed
+
+
+async def close_empty_body_prs(
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    open_prs: list[PullRequest],
+    *,
+    dry_run: bool = False,
+) -> list[int]:
+    """Close PRs that have no substantive description in their body.
+
+    A PR body is considered empty when it is blank or contains only boilerplate
+    (checklists, HTML comments, placeholder text). This heuristic applies
+    regardless of PR author so that QA scenario PRs with placeholder bodies
+    (e.g. ``qa/scenario-10-empty-pr``) are caught even when opened by the
+    repo owner.
+    """
+    closed: list[int] = []
+    for pr in open_prs:
+        if not _is_empty_pr_body(pr):
+            continue
+        reason = "PR description is empty or contains only boilerplate; please add context."
+        if dry_run:
+            closed.append(pr.number)
+            continue
+        await _post_close_comment(github, owner, repo, pr.number, reason)
+        try:
+            await github.update_issue(owner, repo, pr.number, state="closed")
+            closed.append(pr.number)
+        except Exception as exc:
+            logger.warning("Failed to close empty-body PR #%d: %s", pr.number, exc)
     return closed
 
 
@@ -288,6 +337,14 @@ async def run_pr_triage(
         )
     except Exception as exc:
         report.errors.append(f"close_empty_prs: {exc}")
+
+    try:
+        empty_body = await close_empty_body_prs(
+            github, owner, repo, open_prs, dry_run=config.dry_run
+        )
+        report.closed_empty.extend(empty_body)
+    except Exception as exc:
+        report.errors.append(f"close_empty_body_prs: {exc}")
 
     try:
         report.closed_conflicted = await close_binary_conflicted_prs(

--- a/tests/test_issue_agent/test_issue_triage.py
+++ b/tests/test_issue_agent/test_issue_triage.py
@@ -77,6 +77,54 @@ async def test_close_empty_issues_respects_keep_open_label() -> None:
 
 
 @pytest.mark.asyncio
+async def test_close_empty_issues_skips_qa_scenario() -> None:
+    """Issues with the QA-scenario marker must never be closed by triage."""
+    qa_issue = make_issue(
+        5,
+        body="<!-- caretaker:qa-scenario -->\n\nThis is a test fixture.",
+    )
+    gh = _FakeGH()
+    closed = await close_empty_issues(gh, "o", "r", [qa_issue])
+    assert closed == []
+    assert gh.closed == []
+
+
+@pytest.mark.asyncio
+async def test_close_duplicate_issues_skips_qa_scenario() -> None:
+    """QA-scenario issues must not be considered for duplicate detection."""
+    from caretaker.issue_agent.issue_triage import close_duplicate_issues
+
+    qa_issue = make_issue(
+        10,
+        title="duplicate title for testing",
+        body="<!-- caretaker:qa-scenario -->\nsome content here",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    qa_issue2 = make_issue(
+        11,
+        title="duplicate title for testing",
+        body="<!-- caretaker:qa-scenario -->\nsome content here too",
+        created_at=datetime(2026, 2, 1, tzinfo=UTC),
+    )
+    gh = _FakeGH()
+    closed = await close_duplicate_issues(gh, "o", "r", [qa_issue, qa_issue2])
+    assert closed == []
+
+
+@pytest.mark.asyncio
+async def test_mark_stale_issues_skips_qa_scenario() -> None:
+    """QA-scenario issues must not be closed as stale."""
+    qa_issue = make_issue(
+        20,
+        body="<!-- caretaker:qa-scenario -->\nThis is a test fixture.",
+        updated_at=datetime.now(UTC) - timedelta(days=300),
+    )
+    gh = _FakeGH()
+    closed = await mark_stale_issues(gh, "o", "r", [qa_issue], stale_days=30)
+    assert closed == []
+
+
+@pytest.mark.asyncio
 async def test_close_duplicate_issues_by_cve() -> None:
     older = make_issue(
         10,

--- a/tests/test_pr_agent/test_pr_triage.py
+++ b/tests/test_pr_agent/test_pr_triage.py
@@ -11,6 +11,7 @@ from caretaker.github_client.models import PRState
 from caretaker.pr_agent.pr_triage import (
     close_binary_conflicted_prs,
     close_duplicate_fix_prs,
+    close_empty_body_prs,
     close_empty_prs,
     run_pr_triage,
 )
@@ -157,3 +158,61 @@ async def test_run_pr_triage_pr_triage_toggle() -> None:
     report = await run_pr_triage(gh, "o", "r", [pr], cfg)
     assert report.closed_empty == []
     assert gh.closed == []
+
+
+# ── Fix 2: close_empty_body_prs ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_close_empty_body_prs_closes_blank_body() -> None:
+    """A PR with no body at all should be closed."""
+    pr = make_pr(number=99)
+    # make_pr defaults body to "" — meets the empty criterion
+    gh = _FakeGH()
+    closed = await close_empty_body_prs(gh, "o", "r", [pr])
+    assert closed == [99]
+    assert 99 in gh.closed
+
+
+@pytest.mark.asyncio
+async def test_close_empty_body_prs_closes_boilerplate_body() -> None:
+    """A PR body with only checklist boilerplate is treated as empty."""
+    from caretaker.github_client.models import User
+    from tests.conftest import make_pr as _make_pr
+
+    pr = _make_pr(number=100)
+    pr = pr.model_copy(update={"body": "- [ ] TODO\n- [ ] N/A\n<!-- placeholder -->"})
+    gh = _FakeGH()
+    closed = await close_empty_body_prs(gh, "o", "r", [pr])
+    assert closed == [100]
+
+
+@pytest.mark.asyncio
+async def test_close_empty_body_prs_keeps_real_description() -> None:
+    """PRs with a substantive description must not be closed."""
+    pr = make_pr(number=101)
+    pr = pr.model_copy(update={"body": "This PR fixes the authentication bug by adding token refresh logic."})
+    gh = _FakeGH()
+    closed = await close_empty_body_prs(gh, "o", "r", [pr])
+    assert closed == []
+
+
+@pytest.mark.asyncio
+async def test_close_empty_body_prs_dry_run() -> None:
+    pr = make_pr(number=102)
+    gh = _FakeGH()
+    closed = await close_empty_body_prs(gh, "o", "r", [pr], dry_run=True)
+    assert closed == [102]
+    assert gh.closed == []
+
+
+@pytest.mark.asyncio
+async def test_run_pr_triage_closes_empty_body_pr() -> None:
+    """Scenario 10: empty-body PR is closed by the triage pass regardless of author."""
+    pr = make_pr(number=20)
+    # body="" — empty
+    gh = _FakeGH(files_by_pr={20: [{"path": "src/real.py", "additions": 5}]})
+    cfg = TriageConfig()
+    report = await run_pr_triage(gh, "o", "r", [pr], cfg)
+    assert 20 in report.closed_empty
+    assert 20 in gh.closed

--- a/tests/test_pr_agent/test_states.py
+++ b/tests/test_pr_agent/test_states.py
@@ -550,3 +550,55 @@ class TestEvaluatePRAutoMergeGate:
         checks = [make_check_run(name="test")]
         result = evaluate_pr(pr, checks, [], PRTrackingState.CI_PASSING)
         assert result.recommended_state == PRTrackingState.MERGE_READY
+
+
+# ── Fix 3: Copilot PR awaiting workflow approval ─────────────────────
+
+
+class TestCopilotActionRequired:
+    """Fix 3: Copilot PRs with action_required runs must surface action_required_runs
+    so the stuck-PR guard in agent.py can suppress escalation."""
+
+    def test_copilot_pr_action_required_surfaced(self) -> None:
+        """action_required_runs is populated for Copilot PRs — agent guard can fire."""
+        from caretaker.github_client.models import User
+
+        copilot_user = User(login="copilot[bot]", id=1, type="Bot")
+        pr = make_pr(user=copilot_user)
+        assert pr.is_copilot_pr
+
+        action_req_run = make_check_run(
+            name="CI / test",
+            status=CheckStatus.COMPLETED,
+            conclusion=CheckConclusion.ACTION_REQUIRED,
+        )
+        result = evaluate_pr(
+            pr,
+            [action_req_run],
+            [],
+            PRTrackingState.CI_PENDING,
+            auto_approve_workflows=False,
+        )
+        assert result.recommended_state == PRTrackingState.CI_PENDING
+        assert result.recommended_action == "wait"
+        assert len(result.ci.action_required_runs) == 1
+
+    def test_copilot_awaiting_approval_guard_condition(self) -> None:
+        """Verify the guard condition: is_copilot_pr AND action_required_runs non-empty."""
+        from caretaker.github_client.models import User
+
+        copilot_user = User(login="copilot[bot]", id=1, type="Bot")
+        copilot_pr = make_pr(user=copilot_user)
+        human_pr = make_pr()
+
+        action_req_run = make_check_run(
+            name="CI / test",
+            conclusion=CheckConclusion.ACTION_REQUIRED,
+        )
+        ci_eval = evaluate_ci([action_req_run])
+
+        # Copilot PR with action_required → guard suppresses stuck escalation
+        assert copilot_pr.is_copilot_pr and bool(ci_eval.action_required_runs)
+
+        # Human PR with action_required → guard does NOT suppress (human-owned stalls are real)
+        assert not (human_pr.is_copilot_pr and bool(ci_eval.action_required_runs))


### PR DESCRIPTION
## Summary

- **Fix 1 — QA-scenario dispatch suppression**: Issues with `<!-- caretaker:qa-scenario -->` in their body are now skipped by `close_empty_issues`, `close_duplicate_issues`, `mark_stale_issues`, and the issue agent's classify/dispatch loop. These are synthetic test fixtures and must never be acted on by caretaker.
- **Fix 2 — Scenario 10 empty PR body close**: Added `close_empty_body_prs()` to `pr_triage.py` that closes PRs with no substantive description (blank, boilerplate-only, or < 20 chars). Hooked into `run_pr_triage()`. Applies to all PR authors, fixing the gap where QA scenario-10 placeholder PRs were not being caught.
- **Fix 3 — Copilot action_required escalation suppression**: Added a guard in `PrAgent._evaluate_pr()` that skips the stuck-PR escalation gate for Copilot-authored PRs that have `action_required` CI runs. These PRs are waiting for owner workflow approval — not stalled — so escalating after the `stuck_age_hours` threshold was a false positive.

## Tests

71 tests passing. New tests added:
- `test_close_empty_issues_skips_qa_scenario`
- `test_close_duplicate_issues_skips_qa_scenario`
- `test_mark_stale_issues_skips_qa_scenario`
- `test_close_empty_body_prs_closes_blank_body`
- `test_close_empty_body_prs_closes_boilerplate_body`
- `test_close_empty_body_prs_keeps_real_description`
- `test_close_empty_body_prs_dry_run`
- `test_run_pr_triage_closes_empty_body_pr`
- `TestCopilotActionRequired.test_copilot_pr_action_required_surfaced`
- `TestCopilotActionRequired.test_copilot_awaiting_approval_guard_condition`