### PR TITLE
feat(causal): persistent CausalEventStore + parent threading across agents

### DIFF
--- a/src/caretaker/admin/causal_store.py
+++ b/src/caretaker/admin/causal_store.py
@@ -1,49 +1,276 @@
-"""In-memory store of causal events lifted from GitHub bodies/comments.
+"""Persistent store of causal events lifted from GitHub bodies/comments.
 
-Populated by :func:`refresh_from_github` — walks open issues + tracked PRs
-+ the orchestrator tracking issue's comment stream, pulls every
-``<!-- caretaker:causal ... -->`` marker, and indexes by id so the admin
-dashboard can walk chains on demand.
+Causal events were originally held in an in-memory dict that was *cleared*
+on every refresh tick (every 60s). That made the Causal Chain dashboard
+unable to walk lineage across runs: closed issues drop out of
+``OrchestratorState.tracked_*`` after a few cycles, their bodies stop
+being scanned, and any event whose parent lived on one of those bodies
+became orphaned. Pod restarts wiped everything entirely.
+
+This module now backs the store with Neo4j (the same graph the rest of
+the dashboard already reads from). The in-memory ``OrderedDict`` is kept
+only as a fast LRU read-through cache — it is *populated* from Neo4j on
+first use and *warmed* by writes, never wiped on refresh. Writes go
+through the shared :class:`~caretaker.graph.writer.GraphWriter` so they
+survive process death and subsequent ticks.
+
+Memory bounds
+-------------
+The cache is bounded by ``CARETAKER_CAUSAL_CACHE_MAX_EVENTS`` (default
+``5000``). Insertions evict the oldest LRU entry when the bound is
+exceeded; warming from Neo4j respects the same cap by ordering rows
+``observed_at DESC`` and only loading the newest slice. Lineage walks
+that miss the cache fall through to a Neo4j-backed traversal
+(:meth:`awalk`, :meth:`adescendants`) so closed-issue events arbitrarily
+deep in history remain reachable without pinning them in memory.
+
+When no :class:`~caretaker.graph.store.GraphStore` is wired (unit tests,
+local dev without Neo4j) the store still works as a pure in-memory dict
+to preserve the contract older callers depend on.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
-from typing import TYPE_CHECKING
+import os
+from collections import OrderedDict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 
 from caretaker.causal_chain import (
     CausalEvent,
     CausalEventRef,
     Chain,
     descendants,
-    extract_from_body,
+    extract_all_from_body,
+    parse_run_id,
     walk_chain,
 )
+from caretaker.graph.models import NodeType, RelType
+from caretaker.graph.writer import get_writer
 from caretaker.state.tracker import TRACKING_ISSUE_TITLE, TRACKING_LABEL
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from caretaker.github_client.api import GitHubClient
+    from caretaker.graph.store import GraphStore
     from caretaker.state.models import OrchestratorState
 
 logger = logging.getLogger(__name__)
 
 
-class CausalEventStore:
-    """Indexed collection of :class:`CausalEvent` observed across the repo."""
+DEFAULT_CACHE_MAX_EVENTS = 5000
+CACHE_MAX_EVENTS_ENV = "CARETAKER_CAUSAL_CACHE_MAX_EVENTS"
 
-    def __init__(self) -> None:
-        self._index: dict[str, CausalEvent] = {}
+
+def _resolve_default_cache_cap() -> int:
+    """Read the env-configured cap, clamped to a sensible floor of 100."""
+    raw = os.environ.get(CACHE_MAX_EVENTS_ENV)
+    if not raw:
+        return DEFAULT_CACHE_MAX_EVENTS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an int; falling back to %d",
+            CACHE_MAX_EVENTS_ENV,
+            raw,
+            DEFAULT_CACHE_MAX_EVENTS,
+        )
+        return DEFAULT_CACHE_MAX_EVENTS
+    return max(100, value)
+
+
+def _causal_node_id(event_id: str) -> str:
+    """Graph-side id used by the builder for ``:CausalEvent`` nodes."""
+    return f"causal:{event_id}"
+
+
+def _strip_node_prefix(node_id: str) -> str:
+    """Inverse of :func:`_causal_node_id`."""
+    if node_id.startswith("causal:"):
+        return node_id[len("causal:") :]
+    return node_id
+
+
+def _parse_observed_at(raw: Any) -> datetime | None:
+    if raw in (None, "", b""):
+        return None
+    if isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, str):
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+    return None
+
+
+def _row_to_event(row: dict[str, Any]) -> CausalEvent | None:
+    """Reconstruct a :class:`CausalEvent` from a graph property dict."""
+    raw_id = row.get("id") or row.get("name")
+    if not raw_id:
+        return None
+    event_id = _strip_node_prefix(str(raw_id))
+    ref_kind = (row.get("ref_kind") or row.get("kind") or "issue") or "issue"
+    ref_number = row.get("ref_number")
+    if ref_number is not None:
+        try:
+            ref_number_int: int | None = int(ref_number)
+        except (TypeError, ValueError):
+            ref_number_int = None
+    else:
+        ref_number_int = None
+    comment_id = row.get("ref_comment_id")
+    if comment_id is not None:
+        try:
+            comment_id_int: int | None = int(comment_id)
+        except (TypeError, ValueError):
+            comment_id_int = None
+    else:
+        comment_id_int = None
+    owner = row.get("ref_owner") or row.get("owner") or ""
+    repo_slug = row.get("repo") or ""
+    repo_name = ""
+    if isinstance(repo_slug, str) and "/" in repo_slug:
+        owner = owner or repo_slug.split("/", 1)[0]
+        repo_name = repo_slug.split("/", 1)[1]
+    parent = row.get("parent_id") or None
+    if parent == "":
+        parent = None
+    ref = CausalEventRef(
+        kind=str(ref_kind),
+        number=ref_number_int,
+        comment_id=comment_id_int,
+        owner=str(owner or ""),
+        repo=str(repo_name or ""),
+    )
+    return CausalEvent(
+        id=event_id,
+        source=str(row.get("source") or ""),
+        parent_id=str(parent) if parent else None,
+        ref=ref,
+        run_id=str(row.get("run_id")) if row.get("run_id") else parse_run_id(event_id),
+        title=str(row.get("title") or ""),
+        observed_at=_parse_observed_at(row.get("observed_at")),
+        span_id=row.get("span_id") or None,
+        parent_span_id=row.get("parent_span_id") or None,
+    )
+
+
+def _event_node_props(event: CausalEvent, repo_slug: str) -> dict[str, Any]:
+    """Property bag the writer / builder stores on a :CausalEvent node."""
+    props: dict[str, Any] = {
+        "name": event.id,
+        "source": event.source,
+        "run_id": event.run_id,
+        "title": event.title,
+        "ref_kind": event.ref.kind,
+        "ref_number": event.ref.number,
+        "ref_comment_id": event.ref.comment_id,
+        "ref_owner": event.ref.owner,
+        "repo": repo_slug,
+    }
+    if event.parent_id:
+        props["parent_id"] = event.parent_id
+    if event.observed_at:
+        props["observed_at"] = event.observed_at.isoformat()
+    if event.span_id:
+        props["span_id"] = event.span_id
+    if event.parent_span_id:
+        props["parent_span_id"] = event.parent_span_id
+    # Strip None values — GraphWriter is tolerant but the builder treats
+    # missing keys differently from explicit None on subsequent merges.
+    return {k: v for k, v in props.items() if v is not None}
+
+
+class CausalEventStore:
+    """Indexed collection of :class:`CausalEvent` observed across the repo.
+
+    Backed by Neo4j when a :class:`GraphStore` is wired via
+    :meth:`attach_graph_store`; otherwise behaves as a pure in-memory
+    LRU dict (used by unit tests and local development).
+    """
+
+    def __init__(
+        self,
+        graph_store: GraphStore | None = None,
+        *,
+        cache_max_events: int | None = None,
+    ) -> None:
+        # OrderedDict order tracks LRU. Most-recently used is at the
+        # tail; the head is the eviction candidate.
+        self._index: OrderedDict[str, CausalEvent] = OrderedDict()
+        self._graph_store: GraphStore | None = graph_store
+        self._cache_warmed = False
+        self._cache_cap = (
+            cache_max_events if cache_max_events is not None else _resolve_default_cache_cap()
+        )
+        # Diagnostic counters surfaced via :meth:`stats`.
+        self._neo4j_reads = 0
+        self._neo4j_writes = 0
+        self._evictions = 0
+
+    # ── Wiring ────────────────────────────────────────────────────────────
+
+    def attach_graph_store(self, store: GraphStore | None) -> None:
+        """Wire the persistent backend (idempotent).
+
+        Called from :mod:`caretaker.admin.state_loader` once the shared
+        :class:`GraphStore` has been constructed. After this point all
+        queries and writes go through Neo4j; the in-memory dict remains
+        as a fast cache.
+        """
+        if store is self._graph_store:
+            return
+        self._graph_store = store
+        self._cache_warmed = False  # force warm on next read
+
+    @property
+    def is_persistent(self) -> bool:
+        return self._graph_store is not None
+
+    @property
+    def cache_cap(self) -> int:
+        return self._cache_cap
 
     # ── Ingestion ─────────────────────────────────────────────────────────
 
     def clear(self) -> None:
