### PR TITLE
fix(shepherd): validate ShepherdConfig numeric bounds

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -180,9 +180,10 @@ class ShepherdConfig(StrictBaseModel):
     stale_dirty_reaper: bool = True
     merge_chain: bool = True
     # Per-run LLM call budget (Delta F). 0 disables LLM escalation entirely.
-    max_llm_calls_per_run: int = 3
-    # Age in days before a DIRTY draft is closed as stale.
-    stale_dirty_days: int = 14
+    max_llm_calls_per_run: int = Field(default=3, ge=0)
+    # Age in days before a DIRTY draft is closed as stale. Must be >= 1 so
+    # a misconfigured 0 doesn't close every DIRTY draft on first run.
+    stale_dirty_days: int = Field(default=14, ge=1)
     # Which mechanical fixers to try, in order. Names map to fix_ladder rungs.
     mechanical_fix_rungs: list[str] = Field(
         default_factory=lambda: ["ruff-format", "ruff-check-fix"],

--- a/tests/test_pr_agent/test_shepherd.py
+++ b/tests/test_pr_agent/test_shepherd.py
@@ -98,6 +98,22 @@ class _FakeShepherdGH:
         return []
 
 
+def test_shepherd_config_rejects_zero_stale_dirty_days() -> None:
+    """`stale_dirty_days=0` would close every DIRTY draft on first run —
+    reject at config load so operators see the error immediately."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ShepherdConfig(stale_dirty_days=0)
+
+
+def test_shepherd_config_rejects_negative_max_llm_calls() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ShepherdConfig(max_llm_calls_per_run=-1)
+
+
 @pytest.mark.asyncio
 async def test_shepherd_disabled_returns_empty_report_without_listing_prs() -> None:
     """Disabled config is the byte-identical opt-out — no inventory call."""


### PR DESCRIPTION
## Summary

Follow-up to PR #547: apply the `stale_dirty_days` validation recommended in the code review.

- `stale_dirty_days: int = Field(default=14, ge=1)` — `0` would close every DIRTY draft on first run.
- `max_llm_calls_per_run: int = Field(default=3, ge=0)` — negative values previously slipped past the `<= 0` guard in `run_shepherd` and silently disabled LLM escalation without warning.

Both now fail at config load with a clear pydantic error instead of silently producing destructive behaviour.

## Test plan

- [x] 2 new tests in `test_shepherd.py` assert pydantic rejects `0` and negative values
- [x] Full `test_shepherd.py` suite still passes (32 tests)
- [x] ruff format + check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)