### PR TITLE
feat(github-app): wire active-mode dispatcher plumbing

### DIFF
--- a/docs/github-app-phase2.md
+++ b/docs/github-app-phase2.md
@@ -42,7 +42,7 @@ Set via `CARETAKER_WEBHOOK_DISPATCH_MODE` on the backend:
 |---|---|
 | `off` (default) | Webhook endpoint is a plain 202-acking recorder. Matches Phase 1 exactly. |
 | `shadow` | Dispatcher resolves agents, emits metrics + structured logs, does **not** run any agent. Safe everywhere. |
-| `active` | Dispatcher runs resolved agents. **Not wired yet** — raises `NotImplementedError` (which the dispatcher catches and records as `outcome=error`). Follow-up PR lands this. |
+| `active` | Dispatcher runs resolved agents via the injected `AgentContextFactory` + `AgentRunner`. A `CARETAKER_WEBHOOK_ACTIVE_AGENTS` allow-list lets you promote agents one at a time — un-promoted agents fall back to shadow logging. Misconfiguration (mode set but no factory wired) records `outcome=error` instead of silently doing nothing. |
 
 Unknown values downgrade to `off` with a warning log — never crash the
 webhook handler over a typo in an env var.
@@ -79,10 +79,13 @@ down":
 
 Deliberate cuts so this PR stays small:
 
-1. **Per-installation `AgentContext` construction.** Active mode needs
-   it (installation token → `GitHubClient`, `.github/maintainer/config.yml`
-   fetched via Contents API, memory store opened against the shared
-   backend). Separate PR.
+1. **Concrete `AgentContextFactory` + `AgentRunner` wiring.** The
+   dispatcher now accepts both as injected collaborators, and the
+   Protocols are defined in `caretaker.github_app.dispatcher`. The
+   concrete implementations (installation token → `GitHubClient`,
+   `.github/maintainer/config.yml` fetched via Contents API, memory
+   store opened against the shared backend, `AgentRegistry.run_one`
+   adapter) land in the follow-up PR that wires the backend startup.
 2. **Agent `event_payload` handling.** The base protocol already
    accepts `event_payload` but no agent currently uses it — that
    migration is per-agent and independent of the dispatcher.

--- a/src/caretaker/github_app/dispatcher.py
+++ b/src/caretaker/github_app/dispatcher.py
@@ -45,7 +45,7 @@ import logging
 import time
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from caretaker.github_app.events import agents_for_event
 from caretaker.observability.metrics import (
@@ -55,9 +55,46 @@ from caretaker.observability.metrics import (
 )
 
 if TYPE_CHECKING:
+    from caretaker.agent_protocol import AgentContext
     from caretaker.github_app.webhooks import ParsedWebhook
 
 logger = logging.getLogger(__name__)
+
+
+class AgentContextFactory(Protocol):
+    """Build an :class:`AgentContext` for a parsed webhook.
+
+    Implementations resolve the installation token, construct a
+    ``GitHubClient``, fetch the target repo's maintainer config, and
+    open a ``MemoryStore`` — all the plumbing active-mode dispatch needs
+    but the dispatcher itself deliberately stays ignorant of. The
+    concrete factory lives in a separate module so ``WebhookDispatcher``
+    has zero dependency on the GitHub App credential broker at import
+    time; ``off`` / ``shadow`` modes never build a context.
+    """
+
+    async def build(self, parsed: ParsedWebhook) -> AgentContext: ...
+
+
+class AgentRunner(Protocol):
+    """Execute a single named agent against a built ``AgentContext``.
+
+    The dispatcher doesn't know about ``AgentRegistry`` / ``BaseAgent``
+    / ``OrchestratorState`` — it delegates agent execution entirely.
+    This keeps the active-mode unit tests free of agent-runtime
+    imports.
+
+    Returns a bounded outcome label suitable for Prometheus: one of
+    ``"success"``, ``"failure"``, or ``"disabled"``.
+    """
+
+    async def run(
+        self,
+        *,
+        agent_name: str,
+        context: AgentContext,
+        parsed: ParsedWebhook,
+    ) -> str: ...
 
 
 class DispatchMode(StrEnum):
@@ -123,9 +160,18 @@ class WebhookDispatcher:
         *,
         mode: DispatchMode = DispatchMode.OFF,
         agent_timeout_seconds: float = _DEFAULT_AGENT_TIMEOUT_SECONDS,
+        context_factory: AgentContextFactory | None = None,
+        agent_runner: AgentRunner | None = None,
+        active_agents: frozenset[str] | None = None,
     ) -> None:
         self._mode = mode
         self._agent_timeout = agent_timeout_seconds