-        self._index = {}
+        """Drop the in-memory cache.
+
+        Does **not** clear Neo4j — that's intentional: the persistent
+        store survives across refresh ticks and pod restarts. Tests that
+        need a clean slate should construct a fresh
+        :class:`CausalEventStore` (or use the in-memory mode without a
+        :class:`GraphStore`).
+        """
+        self._index.clear()
+        self._cache_warmed = False
 
     def ingest(self, event: CausalEvent) -> None:
-        """Upsert ``event`` into the index. Later writes win on duplicate id."""
+        """Upsert ``event`` into the index.
+
+        Writes go to:
+
+        * The in-memory LRU cache (immediately readable by the same
+          process; oldest entry evicted when over the cap).
+        * The shared :class:`GraphWriter` queue (durable, asynchronously
+          flushed to Neo4j by the writer's drain task).
+
+        Later writes win on duplicate id. The graph-side merge is keyed
+        by ``causal:<event.id>`` to match what
+        :class:`~caretaker.graph.builder.GraphBuilder` produces.
+        """
+        if event.id in self._index:
+            self._index.move_to_end(event.id)
         self._index[event.id] = event
+        self._enforce_cache_cap()
+        self._enqueue_event(event)
 
     def ingest_body(
         self,
@@ -53,10 +280,85 @@ class CausalEventStore:
         title: str = "",
         observed_at: datetime | None = None,
     ) -> CausalEvent | None:
-        event = extract_from_body(body or "", ref=ref, title=title, observed_at=observed_at)
-        if event is not None:
+        """Parse + ingest **every** causal marker in ``body``.
+
+        Returns the first event for backwards compatibility with callers
+        that only care whether a marker was present. Multi-marker bodies
+        (digest comments, orchestrator state comments) used to silently
+        drop the trailing markers because the underlying extractor only
+        returned the first match — that bug is fixed here.
+        """
+        events = extract_all_from_body(
+            body or "",
+            ref=ref,
+            title=title,
+            observed_at=observed_at,
+        )
+        if not events:
+            return None
+        for event in events:
             self.ingest(event)
-        return event
+        return events[0]
+
+    def _enforce_cache_cap(self) -> None:
+        """Evict oldest entries until ``len(self._index) <= self._cache_cap``."""
+        cap = self._cache_cap
+        if cap <= 0:
+            return
+        while len(self._index) > cap:
+            self._index.popitem(last=False)
+            self._evictions += 1
+
+    def _enqueue_event(self, event: CausalEvent) -> None:
+        """Queue a Neo4j write through the shared :class:`GraphWriter`.
+
+        Best-effort — when the writer is not configured (offline tests,
+        local dev) the call is a no-op and only the in-memory cache is
+        updated. Writes are asynchronous; downstream readers may need to
+        consult Neo4j directly through :meth:`get` / :meth:`walk` to see
+        them after the writer has flushed.
+        """
+        if self._graph_store is None:
+            return
+        writer = get_writer()
+        repo_slug = self._derive_repo_slug(event)
+        node_id = _causal_node_id(event.id)
+        try:
+            writer.record_node(
+                NodeType.CAUSAL_EVENT,
+                node_id,
+                _event_node_props(event, repo_slug),
+            )
+            if repo_slug:
+                writer.record_node(NodeType.REPO, f"repo:{repo_slug}", {"name": repo_slug})
+                writer.record_edge(
+                    NodeType.CAUSAL_EVENT,
+                    node_id,
+                    NodeType.REPO,
+                    f"repo:{repo_slug}",
+                    RelType.BELONGS_TO,
+                    {"observed_at": _now_iso()},
+                )
+            if event.parent_id:
+                writer.record_edge(
+                    NodeType.CAUSAL_EVENT,
+                    node_id,
+                    NodeType.CAUSAL_EVENT,
+                    _causal_node_id(event.parent_id),
+                    RelType.CAUSED_BY,
+                    {"observed_at": _now_iso()},
+                )
+            self._neo4j_writes += 1
+        except Exception:  # pragma: no cover - writer is best-effort
+            logger.debug("CausalEventStore: graph enqueue failed for %s", event.id, exc_info=True)
+
+    @staticmethod
+    def _derive_repo_slug(event: CausalEvent) -> str:
+        owner = event.ref.owner or ""
+        repo = event.ref.repo or ""
+        if owner and repo:
+            return f"{owner}/{repo}"
+        return ""
 
     async def refresh_from_github(
         self,
@@ -65,9 +367,18 @@ class CausalEventStore:
         repo: str,
         state: OrchestratorState,
     ) -> int:
-        """Scan tracked PRs/issues + tracking issue comments; return event count."""
-        self.clear()
+        """Scan tracked PRs/issues + tracking issue comments; return event count.
 
+        Crucially this method **does not** clear the index any more.
+        Events are upserted incrementally so causal history survives
+        across refresh ticks and pod restarts. Closing an issue or
+        deleting a comment no longer destroys the lineage record — the
+        graph remains the source of truth.
+
+        Returns the post-refresh size of the in-memory cache (Neo4j may
+        hold strictly more events than the cache, since closed issues
+        drop out of the scan window).
+        """
         # Tracked issues — fetch body + comments.
         for number in list(state.tracked_issues.keys()):
             try:
@@ -129,6 +440,19 @@ class CausalEventStore:
             for tracker_issue in issues:
                 if tracker_issue.title != TRACKING_ISSUE_TITLE:
                     continue
