### PR TITLE
feat: fleet-wide upgrade defaults — auto_approve + auto_ready_drafts (v0.19.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caretaker-github"
-version = "0.19.0"
+version = "0.19.1"
 description = "Autonomous GitHub repository maintenance powered by Copilot"
 readme = "README.md"
 license = "MIT"

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -158,6 +158,11 @@ class UpgradeAgentConfig(StrictBaseModel):
     strategy: Literal["auto-minor", "auto-patch", "latest", "pinned", "manual"] = "auto-minor"
     channel: Literal["stable", "preview"] = "stable"
     auto_merge_non_breaking: bool = True
+    # When True, the upgrade-agent will mark its own draft PRs ready-for-review
+    # once all required CI checks pass.  This closes the loop where Copilot opens
+    # upgrade PRs as drafts and they never auto-promote because ``pr_ci_approver``
+    # isn't enabled on the consumer repo.
+    auto_ready_drafts: bool = True
 
 
 class EscalationConfig(StrictBaseModel):
@@ -586,10 +591,13 @@ class PRCIApproverConfig(StrictBaseModel):
             "the-care-taker[bot]",
         ]
     )
-    # When True, call the approve endpoint. When False (default) the agent
-    # only *surfaces* stuck runs in the digest and as a maintainer:escalated
+    # When True, call the approve endpoint. When False the agent only
+    # *surfaces* stuck runs in the digest and as a maintainer:escalated
     # issue hint — no side effects on GitHub.
-    auto_approve: bool = False
+    # Defaulting to True because the ``allowed_actors`` list is intentionally
+    # tight (bots only) and the common fleet issue is upgrade PRs that stall
+    # forever awaiting a manual Actions UI click.
+    auto_approve: bool = True
     # Maximum runs to process per caretaker run (cap API usage).
     max_runs_per_run: int = 25
     # Skip runs older than this many hours (avoids approving ancient runs

--- a/src/caretaker/github_client/api.py
+++ b/src/caretaker/github_client/api.py
@@ -417,6 +417,42 @@ class GitHubClient:
             return []
         return [int(n["number"]) for n in nodes if n and "number" in n]
 
+    async def mark_pull_request_ready(self, pr_node_id: str) -> bool:
+        """Flip a draft PR to ready-for-review via GraphQL mutation.
+
+        Uses the ``markPullRequestReadyForReview`` mutation which requires
+        the global node ID (``PR.node_id``, not the integer number).
+        Returns ``True`` on success, ``False`` if the mutation reports errors
+        or the request fails.
+        """
+        mutation = (
+            "mutation($id:ID!){"
+            " markPullRequestReadyForReview(input:{pullRequestId:$id}){"
+            "  pullRequest{isDraft}"
+            " }"
+            "}"
+        )
+        try:
+            result = await self._post(
+                "/graphql",
+                json={"query": mutation, "variables": {"id": pr_node_id}},
+            )
+        except Exception as exc:
+            logger.warning("markPullRequestReadyForReview failed for %s: %s", pr_node_id, exc)
+            return False
+        if result and result.get("errors"):
+            logger.warning(
+                "markPullRequestReadyForReview errors for %s: %s",
+                pr_node_id,
+                result["errors"],
+            )
+            return False
+        try:
+            is_draft = result["data"]["markPullRequestReadyForReview"]["pullRequest"]["isDraft"]
+            return not is_draft
+        except (KeyError, TypeError):
+            return result is not None and "errors" not in result
+
     async def merge_pull_request(
         self, owner: str, repo: str, number: int, method: str = "squash"
     ) -> bool:
@@ -1303,6 +1339,7 @@ class GitHubClient:
             mergeable=data.get("mergeable"),
             merged=data.get("merged", False),
             draft=data.get("draft", False),