+        self._context_factory = context_factory
+        self._agent_runner = agent_runner
+        # None = all agents resolved by ``agents_for_event`` run in active
+        # mode. A set = the allow-list; agents not in it silently fall back
+        # to ``shadow`` treatment so we can roll out one agent at a time.
+        self._active_agents = active_agents
 
     @property
     def mode(self) -> DispatchMode:
@@ -206,23 +252,102 @@ class WebhookDispatcher:
         return f"shadow-dispatched to {len(agents)} agents"
 
     async def _run_active(self, parsed: ParsedWebhook, agents: tuple[str, ...]) -> tuple[str, str]:
-        """Run resolved agents (follow-up PR).
+        """Run resolved agents against a per-installation context.
 
-        Intentionally not implemented. Active mode requires a
-        per-installation ``AgentContext`` factory — installation token
-        from the broker, ``.github/maintainer/config.yml`` fetched from
-        the target repo via Contents API, ``MemoryStore`` opened
-        against the shared backend, ``GitHubClient`` constructed from
-        the installation token — which is a separate, testable piece
-        of work. Raising here ensures an operator who sets
-        ``CARETAKER_WEBHOOK_DISPATCH_MODE=active`` before that work
-        lands gets a loud failure instead of a silent no-op.
+        Agents in :attr:`_active_agents` (or all, when ``None``) run
+        through :attr:`_agent_runner`; others fall back to shadow
+        logging so a partial allow-list still produces observability
+        for the un-promoted agents during rollout. Each invocation is
+        bounded by :attr:`_agent_timeout` and fully error-isolated —
+        one failing agent never affects siblings.
+
+        Missing factory / runner is a misconfiguration: raises so
+        ``dispatch``'s outer guard records ``outcome="error"`` instead
+        of silently doing nothing.
         """
-        raise NotImplementedError(
-            "active dispatch mode is not yet wired — run shadow mode until "
-            "per-installation AgentContext construction lands (see "
-            "docs/github-app-phase2.md)."
-        )
+        if self._context_factory is None or self._agent_runner is None:
+            raise RuntimeError(
+                "active dispatch mode requires both context_factory and "
+                "agent_runner — pass them to WebhookDispatcher(...) or "
+                "keep mode=shadow until they are wired (see "
+                "docs/github-app-phase2.md)."
+            )
+
+        context = await self._context_factory.build(parsed)
+        ran: list[str] = []
+        shadowed: list[str] = []
+        failed: list[str] = []
+
+        for agent in agents:
+            if self._active_agents is not None and agent not in self._active_agents:
+                # Outside the allow-list → shadow. Keeps dashboards
+                # populated for un-promoted agents during rollout.
+                self._log_agent_would_run(parsed, agent)
+                record_worker_job(job=f"webhook:{agent}", outcome="shadow", duration=0.0)
+                shadowed.append(agent)
+                continue
+
+            outcome = await self._run_one_active_agent(parsed, agent, context)
+            if outcome == "success":
+                ran.append(agent)
+            else:
+                failed.append(agent)
+
+        self._log(parsed, "active", agents)
+        detail = f"active ran={len(ran)} failed={len(failed)} shadowed={len(shadowed)}"
+        outcome = "active" if not failed else "active_partial"
+        return outcome, detail
+
+    async def _run_one_active_agent(
+        self,
+        parsed: ParsedWebhook,
+        agent: str,
+        context: AgentContext,
+    ) -> str:
+        """Run a single agent with timeout + error isolation.
+
+        Returns the per-agent outcome label recorded on
+        ``worker_jobs_total{job="webhook:<agent>"}``.
+        """
+        assert self._agent_runner is not None  # guarded by _run_active
+        started = time.monotonic()
+        outcome = "failure"
+        try:
+            outcome = await asyncio.wait_for(
+                self._agent_runner.run(
+                    agent_name=agent,
+                    context=context,
+                    parsed=parsed,
+                ),
+                timeout=self._agent_timeout,
+            )
+        except TimeoutError:
+            logger.error(
+                "webhook active agent timeout agent=%s event=%s delivery=%s timeout=%.1fs",
+                agent,
+                parsed.event_type,
+                parsed.delivery_id,
+                self._agent_timeout,
+            )
+            record_error(kind="webhook_dispatch")
+            outcome = "timeout"
+        except Exception as exc:
+            logger.exception(
+                "webhook active agent failed agent=%s event=%s delivery=%s: %s",
+                agent,
+                parsed.event_type,
+                parsed.delivery_id,
+                exc,
+            )
+            record_error(kind="webhook_dispatch")
+            outcome = "failure"
+        finally:
+            record_worker_job(
+                job=f"webhook:{agent}",
+                outcome=outcome,
+                duration=time.monotonic() - started,
+            )
+        return outcome
 
     # ── Logging helpers ─────────────────────────────────────────────
 
@@ -278,6 +403,8 @@ def dispatch_in_background(
 
 
 __all__ = [
+    "AgentContextFactory",
+    "AgentRunner",
     "DispatchMode",
     "DispatchResult",
     "WebhookDispatcher",

--- a/tests/test_github_app/test_dispatcher.py
+++ b/tests/test_github_app/test_dispatcher.py
@@ -7,6 +7,8 @@ import asyncio
 import pytest
 
 from caretaker.github_app.dispatcher import (
+    AgentContextFactory,
+    AgentRunner,
     DispatchMode,
     WebhookDispatcher,
     dispatch_in_background,
@@ -115,18 +117,204 @@ async def test_shadow_mode_emits_structured_log_per_agent(
 # ── active mode ──────────────────────────────────────────────────────
 
 
+class _FakeContext:
+    """Stand-in for ``AgentContext`` — the dispatcher treats it as opaque."""
+
+
+class _FakeFactory:
+    """Records build() calls so tests can assert we don't build once per agent."""
+
+    def __init__(self) -> None:
+        self.builds: list[ParsedWebhook] = []
+
+    async def build(self, parsed: ParsedWebhook) -> _FakeContext:  # type: ignore[override]
+        self.builds.append(parsed)
+        return _FakeContext()
+
+
+class _RecordingRunner:
+    """Runner that returns a caller-supplied outcome per agent name."""
+
+    def __init__(self, outcomes: dict[str, str]) -> None:
+        self._outcomes = outcomes
+        self.calls: list[str] = []
+
+    async def run(
+        self,
+        *,
+        agent_name: str,
+        context: _FakeContext,  # type: ignore[override]
+        parsed: ParsedWebhook,
+    ) -> str:
+        self.calls.append(agent_name)
+        outcome = self._outcomes.get(agent_name, "success")
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
 @pytest.mark.asyncio
