### PR TITLE
feat(deploy): flip webhook dispatcher to active mode

### DIFF
--- a/infra/k8s/caretaker-mcp-deployment.yaml
+++ b/infra/k8s/caretaker-mcp-deployment.yaml
@@ -81,6 +81,8 @@ spec:
                   optional: true
             - name: CARETAKER_GITHUB_APP_INSTALLATION_ID
               value: "124850811"
+            - name: CARETAKER_WEBHOOK_DISPATCH_MODE
+              value: "active"
             - name: CARETAKER_ADMIN_WATCHED_REPO
               value: "ianlintner/caretaker"
             - name: CARETAKER_ADMIN_ENABLED


### PR DESCRIPTION
## Summary
- Sets \`CARETAKER_WEBHOOK_DISPATCH_MODE=active\` on the MCP backend deployment
- Skips the shadow ladder per sandbox-mode operator directive
- No \`CARETAKER_WEBHOOK_ACTIVE_AGENTS\` allow-list — full fleet runs

## Test plan
- [ ] \`kubectl rollout\` completes
- [ ] \`/health\` reports \`dispatch_mode: active\`, \`github_app_configured: true\`
- [ ] Trigger a webhook (open a PR on a connected repo); confirm \`caretaker_webhook_events_total{mode="active",outcome="active"}\` increments
- [ ] \`caretaker_errors_total{kind="webhook_dispatch"}\` stays at zero

## Rollback
Single env flip — see \`docs/github-app-rollout.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)