+            node_id=data.get("node_id", ""),
             labels=[
                 Label(name=lbl["name"], color=lbl.get("color", ""))
                 for lbl in data.get("labels", [])

--- a/src/caretaker/github_client/models.py
+++ b/src/caretaker/github_client/models.py
@@ -131,6 +131,11 @@ class PullRequest(BaseModel):
     mergeable: bool | None = None
     merged: bool = False
     draft: bool = False
+    # GitHub's global node ID — required for GraphQL mutations such as
+    # markPullRequestReadyForReview.  Populated from the REST ``node_id``
+    # field; empty string when fetched via older code paths that pre-date
+    # this field.
+    node_id: str = ""
     labels: list[Label] = Field(default_factory=list)
     created_at: dt.datetime | None = None
     updated_at: dt.datetime | None = None

--- a/src/caretaker/pr_agent/pr_triage.py
+++ b/src/caretaker/pr_agent/pr_triage.py
@@ -303,15 +303,18 @@ async def ready_valid_copilot_drafts(
             readied.append(pr.number)
             continue
         try:
-            # Flip draft → ready via GraphQL markPullRequestReadyForReview; fall
-            # back to a body edit request for clients without GraphQL. The GH
-            # client doesn't expose this directly today — log and skip so the
-            # existing PR agent's ready-for-review path handles it next cycle.
-            logger.info(
-                "PR #%d is a passing Copilot draft — leaving draft flip to PR agent",
-                pr.number,
-            )
-            readied.append(pr.number)
+            if not pr.node_id:
+                logger.warning(
+                    "PR #%d has no node_id — cannot flip draft bit via GraphQL; skipping",
+                    pr.number,
+                )
+                continue
+            ok = await github.mark_pull_request_ready(pr.node_id)
+            if ok:
+                logger.info("Marked draft PR #%d ready-for-review", pr.number)
+                readied.append(pr.number)
+            else:
+                logger.warning("mark_pull_request_ready returned False for PR #%d", pr.number)
         except Exception as exc:
             logger.warning("Failed to ready draft PR #%d: %s", pr.number, exc)
     return readied

--- a/src/caretaker/upgrade_agent/agent.py
+++ b/src/caretaker/upgrade_agent/agent.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from caretaker.pr_agent.pr_triage import ready_valid_copilot_drafts
 from caretaker.upgrade_agent.planner import UpgradePlanner
 from caretaker.upgrade_agent.release_checker import fetch_releases, needs_upgrade
 
@@ -24,6 +25,7 @@ class UpgradeAgentReport:
     upgrade_needed: bool = False
     upgrade_issue: int | None = None
     superseded_prs: list[int] = field(default_factory=list)
+    readied_draft_prs: list[int] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
 
@@ -86,5 +88,26 @@ class UpgradeAgent:
         except Exception as e:
             logger.error("Upgrade check failed: %s", e)
             report.errors.append(str(e))
+
+        # Promote our own draft upgrade PRs once CI passes, regardless of
+        # whether an upgrade was needed this run.  This closes the loop where
+        # Copilot opens upgrade PRs as drafts and they stall forever because
+        # pr_ci_approver isn't enabled on the consumer repo.
+        if self._config.auto_ready_drafts:
+            try:
+                open_prs = await self._github.list_pull_requests(
+                    self._owner, self._repo, state="open"
+                )
+                report.readied_draft_prs = await ready_valid_copilot_drafts(
+                    self._github, self._owner, self._repo, open_prs
+                )
+                if report.readied_draft_prs:
+                    logger.info(
+                        "auto_ready_drafts: promoted %d draft PR(s) to ready-for-review: %s",
+                        len(report.readied_draft_prs),
+                        report.readied_draft_prs,
+                    )
+            except Exception as e:
+                logger.warning("auto_ready_drafts check failed: %s", e)
 
         return report

--- a/tests/test_pr_ci_approver.py
+++ b/tests/test_pr_ci_approver.py
@@ -71,8 +71,9 @@ def _make_ctx(cfg: PRCIApproverConfig | None = None) -> AgentContext:
 def test_pr_ci_approver_defaults_are_safe() -> None:
     cfg = PRCIApproverConfig()
     assert cfg.enabled is True
-    # Default is surface-only — no GitHub side effects without an opt-in.
-    assert cfg.auto_approve is False
+    # Default is auto_approve=True — tight allowed_actors list (bots only) makes
+    # this safe and avoids upgrade PRs stalling forever on a manual UI click.
+    assert cfg.auto_approve is True
     assert cfg.max_age_hours == 48
     assert cfg.max_runs_per_run == 25
     # Whitelist must include Copilot's usual logins and known bots.
@@ -93,9 +94,9 @@ def test_pr_ci_approver_in_maintainer_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_surfaces_stuck_copilot_run_without_approving_by_default() -> None:
-    """Default auto_approve=False → count the run, don't call approve."""
-    ctx = _make_ctx()
+async def test_surfaces_stuck_copilot_run_without_approving_when_disabled() -> None:
+    """Explicit auto_approve=False → count the run, don't call approve."""
+    ctx = _make_ctx(PRCIApproverConfig(auto_approve=False))
     ctx.github.list_workflow_runs = AsyncMock(return_value=[_make_run()])  # type: ignore[method-assign]
     ctx.github.approve_workflow_run = AsyncMock()  # type: ignore[method-assign]
 
@@ -107,6 +108,21 @@ async def test_surfaces_stuck_copilot_run_without_approving_by_default() -> None
     assert result.extra["runs_approved"] == 0
     assert result.extra["runs_surfaced"] == 1
     ctx.github.approve_workflow_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_approve_true_by_default_calls_approve_endpoint() -> None:
+    """Default auto_approve=True → approve endpoint is called for bot runs."""
+    ctx = _make_ctx()  # uses PRCIApproverConfig() defaults
+    ctx.github.list_workflow_runs = AsyncMock(return_value=[_make_run(run_id=55)])  # type: ignore[method-assign]
+    ctx.github.approve_workflow_run = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    agent = PRCIApproverAgent(ctx)
+    result = await agent.execute(OrchestratorState())
+
+    ctx.github.approve_workflow_run.assert_awaited_once_with("o", "r", 55)
+    assert result.extra["runs_approved"] == 1
+    assert result.extra["runs_surfaced"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_upgrade_agent/test_agent.py
+++ b/tests/test_upgrade_agent/test_agent.py
@@ -109,7 +109,8 @@ class TestUpgradeAgent:
             current_version="1.1.0",
         )
         release = Release(version="1.1.0", min_compatible="1.0.0", changelog_url="")
-        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=AsyncMock(return_value=[release])):
+        fetch_mock = AsyncMock(return_value=[release])
+        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=fetch_mock):
             report = await agent.run()
 
         github.mark_pull_request_ready.assert_awaited_once_with("PR_kwDOABC123")
