### PR TITLE
feat(graph): wire hierarchical edges so the knowledge graph actually links

### DIFF
--- a/src/caretaker/auth/bearer.py
+++ b/src/caretaker/auth/bearer.py
@@ -53,7 +53,7 @@ import jwt
 from fastapi import HTTPException, Request, status
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Awaitable, Callable, Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -122,9 +122,7 @@ async def configure(
         response.raise_for_status()
         data = response.json()
         if not isinstance(data, dict):  # pragma: no cover - defensive
-            raise RuntimeError(
-                f"OIDC discovery at {discovery_url} returned non-object"
-            )
+            raise RuntimeError(f"OIDC discovery at {discovery_url} returned non-object")
         return data
 
     if http_client is None:
@@ -143,9 +141,7 @@ async def configure(
 
     jwks_uri = metadata.get("jwks_uri")
     if not isinstance(jwks_uri, str) or not jwks_uri:
-        raise RuntimeError(
-            f"OIDC discovery at {discovery_url} missing 'jwks_uri'"
-        )
+        raise RuntimeError(f"OIDC discovery at {discovery_url} missing 'jwks_uri'")
 
     jwk_client = jwt.PyJWKClient(jwks_uri, cache_keys=True, lifespan=600)
     required = frozenset(s for s in required_scopes if s)
@@ -273,12 +269,7 @@ def _verify_token(state: _BearerAuthState, token: str) -> BearerPrincipal:
             headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
         ) from exc
 
-    client_id = (
-        claims.get("client_id")
-        or claims.get("azp")
-        or claims.get("sub")
-        or ""
-    )
+    client_id = claims.get("client_id") or claims.get("azp") or claims.get("sub") or ""
     scopes = _scopes_from_claims(claims)
     return BearerPrincipal(client_id=str(client_id), scopes=scopes, raw_claims=claims)
 
@@ -291,14 +282,15 @@ def _enforce_scopes(principal: BearerPrincipal, scopes: Iterable[str]) -> None:
             detail=f"Token missing required scope(s): {', '.join(sorted(missing))}",
             headers={
                 "WWW-Authenticate": (
-                    'Bearer error="insufficient_scope", '
-                    f'scope="{" ".join(sorted(missing))}"'
+                    f'Bearer error="insufficient_scope", scope="{" ".join(sorted(missing))}"'
                 )
             },
         )
 
 