-async def test_active_mode_surfaces_error_outcome_until_wired() -> None:
-    """Active mode is intentionally unwired — dispatch catches the
-    NotImplementedError and maps it to an ``error`` outcome so a
-    premature flip still produces a metric instead of a crash."""
+async def test_active_mode_without_factory_or_runner_surfaces_error() -> None:
+    """Missing collaborators is a misconfiguration — dispatch must record
+    an error outcome loudly rather than silently running nothing."""
     dispatcher = WebhookDispatcher(mode=DispatchMode.ACTIVE)
     result = await dispatcher.dispatch(_make_parsed())
 
     assert result.mode is DispatchMode.ACTIVE
     assert result.outcome == "error"
     assert result.detail is not None
-    assert "NotImplementedError" in result.detail
+    assert "context_factory" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_active_mode_runs_resolved_agents_and_builds_context_once() -> None:
+    factory = _FakeFactory()
+    runner = _RecordingRunner(outcomes={"pr": "success", "pr-reviewer": "success"})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+    )
+
+    result = await dispatcher.dispatch(_make_parsed())
+
+    assert result.outcome == "active"
+    assert result.detail == "active ran=2 failed=0 shadowed=0"
+    # Context must be built once per dispatch, not once per agent — it's
+    # the installation token / GitHubClient that's expensive to mint.
+    assert len(factory.builds) == 1
+    # Runner called once per agent, in order.
+    assert runner.calls == ["pr", "pr-reviewer"]
+
+
+@pytest.mark.asyncio
+async def test_active_mode_allow_list_shadows_unlisted_agents() -> None:
+    factory = _FakeFactory()
+    runner = _RecordingRunner(outcomes={"pr-reviewer": "success"})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+        active_agents=frozenset({"pr-reviewer"}),
+    )
+
+    result = await dispatcher.dispatch(_make_parsed())
+
+    # Only pr-reviewer runs; "pr" is shadowed.
+    assert runner.calls == ["pr-reviewer"]
+    assert result.outcome == "active"
+    assert result.detail == "active ran=1 failed=0 shadowed=1"
+
+
+@pytest.mark.asyncio
+async def test_active_mode_empty_allow_list_shadows_everything() -> None:
+    """A rollout starting with zero promoted agents still builds context
+    and logs — but never calls the runner."""
+    factory = _FakeFactory()
+    runner = _RecordingRunner(outcomes={})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+        active_agents=frozenset(),
+    )
+
+    result = await dispatcher.dispatch(_make_parsed())
+
+    assert runner.calls == []
+    assert result.outcome == "active"
+    assert result.detail == "active ran=0 failed=0 shadowed=2"
+
+
+@pytest.mark.asyncio
+async def test_active_mode_isolates_one_agent_failure_from_siblings() -> None:
+    """One agent raising must not abort the rest of the fan-out."""
+    factory = _FakeFactory()
+    runner = _RecordingRunner(
+        outcomes={
+            "pr": RuntimeError("pr agent exploded"),
+            "pr-reviewer": "success",
+        },
+    )
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+    )
+
+    result = await dispatcher.dispatch(_make_parsed())
+
+    # Both agents were attempted — the second still ran after the first raised.
+    assert runner.calls == ["pr", "pr-reviewer"]
+    assert result.outcome == "active_partial"
+    assert result.detail == "active ran=1 failed=1 shadowed=0"
+
+
+@pytest.mark.asyncio
+async def test_active_mode_per_agent_timeout_maps_to_timeout_outcome() -> None:
+    """A slow agent must be bounded by ``agent_timeout_seconds`` and
+    surface as ``active_partial`` without hanging the dispatch."""
+
+    class _SlowRunner:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def run(
+            self,
+            *,
+            agent_name: str,
+            context: _FakeContext,  # type: ignore[override]
+            parsed: ParsedWebhook,
+        ) -> str:
+            self.calls.append(agent_name)
+            await asyncio.sleep(10.0)
+            return "success"  # pragma: no cover — timeout fires first
+
+    factory = _FakeFactory()
+    runner = _SlowRunner()
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        agent_timeout_seconds=0.05,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+        active_agents=frozenset({"pr"}),  # keep the fan-out to one agent
+    )
+
+    result = await dispatcher.dispatch(_make_parsed())
+
+    assert runner.calls == ["pr"]
+    assert result.outcome == "active_partial"
+    assert "failed=1" in (result.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_active_mode_factory_failure_records_error_outcome() -> None:
+    """If the factory itself raises (e.g. installation token mint
+    failed), dispatch must record ``error`` — not partial success."""
+
+    class _BrokenFactory:
+        async def build(self, parsed: ParsedWebhook) -> _FakeContext:  # type: ignore[override]
+            raise RuntimeError("token broker unreachable")
+
+    runner = _RecordingRunner(outcomes={})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=_BrokenFactory(),  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+    )
+
+    result = await dispatcher.dispatch(_make_parsed())
+
+    assert result.outcome == "error"
+    assert runner.calls == []
+    assert "token broker unreachable" in (result.detail or "")
+
+
+def test_protocols_are_runtime_importable() -> None:
+    """Protocols are exported from the dispatcher module so third-party
+    implementations can type-check against them."""
+    assert AgentContextFactory is not None
+    assert AgentRunner is not None
 
 
 # ── dispatch() error isolation ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the active-mode `NotImplementedError` stub (introduced in #551) with Protocol-based plumbing so a follow-up PR only has to supply the concrete factory + runner — the dispatcher itself stops growing.