@@ -138,7 +139,8 @@ class TestUpgradeAgent:
             current_version="1.1.0",
         )
         release = Release(version="1.1.0", min_compatible="1.0.0", changelog_url="")
-        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=AsyncMock(return_value=[release])):
+        fetch_mock = AsyncMock(return_value=[release])
+        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=fetch_mock):
             report = await agent.run()
 
         github.mark_pull_request_ready.assert_not_awaited()
@@ -167,7 +169,8 @@ class TestUpgradeAgent:
             current_version="1.1.0",
         )
         release = Release(version="1.1.0", min_compatible="1.0.0", changelog_url="")
-        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=AsyncMock(return_value=[release])):
+        fetch_mock = AsyncMock(return_value=[release])
+        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=fetch_mock):
             report = await agent.run()
 
         github.mark_pull_request_ready.assert_not_awaited()

--- a/tests/test_upgrade_agent/test_agent.py
+++ b/tests/test_upgrade_agent/test_agent.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from caretaker.config import UpgradeAgentConfig
-from caretaker.github_client.models import PullRequest
+from caretaker.github_client.models import PRState, PullRequest, User
 from caretaker.upgrade_agent.agent import UpgradeAgent
 from caretaker.upgrade_agent.release_checker import Release
 
@@ -92,10 +92,11 @@ class TestUpgradeAgent:
         draft_pr = PullRequest(
             number=7,
             title="Upgrade to v1.1.0",
+            state=PRState.OPEN,
+            user=User(login="copilot-swe-agent[bot]", id=1),
             head_sha="abc123",
             draft=True,
             node_id="PR_kwDOABC123",
-            user_login="copilot-swe-agent[bot]",
         )
         github.list_pull_requests = AsyncMock(return_value=[draft_pr])
         github.get_combined_status = AsyncMock(return_value="success")
