### PR TITLE
fix(release): ensure caretaker:reviewed label exists before gh pr create

### DIFF
--- a/.github/workflows/update-releases-json.yml
+++ b/.github/workflows/update-releases-json.yml
@@ -132,6 +132,15 @@ jobs:
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
         id: push
 
+      - name: Ensure caretaker:reviewed label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "caretaker:reviewed" \
+            --description "Reviewed by caretaker — safe to merge without further review" \
+            --color "0e8a16" \
+            --repo "${{ github.repository }}" 2>/dev/null || true
+
       - name: Open pull request
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

`update-releases-json.yml` failed on the v0.19.0 run:
```
could not add label: 'caretaker:reviewed' not found
```

The `gh pr create --label` flag requires the label to already exist.

## Fix

Add an idempotent `gh label create … || true` step before opening the PR — self-healing on fresh repos. The label was created manually and PR #534 was opened by hand to unblock the v0.19.0 release.

Follow-up fix for #523.