### PR TITLE
feat(github-app): wire concrete AgentContextFactory and AgentRunner for active dispatch

### DIFF
--- a/src/caretaker/github_app/__init__.py
+++ b/src/caretaker/github_app/__init__.py
@@ -13,6 +13,8 @@ and the FastAPI webhook receiver without circular imports.
 
 from __future__ import annotations
 
+from .agent_runner import RegistryAgentRunner
+from .context_factory import GitHubAppContextFactory
 from .dispatch_guard import (
     DispatchEvent,
     DispatchVerdict,
@@ -48,6 +50,8 @@ from .webhooks import (
 __all__ = [
     "EVENT_AGENT_MAP",
     "AppJWTSigner",
+    "GitHubAppContextFactory",
+    "RegistryAgentRunner",
     "DispatchEvent",
     "DispatchMode",
     "DispatchResult",

--- a/src/caretaker/github_app/agent_runner.py
+++ b/src/caretaker/github_app/agent_runner.py
@@ -1,0 +1,77 @@
+"""Concrete AgentRunner for GitHub App webhook dispatch.
+
+Delegates to the central AgentRegistry so the dispatcher never needs
+to import agent adapters or know about OrchestratorState.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from caretaker.agents._registry_data import build_registry
+from caretaker.state.models import OrchestratorState, RunSummary
+
+if TYPE_CHECKING:
+    from caretaker.agent_protocol import AgentContext
+    from caretaker.github_app.webhooks import ParsedWebhook
+
+logger = logging.getLogger(__name__)
+
+
+class RegistryAgentRunner:
+    """Run a named agent via the caretaker :class:`~caretaker.registry.AgentRegistry`.
+
+    One instance is shared across all deliveries.  Each :meth:`run` call
+    builds a fresh registry (and fresh ephemeral state) from the per-delivery
+    :class:`~caretaker.agent_protocol.AgentContext`, so there is no cross-
+    delivery state leakage.
+
+    Returns a bounded outcome string:
+    - ``"success"`` — agent ran without errors.
+    - ``"failure"`` — agent raised or returned errors.
+    - ``"disabled"`` — agent not found or reports ``enabled() == False``.
+    """
+
+    async def run(
+        self,
+        *,
+        agent_name: str,
+        context: AgentContext,
+        parsed: ParsedWebhook,
+    ) -> str:
+        registry = build_registry(context)
+        agent = registry.get(agent_name)
+
+        if agent is None:
+            logger.warning(
+                "webhook runner: agent %r not found in registry delivery=%s",
+                agent_name,
+                parsed.delivery_id,
+            )
+            return "disabled"
+
+        if not agent.enabled():
+            logger.info(
+                "webhook runner: agent %r is disabled delivery=%s",
+                agent_name,
+                parsed.delivery_id,
+            )
+            return "disabled"
+
+        state = OrchestratorState()
+        summary = RunSummary()
+
+        result = await registry.run_one(
+            agent,
+            state,
+            summary,
+            event_payload=parsed.payload,
+        )
+
+        if result is None or result.errors:
+            return "failure"
+        return "success"
+
+
+__all__ = ["RegistryAgentRunner"]

--- a/src/caretaker/github_app/context_factory.py
+++ b/src/caretaker/github_app/context_factory.py
@@ -1,0 +1,128 @@
+"""Concrete AgentContextFactory for GitHub App webhook dispatch.
+
+Wires together the installation token minter, GitHubClient construction,
+per-repo MaintainerConfig fetching, and LLMRouter so the dispatcher
+never needs to know about any of these.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import TYPE_CHECKING
+
+import yaml
+
+from caretaker.agent_protocol import AgentContext
+from caretaker.config import MaintainerConfig
+from caretaker.github_client.api import GitHubClient
+
+if TYPE_CHECKING:
+    from caretaker.github_app.installation_tokens import InstallationTokenMinter
+    from caretaker.github_app.webhooks import ParsedWebhook
+    from caretaker.llm.router import LLMRouter
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_PATH = ".github/maintainer/config.yml"
+
+
+class GitHubAppContextFactory:
+    """Build an :class:`AgentContext` for each incoming webhook delivery.
+
+    One instance is created at backend startup and shared across all
+    deliveries (it is stateless beyond the injected collaborators).
+
+    Args:
+        minter: The installation token minter. Must not be ``None`` — callers
+            should verify the GitHub App is configured before constructing this.
+        llm_router: Shared LLM router built from the backend's own config.
+        default_config: Fallback ``MaintainerConfig`` used when the target
+            repo has no ``.github/maintainer/config.yml``. Defaults to an
+            all-defaults instance.
+        dry_run: When ``True`` all constructed :class:`AgentContext` instances
+            have ``dry_run=True`` so agents skip mutating API calls.
+    """
+
+    def __init__(
+        self,
+        *,
+        minter: InstallationTokenMinter,
+        llm_router: LLMRouter,
+        default_config: MaintainerConfig | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        self._minter = minter
+        self._llm_router = llm_router
+        self._default_config = default_config or MaintainerConfig()
+        self._dry_run = dry_run
+
+    async def build(self, parsed: ParsedWebhook) -> AgentContext:
+        """Mint a token, construct a client, and load the repo config."""
+        if parsed.installation_id is None:
+            raise ValueError(
+                f"delivery {parsed.delivery_id}: installation_id is None — "
+                "cannot mint installation token for anonymous deliveries"
+            )
+
+        token = await self._minter.get_token(parsed.installation_id)
+        client = GitHubClient(token=token.token)
+
+        owner, repo = _split_repo(parsed.repository_full_name, parsed.delivery_id)
+        config = await self._load_config(client, owner, repo)
+
+        logger.debug(
+            "built AgentContext owner=%s repo=%s installation=%s delivery=%s",
+            owner,
+            repo,
+            parsed.installation_id,
+            parsed.delivery_id,
+        )
+        return AgentContext(
+            github=client,
+            owner=owner,
+            repo=repo,
+            config=config,
+            llm_router=self._llm_router,
+            dry_run=self._dry_run,
+        )
+
+    async def _load_config(self, client: GitHubClient, owner: str, repo: str) -> MaintainerConfig:
+        """Fetch the repo's maintainer config or return the default."""
+        try:
+            raw = await client.get_file_contents(owner, repo, _CONFIG_PATH)
+            if raw is None:
+                logger.debug(
+                    "no maintainer config at %s in %s/%s; using defaults",
+                    _CONFIG_PATH,
+                    owner,
+                    repo,
+                )
+                return self._default_config
+
+            content_b64: str = raw.get("content", "")
+            content_bytes = base64.b64decode(content_b64.replace("\n", ""))
+            data = yaml.safe_load(content_bytes.decode()) or {}
+            return MaintainerConfig.model_validate(data)
+        except Exception:
+            logger.warning(
+                "failed to load maintainer config from %s/%s; using defaults",
+                owner,
+                repo,
+                exc_info=True,
+            )
+            return self._default_config
+
+
+def _split_repo(repository_full_name: str | None, delivery_id: str) -> tuple[str, str]:
+    """Split ``owner/repo`` into ``(owner, repo)``, raising on bad input."""
+    if not repository_full_name or "/" not in repository_full_name:
+        raise ValueError(
+            f"delivery {delivery_id}: repository_full_name {repository_full_name!r} "
+            "is not in 'owner/repo' format"
+        )
+    owner, _, repo = repository_full_name.partition("/")
+    return owner, repo
+
+
+__all__ = ["GitHubAppContextFactory"]

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -31,6 +31,8 @@ from pydantic import BaseModel
 
 from caretaker.github_app import (
     DispatchMode,
+    GitHubAppContextFactory,
+    RegistryAgentRunner,
     WebhookDispatcher,
     WebhookSignatureError,
     agents_for_event,
@@ -347,11 +349,72 @@ _dispatcher: WebhookDispatcher | None = None
 
 
 def _get_dispatcher() -> WebhookDispatcher:
-    """Return the module-level dispatcher singleton, building on first use."""
+    """Return the module-level dispatcher singleton, building on first use.
+
+    Active mode requires the GitHub App to be configured (``_token_broker``
+    must not be ``None``). If the App is unconfigured and mode is ``active``,
+    the dispatcher falls back to ``off`` with a warning so the webhook handler
+    keeps returning 202s rather than crashing.
+    """
     global _dispatcher  # noqa: PLW0603
     if _dispatcher is None:
         mode = DispatchMode.parse(os.environ.get("CARETAKER_WEBHOOK_DISPATCH_MODE"))
-        _dispatcher = WebhookDispatcher(mode=mode)
+
+        context_factory = None
+        agent_runner = None
+        active_agents: frozenset[str] | None = None
+
+        if mode is DispatchMode.ACTIVE:
+            if _token_broker is None:
+                logger.warning(
+                    "CARETAKER_WEBHOOK_DISPATCH_MODE=active but GitHub App is not "
+                    "configured; downgrading to 'off'. Set CARETAKER_GITHUB_APP_ID "
+                    "and CARETAKER_GITHUB_APP_PRIVATE_KEY to enable active dispatch."
+                )
+                mode = DispatchMode.OFF
+            else:
+                from caretaker.config import MaintainerConfig
+                from caretaker.llm.router import LLMRouter
+
+                cfg_path = os.environ.get("CARETAKER_CONFIG_PATH", ".github/maintainer/config.yml")
+                try:
+                    default_cfg = MaintainerConfig.from_yaml(cfg_path)
+                except Exception:
+                    logger.info(
+                        "No local maintainer config at %r; using defaults for active dispatch",
+                        cfg_path,
+                    )
+                    default_cfg = MaintainerConfig()
+
+                llm_router = LLMRouter(default_cfg.llm)
+                dry_run = os.environ.get("CARETAKER_DRY_RUN", "").lower() in ("1", "true", "yes")
+
+                context_factory = GitHubAppContextFactory(
+                    minter=_token_broker,
+                    llm_router=llm_router,
+                    default_config=default_cfg,
+                    dry_run=dry_run,
+                )
+                agent_runner = RegistryAgentRunner()
+
+                # CARETAKER_WEBHOOK_ACTIVE_AGENTS: comma-separated allow-list,
+                # e.g. "pr-reviewer,pr". When unset all resolved agents run.
+                raw_active = os.environ.get("CARETAKER_WEBHOOK_ACTIVE_AGENTS", "").strip()
+                if raw_active:
+                    active_agents = frozenset(
+                        name.strip() for name in raw_active.split(",") if name.strip()
+                    )
+                    logger.info(
+                        "webhook active dispatch allow-list: %s",
+                        sorted(active_agents),
+                    )
+
+        _dispatcher = WebhookDispatcher(
+            mode=mode,
+            context_factory=context_factory,
+            agent_runner=agent_runner,
+            active_agents=active_agents,
+        )
         logger.info("webhook dispatcher initialised mode=%s", mode.value)
     return _dispatcher
 

--- a/tests/test_github_app/test_agent_runner.py
+++ b/tests/test_github_app/test_agent_runner.py
@@ -1,0 +1,182 @@
+"""Tests for RegistryAgentRunner."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from caretaker.agent_protocol import AgentContext, AgentResult
+from caretaker.github_app.agent_runner import RegistryAgentRunner
+from caretaker.github_app.webhooks import ParsedWebhook
+
+
+def _make_parsed(
+    *,
+    delivery: str = "d-0001",
+    event: str = "pull_request",
+    action: str = "opened",
+) -> ParsedWebhook:
+    return ParsedWebhook(
+        event_type=event,
+        delivery_id=delivery,
+        action=action,
+        installation_id=42,
+        repository_full_name="acme/widget",
+        payload={"action": action},
+    )
+
+
+def _make_context() -> MagicMock:
+    return MagicMock(spec=AgentContext)
+
+
+def _make_agent(*, name: str = "pr", enabled: bool = True) -> MagicMock:
+    agent = MagicMock()
+    agent.name = name
+    agent.enabled.return_value = enabled
+    return agent
+
+
+# ── RegistryAgentRunner ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_returns_disabled_when_agent_not_in_registry() -> None:
+    runner = RegistryAgentRunner()
+    registry = MagicMock()
+    registry.get.return_value = None
+
+    with patch("caretaker.github_app.agent_runner.build_registry", return_value=registry):
+        outcome = await runner.run(
+            agent_name="unknown-agent",
+            context=_make_context(),
+            parsed=_make_parsed(),
+        )
+
+    assert outcome == "disabled"
+    registry.run_one.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_returns_disabled_when_agent_reports_disabled() -> None:
+    runner = RegistryAgentRunner()
+    agent = _make_agent(name="pr", enabled=False)
+    registry = MagicMock()
+    registry.get.return_value = agent
+
+    with patch("caretaker.github_app.agent_runner.build_registry", return_value=registry):
+        outcome = await runner.run(
+            agent_name="pr",
+            context=_make_context(),
+            parsed=_make_parsed(),
+        )
+
+    assert outcome == "disabled"
+    registry.run_one.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_returns_success_when_agent_runs_cleanly() -> None:
+    runner = RegistryAgentRunner()
+    agent = _make_agent(name="pr")
+    result = AgentResult(processed=1, actions=["merged pr #1"])
+    registry = MagicMock()
+    registry.get.return_value = agent
+    registry.run_one = AsyncMock(return_value=result)
+
+    with patch("caretaker.github_app.agent_runner.build_registry", return_value=registry):
+        outcome = await runner.run(
+            agent_name="pr",
+            context=_make_context(),
+            parsed=_make_parsed(),
+        )
+
+    assert outcome == "success"
+    registry.run_one.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_returns_failure_when_agent_returns_errors() -> None:
+    runner = RegistryAgentRunner()
+    agent = _make_agent(name="pr")
+    result = AgentResult(errors=["something went wrong"])
+    registry = MagicMock()
+    registry.get.return_value = agent
+    registry.run_one = AsyncMock(return_value=result)
+
+    with patch("caretaker.github_app.agent_runner.build_registry", return_value=registry):
+        outcome = await runner.run(
+            agent_name="pr",
+            context=_make_context(),
+            parsed=_make_parsed(),
+        )
+
+    assert outcome == "failure"
+
+
+@pytest.mark.asyncio
+async def test_run_returns_failure_when_run_one_returns_none() -> None:
+    """registry.run_one returns None when the agent raises internally."""
+    runner = RegistryAgentRunner()
+    agent = _make_agent(name="pr")
+    registry = MagicMock()
+    registry.get.return_value = agent
+    registry.run_one = AsyncMock(return_value=None)
+
+    with patch("caretaker.github_app.agent_runner.build_registry", return_value=registry):
+        outcome = await runner.run(
+            agent_name="pr",
+            context=_make_context(),
+            parsed=_make_parsed(),
+        )
+
+    assert outcome == "failure"
+
+
+@pytest.mark.asyncio
+async def test_run_passes_event_payload_to_run_one() -> None:
+    runner = RegistryAgentRunner()
+    agent = _make_agent(name="pr")
+    result = AgentResult(processed=1)
+    registry = MagicMock()
+    registry.get.return_value = agent
+    registry.run_one = AsyncMock(return_value=result)
+
+    parsed = _make_parsed()
+    with patch("caretaker.github_app.agent_runner.build_registry", return_value=registry):
+        await runner.run(agent_name="pr", context=_make_context(), parsed=parsed)
+
+    _, kwargs = registry.run_one.call_args
+    assert kwargs.get("event_payload") == parsed.payload
+
+
+@pytest.mark.asyncio
+async def test_run_builds_fresh_state_and_summary_each_call() -> None:
+    """Each dispatch gets isolated ephemeral state — no cross-delivery leakage."""
+    from caretaker.state.models import OrchestratorState, RunSummary
+
+    captured_states = []
+    captured_summaries = []
+
+    runner = RegistryAgentRunner()
+    agent = _make_agent(name="pr")
+    registry = MagicMock()
+    registry.get.return_value = agent
+
+    async def capture_run_one(ag, state, summary, *, event_payload=None):
+        captured_states.append(state)
+        captured_summaries.append(summary)
+        return AgentResult(processed=1)
+
+    registry.run_one = capture_run_one
+
+    parsed = _make_parsed()
+    with patch("caretaker.github_app.agent_runner.build_registry", return_value=registry):
+        await runner.run(agent_name="pr", context=_make_context(), parsed=parsed)
+        await runner.run(agent_name="pr", context=_make_context(), parsed=parsed)
+
+    assert len(captured_states) == 2
+    assert captured_states[0] is not captured_states[1]
+    assert isinstance(captured_states[0], OrchestratorState)
+    assert isinstance(captured_summaries[0], RunSummary)

--- a/tests/test_github_app/test_context_factory.py
+++ b/tests/test_github_app/test_context_factory.py
@@ -1,0 +1,186 @@
+"""Tests for GitHubAppContextFactory."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+from caretaker.github_app.context_factory import GitHubAppContextFactory, _split_repo
+from caretaker.github_app.installation_tokens import InstallationToken
+from caretaker.github_app.webhooks import ParsedWebhook
+
+
+def _make_parsed(
+    *,
+    installation_id: int | None = 42,
+    repository_full_name: str | None = "acme/widget",
+    delivery: str = "d-0001",
+) -> ParsedWebhook:
+    return ParsedWebhook(
+        event_type="pull_request",
+        delivery_id=delivery,
+        action="opened",
+        installation_id=installation_id,
+        repository_full_name=repository_full_name,
+        payload={"action": "opened"},
+    )
+
+
+def _fake_token(installation_id: int = 42) -> InstallationToken:
+    return InstallationToken(
+        token="ghs_fake_token",
+        expires_at=9_999_999_999,
+        installation_id=installation_id,
+    )
+
+
+def _fake_minter(token: InstallationToken | None = None) -> MagicMock:
+    minter = MagicMock()
+    minter.get_token = AsyncMock(return_value=token or _fake_token())
+    return minter
+
+
+def _fake_llm_router() -> MagicMock:
+    return MagicMock()
+
+
+# ── _split_repo ───────────────────────────────────────────────────────
+
+
+def test_split_repo_parses_owner_and_name() -> None:
+    assert _split_repo("acme/widget", "d-0001") == ("acme", "widget")
+
+
+def test_split_repo_handles_org_with_slash() -> None:
+    # Only the first slash is the separator.
+    owner, repo = _split_repo("acme/widget/v2", "d-0001")
+    assert owner == "acme"
+    assert repo == "widget/v2"
+
+
+def test_split_repo_raises_on_missing_slash() -> None:
+    with pytest.raises(ValueError, match="owner/repo"):
+        _split_repo("acmewidget", "d-0001")
+
+
+def test_split_repo_raises_on_none() -> None:
+    with pytest.raises(ValueError, match="owner/repo"):
+        _split_repo(None, "d-0001")
+
+
+# ── GitHubAppContextFactory ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_mints_token_for_installation() -> None:
+    minter = _fake_minter()
+    factory = GitHubAppContextFactory(minter=minter, llm_router=_fake_llm_router())
+
+    parsed = _make_parsed(installation_id=99)
+    with _patch_client_no_config(factory):
+        ctx = await factory.build(parsed)
+
+    minter.get_token.assert_awaited_once_with(99)
+    assert ctx.owner == "acme"
+    assert ctx.repo == "widget"
+
+
+@pytest.mark.asyncio
+async def test_build_raises_when_installation_id_is_none() -> None:
+    factory = GitHubAppContextFactory(minter=_fake_minter(), llm_router=_fake_llm_router())
+    with pytest.raises(ValueError, match="installation_id is None"):
+        await factory.build(_make_parsed(installation_id=None))
+
+
+@pytest.mark.asyncio
+async def test_build_uses_default_config_when_file_missing() -> None:
+    from caretaker.config import MaintainerConfig
+
+    default = MaintainerConfig()
+    factory = GitHubAppContextFactory(
+        minter=_fake_minter(),
+        llm_router=_fake_llm_router(),
+        default_config=default,
+    )
+
+    # get_file_contents returns None → file absent → fall back to default
+    with _patch_client_returns(factory, file_content=None):
+        ctx = await factory.build(_make_parsed())
+
+    assert ctx.config is default
+
+
+@pytest.mark.asyncio
+async def test_build_loads_config_from_repo_when_present() -> None:
+    from caretaker.config import MaintainerConfig
+
+    cfg_yaml = yaml.dump({"version": "v1", "pr_agent": {"stuck_age_hours": 48}})
+    encoded = base64.b64encode(cfg_yaml.encode()).decode()
+
+    factory = GitHubAppContextFactory(minter=_fake_minter(), llm_router=_fake_llm_router())
+
+    with _patch_client_returns(factory, file_content={"content": encoded}):
+        ctx = await factory.build(_make_parsed())
+
+    assert isinstance(ctx.config, MaintainerConfig)
+    assert ctx.config.pr_agent.stuck_age_hours == 48
+
+
+@pytest.mark.asyncio
+async def test_build_falls_back_to_default_on_github_error() -> None:
+    from caretaker.config import MaintainerConfig
+
+    default = MaintainerConfig()
+    factory = GitHubAppContextFactory(
+        minter=_fake_minter(),
+        llm_router=_fake_llm_router(),
+        default_config=default,
+    )
+
+    with _patch_client_raises(factory):
+        ctx = await factory.build(_make_parsed())
+
+    assert ctx.config is default
+
+
+@pytest.mark.asyncio
+async def test_build_propagates_dry_run_flag() -> None:
+    factory = GitHubAppContextFactory(
+        minter=_fake_minter(), llm_router=_fake_llm_router(), dry_run=True
+    )
+    with _patch_client_no_config(factory):
+        ctx = await factory.build(_make_parsed())
+    assert ctx.dry_run is True
+
+
+# ── context manager helpers ───────────────────────────────────────────
+
+
+def _patch_client_no_config(factory: GitHubAppContextFactory):
+    """Patch GitHubClient so get_file_contents returns None (no config file)."""
+    return _patch_client_returns(factory, file_content=None)
+
+
+def _patch_client_returns(factory: GitHubAppContextFactory, *, file_content):
+    import unittest.mock as mock
+
+    client_instance = MagicMock()
+    client_instance.get_file_contents = AsyncMock(return_value=file_content)
+    return mock.patch(
+        "caretaker.github_app.context_factory.GitHubClient",
+        return_value=client_instance,
+    )
+
+
+def _patch_client_raises(factory: GitHubAppContextFactory):
+    import unittest.mock as mock
+
+    client_instance = MagicMock()
+    client_instance.get_file_contents = AsyncMock(side_effect=RuntimeError("network error"))
+    return mock.patch(
+        "caretaker.github_app.context_factory.GitHubClient",
+        return_value=client_instance,
+    )


### PR DESCRIPTION
## Summary

Completes the active-mode dispatcher plumbing from [#553](https://github.com/ianlintner/caretaker/pull/553) by providing concrete implementations of the two injected Protocols and wiring them into the backend startup.

- **`GitHubAppContextFactory`** (`github_app/context_factory.py`): for each webhook delivery, mints an installation token, constructs a `GitHubClient`, fetches `.github/maintainer/config.yml` from the target repo via the Contents API (falling back to a default `MaintainerConfig` on missing file or any fetch error), and returns a fully populated `AgentContext`.
- **`RegistryAgentRunner`** (`github_app/agent_runner.py`): calls `build_registry()` for each dispatch, looks up the agent by name, and delegates to `registry.run_one()` with a fresh ephemeral `OrchestratorState` + `RunSummary`. Returns bounded outcome labels: `"success"`, `"failure"`, `"disabled"`.
- **`_get_dispatcher()` in `mcp_backend/main.py`**: wires both collaborators when `CARETAKER_WEBHOOK_DISPATCH_MODE=active` and the GitHub App is configured (`_token_broker` is not None). Reads `CARETAKER_WEBHOOK_ACTIVE_AGENTS` (comma-separated) to build the per-agent allow-list for progressive rollout. Falls back to `off` with a warning when the App is unconfigured rather than crashing.

## Env vars (active mode)

| Var | Purpose |
|---|---|
| `CARETAKER_WEBHOOK_DISPATCH_MODE=active` | Enable active dispatch |
| `CARETAKER_GITHUB_APP_ID` + `CARETAKER_GITHUB_APP_PRIVATE_KEY` | Required; unconfigured downgrades to `off` |
| `CARETAKER_WEBHOOK_ACTIVE_AGENTS` | Comma-separated allow-list, e.g. `pr-reviewer,pr`. Unset = all agents run |
| `CARETAKER_DRY_RUN=true` | All dispatched agents skip mutating API calls |
| `CARETAKER_CONFIG_PATH` | Path to local `config.yml` used as the default fallback (default: `.github/maintainer/config.yml`) |

## Test plan

- [x] 17 new unit tests covering `GitHubAppContextFactory` and `RegistryAgentRunner`
- [x] Full `tests/test_github_app/` suite: 125 passed
- [x] Ruff format + check

🤖 Generated with [Claude Code](https://claude.com/claude-code)