@@ -122,10 +123,11 @@ class TestUpgradeAgent:
         draft_pr = PullRequest(
             number=8,
             title="Upgrade to v1.1.0",
+            state=PRState.OPEN,
+            user=User(login="copilot-swe-agent[bot]", id=1),
             head_sha="def456",
             draft=True,
             node_id="PR_kwDODEF456",
-            user_login="copilot-swe-agent[bot]",
         )
         github.list_pull_requests = AsyncMock(return_value=[draft_pr])
         github.get_combined_status = AsyncMock(return_value="success")
@@ -152,10 +154,11 @@ class TestUpgradeAgent:
         ready_pr = PullRequest(
             number=9,
             title="Upgrade to v1.1.0",
+            state=PRState.OPEN,
+            user=User(login="copilot-swe-agent[bot]", id=1),
             head_sha="ghi789",
             draft=False,
             node_id="PR_kwDOGHI789",
-            user_login="copilot-swe-agent[bot]",
         )
         github.list_pull_requests = AsyncMock(return_value=[ready_pr])
         github.get_combined_status = AsyncMock(return_value="success")

--- a/tests/test_upgrade_agent/test_agent.py
+++ b/tests/test_upgrade_agent/test_agent.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from caretaker.config import UpgradeAgentConfig
+from caretaker.github_client.models import PullRequest
 from caretaker.upgrade_agent.agent import UpgradeAgent
 from caretaker.upgrade_agent.release_checker import Release
 
@@ -80,3 +81,94 @@ class TestUpgradeAgent:
         assert report.checked is True
         assert report.upgrade_needed is False
         assert report.upgrade_issue is None
