### PR TITLE
fix(mcp): harden caretaker-mcp against OOM under webhook bursts + GitHub cooldown

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -111,6 +111,7 @@ jobs:
           kubectl apply \
             -n "${{ vars.CARETAKER_MCP_NAMESPACE }}" \
             -f infra/k8s/caretaker-mcp-service.yaml \
+            -f infra/k8s/caretaker-mcp-pdb.yaml \
             -f infra/k8s/redis-statefulset.yaml \
             -f infra/k8s/neo4j-statefulset.yaml
 

--- a/infra/k8s/caretaker-mcp-deployment.yaml
+++ b/infra/k8s/caretaker-mcp-deployment.yaml
@@ -10,7 +10,15 @@ metadata:
     app.kubernetes.io/part-of: caretaker
     app.kubernetes.io/managed-by: kubectl
 spec:
-  replicas: 1
+  # Two replicas + a PodDisruptionBudget (see caretaker-mcp-pdb.yaml) keeps
+  # the webhook ack path available across single-pod OOMs and rolling
+  # restarts. The webhook payload is idempotent (deduped on delivery_id).
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: caretaker-mcp
@@ -144,10 +152,14 @@ spec:
           resources:
             requests:
               cpu: "10m"
-              memory: "64Mi"
+              memory: "128Mi"
             limits:
               cpu: "250m"
-              memory: "256Mi"
+              # Bumped from 256Mi → 512Mi after observed OOMKills under
+              # webhook bursts coinciding with GitHub rate-limit cooldown.
+              # The bounded in-flight cap in github_app/dispatcher.py keeps
+              # this from masking a real leak.
+              memory: "512Mi"
           livenessProbe:
             httpGet:
               path: /health

--- a/infra/k8s/caretaker-mcp-pdb.yaml
+++ b/infra/k8s/caretaker-mcp-pdb.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: caretaker-mcp
+  labels:
+    app: caretaker-mcp
+    app.kubernetes.io/name: caretaker-mcp
+    app.kubernetes.io/instance: caretaker-mcp
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: caretaker
+    app.kubernetes.io/managed-by: kubectl
+spec:
+  # Pair with replicas: 2 in caretaker-mcp-deployment.yaml — voluntary
+  # disruptions (node drains, cluster autoscaler scale-down on spot) must
+  # leave at least one webhook receiver up so GitHub never sees a 5xx.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: caretaker-mcp

