### PR TITLE
chore: add v0.19.2 to releases.json

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,13 @@
 {
   "releases": [
     {
+      "version": "0.19.2",
+      "min_compatible": "0.19.1",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.19.2",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.19.2 -->\n\n## What's Changed\n### Other Changes\n* chore: add v0.19.1 to releases.json by @ianlintner in https://github.com/ianlintner/caretaker/pull/544\n* feat(phase5): fleet lag regression harness \u2014 fleet.yml, weekly cron, caretaker fleet lag CLI by @ianlintner in https://github.com/ianlintner/caretaker/pull/545\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.19.1...v0.19.2",
+      "breaking": false
+    },
+    {
       "version": "0.19.1",
       "min_compatible": "0.19.0",
       "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.19.1",


### PR DESCRIPTION
Automated: adds v0.19.2 entry to releases.json (fleet lag report harness release).