+
+    async def test_auto_ready_drafts_default_is_true(self) -> None:
+        cfg = UpgradeAgentConfig()
+        assert cfg.auto_ready_drafts is True
+
+    async def test_auto_ready_drafts_promotes_passing_copilot_draft(self) -> None:
+        """When auto_ready_drafts=True and a Copilot draft PR has CI green, it is readied."""
+        github = AsyncMock()
+        draft_pr = PullRequest(
+            number=7,
+            title="Upgrade to v1.1.0",
+            head_sha="abc123",
+            draft=True,
+            node_id="PR_kwDOABC123",
+            user_login="copilot-swe-agent[bot]",
+        )
+        github.list_pull_requests = AsyncMock(return_value=[draft_pr])
+        github.get_combined_status = AsyncMock(return_value="success")
+        github.mark_pull_request_ready = AsyncMock(return_value=True)
+
+        agent = UpgradeAgent(
+            github=github,
+            owner="o",
+            repo="r",
+            config=UpgradeAgentConfig(enabled=True, auto_ready_drafts=True),
+            current_version="1.1.0",
+        )
+        release = Release(version="1.1.0", min_compatible="1.0.0", changelog_url="")
+        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=AsyncMock(return_value=[release])):
+            report = await agent.run()
+
+        github.mark_pull_request_ready.assert_awaited_once_with("PR_kwDOABC123")
+        assert report.readied_draft_prs == [7]
+
+    async def test_auto_ready_drafts_disabled_skips_draft_promotion(self) -> None:
+        """When auto_ready_drafts=False, draft PRs are not touched."""
+        github = AsyncMock()
+        draft_pr = PullRequest(
+            number=8,
+            title="Upgrade to v1.1.0",
+            head_sha="def456",
+            draft=True,
+            node_id="PR_kwDODEF456",
+            user_login="copilot-swe-agent[bot]",
+        )
+        github.list_pull_requests = AsyncMock(return_value=[draft_pr])
+        github.get_combined_status = AsyncMock(return_value="success")
+        github.mark_pull_request_ready = AsyncMock(return_value=True)
+
+        agent = UpgradeAgent(
+            github=github,
+            owner="o",
+            repo="r",
+            config=UpgradeAgentConfig(enabled=True, auto_ready_drafts=False),
+            current_version="1.1.0",
+        )
+        release = Release(version="1.1.0", min_compatible="1.0.0", changelog_url="")
+        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=AsyncMock(return_value=[release])):
+            report = await agent.run()
+
+        github.mark_pull_request_ready.assert_not_awaited()
+        assert report.readied_draft_prs == []
+
+    async def test_auto_ready_drafts_non_draft_pr_not_touched(self) -> None:
+        """Non-draft PRs are not affected even if CI is green."""
+        github = AsyncMock()
+        ready_pr = PullRequest(
+            number=9,
+            title="Upgrade to v1.1.0",
+            head_sha="ghi789",
+            draft=False,
+            node_id="PR_kwDOGHI789",
+            user_login="copilot-swe-agent[bot]",
+        )
+        github.list_pull_requests = AsyncMock(return_value=[ready_pr])
+        github.get_combined_status = AsyncMock(return_value="success")
+        github.mark_pull_request_ready = AsyncMock(return_value=True)
+
+        agent = UpgradeAgent(
+            github=github,
+            owner="o",
+            repo="r",
+            config=UpgradeAgentConfig(enabled=True, auto_ready_drafts=True),
+            current_version="1.1.0",
+        )
+        release = Release(version="1.1.0", min_compatible="1.0.0", changelog_url="")
+        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=AsyncMock(return_value=[release])):
+            report = await agent.run()
+
+        github.mark_pull_request_ready.assert_not_awaited()
+        assert report.readied_draft_prs == []


### PR DESCRIPTION
## Summary

Fixes the fleet-wide issue where Copilot-opened **draft** upgrade PRs stall indefinitely because:
1. `PRCIApproverConfig.auto_approve` defaulted to `False` — the bot never approved its own upgrade PRs
2. Draft PRs were never promoted to ready-for-review — `ready_valid_copilot_drafts()` was a stub

### Changes

**`PRCIApproverConfig.auto_approve` default: `False` → `True`**
- Safe: the `allowed_actors` list already restricts approval to known bot identities
  (`copilot-swe-agent[bot]`, `github-actions[bot]`, `dependabot[bot]`, `copilot[bot]`, `the-care-taker[bot]`)

**`UpgradeAgentConfig.auto_ready_drafts: bool = True` (new field)**
- After each upgrade run, the agent calls `ready_valid_copilot_drafts()` on its own PRs
- Promotes draft upgrade PRs to ready once CI is passing

**`PullRequest.node_id` field** (populated from REST `node_id`)
- Required for the `markPullRequestReadyForReview` GraphQL mutation

**`GitHubClient.mark_pull_request_ready(pr_node_id)`** (new method)
- GraphQL mutation wrapper; snip returns True on success, logs warnings on error

**`ready_valid_copilot_drafts()` in `pr_triage.py`** — upgraded from stub → real implementation

### Tests
- Updated `test_pr_ci_approver_defaults_are_safe` to reflect new default
- Renamed existing "disabled by default" test to use `auto_approve=False` explicitly
- Added `test_auto_approve_true_by_default_calls_approve_endpoint`
- Added 4 new tests in `TestUpgradeAgent` covering auto_ready_drafts (default, enabled, disabled, non-draft)

### Fleet context
Audit of 12 consumer repos found all upgrade PRs stuck as drafts. This patch + follow-up Phase 1 (close stale PRs) + Phase 3 (force-dispatch) will unblock the entire fleet to v0.19.1.

Closes #N/A (fleet health initiative)