- **`AgentContextFactory`** and **`AgentRunner`** Protocols live in `caretaker.github_app.dispatcher` so active mode can delegate per-installation context construction and agent execution without depending on the GitHub App credential broker or `AgentRegistry` at import time. `shadow`/`off` paths stay zero-dependency.
- **`active_agents: frozenset[str] | None`** allow-list promotes agents one at a time; un-promoted agents fall back to shadow logging so dashboards stay populated during rollout.
- **Per-agent `asyncio.wait_for` timeout** (default 120s) + full error isolation — one failing or hung agent never affects siblings. Fan-out partial failures surface as `active_partial` rather than `error`.
- **Factory failure** (e.g. installation token mint) records `outcome=error` at dispatch level rather than leaking a partial-success label.
- Doc updates in `docs/github-app-phase2.md` to reflect the new table + scope cut.

## What's still deliberately out of scope

The concrete `AgentContextFactory` (wraps `InstallationTokenMinter` + `GitHubClient` + `.github/maintainer/config.yml` fetch + `MemoryStore`) and `AgentRunner` (wraps `AgentRegistry.run_one`) land in the next PR, which also wires them into the backend startup path. Keeping that split keeps this one a pure, unit-tested plumbing change.

## Test plan

- [x] `pytest tests/test_github_app/` — 108 passed
- [x] Ruff format + check
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)