### PR TITLE
fix(doctor): drop legacy CARETAKER_FLEET_SECRET HMAC check

### DIFF
--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -177,17 +177,11 @@ def collect_env_references(config: MaintainerConfig) -> list[EnvReference]:
         )
     )
 
-    # Fleet registry HMAC secret (used by the outbound heartbeat emitter).
-    refs.append(
-        EnvReference(
-            env_name=config.fleet_registry.secret_env,
-            config_path="fleet_registry.secret_env",
-            owner_enabled=config.fleet_registry.enabled,
-            purpose="Fleet registry HMAC shared secret",
-        )
-    )
-
-    # Fleet registry optional OAuth2 client creds.
+    # Fleet registry OAuth2 client creds. The legacy HMAC ``secret_env``
+    # check was removed in v0.20.1 — v0.20.0 dropped HMAC heartbeat auth
+    # entirely (emitter no longer signs, receiver no longer verifies), so
+    # demanding ``CARETAKER_FLEET_SECRET`` here would FAIL bootstrap-check
+    # for every consumer that correctly migrated to OAuth2.
     fleet_oauth = config.fleet_registry.oauth2
     fleet_oauth_enabled = config.fleet_registry.enabled and fleet_oauth.enabled
     for env_name, sub in (

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -92,11 +92,19 @@ class TestCollectEnvReferences:
         names = {r.env_name for r in refs}
         assert "MONGODB_URL" in names
         assert "REDIS_URL" in names
-        assert "CARETAKER_FLEET_SECRET" in names
         assert "CARETAKER_GITHUB_APP_PRIVATE_KEY" in names
         assert "CARETAKER_ADMIN_OIDC_CLIENT_ID" in names
         assert "NEO4J_URL" in names
         assert "NEO4J_AUTH" in names
+        # CARETAKER_FLEET_SECRET (legacy HMAC) was removed in v0.20.1;
+        # OAuth2 is the only supported heartbeat auth mode.
+        assert "CARETAKER_FLEET_SECRET" not in names
+
+    def test_fleet_registry_oauth2_envs_referenced_when_enabled(self) -> None:
+        config = _load_config({"fleet_registry": {"enabled": True, "oauth2": {"enabled": True}}})
+        refs = collect_env_references(config)
+        names = {r.env_name for r in refs if r.owner_enabled}
+        assert {"OAUTH2_CLIENT_ID", "OAUTH2_CLIENT_SECRET", "OAUTH2_TOKEN_URL"} <= names
 
     def test_owner_enabled_tracks_block_state(self) -> None:
         config = _load_config({"mongo": {"enabled": True}})
@@ -764,8 +772,9 @@ class TestBootstrapCheckCLI:
         pin.write_text("0.12.0\n")
         monkeypatch.setenv("GITHUB_TOKEN", "x")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-x")
-        # Deliberately do NOT set CARETAKER_FLEET_SECRET / OAUTH2_* — the
-        # enabled block demands them, bootstrap-check should FAIL.
+        # Deliberately do NOT set OAUTH2_CLIENT_ID / OAUTH2_CLIENT_SECRET /
+        # OAUTH2_TOKEN_URL — the enabled OAuth2 block demands them, so
+        # bootstrap-check must FAIL.
         runner = CliRunner()
         result = runner.invoke(
             cli_main,
@@ -779,3 +788,41 @@ class TestBootstrapCheckCLI:
             ],
         )
         assert result.exit_code == 1
+
+    def test_bootstrap_check_oauth2_only_passes_without_hmac_secret(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reproduces the space-tycoon v0.20.x failure mode: fleet_registry
+        # is OAuth2-only and CARETAKER_FLEET_SECRET is intentionally unset
+        # (HMAC was removed in v0.20.0). Bootstrap-check must NOT FAIL on
+        # the absent legacy HMAC secret.
+        cfg = _write_config(
+            tmp_path / "config.yml",
+            {
+                "fleet_registry": {
+                    "enabled": True,
+                    "oauth2": {"enabled": True},
+                }
+            },
+        )
+        pin = tmp_path / ".version"
+        pin.write_text("0.20.1\n")
+        monkeypatch.setenv("GITHUB_TOKEN", "x")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-x")
+        monkeypatch.setenv("OAUTH2_CLIENT_ID", "id")
+        monkeypatch.setenv("OAUTH2_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("OAUTH2_TOKEN_URL", "https://oidc.example/token")
+        # CARETAKER_FLEET_SECRET deliberately unset.
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            [
+                "doctor",
+                "--config",
+                str(cfg),
+                "--bootstrap-check",
+                "--pin-path",
+                str(pin),
+            ],
+        )
+        assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

- v0.20.0 dropped HMAC heartbeat auth entirely (commit 23f485d) but the bootstrap doctor still treated `fleet_registry.secret_env` as required whenever `fleet_registry.enabled=true`. Every consumer that correctly migrated to OAuth2 hit a hard FAIL on `CARETAKER_FLEET_SECRET missing` and could not run the maintainer workflow.
- Removes the standalone HMAC env reference from `collect_env_references` in [doctor.py](src/caretaker/doctor.py). `FleetRegistryConfig.secret_env` stays in the schema as documented-deprecated, so older `config-default.yml` copies still parse — the field just no longer drives a doctor row. OAuth2 client-credential checks are unchanged.
- Also adds a missing return-type annotation on `require_bearer_token` in [auth/bearer.py](src/caretaker/auth/bearer.py) so the strict-mypy pre-commit hook passes — pre-existing regression introduced by v0.20.0 that this PR's hook run surfaced.

## Repro

Observed on space-tycoon's bootstrap-check: https://github.com/ianlintner/space-tycoon/actions/runs/24952533549/job/73065074681

```
bootstrap  CARETAKER_FLEET_SECRET  FAIL  Fleet registry HMAC shared secret missing (fleet_registry.secret_env is enabled)
```

Their config has `fleet_registry.oauth2.enabled: true` with `OAUTH2_CLIENT_ID` / `OAUTH2_CLIENT_SECRET` / `OAUTH2_TOKEN_URL` correctly wired in the maintainer workflow. There is no longer any code path that consumes `CARETAKER_FLEET_SECRET`.

## Test plan

- [x] New regression test `test_bootstrap_check_oauth2_only_passes_without_hmac_secret` reproduces space-tycoon's exact env shape and asserts `bootstrap-check` exits 0.
- [x] Existing `test_bootstrap_check_enabled_block_missing_secret_exits_1` updated — still asserts FAIL when the OAuth2 envs themselves are unset.
- [x] `test_includes_all_known_env_names_by_default` now asserts `CARETAKER_FLEET_SECRET` is **not** in the collected refs (negative regression guard).
- [x] New `test_fleet_registry_oauth2_envs_referenced_when_enabled` confirms the OAuth2 trio is still picked up as `owner_enabled=True`.
- [x] Full suite passes locally: `2096 passed, 1 skipped in 29.74s`.

## Release

Targets v0.20.1 (patch) — release-prepare workflow will bump `pyproject.toml` and tag automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)