--- a/src/caretaker/admin/health_api.py
+++ b/src/caretaker/admin/health_api.py
@@ -147,9 +147,7 @@ async def doctor(
     oauth_token_url = os.environ.get("OAUTH2_TOKEN_URL")
     oauth_present = bool(oauth_id and oauth_secret and oauth_token_url)
     if oauth_present:
-        oauth_detail = (
-            f"OAuth2 client_credentials configured (token_url={oauth_token_url})"
-        )
+        oauth_detail = f"OAuth2 client_credentials configured (token_url={oauth_token_url})"
         oauth_status: CheckStatus = "ok"
     else:
         missing = [

--- a/src/caretaker/auth/bearer.py
+++ b/src/caretaker/auth/bearer.py
@@ -53,7 +53,7 @@ import jwt
 from fastapi import HTTPException, Request, status
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Coroutine, Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -122,9 +122,7 @@ async def configure(
         response.raise_for_status()
         data = response.json()
         if not isinstance(data, dict):  # pragma: no cover - defensive
-            raise RuntimeError(
-                f"OIDC discovery at {discovery_url} returned non-object"
-            )
+            raise RuntimeError(f"OIDC discovery at {discovery_url} returned non-object")
         return data
 
     if http_client is None:
@@ -143,9 +141,7 @@ async def configure(
 
     jwks_uri = metadata.get("jwks_uri")
     if not isinstance(jwks_uri, str) or not jwks_uri:
-        raise RuntimeError(
-            f"OIDC discovery at {discovery_url} missing 'jwks_uri'"
-        )
+        raise RuntimeError(f"OIDC discovery at {discovery_url} missing 'jwks_uri'")
 
     jwk_client = jwt.PyJWKClient(jwks_uri, cache_keys=True, lifespan=600)
     required = frozenset(s for s in required_scopes if s)
@@ -273,12 +269,7 @@ def _verify_token(state: _BearerAuthState, token: str) -> BearerPrincipal:
             headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
         ) from exc
 
-    client_id = (
-        claims.get("client_id")
-        or claims.get("azp")
-        or claims.get("sub")
-        or ""
-    )
+    client_id = claims.get("client_id") or claims.get("azp") or claims.get("sub") or ""
     scopes = _scopes_from_claims(claims)
     return BearerPrincipal(client_id=str(client_id), scopes=scopes, raw_claims=claims)
 
@@ -291,14 +282,15 @@ def _enforce_scopes(principal: BearerPrincipal, scopes: Iterable[str]) -> None:
             detail=f"Token missing required scope(s): {', '.join(sorted(missing))}",
             headers={
                 "WWW-Authenticate": (
-                    'Bearer error="insufficient_scope", '
-                    f'scope="{" ".join(sorted(missing))}"'
+                    f'Bearer error="insufficient_scope", scope="{" ".join(sorted(missing))}"'
                 )
             },
         )
 
 
-def require_bearer_token(*scopes: str):
+def require_bearer_token(
+    *scopes: str,
+) -> Callable[[Request], Coroutine[Any, Any, BearerPrincipal]]:
     """FastAPI dependency factory: returns a Depends-able callable.
 
     The returned callable validates the request's bearer token and ensures the

--- a/src/caretaker/cli.py
+++ b/src/caretaker/cli.py
@@ -1138,16 +1138,12 @@ def fleet_status(config_path: str) -> None:
     click.echo(f"timeout_seconds          : {registry.timeout_seconds}")
     click.echo("oauth2 (canonical auth)  :")
     click.echo(f"  {client_id_env:<22}: {'set' if client_id_present else 'NOT SET'}")
-    click.echo(
-        f"  {client_secret_env:<22}: {'set' if client_secret_present else 'NOT SET'}"
-    )
+    click.echo(f"  {client_secret_env:<22}: {'set' if client_secret_present else 'NOT SET'}")
     click.echo(f"  {token_url_env:<22}: {token_url or 'NOT SET'}")
     click.echo(f"  scope                 : {scope_value or '<empty>'}")
     oauth_ready = client_id_present and client_secret_present and bool(token_url)
     if not oauth_ready:
-        click.echo(
-            "  ⚠ OAuth2 not fully wired — heartbeats will be rejected by backend (401)."
-        )
+        click.echo("  ⚠ OAuth2 not fully wired — heartbeats will be rejected by backend (401).")
 
     if not registry.enabled:
         click.echo("\n⚠ fleet_registry is disabled — heartbeats will NOT be sent.")

--- a/src/caretaker/github_app/dispatcher.py
+++ b/src/caretaker/github_app/dispatcher.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from dataclasses import dataclass
 from enum import StrEnum
@@ -52,6 +53,7 @@ from caretaker.observability.metrics import (
     record_error,
     record_webhook_event,
     record_worker_job,
+    set_worker_queue_depth,
 )
 
 if TYPE_CHECKING:
@@ -383,23 +385,83 @@ class WebhookDispatcher:
         )
 
 
+def _max_in_flight() -> int:
+    """Bound on concurrent in-flight dispatch tasks.
+
+    Resolved per-call (not cached) so tests and operators can tune via
+    ``CARETAKER_WEBHOOK_MAX_IN_FLIGHT`` without restarting the process.
+    A non-positive / unparseable value falls back to the default.
+    """
+    raw = os.environ.get("CARETAKER_WEBHOOK_MAX_IN_FLIGHT", "")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_IN_FLIGHT
+    return value if value > 0 else _DEFAULT_MAX_IN_FLIGHT
+
+
+_DEFAULT_MAX_IN_FLIGHT: int = 64
+_in_flight: set[asyncio.Task[DispatchResult]] = set()
+
+
+def in_flight_count() -> int:
+    """Return the number of dispatch tasks currently in flight (test/observability hook)."""
+    return len(_in_flight)
+
+
 def dispatch_in_background(
     dispatcher: WebhookDispatcher,
     parsed: ParsedWebhook,
-) -> asyncio.Task[DispatchResult]:
+) -> asyncio.Task[DispatchResult] | None:
     """Schedule :meth:`WebhookDispatcher.dispatch` as a background task.
 
-    Returned so callers can ``await`` it in tests. Production callers
-    (the webhook endpoint) drop the task on the event loop so the
+    Returns the task so callers can ``await`` it in tests; production
+    callers (the webhook endpoint) drop it on the event loop so the
     webhook handler returns immediately.
 
-    The task holds a reference via the default loop; callers do not
-    need to store it themselves unless they want to await.
+    To prevent unbounded memory growth when GitHub is in rate-limit
+    cooldown — every dispatch waits on the cooldown without releasing
+    the parsed payload + agent context — concurrent in-flight tasks are
+    capped by ``CARETAKER_WEBHOOK_MAX_IN_FLIGHT`` (default 64). When the
+    cap is reached the call returns ``None`` and the delivery is dropped
+    on the floor with a counted ``webhook_dispatch_dropped`` error. The
+    webhook itself was already 200-acked, and GitHub won't redeliver
+    successful acks — operators rely on the ``caretaker_errors_total``
+    counter + the ``worker_queue_depth{queue="webhook_dispatch"}`` gauge
+    to notice and either scale up replicas or raise the cap.
     """
-    return asyncio.create_task(
+    cap = _max_in_flight()
+    if len(_in_flight) >= cap:
+        logger.warning(
+            "webhook dispatch dropped (in-flight cap reached) "
+            "in_flight=%d cap=%d event=%s delivery=%s",
+            len(_in_flight),
+            cap,
+            parsed.event_type,
+            parsed.delivery_id,
+        )
+        record_error(kind="webhook_dispatch_dropped")
+        record_webhook_event(
+            event=parsed.event_type,
+            mode=dispatcher.mode.value,
+            outcome="dropped_overload",
+        )
+        set_worker_queue_depth("webhook_dispatch", len(_in_flight))
+        return None
+
+    task = asyncio.create_task(
         dispatcher.dispatch(parsed),
         name=f"webhook-dispatch:{parsed.delivery_id}",
     )
+    _in_flight.add(task)
+    set_worker_queue_depth("webhook_dispatch", len(_in_flight))
+
+    def _on_done(t: asyncio.Task[DispatchResult]) -> None:
+        _in_flight.discard(t)
+        set_worker_queue_depth("webhook_dispatch", len(_in_flight))
+
+    task.add_done_callback(_on_done)
+    return task
 
 
 __all__ = [
@@ -409,4 +471,5 @@ __all__ = [
     "DispatchResult",
     "WebhookDispatcher",
     "dispatch_in_background",
+    "in_flight_count",
 ]

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -40,6 +40,8 @@ from caretaker.github_app import (
     parse_webhook,
     verify_signature,
 )
+from caretaker.github_client.rate_limit import get_cooldown
+from caretaker.observability.metrics import record_webhook_event
 from caretaker.state.dedup import LocalDedup, RedisDedup, build_dedup
 from caretaker.state.token_broker import build_token_broker
 
@@ -101,9 +103,10 @@ async def _lifespan(application: FastAPI):  # type: ignore[no-untyped-def]
     try:
         from caretaker.auth import bearer as fleet_bearer
 
-        issuer_url = os.environ.get("CARETAKER_OIDC_ISSUER_URL", "").strip() or os.environ.get(
-            "CARETAKER_ADMIN_OIDC_ISSUER_URL", ""
-        ).strip()
+        issuer_url = (
+            os.environ.get("CARETAKER_OIDC_ISSUER_URL", "").strip()
+            or os.environ.get("CARETAKER_ADMIN_OIDC_ISSUER_URL", "").strip()
+        )
         if issuer_url:
             try:
                 await fleet_bearer.configure(
@@ -516,6 +519,11 @@ class WebhookAck(BaseModel):
     duplicate: bool
     agents: list[str]
     installation_id: int | None
+    # ``True`` when the dispatcher was scheduled, ``False`` when the
+    # delivery was 200-acked but agent dispatch was deliberately skipped
+    # (e.g. GitHub rate-limit cooldown). Default keeps the field
+    # backwards-compatible with older clients reading the schema.
+    dispatched: bool = True
 
 
 # ── MCP endpoints ------------------------------------------------------
@@ -694,9 +702,21 @@ async def github_webhook(request: Request) -> WebhookAck:
     is_new = await _remember_delivery(parsed.delivery_id)
     agents = agents_for_event(parsed.event_type)
 
+    # If the GitHub client is in a rate-limit cooldown, skip agent
+    # dispatch entirely. Every dispatched task during a cooldown would
+    # block on the GitHub API only to short-circuit on RateLimitError,
+    # while still pinning the parsed payload + agent context in memory —
+    # which is how this pod started OOMKilling under webhook bursts. The
+    # webhook is still 200-acked (GitHub considers the delivery
+    # successful and won't redeliver), and the missed work is recoverable
+    # via the next reconcile loop / manual rerun once the cooldown clears.
+    cooldown = get_cooldown()
+    cooldown_blocked = is_new and cooldown.is_blocked()
+    cooldown_seconds = cooldown.seconds_remaining() if cooldown_blocked else 0.0
+
     logger.info(
         "webhook accepted event=%s delivery=%s action=%s installation=%s "
-        "repository=%s duplicate=%s agents=%s",
+        "repository=%s duplicate=%s agents=%s cooldown_skip=%s",
         parsed.event_type,
         parsed.delivery_id,
         parsed.action,
@@ -704,6 +724,7 @@ async def github_webhook(request: Request) -> WebhookAck:
         parsed.repository_full_name,
         not is_new,
         agents,
+        cooldown_blocked,
     )
 
     # Mirror the delivery into the admin dashboard's recent-deliveries
@@ -715,24 +736,47 @@ async def github_webhook(request: Request) -> WebhookAck:
 
         from caretaker.admin import webhooks_api as _webhooks_api
 
+        if not is_new:
+            mirror_status = "duplicate"
+        elif cooldown_blocked:
+            mirror_status = "deferred_cooldown"
+        else:
+            mirror_status = "ok"
+
         _webhooks_api.register_delivery(
             event=parsed.event_type,
             action=parsed.action,
             installation_id=parsed.installation_id,
             delivery_id=parsed.delivery_id,
             received_at=_dt.now(UTC).isoformat(),
-            agents_fired=list(agents),
-            status="duplicate" if not is_new else "ok",
+            agents_fired=[] if cooldown_blocked else list(agents),
+            status=mirror_status,
         )
     except Exception:
         logger.debug("webhook delivery mirror skipped", exc_info=True)
 
+    dispatched = False
     # Only dispatch fresh deliveries — GitHub retries with the same
     # delivery id on non-2xx, and we already acked once.
-    if is_new:
+    if is_new and not cooldown_blocked:
         dispatcher = _get_dispatcher()
         if dispatcher.mode is not DispatchMode.OFF:
-            dispatch_in_background(dispatcher, parsed)
+            task = dispatch_in_background(dispatcher, parsed)
+            dispatched = task is not None
+    elif cooldown_blocked:
+        logger.warning(
+            "webhook dispatch deferred: GitHub rate-limit cooldown active "
+            "(%.0fs remaining) event=%s delivery=%s",
+            cooldown_seconds,
+            parsed.event_type,
+            parsed.delivery_id,
+        )
+        dispatcher = _get_dispatcher()
+        record_webhook_event(
+            event=parsed.event_type,
+            mode=dispatcher.mode.value,
+            outcome="deferred_cooldown",
+        )
 
     return WebhookAck(
         status="accepted",
@@ -741,6 +785,7 @@ async def github_webhook(request: Request) -> WebhookAck:
         duplicate=not is_new,
         agents=agents,
         installation_id=parsed.installation_id,
+        dispatched=dispatched,
     )
 
 

--- a/tests/test_github_app/test_dispatcher.py
+++ b/tests/test_github_app/test_dispatcher.py
@@ -12,6 +12,7 @@ from caretaker.github_app.dispatcher import (
     DispatchMode,
     WebhookDispatcher,
     dispatch_in_background,
+    in_flight_count,
 )
 from caretaker.github_app.webhooks import ParsedWebhook
 
@@ -377,5 +378,57 @@ async def test_dispatch_in_background_isolates_handler_from_slow_agent(
     dispatcher = WebhookDispatcher(mode=DispatchMode.SHADOW)
     task = dispatch_in_background(dispatcher, _make_parsed())
 
+    assert task is not None
     assert not task.done()  # handler got control back before dispatch ran
     assert await task == "done"
+
+
+# ── in-flight cap ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_in_background_drops_when_in_flight_cap_reached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once the in-flight cap is hit, further dispatches return ``None``
+    and don't grow the in-flight set. This is the memory-pressure relief
+    valve: during GitHub rate-limit cooldown, every dispatch waits on
+    the cooldown without releasing the parsed payload — without a cap,
+    a webhook burst would OOM the pod."""
+    monkeypatch.setenv("CARETAKER_WEBHOOK_MAX_IN_FLIGHT", "2")
+
+    # Block dispatch indefinitely so tasks accumulate in the in-flight set.
+    gate = asyncio.Event()
+
+    async def blocking_dispatch(_self: WebhookDispatcher, _parsed: ParsedWebhook):  # type: ignore[no-untyped-def]
+        await gate.wait()
+        return "done"
+
+    monkeypatch.setattr(WebhookDispatcher, "dispatch", blocking_dispatch)
+
+    dispatcher = WebhookDispatcher(mode=DispatchMode.SHADOW)
+
+    # Drain any existing in-flight tasks from prior tests.
+    starting = in_flight_count()
+
+    t1 = dispatch_in_background(dispatcher, _make_parsed(delivery="d1"))
+    t2 = dispatch_in_background(dispatcher, _make_parsed(delivery="d2"))
+    assert t1 is not None
+    assert t2 is not None
+    assert in_flight_count() == starting + 2
+
+    # Cap is 2 (relative). With ``starting`` already in flight from
+    # outside this test, the third call MAY still slip through if the
+    # global was empty — so use a unique cap baseline.
+    monkeypatch.setenv("CARETAKER_WEBHOOK_MAX_IN_FLIGHT", str(in_flight_count()))
+    dropped = dispatch_in_background(dispatcher, _make_parsed(delivery="d3"))
+    assert dropped is None  # over the cap → dropped
+    assert in_flight_count() == starting + 2  # in-flight set didn't grow
+
+    # Releasing the gate lets the held tasks finish so the in-flight
+    # set shrinks back; verifies the done-callback wires up correctly.
+    gate.set()
+    await asyncio.gather(t1, t2)
+    # The done callback runs on the next event-loop tick.
+    await asyncio.sleep(0)
+    assert in_flight_count() == starting

--- a/tests/test_mcp_backend_github_app.py
+++ b/tests/test_mcp_backend_github_app.py
@@ -238,6 +238,48 @@ def test_webhook_security_event_routed(with_webhook_secret):
     assert "security" in body["agents"]
 
 
+def test_webhook_skips_dispatch_during_github_cooldown(
+    with_webhook_secret, monkeypatch: pytest.MonkeyPatch
+):
+    """When the shared GitHub rate-limit cooldown is active, the webhook
+    must still 200-ack but skip the in-process dispatch — otherwise every
+    delivery during the cooldown pins memory waiting on a doomed call."""
+    import time
+
+    from caretaker.github_client.rate_limit import get_cooldown, reset_for_tests
+
+    reset_for_tests()
+    try:
+        # Engage a 60s cooldown.
+        get_cooldown().mark_blocked(time.time() + 60.0, reason="test cooldown")
+
+        dispatched: list[str] = []
+
+        def _spy(_dispatcher, parsed):  # type: ignore[no-untyped-def]
+            dispatched.append(parsed.delivery_id)
+            return None
+
+        monkeypatch.setattr("caretaker.mcp_backend.main.dispatch_in_background", _spy)
+
+        payload = json.dumps(_pr_payload()).encode()
+        headers = _webhook_headers(
+            secret=WEBHOOK_SECRET,
+            body=payload,
+            event="pull_request",
+            delivery_id="delivery-cooldown-001",
+        )
+        resp = client.post("/webhooks/github", content=payload, headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "accepted"
+        assert body["dispatched"] is False
+        # Spy was not invoked — dispatch was skipped at the front door,
+        # not inside the dispatcher.
+        assert dispatched == []
+    finally:
+        reset_for_tests()
+
+
 def test_webhook_no_installation_id_when_absent(with_webhook_secret):
     """Payload without an installation key → installation_id is None."""
     payload = json.dumps(

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "caretaker-github"
-version = "0.19.2"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Investigation of `caretaker.cat-herding.net` found the `caretaker-mcp` pod stable now but with **8 OOMKill restarts in the prior ~17 min** under heavy GitHub webhook traffic that coincided with a GitHub rate-limit cooldown. Every dispatched task was blocking on the cooldown while pinning its parsed payload + agent context in memory, growing past the 256Mi limit.

This PR ships four mitigations — discussed in the original triage thread — together: a k8s capacity / availability bump, a bounded in-flight cap, fast-ack on cooldown, and a PodDisruptionBudget.

### What's changed

- **k8s** ([caretaker-mcp-deployment.yaml](infra/k8s/caretaker-mcp-deployment.yaml), new [caretaker-mcp-pdb.yaml](infra/k8s/caretaker-mcp-pdb.yaml))
  - `replicas: 1 → 2` with `RollingUpdate` `maxUnavailable=0`, `maxSurge=1`
  - Memory: `request 64Mi → 128Mi`, `limit 256Mi → 512Mi`
  - `PodDisruptionBudget minAvailable: 1` so spot-preemption / drains never empty the receiver pool
- **Dispatcher** ([github_app/dispatcher.py](src/caretaker/github_app/dispatcher.py))
  - Bounded in-flight task cap (`CARETAKER_WEBHOOK_MAX_IN_FLIGHT`, default 64)
  - Over-cap deliveries drop to floor with `caretaker_errors_total{kind="webhook_dispatch_dropped"}` counter and `worker_queue_depth{queue="webhook_dispatch"}` gauge so operators get a signal before users do
- **Webhook handler** ([mcp_backend/main.py](src/caretaker/mcp_backend/main.py))
  - When `get_cooldown().is_blocked()` is True, skip the dispatch entirely; still 200-ack so GitHub doesn't redeliver
  - New `dispatched: bool` on `WebhookAck` surfaces this to clients (default True, backwards-compatible)
  - Admin dashboard mirror records a `deferred_cooldown` status for those deliveries
- **Pre-existing fix** ([auth/bearer.py](src/caretaker/auth/bearer.py))
  - Annotated `require_bearer_token`'s return type so the strict-mypy pre-commit hook passes cleanly. Unrelated to the OOM fix; included so the hook chain runs green.

### Why all four together (not just the memory bump)

Bumping the memory limit alone would mask a real failure mode — the in-process queue can grow arbitrarily during a long cooldown. The bounded cap + fast-ack make the bound architectural; the memory bump + replicas + PDB give us headroom while we get there.

## Test plan

- [x] `uv run python -m pytest -q --ignore=tests/test_e2e --ignore=tests/test_integration` → 2096 passed
- [x] New unit test: `test_dispatch_in_background_drops_when_in_flight_cap_reached`
- [x] New unit test: `test_webhook_skips_dispatch_during_github_cooldown`
- [x] `uv run ruff check` + `uv run ruff format --check` clean across touched files
- [x] `uv run mypy src/caretaker/github_app/dispatcher.py src/caretaker/mcp_backend/main.py src/caretaker/auth/bearer.py` clean
- [x] `kubectl apply --dry-run=server` validates both manifests against the live AKS cluster
- [ ] Apply manifests to `bigboy` AKS and watch a rolling restart → expect `caretaker_errors_total{kind="webhook_dispatch_dropped"}` to stay at 0 in normal traffic, only spiking during cooldowns
- [ ] Trigger a synthetic GitHub 429 (or wait for next rate-limit) and confirm webhook deliveries are 200-acked with `dispatched: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)