+                # Pick up markers stamped on the body itself too — the
+                # orchestrator ships a top-level state marker there.
+                self.ingest_body(
+                    tracker_issue.body or "",
+                    ref=CausalEventRef(
+                        kind="issue",
+                        number=tracker_issue.number,
+                        owner=owner,
+                        repo=repo,
+                    ),
+                    title=tracker_issue.title or "",
+                    observed_at=getattr(tracker_issue, "created_at", None),
+                )
                 comments = await github.get_pr_comments(owner, repo, tracker_issue.number)
                 for c in comments:
                     self.ingest_body(
@@ -145,17 +469,128 @@ class CausalEventStore:
         except Exception:
             logger.debug("Causal refresh: tracking issue scan skipped", exc_info=True)
 
+        # If we have a persistent backend, rehydrate the cache from Neo4j
+        # so closed-issue events (no longer in the scan window) come back
+        # into the in-memory snapshot the chain walker uses.
+        if self._graph_store is not None:
+            try:
+                await self._warm_cache_from_graph(force=True)
+            except Exception:
+                logger.debug("Causal refresh: cache warm from graph failed", exc_info=True)
+
         return len(self._index)
+
+    async def _warm_cache_from_graph(self, *, force: bool = False) -> None:
+        """Load the most-recent ``cache_cap`` :CausalEvent rows from Neo4j.
+
+        Order is ``observed_at DESC`` so the cache holds the freshest
+        slice — older history stays on disk and is reachable via
+        :meth:`aget` / :meth:`awalk` / :meth:`adescendants` when
+        traversal asks for it.
+        """
+        if self._graph_store is None:
+            return
+        if self._cache_warmed and not force:
+            return
+        try:
+            rows = await self._graph_store.list_nodes_with_properties(
+                "CausalEvent",
+                order_by="coalesce(n.observed_at, '') DESC",
+                limit=self._cache_cap,
+            )
+        except TypeError:
+            # Backwards-compat for fakes that don't implement order_by/limit.
+            rows = await self._graph_store.list_nodes_with_properties("CausalEvent")
+        self._neo4j_reads += 1
+        # Load oldest-first so the most recent ends up at the LRU tail.
+        loaded: list[CausalEvent] = []
+        for row in rows:
+            event = _row_to_event(row)
+            if event is not None:
+                loaded.append(event)
+        # Rows from Neo4j are newest-first; reverse so newest end up most-recent.
+        for event in reversed(loaded):
+            # setdefault so an in-process write (potentially richer than
+            # the persisted copy on a previous tick) wins.
+            if event.id not in self._index:
+                self._index[event.id] = event
+        self._enforce_cache_cap()
+        self._cache_warmed = True
 
     # ── Queries ───────────────────────────────────────────────────────────
 
     def size(self) -> int:
         return len(self._index)
 
+    def stats(self) -> dict[str, Any]:
+        """Diagnostic counters used by the admin dashboard."""
+        return {
+            "cache_size": len(self._index),
+            "cache_cap": self._cache_cap,
+            "persistent": self._graph_store is not None,
+            "cache_warmed": self._cache_warmed,
+            "neo4j_reads": self._neo4j_reads,
+            "neo4j_writes": self._neo4j_writes,
+            "evictions": self._evictions,
+        }
+
     def get(self, event_id: str) -> CausalEvent | None:
-        return self._index.get(event_id)
+        """Return the cached event; warm from Neo4j if necessary.
+
+        This is intentionally synchronous to keep the public API stable
+        for callers that only have access to a sync context (admin REST
+        endpoints query through the dict via
+        :meth:`AdminDataAccess.get_causal_chain`). When a sync warm is
+        needed and the cache is cold we *attempt* a synchronous fetch
+        via the running event loop — if there is none we fall through
+        to the cached miss.
+        """
+        cached = self._index.get(event_id)
+        if cached is not None:
+            self._index.move_to_end(event_id)
+            return cached
+        self._maybe_sync_warm()
+        cached = self._index.get(event_id)
+        if cached is not None:
+            self._index.move_to_end(event_id)
+        return cached
+
+    async def aget(self, event_id: str) -> CausalEvent | None:
+        """Async variant of :meth:`get` that always tries the persistent backend."""
+        cached = self._index.get(event_id)
+        if cached is not None:
+            self._index.move_to_end(event_id)
+            return cached
+        if self._graph_store is None:
+            return None
+        try:
+            rows = await self._graph_store.list_nodes_with_properties(
+                "CausalEvent",
+                where="n.id = $id",
+                params={"id": _causal_node_id(event_id)},
+            )
+            self._neo4j_reads += 1
+        except Exception:
+            logger.debug("CausalEventStore: aget failed for %s", event_id, exc_info=True)
+            return None
+        if not rows:
+            return None
+        event = _row_to_event(rows[0])
+        if event is not None:
+            self._index[event.id] = event
+            self._enforce_cache_cap()
+        return event
 
     def index(self) -> dict[str, CausalEvent]:
+        """Return the in-memory index (warming from Neo4j if cold).
+
+        :class:`~caretaker.graph.builder.GraphBuilder` consumes this
+        directly to merge ``:CausalEvent`` nodes during full-sync; warm
+        the cache up front so it sees the freshest slice. Note that this
+        view is bounded by ``cache_cap`` — older lineage lives only in
+        Neo4j and is reached via :meth:`awalk`/:meth:`adescendants`.
+        """
+        self._maybe_sync_warm()
         return self._index
 
     def list_events(
@@ -165,6 +600,7 @@ class CausalEventStore:
         offset: int = 0,
         limit: int = 50,
     ) -> tuple[list[CausalEvent], int]:
+        self._maybe_sync_warm()
         events = list(self._index.values())
         if source:
             events = [e for e in events if e.source == source]
@@ -177,10 +613,105 @@ class CausalEventStore:
         return events[offset : offset + limit], total
 
     def walk(self, event_id: str, *, max_depth: int = 50) -> Chain:
+        self._maybe_sync_warm()
         return walk_chain(self._index, event_id, max_depth=max_depth)
 
     def descendants(self, event_id: str, *, max_depth: int = 50) -> list[CausalEvent]:
+        self._maybe_sync_warm()
         return descendants(self._index, event_id, max_depth=max_depth)
 
+    # ── Async (Neo4j-traversal) variants ──────────────────────────────────
 
-__all__ = ["CausalEventStore"]
+    async def awalk(self, event_id: str, *, max_depth: int = 50) -> Chain:
+        """Walk ancestors using Neo4j when the cache is incomplete.
+
+        Falls back to the cached :meth:`walk` when no graph store is
+        wired. When persistent, traverses ``CAUSED_BY`` edges through
+        Cypher and rebuilds events row-by-row so deeply-historical
+        chains (whose ancestors are no longer in the LRU cache) still
+        return a complete walk.
+        """
+        if self._graph_store is None:
+            return self.walk(event_id, max_depth=max_depth)
+        depth = max(1, int(max_depth))
+        try:
+            rows = await self._graph_store.list_nodes_with_properties(
+                "CausalEvent",
+                where=(f"n.id = $id OR (n)-[:CAUSED_BY*1..{depth}]-(:CausalEvent {{id: $id}})"),
+                params={"id": _causal_node_id(event_id)},
+            )
+            self._neo4j_reads += 1
+        except Exception:
+            logger.debug("CausalEventStore: awalk fallback failed for %s", event_id, exc_info=True)
+            return self.walk(event_id, max_depth=max_depth)
+        snapshot: dict[str, CausalEvent] = {}
+        for row in rows:
+            event = _row_to_event(row)
+            if event is not None:
+                snapshot[event.id] = event
+        # Merge in any cached extras so we don't lose richness.
+        for cached_id, cached_event in self._index.items():
+            snapshot.setdefault(cached_id, cached_event)
+        return walk_chain(snapshot, event_id, max_depth=max_depth)
+
+    async def adescendants(self, event_id: str, *, max_depth: int = 50) -> list[CausalEvent]:
+        """Descendant traversal that consults Neo4j when cache misses."""
+        if self._graph_store is None:
+            return self.descendants(event_id, max_depth=max_depth)
+        depth = max(1, int(max_depth))
+        try:
+            rows = await self._graph_store.list_nodes_with_properties(
+                "CausalEvent",
+                where=(f"n.id = $id OR (:CausalEvent {{id: $id}})-[:CAUSED_BY*1..{depth}]-(n)"),
+                params={"id": _causal_node_id(event_id)},
+            )
+            self._neo4j_reads += 1
+        except Exception:
+            logger.debug(
+                "CausalEventStore: adescendants fallback failed for %s", event_id, exc_info=True
+            )
+            return self.descendants(event_id, max_depth=max_depth)
+        snapshot: dict[str, CausalEvent] = {}
+        for row in rows:
+            event = _row_to_event(row)
+            if event is not None:
+                snapshot[event.id] = event
+        for cached_id, cached_event in self._index.items():
+            snapshot.setdefault(cached_id, cached_event)
+        return descendants(snapshot, event_id, max_depth=max_depth)
+
+    # ── Internal: synchronous warm ────────────────────────────────────────
+
+    def _maybe_sync_warm(self) -> None:
+        """Best-effort cache warm from Neo4j inside a sync entry point.
+
+        The admin REST endpoints are synchronous (they call ``walk`` /
+        ``index`` directly) but the underlying driver is async. We try
+        to drive the warm coroutine on whatever event loop is available;
+        if none is, the call is a no-op and we serve the (possibly
+        stale) cache as before. The 60-second refresh task warms the
+        cache aggressively so this fallback is rarely the only path.
+        """
+        if self._graph_store is None or self._cache_warmed:
+            return
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            return
+        if loop.is_running():
+            # Inside a running loop — schedule the warm as a task; the
+            # caller will see the cache populated on a subsequent call.
+            with contextlib.suppress(RuntimeError):  # pragma: no cover - defensive
+                loop.create_task(self._warm_cache_from_graph())
+            return
+        try:
+            loop.run_until_complete(self._warm_cache_from_graph())
+        except Exception:  # pragma: no cover - best-effort
+            logger.debug("CausalEventStore: sync warm failed", exc_info=True)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+__all__ = ["CausalEventStore", "DEFAULT_CACHE_MAX_EVENTS", "CACHE_MAX_EVENTS_ENV"]

--- a/src/caretaker/admin/state_loader.py
+++ b/src/caretaker/admin/state_loader.py
@@ -124,6 +124,13 @@ def build_refresh_task(data: AdminDataAccess) -> asyncio.Task[None] | None:
                 if not writer_started:
                     await writer.start()
                     writer_started = True
+                # Wire the persistent backend into the causal store so
+                # subsequent refreshes durably write events to Neo4j and
+                # warm the LRU cache from there. Idempotent.
+                try:
+                    data.causal_store.attach_graph_store(persistent_store)
+                except Exception:
+                    logger.debug("Causal store attach_graph_store failed", exc_info=True)
 
             counts = await GraphBuilder(persistent_store).full_sync(
                 state,

--- a/src/caretaker/causal.py
+++ b/src/caretaker/causal.py
@@ -91,8 +91,52 @@ def extract_causal(body: str) -> dict[str, str] | None:
     return out
 
 
+def extract_all_causal(body: str) -> list[dict[str, str]]:
+    """Return every causal marker found in ``body``.
+
+    A single comment / issue body can carry more than one marker — for
+    example the orchestrator tracking issue stamps both
+    ``state-tracker:orchestrator-state`` and ``state-tracker:run-history``
+    each tick, and digest comments aggregate prior markers as evidence.
+    Earlier code only returned the first match (``extract_causal``) which
+    silently dropped the rest. This helper preserves all markers so
+    chain reconstruction does not lose links.
+    """
+    out: list[dict[str, str]] = []
+    for m in _CAUSAL_MARKER_RE.finditer(body or ""):
+        item: dict[str, str] = {"id": m.group("id"), "source": m.group("source") or ""}
+        parent = m.group("parent")
+        if parent:
+            item["parent"] = parent
+        out.append(item)
+    return out
+
+
+def parent_from_body(body: str | None) -> str | None:
+    """Return the most useful causal id to thread as ``parent=``.
+
+    A GitHub issue/PR body can carry multiple causal markers (each
+    bot-authored comment adds its own; the orchestrator stamps state +
+    run-history on the tracking-issue body). When an agent reacts to an
+    object it should chain to the *most recent* marker so the new event
+    extends the chain instead of starting a fresh root.
+
+    The marker regex preserves source order on a single body, so the
+    last match is the most recently appended event. Returns ``None``
+    when no marker is present (or the body is empty / ``None``).
+    """
+    if not body:
+        return None
+    markers = extract_all_causal(body)
+    if not markers:
+        return None
+    return markers[-1].get("id") or None
+
+
 __all__ = [
+    "extract_all_causal",
     "extract_causal",
     "make_causal_id",
     "make_causal_marker",
+    "parent_from_body",
 ]

--- a/src/caretaker/causal_chain.py
+++ b/src/caretaker/causal_chain.py
@@ -17,7 +17,7 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from caretaker.causal import extract_causal
+from caretaker.causal import extract_all_causal, extract_causal
 from caretaker.observability import current_span_ids
 
 if TYPE_CHECKING:
@@ -77,6 +77,13 @@ def extract_from_body(
     """Extract the first causal marker from ``body`` → :class:`CausalEvent`.
 
     Returns ``None`` when the body has no marker.
+
+    .. deprecated::
+        Prefer :func:`extract_all_from_body` so multi-marker bodies (digest
+        comments, the orchestrator tracking issue, agent escalation comments
+        that quote upstream causal ids) do not silently drop the trailing
+        markers. Kept for backwards-compatibility with single-marker call
+        sites.
     """
     fields = extract_causal(body or "")
     if fields is None:
@@ -94,6 +101,43 @@ def extract_from_body(
         span_id=span_id,
         parent_span_id=parent_span_id,
     )
+
+
+def extract_all_from_body(
+    body: str,
+    *,
+    ref: CausalEventRef,
+    title: str = "",
+    observed_at: datetime | None = None,
+) -> list[CausalEvent]:
+    """Extract every causal marker in ``body`` as :class:`CausalEvent`.
+
+    Returns an empty list when no marker is present. The OTel span context
+    is captured once for the whole body — every event in the same body
+    shares the same span/parent_span pair, which matches the semantics of
+    "this comment was emitted under one workflow span".
+    """
+    fields_list = extract_all_causal(body or "")
+    if not fields_list:
+        return []
+    span_id, parent_span_id = current_span_ids()
+    out: list[CausalEvent] = []
+    for fields in fields_list:
+        cid = fields["id"]
+        out.append(
+            CausalEvent(
+                id=cid,
+                source=fields.get("source", ""),
+                parent_id=fields.get("parent"),
+                ref=ref,
+                run_id=parse_run_id(cid),
+                title=title,
+                observed_at=observed_at,
+                span_id=span_id,
+                parent_span_id=parent_span_id,
+            )
+        )
+    return out
 
 
 @dataclass
@@ -180,6 +224,7 @@ __all__ = [
     "CausalEventRef",
     "Chain",
     "descendants",
+    "extract_all_from_body",
     "extract_from_body",
     "parse_run_id",
     "walk_chain",

--- a/src/caretaker/charlie_agent/agent.py
+++ b/src/caretaker/charlie_agent/agent.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from caretaker.causal import make_causal_marker
+from caretaker.causal import make_causal_marker, parent_from_body
 
 if TYPE_CHECKING:
     from caretaker.github_client.api import GitHubClient
@@ -168,7 +168,10 @@ class CharlieAgent:
             for issue in grouped_issues:
                 if issue.number == canonical.number:
                     continue
-                causal = make_causal_marker("charlie:close-duplicate-issue")
+                causal = make_causal_marker(
+                    "charlie:close-duplicate-issue",
+                    parent=parent_from_body(getattr(issue, "body", "") or ""),
+                )
                 await self._comment_and_close_issue(
                     issue.number,
                     (
@@ -206,7 +209,10 @@ class CharlieAgent:
             for pr in grouped_prs:
                 if pr.number == canonical.number:
                     continue
-                causal = make_causal_marker("charlie:close-duplicate-pr")
+                causal = make_causal_marker(
+                    "charlie:close-duplicate-pr",
+                    parent=parent_from_body(getattr(pr, "body", "") or ""),
+                )
                 await self._comment_and_close_pr(
                     pr.number,
                     (
@@ -241,7 +247,10 @@ class CharlieAgent:
             if age_days < self._stale_days:
                 continue
 
-            causal = make_causal_marker("charlie:close-stale-issue")
+            causal = make_causal_marker(
+                "charlie:close-stale-issue",
+                parent=parent_from_body(getattr(issue, "body", "") or ""),
+            )
             await self._comment_and_close_issue(
                 issue.number,
                 (
@@ -274,7 +283,10 @@ class CharlieAgent:
             if age_days < self._stale_days:
                 continue
 
-            causal = make_causal_marker("charlie:close-stale-pr")
+            causal = make_causal_marker(
+                "charlie:close-stale-pr",
+                parent=parent_from_body(getattr(pr, "body", "") or ""),
+            )
             await self._comment_and_close_pr(
                 pr.number,
                 (

--- a/src/caretaker/devops_agent/agent.py
+++ b/src/caretaker/devops_agent/agent.py
@@ -286,10 +286,15 @@ def _failure_signature(summary: FailureSummary) -> str:
 
 
 def _build_issue_body(
-    summary: FailureSummary, sig: str, branch: str, *, run_id: int | None = None
+    summary: FailureSummary,
+    sig: str,
+    branch: str,
+    *,
+    run_id: int | None = None,
+    parent_id: str | None = None,
 ) -> str:
     run_id_fragment = f" run_id:{run_id}" if run_id else ""
-    causal = make_causal_marker("devops", run_id=run_id)
+    causal = make_causal_marker("devops", run_id=run_id, parent=parent_id)
     return f"""{DEVOPS_AGENT_MARKER} sig:{sig}{run_id_fragment} -->
 {causal}
 

--- a/src/caretaker/escalation_agent/agent.py
+++ b/src/caretaker/escalation_agent/agent.py
@@ -82,7 +82,10 @@ class EscalationAgent:
             await self._close_resolved_digest()
             return report
 
-        body = self._build_digest_body(buckets)
+        # Thread weekly digests so each new digest's CausalEvent links back
+        # to the previous one (forming a long-running escalation chain).
+        prior_parent = await self._latest_digest_causal_id()
+        body = self._build_digest_body(buckets, parent_id=prior_parent)
 
         try:
             issue_number = await self._upsert_digest(body)
@@ -135,7 +138,26 @@ class EscalationAgent:
         except Exception as e:
             logger.warning("Escalation agent: could not close digest: %s", e)
 
-    def _build_digest_body(self, buckets: dict[str, list[Any]]) -> str:
+    async def _latest_digest_causal_id(self) -> str | None:
+        """Return the most recent digest CausalEvent id (for parent threading)."""
+        from caretaker.causal import parent_from_body
+
+        try:
+            existing = await self._issues.list(state="open", labels=ESCALATION_DIGEST_LABEL)
+        except Exception:
+            return None
+        for issue in existing:
+            body = getattr(issue, "body", "") or ""
+            if ESCALATION_AGENT_MARKER in body:
+                return parent_from_body(body)
+        return None
+
+    def _build_digest_body(
+        self,
+        buckets: dict[str, list[Any]],
+        *,
+        parent_id: str | None = None,
+    ) -> str:
         week = datetime.now(UTC).strftime("%Y-W%V")
         date = datetime.now(UTC).strftime("%Y-%m-%d")
         lines = [
@@ -173,7 +195,7 @@ class EscalationAgent:
         lines.append(render_debug_dump(debug_payload, title="Digest debug dump"))
 
         lines.append(f"\n---\n{ESCALATION_AGENT_MARKER} week:{week} -->")
-        lines.append(make_causal_marker("escalation-agent:digest"))
+        lines.append(make_causal_marker("escalation-agent:digest", parent=parent_id))
         return "\n".join(lines)
 
 

--- a/src/caretaker/graph/store.py
+++ b/src/caretaker/graph/store.py
@@ -116,18 +116,24 @@ class GraphStore:
         *,
         where: str | None = None,
         params: dict[str, Any] | None = None,
+        order_by: str | None = None,
+        limit: int | None = None,
     ) -> list[dict[str, Any]]:
         """Return raw property dicts for every ``label`` node matching ``where``.
 
         ``where`` is an optional cypher fragment that may reference the node
         alias ``n`` (e.g. ``"n.repo = $repo"``). ``params`` are passed
-        through to the driver. The returned list preserves insertion order
-        from Neo4j and each entry is the plain ``dict(n)`` representation
-        — callers that need degree or relationships should go through
-        ``get_neighbors`` instead.
+        through to the driver. ``order_by`` is an optional cypher fragment
+        (e.g. ``"n.observed_at DESC"``) and ``limit`` caps the row count
+        — both used by the LRU warm path on
+        :class:`~caretaker.admin.causal_store.CausalEventStore`. The
+        returned list preserves the cypher result order and each entry
+        is the plain ``dict(n)`` representation.
         """
         clause = f"WHERE {where} " if where else ""
-        query = f"MATCH (n:{label}) {clause}RETURN n"
+        order_clause = f"ORDER BY {order_by} " if order_by else ""
+        limit_clause = f"LIMIT {int(limit)}" if limit is not None else ""
+        query = f"MATCH (n:{label}) {clause}RETURN n {order_clause}{limit_clause}".strip()
         rows: list[dict[str, Any]] = []
         async with self._driver.session(database=self._database) as session:
             result = await session.run(query, **(params or {}))

--- a/src/caretaker/llm/copilot.py
+++ b/src/caretaker/llm/copilot.py
@@ -56,6 +56,7 @@ class CopilotTask:
     max_attempts: int
     priority: str = "medium"
     context: str = ""
+    parent_causal_id: str | None = None
     _skill_hints: str = field(default="", init=False, repr=False)
 
     def enrich_with_skills(self, skills: list[Skill]) -> None:
@@ -74,7 +75,7 @@ class CopilotTask:
         lines = [
             "@copilot",
             "",
-            make_causal_marker("pr-agent-task"),
+            make_causal_marker("pr-agent-task", parent=self.parent_causal_id),
             TASK_OPEN,
             f"TASK: Fix {self.task_type.value.replace('_', ' ').lower()}",
             f"TYPE: {self.task_type.value}",
@@ -165,6 +166,18 @@ class CopilotProtocol:
         self._repo = repo
 
     async def post_task(self, pr_number: int, task: CopilotTask) -> Comment:
+        # Best-effort: thread this task to the most recent causal marker on
+        # the PR body (typically the issue-agent dispatch event that opened
+        # the PR), so the resulting comment-CausalEvent has a parent.
+        if task.parent_causal_id is None:
+            try:
+                from caretaker.causal import parent_from_body
+
+                pr = await self._github.get_pull_request(self._owner, self._repo, pr_number)
+                pr_body = getattr(pr, "body", "") or ""
+                task.parent_causal_id = parent_from_body(pr_body)
+            except Exception:
+                pass
         body = task.to_comment()
         logger.info(
             "Posting task to PR #%d: %s (attempt %d/%d)",

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from caretaker.causal import make_causal_marker
+from caretaker.causal import make_causal_marker, parent_from_body
 from caretaker.evolution.shadow import shadow_decision
 from caretaker.github_client.api import GitHubAPIError
 from caretaker.github_client.models import PRState
@@ -1186,7 +1186,10 @@ class PRAgent:
             payload["debug"] = debug_data
 
         marker = "<!-- caretaker:escalation -->"
-        causal = make_causal_marker("pr-agent:escalation")
+        causal = make_causal_marker(
+            "pr-agent:escalation",
+            parent=parent_from_body(getattr(pr, "body", "") or ""),
+        )
         body = (
             f"{marker}\n"
             f"{causal}\n\n"

--- a/src/caretaker/self_heal_agent/agent.py
+++ b/src/caretaker/self_heal_agent/agent.py
@@ -914,6 +914,7 @@ def _build_fix_issue_body(
     *,
     run_id: int | None = None,
     ladder_escalation: str | None = None,
+    parent_id: str | None = None,
 ) -> str:
     kind_label = {
         FailureKind.CONFIG_ERROR: "⚙️ Config error",
@@ -922,7 +923,7 @@ def _build_fix_issue_body(
     }.get(kind, "🩺 Error")
 
     run_id_fragment = f" run_id:{run_id}" if run_id else ""
-    causal = make_causal_marker("self-heal", run_id=run_id)
+    causal = make_causal_marker("self-heal", run_id=run_id, parent=parent_id)
     # Wave A3: when the fix ladder escalated (or produced a partial
     # fix that still needs follow-up), surface its verdict in the
     # issue body so the Copilot assignee sees what the deterministic

--- a/src/caretaker/state/tracker.py
+++ b/src/caretaker/state/tracker.py
@@ -6,7 +6,7 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING
 
-from caretaker.causal import make_causal_marker
+from caretaker.causal import extract_all_causal, make_causal_id, make_causal_marker
 from caretaker.github_client.api import RateLimitError
 from caretaker.graph.models import NodeType, RelType
 from caretaker.graph.writer import get_writer
@@ -79,6 +79,15 @@ class StateTracker:
         self._emitted_pr_outcomes: dict[int, set[str]] = {}
         self._emitted_issue_outcomes: dict[int, set[str]] = {}
         self._emitted_intervention_reasons: dict[tuple[str, int], set[str]] = {}
+        # Causal-chain threading. The state-tracker emits two markers per
+        # save (orchestrator-state + run-history). Without parent
+        # threading every save produces two root events and the Causal
+        # Chain UI shows ancestors=0/descendants=0. We thread the chain
+        # both *across* ticks (this tick's orchestrator-state parents the
+        # previous tick's id) and *within* a tick (this tick's
+        # run-history parents this tick's orchestrator-state).
+        self._last_state_causal_id: str | None = None
+        self._last_history_causal_id: str | None = None
 
     @property
     def state(self) -> OrchestratorState:
@@ -94,6 +103,22 @@ class StateTracker:
 
         self._tracking_issue_number = issue_number
         comments = await self._github.get_pr_comments(self._owner, self._repo, issue_number)
+
+        # Scrape the previous-tick causal ids out of the rolling state +
+        # run-history comments so the next save can chain ``parent=`` to
+        # them. This makes the Causal Chain dashboard surface a
+        # continuous thread of orchestrator activity instead of one
+        # root-only event per tick.
+        for comment in comments:
+            for marker in extract_all_causal(comment.body or ""):
+                src = marker.get("source", "")
+                cid = marker.get("id")
+                if not cid:
+                    continue
+                if src == "state-tracker:orchestrator-state":
+                    self._last_state_causal_id = cid
+                elif src == "state-tracker:run-history":
+                    self._last_history_causal_id = cid
 
         # Find the latest state comment (search from newest)
         for comment in reversed(comments):
@@ -472,11 +497,21 @@ class StateTracker:
             return None
         return body[start:end].strip()
 
-    @staticmethod
-    def _build_state_comment(state_json: str, summary: RunSummary | None = None) -> str:
+    def _build_state_comment(self, state_json: str, summary: RunSummary | None = None) -> str:
+        # Thread to the previous tick's orchestrator-state event so the
+        # state lineage forms a chain across save ticks. The ``causal_id``
+        # is minted up-front so we can stash it on the instance and use
+        # it as the parent for *this tick's* run-history marker.
+        cid = make_causal_id("state-tracker:orchestrator-state")
+        marker = make_causal_marker(
+            "state-tracker:orchestrator-state",
+            parent=self._last_state_causal_id,
+            causal_id=cid,
+        )
+        self._last_state_causal_id = cid
         lines = [
             STATE_COMMENT_MARKER,
-            make_causal_marker("state-tracker:orchestrator-state"),
+            marker,
             "",
             "## Orchestrator State Update\n",
         ]
@@ -495,12 +530,27 @@ class StateTracker:
         lines.append(f"{STATE_MARKER_OPEN}\n{state_json}\n{STATE_MARKER_CLOSE}")
         return "\n".join(lines)
 
-    @classmethod
-    def _build_history_comment(cls, runs: list[RunSummary]) -> str:
-        """Render a rolling history of recent runs as one upsertable body."""
+    def _build_history_comment(self, runs: list[RunSummary]) -> str:
+        """Render a rolling history of recent runs as one upsertable body.
+
+        Threads the ``state-tracker:run-history`` causal marker to *this
+        tick's* ``state-tracker:orchestrator-state`` id (stashed on the
+        instance by :meth:`_build_state_comment`) and then to the
+        *previous tick's* run-history id when no fresh state id is
+        available. The result is a connected causal chain instead of
+        two parallel root events per save.
+        """
+        cid = make_causal_id("state-tracker:run-history")
+        parent = self._last_state_causal_id or self._last_history_causal_id
+        marker = make_causal_marker(
+            "state-tracker:run-history",
+            parent=parent,
+            causal_id=cid,
+        )
+        self._last_history_causal_id = cid
         lines = [
             RUN_HISTORY_COMMENT_MARKER,
-            make_causal_marker("state-tracker:run-history"),
+            marker,
             "",
             f"## Maintainer Run History (last {len(runs)} runs)",
             "",
@@ -508,7 +558,7 @@ class StateTracker:
             "",
         ]
         for run in reversed(runs):  # newest first
-            lines.append(cls._format_summary(run))
+            lines.append(self._format_summary(run))
             lines.append("---")
             lines.append("")
         return "\n".join(lines).rstrip() + "\n"

--- a/src/caretaker/upgrade_agent/planner.py
+++ b/src/caretaker/upgrade_agent/planner.py
@@ -37,11 +37,13 @@ def _sync_target_marker(version: str) -> str:
 def build_upgrade_issue_body(
     current_version: str,
     target: Release,
+    *,
+    parent_id: str | None = None,
 ) -> str:
     """Build the body for an upgrade issue."""
     lines = [
         _upgrade_target_marker(target.version),
-        make_causal_marker("upgrade"),
+        make_causal_marker("upgrade", parent=parent_id),
         "",
         f"## [Maintainer] Upgrade to v{target.version}",
         "",

--- a/tests/test_admin/test_causal_store.py
+++ b/tests/test_admin/test_causal_store.py
@@ -217,7 +217,12 @@ class TestRefreshFromGitHub:
         ]
 
     @pytest.mark.asyncio
-    async def test_clears_previous_events(self) -> None:
+    async def test_preserves_previous_events_across_refresh(self) -> None:
+        """Refresh must NOT clear the cache anymore — closed issues drop
+        out of ``state.tracked_*`` after a few cycles, and the previous
+        ``clear()``-on-refresh behaviour orphaned every event whose
+        parent lived on one of those bodies. The new contract is
+        incremental upsert: pre-existing events survive across ticks."""
         store = CausalEventStore()
         store.ingest(
             CausalEvent(id="stale", source="x", parent_id=None, ref=CausalEventRef(kind="issue"))
@@ -225,8 +230,8 @@ class TestRefreshFromGitHub:
         github = _FakeGitHubClient()
         state = OrchestratorState()
         count = await store.refresh_from_github(github, "o", "r", state)  # type: ignore[arg-type]
-        assert count == 0
-        assert store.get("stale") is None
+        assert count == 1
+        assert store.get("stale") is not None
 
     @pytest.mark.asyncio
     async def test_skips_non_tracking_issue_titles(self) -> None:

--- a/tests/test_admin/test_causal_store_persistence.py
+++ b/tests/test_admin/test_causal_store_persistence.py
@@ -1,0 +1,295 @@
+"""LRU bound, persistence, and Neo4j-fallback behaviour for :class:`CausalEventStore`.
+
+These tests guard the bits added when we moved the causal store off
+in-memory-only storage in v0.22.0:
+
+* The cache is now bounded by ``CARETAKER_CAUSAL_CACHE_MAX_EVENTS``
+  (default 5000) using ``OrderedDict`` LRU semantics.
+* :meth:`CausalEventStore.refresh_from_github` no longer wipes the
+  cache; events accumulate across ticks.
+* When a graph backend is attached, writes flow through
+  :class:`GraphWriter` and ``aget`` / ``awalk`` / ``adescendants`` fall
+  back to Neo4j when the requested chain is not in the LRU cache.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+from caretaker.admin.causal_store import (
+    CACHE_MAX_EVENTS_ENV,
+    CausalEventStore,
+    _causal_node_id,
+    _event_node_props,
+)
+from caretaker.causal_chain import CausalEvent, CausalEventRef
+from caretaker.graph.models import NodeType, RelType
+
+
+class _FakeGraphStore:
+    """Minimal async fake backing :class:`CausalEventStore`.
+
+    Stores rows in a flat dict keyed by node id and accepts the
+    ``where`` / ``params`` / ``order_by`` / ``limit`` arguments that the
+    real :class:`GraphStore` supports. The ``CAUSED_BY`` traversal is
+    simulated by following ``parent_id`` properties so the
+    ``awalk`` / ``adescendants`` Neo4j fallbacks can be exercised
+    without standing up a database.
+    """
+
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, Any]] = {}
+
+    def upsert(self, node_id: str, props: dict[str, Any]) -> None:
+        merged = {**self.rows.get(node_id, {}), "id": node_id}
+        merged.update({k: v for k, v in props.items() if v is not None})
+        self.rows[node_id] = merged
+
+    async def list_nodes_with_properties(
+        self,
+        label: str,
+        *,
+        where: str | None = None,
+        params: dict[str, Any] | None = None,
+        order_by: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        assert label == "CausalEvent"
+        params = params or {}
+        target_id = params.get("id")
+        rows = list(self.rows.values())
+        if where and target_id is not None:
+            if "CAUSED_BY*1" in where and "(n)-[" in where and "(:CausalEvent" in where:
+                # Ancestors of target_id (walk parent chain).
+                ancestors = self._ancestors_of(str(target_id))
+                rows = [r for r in rows if r["id"] in ancestors]
+            elif "CAUSED_BY*1" in where and "(:CausalEvent" in where and ")-[" in where:
+                # Descendants of target_id (walk reverse parent chain).
+                descendants = self._descendants_of(str(target_id))
+                rows = [r for r in rows if r["id"] in descendants]
+            elif where == "n.id = $id":
+                rows = [r for r in rows if r["id"] == target_id]
+        if order_by and "observed_at" in order_by:
+            rows.sort(key=lambda r: r.get("observed_at") or "", reverse="DESC" in order_by)
+        if limit is not None:
+            rows = rows[: int(limit)]
+        return rows
+
+    def _ancestors_of(self, target_id: str) -> set[str]:
+        result = {target_id}
+        cursor = target_id
+        for _ in range(64):
+            row = self.rows.get(cursor)
+            if not row:
+                break
+            parent = row.get("parent_id")
+            if not parent:
+                break
+            parent_node = _causal_node_id(parent)
+            if parent_node in result:
+                break
+            result.add(parent_node)
+            cursor = parent_node
+        return result
+
+    def _descendants_of(self, target_id: str) -> set[str]:
+        result = {target_id}
+        frontier = [target_id]
+        for _ in range(64):
+            next_frontier: list[str] = []
+            for node_id in frontier:
+                event_id = node_id.removeprefix("causal:")
+                for candidate in self.rows.values():
+                    if candidate.get("parent_id") == event_id and candidate["id"] not in result:
+                        result.add(candidate["id"])
+                        next_frontier.append(candidate["id"])
+            if not next_frontier:
+                break
+            frontier = next_frontier
+        return result
+
+
+class _RecordingWriter:
+    """Captures GraphWriter calls so tests can inspect what got queued."""
+
+    def __init__(self) -> None:
+        self.nodes: list[tuple[str, str, dict[str, Any] | None]] = []
+        self.edges: list[tuple[str, str, str, str, str, dict[str, Any] | None]] = []
+
+    def record_node(self, label: str, node_id: str, props: dict[str, Any] | None = None) -> None:
+        self.nodes.append((label, node_id, props))
+
+    def record_edge(
+        self,
+        src_label: str,
+        src_id: str,
+        tgt_label: str,
+        tgt_id: str,
+        rel_type: str,
+        props: dict[str, Any] | None = None,
+    ) -> None:
+        self.edges.append((src_label, src_id, tgt_label, tgt_id, rel_type, props))
+
+
+@pytest.fixture
+def recording_writer(monkeypatch: pytest.MonkeyPatch) -> _RecordingWriter:
+    writer = _RecordingWriter()
+    # Patch the lookup the store uses so writes flow into our recorder.
+    monkeypatch.setattr("caretaker.admin.causal_store.get_writer", lambda: writer)
+    return writer
+
+
+def _make_event(
+    event_id: str,
+    *,
+    parent: str | None = None,
+    owner: str = "octo",
+    repo: str = "demo",
+) -> CausalEvent:
+    return CausalEvent(
+        id=event_id,
+        source="test",
+        parent_id=parent,
+        ref=CausalEventRef(kind="issue", number=42, owner=owner, repo=repo),
+        title="t",
+        observed_at=None,
+    )
+
+
+class TestLRUCacheBound:
+    def test_default_cap_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(CACHE_MAX_EVENTS_ENV, "250")
+        store = CausalEventStore()
+        assert store.cache_cap == 250
+
+    def test_evicts_oldest_when_over_cap(self, recording_writer: _RecordingWriter) -> None:
+        # Tiny cap to make eviction trivial to assert on.
+        store = CausalEventStore(cache_max_events=3)
+        for idx in range(5):
+            store.ingest(_make_event(f"evt-{idx}"))
+        # Cache must hold the 3 most-recent ids; the first two are evicted.
+        assert store.size() == 3
+        ids = [e.id for e in store.index().values()]
+        assert ids == ["evt-2", "evt-3", "evt-4"]
+        assert store.stats()["evictions"] == 2
+
+    def test_get_promotes_to_mru(self, recording_writer: _RecordingWriter) -> None:
+        store = CausalEventStore(cache_max_events=3)
+        for idx in range(3):
+            store.ingest(_make_event(f"evt-{idx}"))
+        # Touch evt-0 so it becomes most-recently-used; subsequent
+        # insertion should evict evt-1 instead of evt-0.
+        assert store.get("evt-0") is not None
+        store.ingest(_make_event("evt-3"))
+        ids = [e.id for e in store.index().values()]
+        assert "evt-0" in ids
+        assert "evt-1" not in ids
+
+
+class TestPersistenceWiring:
+    def test_ingest_writes_to_graph(self, recording_writer: _RecordingWriter) -> None:
+        store = CausalEventStore(graph_store=_FakeGraphStore(), cache_max_events=10)
+        store.ingest(_make_event("evt-1"))
+        labels = [(label, node_id) for label, node_id, _ in recording_writer.nodes]
+        assert (NodeType.CAUSAL_EVENT, "causal:evt-1") in labels
+        # Repo node is auto-merged when owner+repo are set on the ref.
+        assert (NodeType.REPO, "repo:octo/demo") in labels
+        assert (RelType.BELONGS_TO, NodeType.CAUSAL_EVENT, NodeType.REPO) in {
+            (rel, src, tgt) for src, _, tgt, _, rel, _ in recording_writer.edges
+        }
+        assert store.stats()["neo4j_writes"] == 1
+
+    def test_parent_creates_caused_by_edge(self, recording_writer: _RecordingWriter) -> None:
+        store = CausalEventStore(graph_store=_FakeGraphStore(), cache_max_events=10)
+        store.ingest(_make_event("parent"))
+        store.ingest(_make_event("child", parent="parent"))
+        caused_by = [
+            (sid, tid)
+            for src, sid, tgt, tid, rel, _ in recording_writer.edges
+            if rel == RelType.CAUSED_BY
+        ]
+        assert ("causal:child", "causal:parent") in caused_by
+
+    @pytest.mark.asyncio
+    async def test_warm_from_graph_respects_cap(self, recording_writer: _RecordingWriter) -> None:
+        """warm_cache loads at most cache_cap rows ordered observed_at DESC."""
+        graph = _FakeGraphStore()
+        # Seed Neo4j with 5 events with monotonically increasing observed_at.
+        for idx in range(5):
+            event = CausalEvent(
+                id=f"evt-{idx}",
+                source="seed",
+                parent_id=None,
+                ref=CausalEventRef(kind="issue", number=1, owner="octo", repo="demo"),
+                title="seeded",
+                observed_at=None,
+            )
+            props = _event_node_props(event, "octo/demo")
+            props["observed_at"] = f"2026-04-25T00:0{idx}:00+00:00"
+            graph.upsert(_causal_node_id(event.id), props)
+
+        store = CausalEventStore(graph_store=graph, cache_max_events=2)
+        await store._warm_cache_from_graph(force=True)
+        ids = [e.id for e in store.index().values()]
+        # Newest two must be in cache; cache is also LRU-ordered with MRU at tail.
+        assert set(ids) == {"evt-3", "evt-4"}
+        # Older history is reachable via the async fetch path.
+        oldest = await store.aget("evt-0")
+        assert oldest is not None
+        assert oldest.id == "evt-0"
+
+    @pytest.mark.asyncio
+    async def test_awalk_falls_back_to_neo4j(self, recording_writer: _RecordingWriter) -> None:
+        """When the parent chain isn't in cache, awalk pulls it from Neo4j."""
+        graph = _FakeGraphStore()
+        # Build a 3-event chain in Neo4j only.
+        chain: Iterable[tuple[str, str | None]] = (
+            ("root", None),
+            ("middle", "root"),
+            ("leaf", "middle"),
+        )
+        for event_id, parent in chain:
+            ev = CausalEvent(
+                id=event_id,
+                source="seed",
+                parent_id=parent,
+                ref=CausalEventRef(kind="issue", number=1, owner="octo", repo="demo"),
+                title="t",
+                observed_at=None,
+            )
+            graph.upsert(_causal_node_id(event_id), _event_node_props(ev, "octo/demo"))
+
+        # Cache is empty: only the leaf id is asked for.
+        store = CausalEventStore(graph_store=graph, cache_max_events=10)
+        walk = await store.awalk("leaf")
+        assert [e.id for e in walk.events] == ["root", "middle", "leaf"]
+
+    @pytest.mark.asyncio
+    async def test_adescendants_falls_back_to_neo4j(
+        self, recording_writer: _RecordingWriter
+    ) -> None:
+        graph = _FakeGraphStore()
+        for event_id, parent in (
+            ("root", None),
+            ("a", "root"),
+            ("b", "root"),
+            ("c", "a"),
+        ):
+            ev = CausalEvent(
+                id=event_id,
+                source="seed",
+                parent_id=parent,
+                ref=CausalEventRef(kind="issue", number=1, owner="octo", repo="demo"),
+                title="t",
+                observed_at=None,
+            )
+            graph.upsert(_causal_node_id(event_id), _event_node_props(ev, "octo/demo"))
+
+        store = CausalEventStore(graph_store=graph, cache_max_events=10)
+        kids = await store.adescendants("root")
+        assert {e.id for e in kids} == {"a", "b", "c"}


### PR DESCRIPTION
## Why

In v0.21.0 we shipped hierarchical edges (Repo→Issue/PR/Run/Comment + ON/HAS_EVENT/EMITS) but the admin **Causal Chain** UI still showed empty ancestors/descendants for every event.

Cluster QA on neo4j-0 confirmed: **0 of 672 CausalEvent nodes had a parent_id**, and CAUSED_BY edge count was 0. Two root causes:

1. `CausalEventStore.refresh_from_github` called `self.clear()` every 60s — when a source issue/PR closed and left `tracked_*`, its events were dropped, breaking parent walks.
2. Only `issue-agent:dispatch` threaded `parent=` in `make_causal_marker(...)`. Every other agent (state-tracker x2, charlie x4, pr-agent escalation, devops, self-heal, upgrade, escalation digest, copilot pr-agent-task) emitted **root-only** markers.

## What

**Persistence:** `CausalEventStore` is now a Neo4j-backed read-through cache. Ingest writes through `GraphWriter` (CausalEvent + Repo + BELONGS_TO + CAUSED_BY when parent set). Refresh is incremental (no `clear()`). Closed-issue events survive forever.

**Bounded memory:** OrderedDict LRU cap configurable via `CARETAKER_CAUSAL_CACHE_MAX_EVENTS` (default 5000, floor 100). `_warm_cache_from_graph` orders by observed_at DESC and limits to cap. `awalk`/`adescendants` fall back to Neo4j `CAUSED_BY*1..n` traversal when chains predate the cache window.

**Parent threading** across all 9 emission sites: `parent_from_body` returns the LAST causal marker on a body so subsequent agents chain to the most recent ancestor. Each agent fetches the prior id from issue/PR body or stores it on the StateTracker instance (orchestrator-state / run-history form a chain across ticks).

**Multi-marker bodies:** `extract_all_causal` + `extract_all_from_body` surface every marker per body (was: first only).

## Tests

- 8 new persistence tests (`tests/test_admin/test_causal_store_persistence.py`): LRU eviction, env-var cap, MRU promotion, write-through to graph, CAUSED_BY edge emission, warm-from-graph respects cap, awalk/adescendants Neo4j fallback.
- Existing `clears_previous_events` test inverted to `preserves_previous_events_across_refresh` to lock in the new contract.
- 2120 tests pass; ruff format/check clean; mypy strict (226 files) clean.

## Expected post-deploy

Cypher on neo4j-0 should show CAUSED_BY > 0 and CausalEvents with parent_id > 0 within 60s of refresh. Admin Causal Chain tab will render non-empty ancestor/descendant chains for events from chained sources (state-tracker, escalation digest, copilot tasks attached to dispatched issues, charlie close events, pr-agent escalations on a PR with prior caretaker activity).