### PR TITLE
fix(pr_agent): head-SHA idempotency for review approvals + 0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.3] — 2026-04-25
+
+Hotfix release covering the duplicate-review and orchestrator-soft-fail symptoms surfaced on `main` after PR #581 merged.
+
+### Fixed
+
+- **`pr_agent._handle_review_approve` head-SHA idempotency** — the auto-approve path was racy across concurrent webhook + scheduled runs. When the state machine emitted `request_review_approve` more than once for the same head SHA, each run submitted a fresh `APPROVE` review, producing the "multiple reviews per caretaker PR" symptom in the field. `TrackedPR.last_approved_sha` now records the head SHA of the most recent successful auto-approval; re-entry on the same SHA short-circuits to `MERGE_READY` without calling `create_review`. A new commit advances `pr.head_sha` and re-arms the gate naturally. Defensive `is_caretaker_pr` guard added — refuses to approve PRs whose `head_ref` doesn't start with `claude/` or `caretaker/` even if upstream routing misfires.
+- **`pr_agent._handle_review_close` reason newlines** — `reason` is sourced from `assess_review_verdict`'s summary slice and may carry embedded newlines from the underlying review body. The closing comment's `> {reason}` markdown blockquote rendered as fragmented sibling blocks instead of one logical quote. Reason now collapses to single-line whitespace before formatting.
+- **Orchestrator transient-only soft-fail (already on main via #581)** — this release ships the fix to deployments still on 0.19.2. Rate-limit-only failures with `transient=1, non_transient=0, work_landed=False` no longer mark the workflow as failed.
+
+### Changed
+
+- **`ReviewConfig.auto_approve_caretaker_prs` default flipped to `False`** (was `True`). Per the PR #579 review, auto-approve rolls out per-repo behind an explicit opt-in until the head-SHA idempotency gate has soaked in production.
+- **`ReviewConfig.close_on_infeasible_review` default flipped to `False`** (was `True`). The substring matcher in `assess_review_verdict` has high false-positive risk on noun phrases like "this duplicate field"; staged rollout per-repo until the heuristic is hardened or replaced by a structured decision channel.
+
+### Notes
+
+- Existing repos that explicitly set `review.auto_approve_caretaker_prs: true` or `review.close_on_infeasible_review: true` in their `caretaker.yaml` are unaffected — only repos relying on the old shipped defaults will see the behaviour change.
+- The duplicate Copilot security PRs for the python-dotenv CVE (#563, #567, #569, #571, #573, #575, #577 — all already-superseded by merged #566) are emitted by the GitHub Copilot security flow upstream of caretaker, not by `dependency_agent`. Out of scope for this hotfix; they can be closed manually.
+
 ## [0.16.0] — 2026-04-22
 
 Completes **Wave A** of the 2026-Q2 R&D plan (`/tmp/caretaker-rd/00-rd-master-plan.md`). Six PRs land foundation work identified by the R&D review — fleet-data unblockers, deterministic-first escalation, standing eval harness, guardrails hardening, and attribution telemetry. All new behaviour is opt-in; defaults keep runtime behaviour byte-identical to 0.15.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caretaker-github"
-version = "0.19.2"
+version = "0.19.3"
 description = "Autonomous GitHub repository maintenance powered by Copilot"
 readme = "README.md"
 license = "MIT"

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -99,11 +99,20 @@ class ReviewConfig(StrictBaseModel):
     # When CI is green and there are no blocking review findings on a caretaker
     # PR (claude/ or caretaker/ branch), automatically submit an APPROVE review
     # so the repo's required-review gate is satisfied without human intervention.
-    auto_approve_caretaker_prs: bool = True
+    #
+    # Defaults to False (staged rollout — see PR #579 review notes). Operators
+    # opt in per-repo once they're comfortable with the auto-approve flow and
+    # the head-SHA idempotency gate in :meth:`_handle_review_approve`.
+    auto_approve_caretaker_prs: bool = False
     # When a reviewer signals infeasibility (duplicate, won't work, out of
     # scope), close the PR instead of dispatching a fix — prevents wasting
     # Copilot/Claude Code cycles on hopeless tasks.
-    close_on_infeasible_review: bool = True
+    #
+    # Defaults to False (staged rollout — substring matching on review body
+    # has high false-positive risk; see PR #579 review notes). Opt in per-repo
+    # once the verdict heuristic has been hardened or replaced by a structured
+    # decision channel.
+    close_on_infeasible_review: bool = False
     # PR additions threshold above which a blocker review triggers escalation
     # to a human instead of a mechanical fix attempt.
     high_loc_escalate_threshold: int = 500

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -970,9 +970,38 @@ class PRAgent:
         PR has not yet been approved.  The caretaker GitHub App identity is
         different from the PR author, so its APPROVE satisfies the
         required-review branch-protection gate.
+
+        Idempotency: ``tracking.last_approved_sha`` records the head SHA of
+        the most recent successful auto-approval. Re-entry on the same SHA
+        (concurrent webhook + scheduled runs, replayed events, or
+        state-machine churn) short-circuits to MERGE_READY without
+        submitting a duplicate review — which is what produced the
+        "multiple reviews per PR" symptom in the field. A new commit
+        advances ``pr.head_sha`` and re-arms the gate naturally.
+
+        Defensive guard: refuse to approve PRs that aren't caretaker-owned
+        even if a state-machine bug routed us here. ``is_caretaker_pr``
+        keys off the ``claude/`` / ``caretaker/`` head-branch prefix.
         """
+        if not getattr(pr, "is_caretaker_pr", False):
+            logger.warning(
+                "PR #%d: refusing auto-approve — not a caretaker PR (head_ref=%r)",
+                pr.number,
+                getattr(pr, "head_ref", ""),
+            )
+            report.waiting.append(pr.number)
+            return tracking
         if not self._config.review.auto_approve_caretaker_prs:
             report.waiting.append(pr.number)
+            return tracking
+        if tracking.last_approved_sha and tracking.last_approved_sha == pr.head_sha:
+            logger.info(
+                "PR #%d: auto-approve idempotency — head SHA %s already approved, skipping",
+                pr.number,
+                pr.head_sha[:8] if pr.head_sha else "?",
+            )
+            tracking.state = PRTrackingState.MERGE_READY
+            report.approved.append(pr.number)
             return tracking
         try:
             await self._github.create_review(
@@ -985,6 +1014,7 @@ class PRAgent:
             )
             logger.info("PR #%d: submitted auto-approval", pr.number)
             tracking.state = PRTrackingState.MERGE_READY
+            tracking.last_approved_sha = pr.head_sha
             _mark_caretaker_touched(tracking)
             report.approved.append(pr.number)
         except Exception as exc:
@@ -1006,11 +1036,16 @@ class PRAgent:
         sets the PR state to closed.  Non-fatal: a failure leaves the PR open
         and adds to report.errors so the operator can investigate.
         """
+        # Reason comes from review-summary text which may include embedded
+        # newlines; preserve them in a single line so the markdown
+        # blockquote (`> {reason}`) renders as one logical quote instead
+        # of fragmenting into multiple sibling blocks.
+        sanitized_reason = " ".join(reason.split()).strip() or "no reason provided"
         body = (
             "<!-- caretaker:review-close -->\n\n"
             "🔴 **Caretaker: Closing PR**\n\n"
             "A reviewer indicated this change is not viable:\n\n"
-            f"> {reason}\n\n"
+            f"> {sanitized_reason}\n\n"
             "Closing to keep the repository clean. "
             "If this was flagged in error, reopen with a comment explaining why "
             "the concern does not apply."

--- a/src/caretaker/state/models.py
+++ b/src/caretaker/state/models.py
@@ -120,6 +120,17 @@ class TrackedPR(BaseModel):
     # "pushed work after caretaker's last action."
     last_caretaker_action_at: datetime | None = None
 
+    # ── Auto-approve idempotency ─────────────────────────────────────────
+    # Head SHA of the most recent successful caretaker auto-approval. The
+    # PR-agent's _handle_review_approve consults this before submitting an
+    # APPROVE review: if it equals pr.head_sha the review is skipped, which
+    # prevents duplicate approval reviews when the state-machine fires
+    # ``request_review_approve`` more than once across concurrent webhook /
+    # scheduled runs. Cleared (left None) on first observation, set on
+    # successful approval; a new push to the PR moves head_sha forward and
+    # naturally re-arms the gate.
+    last_approved_sha: str | None = None
+
 
 class TrackedIssue(BaseModel):
     number: int

--- a/tests/test_pr_agent/test_agent.py
+++ b/tests/test_pr_agent/test_agent.py
@@ -1602,3 +1602,148 @@ class TestRetryWindowHours:
         assert updated.last_copilot_attempt_at is not None
         delta = (datetime.now(UTC) - updated.last_copilot_attempt_at).total_seconds()
         assert 0 <= delta < 5
+
+
+@pytest.mark.asyncio
+class TestHandleReviewApprove:
+    """Tests for _handle_review_approve idempotency, guards, and config gating.
+
+    Pinning down the "multiple reviews per caretaker PR" symptom (PR #581 / v0.19.3):
+    the auto-approve path must (a) refuse non-caretaker PRs, (b) skip duplicate
+    approvals on the same head SHA, and (c) re-arm naturally when a new commit
+    advances the SHA.
+    """
+
+    async def _run(
+        self,
+        pr,
+        tracking: TrackedPR,
+        *,
+        auto_approve: bool = True,
+        github=None,
+    ):
+        from caretaker.config import ReviewConfig
+        from caretaker.pr_agent.agent import PRAgent, PRAgentReport
+
+        config = make_config()
+        config.review = ReviewConfig(auto_approve_caretaker_prs=auto_approve)
+        github = github or AsyncMock()
+        agent = PRAgent(github=github, owner="o", repo="r", config=config)
+        report = PRAgentReport()
+        updated = await agent._handle_review_approve(pr, tracking, report)
+        return updated, report, github
+
+    async def test_approves_caretaker_pr_first_time(self) -> None:
+        pr = make_pr(number=1, head_ref="caretaker/x")
+        pr.head_sha = "abc123"
+        tracking = TrackedPR(number=1)
+
+        updated, report, github = await self._run(pr, tracking)
+
+        github.create_review.assert_awaited_once()
+        assert updated.state == PRTrackingState.MERGE_READY
+        assert updated.last_approved_sha == "abc123"
+        assert 1 in report.approved
+        assert report.errors == []
+
+    async def test_idempotent_skip_on_same_sha(self) -> None:
+        """Re-entry on the same head SHA must NOT submit a duplicate review."""
+        pr = make_pr(number=2, head_ref="caretaker/x")
+        pr.head_sha = "abc123"
+        tracking = TrackedPR(number=2, last_approved_sha="abc123")
+
+        updated, report, github = await self._run(pr, tracking)
+
+        github.create_review.assert_not_awaited()
+        assert updated.state == PRTrackingState.MERGE_READY
+        assert updated.last_approved_sha == "abc123"
+        assert 2 in report.approved
+
+    async def test_new_sha_re_approves(self) -> None:
+        """A new commit (different head SHA) re-arms the gate."""
+        pr = make_pr(number=3, head_ref="caretaker/x")
+        pr.head_sha = "newsha"
+        tracking = TrackedPR(number=3, last_approved_sha="oldsha")
+
+        updated, report, github = await self._run(pr, tracking)
+
+        github.create_review.assert_awaited_once()
+        assert updated.last_approved_sha == "newsha"
+        assert 3 in report.approved
+
+    async def test_refuses_non_caretaker_pr(self) -> None:
+        """Defensive guard: never approve a non-caretaker PR even if routed here."""
+        pr = make_pr(number=4, head_ref="dependabot/npm/foo-1.2.3")
+        pr.head_sha = "abc123"
+        tracking = TrackedPR(number=4)
+
+        updated, report, github = await self._run(pr, tracking)
+
+        github.create_review.assert_not_awaited()
+        assert updated.state != PRTrackingState.MERGE_READY
+        assert updated.last_approved_sha is None
+        assert 4 in report.waiting
+
+    async def test_disabled_flag_skips(self) -> None:
+        pr = make_pr(number=5, head_ref="caretaker/x")
+        pr.head_sha = "abc123"
+        tracking = TrackedPR(number=5)
+
+        updated, report, github = await self._run(pr, tracking, auto_approve=False)
+
+        github.create_review.assert_not_awaited()
+        assert updated.last_approved_sha is None
+        assert 5 in report.waiting
+
+    async def test_create_review_failure_records_error(self) -> None:
+        pr = make_pr(number=6, head_ref="caretaker/x")
+        pr.head_sha = "abc123"
+        tracking = TrackedPR(number=6)
+        github = AsyncMock()
+        github.create_review.side_effect = RuntimeError("boom")
+
+        updated, report, _ = await self._run(pr, tracking, github=github)
+
+        assert updated.last_approved_sha is None
+        assert any("auto-approve failed" in e for e in report.errors)
+        assert 6 in report.waiting
+
+
+@pytest.mark.asyncio
+class TestHandleReviewClose:
+    """Tests for _handle_review_close reason sanitization."""
+
+    async def test_multiline_reason_collapses_to_single_line(self) -> None:
+        from caretaker.pr_agent.agent import PRAgent, PRAgentReport
+
+        pr = make_pr(number=11, head_ref="caretaker/x")
+        tracking = TrackedPR(number=11)
+        config = make_config()
+        github = AsyncMock()
+        agent = PRAgent(github=github, owner="o", repo="r", config=config)
+        report = PRAgentReport()
+
+        reason = "Infeasible / duplicate:\n\nThis already\nlanded in PR #999."
+        await agent._handle_review_close(pr, tracking, report, reason)
+
+        github.add_issue_comment.assert_awaited_once()
+        # The blockquote line in the posted body should be a single line:
+        body = github.add_issue_comment.await_args.args[3]
+        assert "> Infeasible / duplicate: This already landed in PR #999." in body
+        # No newline inside the blockquote:
+        quoted_line = next(line for line in body.splitlines() if line.startswith("> "))
+        assert "\n" not in quoted_line
+
+    async def test_empty_reason_falls_back(self) -> None:
+        from caretaker.pr_agent.agent import PRAgent, PRAgentReport
+
+        pr = make_pr(number=12, head_ref="caretaker/x")
+        tracking = TrackedPR(number=12)
+        config = make_config()
+        github = AsyncMock()
+        agent = PRAgent(github=github, owner="o", repo="r", config=config)
+        report = PRAgentReport()
+
+        await agent._handle_review_close(pr, tracking, report, "   \n\n   ")
+        body = github.add_issue_comment.await_args.args[3]
+        assert "> no reason provided" in body


### PR DESCRIPTION
## Summary

- **Fixes the 'multiple reviews per caretaker PR' symptom** that surfaced after PR #579's auto-approve flow shipped in 0.19.2.
- **Adds the 0.19.3 hotfix release** that also carries PR #581's orchestrator soft-fail fix to deployments still on 0.19.2.
- **Hardens defaults** per ianlintner's review on PR #579 — auto-approve and infeasible-close now default to off (staged rollout).

## Root cause

`_handle_review_approve` (introduced in #579) had no idempotency guard for the app's own approval. When the state machine emitted ``request_review_approve`` more than once for the same head SHA — across concurrent webhook + scheduled runs, replayed events, or state-machine churn — each run submitted a fresh ``APPROVE`` review.

## Fix

1. **`TrackedPR.last_approved_sha`** records the head SHA of the most recent successful auto-approval. ``_handle_review_approve`` checks it against ``pr.head_sha`` before calling ``create_review`` and short-circuits to ``MERGE_READY`` on match. A new commit advances ``pr.head_sha`` and re-arms the gate naturally.
2. **Defensive `is_caretaker_pr` guard** refuses approvals on non-caretaker branches (e.g. ``dependabot/``) even if upstream routing misfires.
3. **`_handle_review_close` newline sanitization** — multi-line review-summary text is collapsed before formatting the markdown blockquote so ``> {reason}`` renders as one logical quote, not fragmented sibling blocks.
4. **Default-flip** ``ReviewConfig.auto_approve_caretaker_prs`` and ``close_on_infeasible_review`` to ``False`` per the PR #579 review notes. Operators opt in per-repo.

## Tests

New ``TestHandleReviewApprove`` and ``TestHandleReviewClose`` classes cover:

- first-time approve sets ``last_approved_sha`` and submits one review
- idempotent skip on same SHA (no ``create_review`` call)
- new SHA re-approves
- non-caretaker PR (``dependabot/...``) refused
- ``auto_approve_caretaker_prs=False`` skipped
- ``create_review`` exception recorded in ``report.errors``
- multi-line reason collapses to single blockquote line
- empty reason falls back to ``no reason provided``

All 1690 non-LLM tests pass (``ruff`` + ``mypy`` clean on touched files).

## Release

- ``pyproject.toml`` ``0.19.2`` → ``0.19.3``
- ``CHANGELOG.md`` entry documents this fix + #581's orchestrator soft-fail fix (already on main but never released).
- ``releases.json`` is updated automatically by ``update-releases-json.yml`` after the tag is cut.

## Out of scope

The duplicate Copilot security PRs for the python-dotenv CVE (#563, #567, #569, #571, #573, #575, #577 — all already-superseded by merged #566) are emitted by the **GitHub Copilot security flow upstream of caretaker**, not by ``dependency_agent``. Closing them is a manual cleanup task; not addressed here.