-def require_bearer_token(*scopes: str):
+def require_bearer_token(
+    *scopes: str,
+) -> Callable[[Request], Awaitable[BearerPrincipal]]:
     """FastAPI dependency factory: returns a Depends-able callable.
 
     The returned callable validates the request's bearer token and ensures the

--- a/src/caretaker/graph/builder.py
+++ b/src/caretaker/graph/builder.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from caretaker.admin.causal_store import CausalEventStore  # noqa: TC001 (runtime-used)
 from caretaker.agents._registry_data import AGENT_MODES, EVENT_AGENT_MAP
+from caretaker.causal_chain import CausalEvent, parse_run_id
 from caretaker.graph.models import NodeType, RelType
 from caretaker.graph.store import GraphStore  # noqa: TC001 (runtime-used)
 from caretaker.state.models import OrchestratorState  # noqa: TC001 (runtime-used)
@@ -118,10 +119,28 @@ class GraphBuilder:
             "runs": 0,
             "causal_events": 0,
             "executors": 0,
+            "comments": 0,
             "edges": 0,
         }
 
         await self._store.ensure_indexes()
+
+        async def _belongs_to(label: NodeType, node_id: str) -> None:
+            """Anchor a per-tenant node to its owning :Repo node.
+
+            Centralised so every section of full_sync uses identical
+            edge properties; the bitemporal stamp keeps temporal
+            queries ("which PRs belonged to repo X on date D") cheap.
+            """
+            await self._store.merge_edge(
+                label,
+                node_id,
+                NodeType.REPO,
+                repo_id,
+                RelType.BELONGS_TO,
+                _bitemporal(),
+            )
+            counts["edges"] += 1
 
         # 0. Tenant Repo node. Every other node merged below carries
         # ``repo=<slug>`` so the whole per-tenant subgraph is scopable.
@@ -170,6 +189,7 @@ class GraphBuilder:
                 },
             )
             counts["prs"] += 1
+            await _belongs_to(NodeType.PR, pr_id)
 
             # PR agent relationships based on state
             if pr.ownership_state != "unowned":
@@ -198,6 +218,7 @@ class GraphBuilder:
                     },
                 )
                 counts["executors"] += 1
+                await _belongs_to(NodeType.EXECUTOR, executor_id)
                 # Use ownership_acquired_at when known so ``valid_from``
                 # marks when this executor actually took the PR, not
                 # when the sync happened to notice.
@@ -238,6 +259,7 @@ class GraphBuilder:
                 },
             )
             counts["issues"] += 1
+            await _belongs_to(NodeType.ISSUE, issue_id)
 
             # Issue ↔ PR linkage. Two directional edges landed in M2 so
             # "which PR resolves this issue" and "which issues does this
@@ -283,11 +305,13 @@ class GraphBuilder:
             {"name": "overall", "aggregate": True, "repo": repo_slug},
         )
         counts["goals"] += 1
+        await _belongs_to(NodeType.GOAL, "goal:overall")
         for goal_id, snapshots in state.goal_history.items():
             latest = snapshots[-1] if snapshots else None
+            full_goal_id = f"goal:{goal_id}"
             await self._store.merge_node(
                 NodeType.GOAL,
-                f"goal:{goal_id}",
+                full_goal_id,
                 {
                     "name": goal_id,
                     "score": latest.score if latest else 0.0,
@@ -297,6 +321,7 @@ class GraphBuilder:
                 },
             )
             counts["goals"] += 1
+            await _belongs_to(NodeType.GOAL, full_goal_id)
 
         # 5. Agent → Goal contributions (based on goal definitions)
         agent_goal_map: dict[str, list[str]] = {
@@ -341,6 +366,7 @@ class GraphBuilder:
                 },
             )
             counts["runs"] += 1
+            await _belongs_to(NodeType.RUN, run_id)
 
             # Run → Agent EXECUTED edges (M2). The mapping is
             # mode-based: a "pr" run dispatches the PR agent, a "full"
@@ -382,9 +408,10 @@ class GraphBuilder:
         if insight_store is not None:
             for category in ("ci", "issue", "build", "security"):
                 for skill in insight_store.top_skills(category, limit=9999):
+                    skill_id = f"skill:{skill.id}"
                     await self._store.merge_node(
                         NodeType.SKILL,
-                        f"skill:{skill.id}",
+                        skill_id,
                         {
                             "name": skill.signature,
                             "category": skill.category,
@@ -396,6 +423,7 @@ class GraphBuilder:
                         },
                     )
                     counts["skills"] += 1
+                    await _belongs_to(NodeType.SKILL, skill_id)
 
                     # Map skill category to agent
                     category_agent = {
@@ -414,13 +442,55 @@ class GraphBuilder:
                     )
                     counts["edges"] += 1
 
-        # 8. Causal events + CAUSED_BY edges. M8 of the memory-graph
-        # plan adds ``span_id`` + ``parent_span_id`` properties when the
-        # CausalEvent was captured inside an OTel ``invoke_agent``
-        # span — makes "which span caused this escalation" a one-hop
-        # cypher query that can be joined against the trace backend.
+        # 8. Causal events + materialised relationships. The previous
+        # implementation merged each :CausalEvent as an island — only
+        # CAUSED_BY chains linked them to anything else, leaving
+        # thousands of orphan nodes in the graph (the symptom that
+        # opened this work item). This pass lifts every scalar
+        # reference into a real edge:
+        #
+        #   * ``ref_kind`` / ``ref_number`` → ``(:CausalEvent)-[:ON]->(:PR|:Issue|:Comment)``
+        #   * ``ref_kind == "comment"``     → materialise a ``:Comment`` node,
+        #                                     attach it to its parent
+        #                                     PR/Issue (also via ``ON``),
+        #                                     and emit
+        #                                     ``(:Comment)-[:EMITS]->(:CausalEvent)``
+        #                                     so the comment carries
+        #                                     the marker.
+        #   * ``run_id`` (parsed from the   → materialise a *live*
+        #     causal id)                      ``:Run`` keyed by the
+        #                                     GitHub workflow id and
+        #                                     attach
+        #                                     ``(:Run)-[:HAS_EVENT]->(:CausalEvent)``.
+        #
+        # The state-tracker-emitted ``:Run`` nodes (id =
+        # ``run:<isoformat>``) describe the orchestrator's view of a
+        # cycle but cannot be joined directly to causal events because
+        # ``RunSummary`` doesn't carry the workflow id. The two
+        # populations are intentionally kept separate; queries that
+        # need both can hop through ``BELONGS_TO`` on the shared
+        # :Repo node and filter by ``run_at`` window.
+        # M8 of the memory-graph plan adds ``span_id`` +
+        # ``parent_span_id`` properties when the CausalEvent was
+        # captured inside an OTel ``invoke_agent`` span — makes
+        # "which span caused this escalation" a one-hop cypher query
+        # that can be joined against the trace backend.
         if causal_store is not None:
-            for event in causal_store.index().values():
+            # Track which (number, comment_id) tuples we've already
+            # materialised so a comment that's referenced by multiple
+            # markers (rare today, common after the multi-marker fix)
+            # only gets one :Comment node.
+            comment_seen: set[str] = set()
+            # Track which live workflow run ids we've already merged so
+            # one Run node represents many CausalEvents from the same
+            # workflow run.
+            live_run_seen: set[str] = set()
+
+            causal_events: list[CausalEvent] = list(causal_store.index().values())
+
+            # Pass 1: merge :CausalEvent + :Comment + live :Run nodes
+            # so every endpoint exists before pass 2 wires edges.
+            for event in causal_events:
                 event_id = f"causal:{event.id}"
                 await self._store.merge_node(
                     NodeType.CAUSAL_EVENT,
@@ -439,25 +509,175 @@ class GraphBuilder:
                     },
                 )
                 counts["causal_events"] += 1
+                await _belongs_to(NodeType.CAUSAL_EVENT, event_id)
 
-            # Second pass so both endpoints exist before edges are merged.
-            for event in causal_store.index().values():
-                if not event.parent_id:
-                    continue
-                if causal_store.get(event.parent_id) is None:
-                    continue
-                await self._store.merge_edge(
-                    NodeType.CAUSAL_EVENT,
-                    f"causal:{event.id}",
-                    NodeType.CAUSAL_EVENT,
-                    f"causal:{event.parent_id}",
-                    RelType.CAUSED_BY,
-                )
-                counts["edges"] += 1
+                # Materialise a :Comment node when the marker came
+                # from a GitHub comment (vs an issue/PR body). The
+                # node id encodes both the parent thread number and
+                # the comment id so it's stable across refreshes.
+                if (
+                    event.ref.kind == "comment"
+                    and event.ref.number is not None
+                    and event.ref.comment_id is not None
+                ):
+                    comment_id = f"comment:{event.ref.number}:{event.ref.comment_id}"
+                    if comment_id not in comment_seen:
+                        comment_seen.add(comment_id)
+                        await self._store.merge_node(
+                            NodeType.COMMENT,
+                            comment_id,
+                            {
+                                "thread_number": event.ref.number,
+                                "comment_id": event.ref.comment_id,
+                                "observed_at": event.observed_at.isoformat()
+                                if event.observed_at
+                                else "",
+                                "repo": repo_slug,
+                            },
+                        )
+                        counts["comments"] += 1
+                        await _belongs_to(NodeType.COMMENT, comment_id)
+
+                # Materialise a live :Run keyed by the GitHub
+                # workflow id parsed off the causal id (e.g.
+                # ``run-24944914320-...`` → ``run:gh:24944914320``).
+                # Distinct from the state-tracker run id so we don't
+                # collide on the unique constraint, and so live runs
+                # remain visible after the rolling 20-run state
+                # window evicts the orchestrator-side row.
+                live_run_id = parse_run_id(event.id)
+                if live_run_id and live_run_id not in live_run_seen:
+                    live_run_seen.add(live_run_id)
+                    live_run_node_id = f"run:gh:{live_run_id}"
+                    await self._store.merge_node(
+                        NodeType.RUN,
+                        live_run_node_id,
+                        {
+                            "name": f"GitHub run {live_run_id}",
+                            "live_run_id": live_run_id,
+                            "source": "github_workflow",
+                            "repo": repo_slug,
+                        },
+                    )
+                    counts["runs"] += 1
+                    await _belongs_to(NodeType.RUN, live_run_node_id)
+
+            # Pass 2: edges. Both endpoints are guaranteed to exist
+            # because pass 1 covered every node we'll merge against
+            # (and tracked-PR/issue nodes are merged earlier in
+            # full_sync).
+            tracked_prs = set(state.tracked_prs.keys())
+            tracked_issues = set(state.tracked_issues.keys())
+            for event in causal_events:
+                event_id = f"causal:{event.id}"
+                event_valid_from = event.observed_at.isoformat() if event.observed_at else None
+
+                # ── CAUSED_BY (parent chain) ────────────────────────
+                if event.parent_id and causal_store.get(event.parent_id) is not None:
+                    await self._store.merge_edge(
+                        NodeType.CAUSAL_EVENT,
+                        event_id,
+                        NodeType.CAUSAL_EVENT,
+                        f"causal:{event.parent_id}",
+                        RelType.CAUSED_BY,
+                        _bitemporal(valid_from=event_valid_from),
+                    )
+                    counts["edges"] += 1
+
+                # ── ON (CausalEvent → PR/Issue/Comment) ─────────────
+                ref_kind = event.ref.kind
+                ref_number = event.ref.number
+                if ref_kind == "pr" and ref_number is not None and ref_number in tracked_prs:
+                    await self._store.merge_edge(
+                        NodeType.CAUSAL_EVENT,
+                        event_id,
+                        NodeType.PR,
+                        f"pr:{ref_number}",
+                        RelType.ON,
+                        _bitemporal(valid_from=event_valid_from),
+                    )
+                    counts["edges"] += 1
+                elif (
+                    ref_kind == "issue" and ref_number is not None and ref_number in tracked_issues
+                ):
+                    await self._store.merge_edge(
+                        NodeType.CAUSAL_EVENT,
+                        event_id,
+                        NodeType.ISSUE,
+                        f"issue:{ref_number}",
+                        RelType.ON,
+                        _bitemporal(valid_from=event_valid_from),
+                    )
+                    counts["edges"] += 1
+                elif (
+                    ref_kind == "comment"
+                    and ref_number is not None
+                    and event.ref.comment_id is not None
+                ):
+                    comment_id = f"comment:{ref_number}:{event.ref.comment_id}"
+                    # CausalEvent → Comment (the marker lives on the comment).
+                    await self._store.merge_edge(
+                        NodeType.CAUSAL_EVENT,
+                        event_id,
+                        NodeType.COMMENT,
+                        comment_id,
+                        RelType.ON,
+                        _bitemporal(valid_from=event_valid_from),
+                    )
+                    counts["edges"] += 1
+                    # Comment → CausalEvent (1:1 today; 1:N once
+                    # multi-marker bodies are supported).
+                    await self._store.merge_edge(
+                        NodeType.COMMENT,
+                        comment_id,
+                        NodeType.CAUSAL_EVENT,
+                        event_id,
+                        RelType.EMITS,
+                        _bitemporal(valid_from=event_valid_from),
+                    )
+                    counts["edges"] += 1
+                    # Comment → parent thread (PR or Issue, whichever
+                    # is tracked). Without this link, cypher queries
+                    # rooted at a PR/Issue can't reach comments
+                    # directly.
+                    if ref_number in tracked_prs:
+                        await self._store.merge_edge(
+                            NodeType.COMMENT,
+                            comment_id,
+                            NodeType.PR,
+                            f"pr:{ref_number}",
+                            RelType.ON,
+                            _bitemporal(valid_from=event_valid_from),
+                        )
+                        counts["edges"] += 1
+                    elif ref_number in tracked_issues:
+                        await self._store.merge_edge(
+                            NodeType.COMMENT,
+                            comment_id,
+                            NodeType.ISSUE,
+                            f"issue:{ref_number}",
+                            RelType.ON,
+                            _bitemporal(valid_from=event_valid_from),
+                        )
+                        counts["edges"] += 1
+
+                # ── HAS_EVENT (live :Run → :CausalEvent) ────────────
+                live_run_id = parse_run_id(event.id)
+                if live_run_id:
+                    live_run_node_id = f"run:gh:{live_run_id}"
+                    await self._store.merge_edge(
+                        NodeType.RUN,
+                        live_run_node_id,
+                        NodeType.CAUSAL_EVENT,
+                        event_id,
+                        RelType.HAS_EVENT,
+                        _bitemporal(valid_from=event_valid_from),
+                    )
+                    counts["edges"] += 1
 
         logger.info(
             "Graph sync complete: %d agents, %d PRs, %d issues, %d goals, "
-            "%d skills, %d runs, %d causal events, %d executors, %d edges",
+            "%d skills, %d runs, %d causal events, %d comments, %d executors, %d edges",
             counts["agents"],
             counts["prs"],
             counts["issues"],
@@ -465,6 +685,7 @@ class GraphBuilder:
             counts["skills"],
             counts["runs"],
             counts["causal_events"],
+            counts["comments"],
             counts["executors"],
             counts["edges"],
         )

--- a/src/caretaker/graph/models.py
+++ b/src/caretaker/graph/models.py
@@ -115,6 +115,23 @@ class RelType(StrEnum):
     # mirrors the CoALA "working memory" scope. One edge per agent-run,
     # replaced in-place so the "current core memory" stays at the head.
     CORE_MEMORY_OF = "CORE_MEMORY_OF"
+    # ── Hierarchical scoping + causal materialisation ───────────────────
+    # ``BELONGS_TO`` anchors every per-tenant node (PR/Issue/Run/Skill/
+    # Comment/Executor/CheckRun/CausalEvent) to its owning ``:Repo`` so a
+    # subgraph rooted at the repo is one ``MATCH (r:Repo {id:$id})<-[:BELONGS_TO]-(n)``
+    # away. ``ON`` lifts ``CausalEvent.ref`` (kind+number scalars) into a
+    # real edge — ``(:CausalEvent)-[:ON]->(:PR|:Issue|:Comment)`` — and is
+    # also reused for ``(:Comment)-[:ON]->(:PR|:Issue)`` so a comment is
+    # always attached to its parent thread. ``EMITS`` connects a Comment
+    # to the CausalEvent it carries (1:1 today; 1:N once
+    # :class:`CausalEventStore` learns to ingest multiple markers from a
+    # single body). ``HAS_EVENT`` joins a ``:Run`` to every
+    # ``:CausalEvent`` whose parsed ``run_id`` matches the run's GitHub
+    # workflow id, finally bridging the two halves of the run-of-record.
+    BELONGS_TO = "BELONGS_TO"
+    ON = "ON"
+    EMITS = "EMITS"
+    HAS_EVENT = "HAS_EVENT"
 
 
 class GraphNode(BaseModel):

--- a/src/caretaker/k8s_worker/launcher.py
+++ b/src/caretaker/k8s_worker/launcher.py
@@ -241,7 +241,7 @@ class K8sAgentLauncher:
         if self._batch_api is not None:
             return self._batch_api
         try:
-            from kubernetes import client  # type: ignore[import-not-found]
+            from kubernetes import client  # type: ignore[import-untyped]
             from kubernetes import config as kube_config
         except ImportError as exc:
             raise K8sLauncherError(

--- a/src/caretaker/llm/provider.py
+++ b/src/caretaker/llm/provider.py
@@ -273,7 +273,7 @@ class LiteLLMProvider:
         self._import_error: Exception | None = None
 
         try:
-            from litellm import acompletion  # type: ignore[import-not-found]
+            from litellm import acompletion
 
             self._acompletion = acompletion
         except ImportError as exc:

--- a/src/caretaker/memory/embeddings.py
+++ b/src/caretaker/memory/embeddings.py
@@ -88,7 +88,7 @@ class LiteLLMEmbedder:
         self._timeout = timeout
         self._aembedding: Any = None
         try:
-            from litellm import aembedding  # type: ignore[import-not-found]
+            from litellm import aembedding
 
             self._aembedding = aembedding
         except ImportError as exc:  # pragma: no cover - optional dep path

--- a/src/caretaker/observability/otel.py
+++ b/src/caretaker/observability/otel.py
@@ -51,6 +51,16 @@ logger = logging.getLogger(__name__)
 # back to :class:`_NullSpan` so call sites can use ``with agent_span(...)``
 # unconditionally.
 
+# OTel symbols are typed as ``Any`` so the module imports cleanly even
+# when the optional ``otel`` extra isn't installed and so call sites that
+# stamp ad-hoc attributes (e.g. our hex ``trace_id``) onto the live span
+# don't fight strict mypy.
+_otel_trace: Any
+_OTLPSpanExporter: Any
+_OTelResource: Any
+_TracerProvider: Any
+_BatchSpanProcessor: Any
+
 try:  # pragma: no cover - exercised by the fallback path in tests
     from opentelemetry import trace as _otel_trace
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (

--- a/tests/test_graph_builder_hierarchy.py
+++ b/tests/test_graph_builder_hierarchy.py
@@ -1,0 +1,499 @@
+"""Tests for the hierarchical graph wiring (Repo → Issue/PR → Run/Comment/CausalEvent).
+
+Covers the relationship work that closed out the "knowledge graph nodes are
+disconnected" bug:
+
+* Every per-tenant node is anchored to its owning ``:Repo`` via ``BELONGS_TO``.
+* ``CausalEvent.ref`` is lifted into ``ON`` edges
+  (CausalEvent → PR / Issue / Comment).
+* Marker-bearing comments materialise as ``:Comment`` nodes attached to
+  their parent thread (PR/Issue) and to the ``:CausalEvent`` they emit.
+* Live workflow runs (parsed from ``run-<id>-<source>`` causal ids) get
+  their own ``:Run`` nodes joined to every causal event they emitted via
+  ``HAS_EVENT``.
+
+Uses the same ``RecordingStore`` fake pattern as the M2/M3 suites — no
+Neo4j dependency in the test path.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from caretaker.admin.causal_store import CausalEventStore
+from caretaker.causal_chain import CausalEvent, CausalEventRef
+from caretaker.goals.models import GoalSnapshot
+from caretaker.graph.builder import GraphBuilder
+from caretaker.graph.models import NodeType, RelType
+from caretaker.state.models import (
+    IssueTrackingState,
+    OrchestratorState,
+    OwnershipState,
+    PRTrackingState,
+    RunSummary,
+    TrackedIssue,
+    TrackedPR,
+)
+
+
+class RecordingStore:
+    """Fake :class:`GraphStore` — captures every merge for assertions."""
+
+    def __init__(self) -> None:
+        self.nodes: list[tuple[str, str, dict[str, Any]]] = []
+        self.edges: list[tuple[str, str, str, str, str, dict[str, Any]]] = []
+        self.indexes_ensured = False
+
+    async def ensure_indexes(self) -> None:
+        self.indexes_ensured = True
+
+    async def merge_node(self, label: str, node_id: str, props: dict[str, Any]) -> None:
+        self.nodes.append((label, node_id, props))
+
+    async def merge_edge(
+        self,
+        source_label: str,
+        source_id: str,
+        target_label: str,
+        target_id: str,
+        rel_type: str,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        self.edges.append(
+            (
+                source_label,
+                source_id,
+                target_label,
+                target_id,
+                rel_type,
+                properties or {},
+            )
+        )
+
+
+_EdgeTuple = tuple[str, str, str, str, str, dict[str, Any]]
+
+
+def _edges_of(store: RecordingStore, rel: str) -> list[_EdgeTuple]:
+    return [e for e in store.edges if e[4] == rel]
+
+
+def _nodes_of(store: RecordingStore, label: str) -> list[tuple[str, str, dict[str, Any]]]:
+    return [n for n in store.nodes if n[0] == label]
+
+
+def _has_edge(
+    store: RecordingStore,
+    *,
+    source_label: str,
+    source_id: str,
+    target_label: str,
+    target_id: str,
+    rel: str,
+) -> bool:
+    return any(
+        e[0] == source_label
+        and e[1] == source_id
+        and e[2] == target_label
+        and e[3] == target_id
+        and e[4] == rel
+        for e in store.edges
+    )
+
+
+def _sample_state() -> OrchestratorState:
+    """A state with one tracked PR, one tracked issue, and one run."""
+    state = OrchestratorState()
+    state.tracked_prs[42] = TrackedPR(
+        number=42,
+        state=PRTrackingState.CI_PASSING,
+        ownership_state=OwnershipState.OWNED,
+        owned_by="copilot",
+        ownership_acquired_at=datetime(2026, 4, 20, 11, 30, tzinfo=UTC),
+    )
+    state.tracked_issues[7] = TrackedIssue(
+        number=7,
+        state=IssueTrackingState.PR_OPENED,
+        assigned_pr=42,
+    )
+    state.goal_history["ci_health"] = [
+        GoalSnapshot(goal_id="ci_health", score=0.9, status="satisfied"),
+    ]
+    state.run_history.append(
+        RunSummary(
+            run_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+            mode="pr",
+            prs_merged=1,
+            goal_health=0.87,
+            escalation_rate=0.1,
+        )
+    )
+    return state
+
+
+def _causal_store_with_events() -> CausalEventStore:
+    """Build a causal store with three events spanning all three ref kinds.
+
+    * ``run-9001-pr-agent:escalation`` → ON the PR.
+    * ``run-9001-issue-agent:dispatch`` → ON a comment that lives on the
+      issue (and Comment → ON → Issue, EMITS → CausalEvent).
+    * ``run-9002-charlie:close-stale-issue`` → ON the issue (different
+      live run id so we exercise the per-run materialisation).
+    """
+    store = CausalEventStore()
+    now = datetime(2026, 4, 20, 12, 5, tzinfo=UTC)
+
+    pr_event = CausalEvent(
+        id="run-9001-pr-agent:escalation",
+        source="pr-agent:escalation",
+        parent_id=None,
+        ref=CausalEventRef(kind="pr", number=42, owner="acme", repo="widgets"),
+        run_id="9001",
+        title="PR #42 needs escalation",
+        observed_at=now,
+    )
+    comment_event = CausalEvent(
+        id="run-9001-issue-agent:dispatch",
+        source="issue-agent:dispatch",
+        parent_id="run-9001-pr-agent:escalation",
+        ref=CausalEventRef(
+            kind="comment",
+            number=7,
+            comment_id=555,
+            owner="acme",
+            repo="widgets",
+        ),
+        run_id="9001",
+        title="Dispatched issue agent",
+        observed_at=now,
+    )
+    second_run_event = CausalEvent(
+        id="run-9002-charlie:close-stale-issue",
+        source="charlie:close-stale-issue",
+        parent_id=None,
+        ref=CausalEventRef(kind="issue", number=7, owner="acme", repo="widgets"),
+        run_id="9002",
+        title="Charlie closed stale issue",
+        observed_at=now,
+    )
+    store.ingest(pr_event)
+    store.ingest(comment_event)
+    store.ingest(second_run_event)
+    return store
+
+
+# ── BELONGS_TO scoping ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_belongs_to_anchors_pr_issue_run_to_repo() -> None:
+    """PR / Issue / Run nodes each get a ``BELONGS_TO`` edge to their :Repo."""
+    store = RecordingStore()
+    await GraphBuilder(store).full_sync(_sample_state(), repo="acme/widgets")
+
+    repo_id = "repo:acme/widgets"
+    belongs_to = _edges_of(store, RelType.BELONGS_TO.value)
+    pairs = {(e[0], e[1]) for e in belongs_to}
+
+    assert (NodeType.PR, "pr:42") in pairs
+    assert (NodeType.ISSUE, "issue:7") in pairs
+    # Run id is keyed off the run_at isoformat in section 6.
+    assert (NodeType.RUN, "run:2026-04-20T12:00:00+00:00") in pairs
+    # Goals (synthetic + real) are anchored too.
+    assert (NodeType.GOAL, "goal:overall") in pairs
+    assert (NodeType.GOAL, "goal:ci_health") in pairs
+
+    # Every BELONGS_TO must terminate at the tenant repo node.
+    for _src_label, _src_id, tgt_label, tgt_id, _rel, _props in belongs_to:
+        assert tgt_label == NodeType.REPO
+        assert tgt_id == repo_id
+
+
+@pytest.mark.asyncio
+async def test_belongs_to_anchors_executor_to_repo() -> None:
+    """Executor nodes (copilot/foundry/claude_code) are tenant-scoped too."""
+    store = RecordingStore()
+    await GraphBuilder(store).full_sync(_sample_state(), repo="acme/widgets")
+
+    assert _has_edge(
+        store,
+        source_label=NodeType.EXECUTOR,
+        source_id="executor:copilot",
+        target_label=NodeType.REPO,
+        target_id="repo:acme/widgets",
+        rel=RelType.BELONGS_TO.value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_belongs_to_carries_bitemporal_props() -> None:
+    """Every BELONGS_TO edge carries observed_at + valid_from (M2 bitemporal)."""
+    store = RecordingStore()
+    await GraphBuilder(store).full_sync(_sample_state(), repo="acme/widgets")
+
+    for _src_label, _src_id, _tgt_label, _tgt_id, _rel, props in _edges_of(
+        store, RelType.BELONGS_TO.value
+    ):
+        assert "observed_at" in props
+        assert "valid_from" in props
+
+
+# ── CausalEvent → ON → PR / Issue ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_causal_event_on_pr_edge_when_ref_is_pr() -> None:
+    """``ref.kind == 'pr'`` materialises CausalEvent-ON-PR for tracked PRs."""
+    record = RecordingStore()
+    await GraphBuilder(record).full_sync(
+        _sample_state(),
+        causal_store=_causal_store_with_events(),
+        repo="acme/widgets",
+    )
+
+    assert _has_edge(
+        record,
+        source_label=NodeType.CAUSAL_EVENT,
+        source_id="causal:run-9001-pr-agent:escalation",
+        target_label=NodeType.PR,
+        target_id="pr:42",
+        rel=RelType.ON.value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_causal_event_on_issue_edge_when_ref_is_issue() -> None:
+    """``ref.kind == 'issue'`` materialises CausalEvent-ON-Issue for tracked issues."""
+    record = RecordingStore()
+    await GraphBuilder(record).full_sync(
+        _sample_state(),
+        causal_store=_causal_store_with_events(),
+        repo="acme/widgets",
+    )
+
+    assert _has_edge(
+        record,
+        source_label=NodeType.CAUSAL_EVENT,
+        source_id="causal:run-9002-charlie:close-stale-issue",
+        target_label=NodeType.ISSUE,
+        target_id="issue:7",
+        rel=RelType.ON.value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_causal_event_on_pr_skipped_when_pr_not_tracked() -> None:
+    """ON edges only land for refs that match a tracked PR/Issue.
+
+    Without this guard the builder would invent dangling edges to PR
+    nodes that were never merged (the unique-id constraint would still
+    succeed because ``MATCH ... MATCH`` no-ops on missing endpoints,
+    but the resulting graph would lie about which PRs caretaker tracks).
+    """
+    causal = CausalEventStore()
+    causal.ingest(
+        CausalEvent(
+            id="run-9999-pr-agent:escalation",
+            source="pr-agent:escalation",
+            parent_id=None,
+            ref=CausalEventRef(kind="pr", number=8675309, owner="acme", repo="widgets"),
+            run_id="9999",
+            title="phantom PR",
+            observed_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        )
+    )
+
+    record = RecordingStore()
+    await GraphBuilder(record).full_sync(_sample_state(), causal_store=causal, repo="acme/widgets")
+
+    on_edges = [
+        e
+        for e in _edges_of(record, RelType.ON.value)
+        if e[2] == NodeType.PR and e[3] == "pr:8675309"
+    ]
+    assert on_edges == []
+
+
+# ── Comment node materialisation + EMITS / ON wiring ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_comment_node_is_materialised_for_comment_ref() -> None:
+    """A causal event with ``ref.kind == 'comment'`` mints a :Comment node."""
+    record = RecordingStore()
+    await GraphBuilder(record).full_sync(
+        _sample_state(),
+        causal_store=_causal_store_with_events(),
+        repo="acme/widgets",
+    )
+
+    comments = _nodes_of(record, NodeType.COMMENT.value)
+    ids = {n[1] for n in comments}
+    assert "comment:7:555" in ids
+
+    # The Comment node carries the parent thread number, the comment id,
+    # and the tenant scope.
+    _, _, props = next(n for n in comments if n[1] == "comment:7:555")
+    assert props["thread_number"] == 7
+    assert props["comment_id"] == 555
+    assert props["repo"] == "acme/widgets"
+
+
+@pytest.mark.asyncio
+async def test_comment_emits_causal_event_and_on_issue() -> None:
+    """Comment-EMITS-CausalEvent and Comment-ON-Issue both land."""
+    record = RecordingStore()
+    await GraphBuilder(record).full_sync(
+        _sample_state(),
+        causal_store=_causal_store_with_events(),
+        repo="acme/widgets",
+    )
+
+    # The marker lives on the comment; the comment "emits" the causal event.
+    assert _has_edge(
+        record,
+        source_label=NodeType.COMMENT,
+        source_id="comment:7:555",
+        target_label=NodeType.CAUSAL_EVENT,
+        target_id="causal:run-9001-issue-agent:dispatch",
+        rel=RelType.EMITS.value,
+    )
+    # The causal event references the comment via ON.
+    assert _has_edge(
+        record,
+        source_label=NodeType.CAUSAL_EVENT,
+        source_id="causal:run-9001-issue-agent:dispatch",
+        target_label=NodeType.COMMENT,
+        target_id="comment:7:555",
+        rel=RelType.ON.value,
+    )
+    # And the comment is attached to its parent issue thread.
+    assert _has_edge(
+        record,
+        source_label=NodeType.COMMENT,
+        source_id="comment:7:555",
+        target_label=NodeType.ISSUE,
+        target_id="issue:7",
+        rel=RelType.ON.value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_comment_on_pr_when_thread_is_a_tracked_pr() -> None:
+    """Comments observed on a PR thread attach to the PR, not the issue."""
+    causal = CausalEventStore()
+    causal.ingest(
+        CausalEvent(
+            id="run-9001-pr-agent-task",
+            source="pr-agent-task",
+            parent_id=None,
+            ref=CausalEventRef(
+                kind="comment",
+                number=42,
+                comment_id=999,
+                owner="acme",
+                repo="widgets",
+            ),
+            run_id="9001",
+            title="task comment",
+            observed_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        )
+    )
+
+    record = RecordingStore()
+    await GraphBuilder(record).full_sync(_sample_state(), causal_store=causal, repo="acme/widgets")
+
+    assert _has_edge(
+        record,
+        source_label=NodeType.COMMENT,
+        source_id="comment:42:999",
+        target_label=NodeType.PR,
+        target_id="pr:42",
+        rel=RelType.ON.value,
+    )
+    # And the comment is anchored to the tenant.
+    assert _has_edge(
+        record,
+        source_label=NodeType.COMMENT,
+        source_id="comment:42:999",
+        target_label=NodeType.REPO,
+        target_id="repo:acme/widgets",
+        rel=RelType.BELONGS_TO.value,
+    )
+
+
+# ── Live :Run node + HAS_EVENT wiring ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_live_run_node_minted_per_workflow_id() -> None:
+    """Each unique parsed ``run_id`` yields one ``run:gh:<id>`` :Run node."""
+    record = RecordingStore()
+    await GraphBuilder(record).full_sync(
+        _sample_state(),
+        causal_store=_causal_store_with_events(),
+        repo="acme/widgets",
+    )
+
+    live_runs = {n[1] for n in _nodes_of(record, NodeType.RUN.value) if n[1].startswith("run:gh:")}
+    assert live_runs == {"run:gh:9001", "run:gh:9002"}
+
+
+@pytest.mark.asyncio
+async def test_run_has_event_links_workflow_run_to_causal_events() -> None:
+    """Every causal event with a parsed run_id is joined to its live :Run."""
+    record = RecordingStore()
+    await GraphBuilder(record).full_sync(
+        _sample_state(),
+        causal_store=_causal_store_with_events(),
+        repo="acme/widgets",
+    )
+
+    has_event = _edges_of(record, RelType.HAS_EVENT.value)
+    pairs = {(e[1], e[3]) for e in has_event}
+
+    # Run 9001 emitted two events (the PR escalation and the dispatch comment).
+    assert ("run:gh:9001", "causal:run-9001-pr-agent:escalation") in pairs
+    assert ("run:gh:9001", "causal:run-9001-issue-agent:dispatch") in pairs
+    # Run 9002 emitted the charlie close.
+    assert ("run:gh:9002", "causal:run-9002-charlie:close-stale-issue") in pairs
+
+
+@pytest.mark.asyncio
+async def test_caused_by_chain_still_emitted() -> None:
+    """The original CAUSED_BY chain is preserved — refactor must not regress it."""
+    record = RecordingStore()
+    await GraphBuilder(record).full_sync(
+        _sample_state(),
+        causal_store=_causal_store_with_events(),
+        repo="acme/widgets",
+    )
+
+    assert _has_edge(
+        record,
+        source_label=NodeType.CAUSAL_EVENT,
+        source_id="causal:run-9001-issue-agent:dispatch",
+        target_label=NodeType.CAUSAL_EVENT,
+        target_id="causal:run-9001-pr-agent:escalation",
+        rel=RelType.CAUSED_BY.value,
+    )
+
+
+# ── Counts ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_full_sync_returns_comments_count() -> None:
+    """The returned counts dict exposes the new ``comments`` tally."""
+    record = RecordingStore()
+    counts = await GraphBuilder(record).full_sync(
+        _sample_state(),
+        causal_store=_causal_store_with_events(),
+        repo="acme/widgets",
+    )
+
+    assert counts["comments"] == 1  # only the issue-agent dispatch comment
+    assert counts["causal_events"] == 3


### PR DESCRIPTION
## Summary
The Knowledge Graph was reporting **27692 nodes / 28541 edges** — a near-1:1 ratio, with a Causal Chain UI where every event showed *0 descendants*. Tracing the population pipeline showed why: every node carried a `repo` scalar but no edge to a Repo, CausalEvents only linked to other CausalEvents (so every event whose parent was pruned ended up orphaned), and Comments / live workflow Runs were never materialised at all.

This PR wires the hierarchy `Repo → Issues → PRs → Runs → Comments → CausalEvents` end-to-end.

## What changed
* New `RelType` members: `BELONGS_TO`, `ON`, `EMITS`, `HAS_EVENT`.
* `GraphBuilder.full_sync` now emits `BELONGS_TO` from every PR / Issue / Run / Goal / Skill / Executor / CausalEvent / Comment back to the `:Repo` root, giving the Explorer view a real subgraph rooted at each repo.
* `CausalEvent.ref` is lifted from a scalar tuple to real edges: `(:CausalEvent)-[:ON]->(:PR | :Issue | :Comment)` when the referenced node is tracked. Phantom-target guard keeps us from inventing nodes that aren't in `state.tracked_prs / tracked_issues`.
* Comments are now first-class: when a CausalEvent points at a comment we mint `:Comment{thread_number,comment_id,observed_at}`, link `Comment-EMITS->CausalEvent`, and add `Comment-ON->PR/Issue` when the thread is tracked.
* Live workflow runs are materialised from `CausalEvent.run_id` (parsed from the canonical `run-<gh_id>-<source>` marker) and connected via `Run-HAS_EVENT->CausalEvent`, finally bridging the gap between the orchestrator's `run:<isoformat>` snapshot nodes and GitHub's actual workflow runs.

## Tests
* New `tests/test_graph_builder_hierarchy.py` (13 cases) covers BELONGS_TO scoping, CausalEvent→ON→PR/Issue, phantom-PR guard, Comment minting, Comment-EMITS+ON, live :Run minting + HAS_EVENT, plus a CAUSED_BY regression.
* 25 `graph_builder*` tests pass; 66 graph-touching tests pass overall; 149 targeted tests pass with the drive-by fixes below.

## Drive-by: unblock pre-commit
The pre-commit hook added in `85a2f56` was failing on 16 strict-mypy errors that pre-existed on `main`. Cleared all of them so the hook is honest going forward:
* `observability/otel.py` — optional-import symbols typed as `Any`; `_NullSpan` already stamps `trace_id`, so no runtime change.
* `auth/bearer.py` — added return annotation on `require_bearer_token`.
* `llm/provider.py`, `memory/embeddings.py` — dropped stale `# type: ignore[import-not-found]` (litellm is now resolvable).
* `k8s_worker/launcher.py` — switched ignore tag to `import-untyped` (kubernetes ships without stubs).