### PR TITLE
docs(skills): add caretaker-qa-cycle skill + backfill releases.json v0.22.0–v0.22.2

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -45,6 +45,13 @@ Skills are specialized knowledge modules that provide:
    - Plan migration
    - Execute upgrade
 
+6. **[caretaker-qa-cycle](./caretaker-qa-cycle.md)** - Run a live-fire QA cycle against caretaker-qa
+   - Decide whether a release warrants a live-fire QA cycle
+   - Author scenario issues that exercise specific behaviors
+   - Fast-forward the testbed pin to the release under test
+   - Watch a scheduled run and assert against documented invariants
+   - Triage findings and ship the fix
+
 ## How to Use Skills
 
 ### For Human Developers

--- a/.github/skills/caretaker-qa-cycle.md
+++ b/.github/skills/caretaker-qa-cycle.md
@@ -1,0 +1,281 @@
+# Skill: caretaker-qa-cycle
+
+## Purpose
+
+Run a structured QA test cycle of caretaker against the live
+[ianlintner/caretaker-qa](https://github.com/ianlintner/caretaker-qa)
+testbed. Use this when validating a release end-to-end (especially
+releases that change orchestrator/PR-agent behavior, autonomy posture,
+or the merge-authority surface).
+
+This is the **live-fire layer** described in
+`docs/plans/2026-04-25-qa-orchestration-test-plan.md` §4.5. Unit and
+state-machine tests cover individual transitions; this skill exercises
+the real LLM, real GitHub permissions, real webhook timing, and real
+multi-actor concurrency by driving caretaker through purpose-built
+scenarios on a real repo.
+
+## Capabilities
+
+- Decide whether a release warrants a live-fire QA cycle
+- Author QA scenario issues that exercise specific behaviors
+- Fast-forward the testbed's pin to the release under test
+- Watch a scheduled run and assert against the documented invariants
+- Triage findings and either fix in caretaker or record as a known gap
+
+## When to Use
+
+Trigger this skill when **any** of the following are true:
+
+- A release touches `pr_agent/`, `orchestrator/`, `pr_reviewer/`,
+  `merge_authority/`, `executor/`, or the readiness check publisher
+- A release changes default config values (autonomy / merge / review)
+- A release introduces a new external write (GitHub API call, label,
+  comment marker, check-run conclusion)
+- An incident's root-cause was not catchable by unit tests alone (i.e.
+  required event ordering, idempotency, or cross-agent state to surface)
+- The user asks to "test caretaker", "QA the release", "exercise
+  caretaker against caretaker-qa", or similar
+
+Do **not** trigger for purely internal refactors with no observable
+behavior change, or for doc-only PRs.
+
+## Prerequisites
+
+- `gh` authenticated as a user with write access to both
+  `ianlintner/caretaker` and `ianlintner/caretaker-qa`
+- Latest release tag exists (`gh release list -R ianlintner/caretaker`)
+- caretaker-qa workflow secrets present: `COPILOT_PAT`,
+  `ANTHROPIC_API_KEY` (or `AZURE_AI_API_KEY` + `AZURE_AI_API_BASE`),
+  optionally `CARETAKER_FLEET_SECRET` / OAuth2 fleet creds
+
+## QA cycle (5 steps)
+
+### 1. Identify the release surface
+
+Before writing scenarios, identify what behavior changed:
+
+```bash
+# What's the latest tag?
+gh release list -R ianlintner/caretaker --limit 5
+
+# What did it touch?
+gh pr list -R ianlintner/caretaker --search "merged:>=$(date -v-7d +%F)" \
+  --json number,title,files --limit 20
+
+# For a specific PR:
+gh pr view 604 -R ianlintner/caretaker --json files --jq '.files[].path'
+```
+
+Map each changed file to the user-observable behavior it controls. The
+scenarios in step 3 should exercise those behaviors — not the code
+paths, but the **outcomes** an operator would notice.
+
+### 2. Verify the testbed is current enough to exercise the release
+
+```bash
+# Pinned version on caretaker-qa:
+gh api /repos/ianlintner/caretaker-qa/contents/.github/maintainer/.version \
+  --jq '.content' | base64 -d
+```
+
+If the pin is older than the release under test, the testbed is not
+running the new code at all. Two options:
+
+- **Fast-forward** (recommended for QA cycles): open a PR bumping
+  `.github/maintainer/.version` to the release tag. The bump PR itself
+  is a live test of the autonomy / advisory-merge surface — if the
+  fixed pr-readiness check would have blocked it, that's the regression
+  signal.
+- **Honor the upgrade chain**: let the existing
+  `[Maintainer] Upgrade to vX.Y.Z` issues drive the bump organically.
+  Slower but tests the upgrade agent path. Use this if the release
+  changed upgrade-agent semantics.
+
+### 3. Author scenario issues in caretaker-qa
+
+Each scenario is one GitHub issue in caretaker-qa with a
+`<!-- caretaker:qa-scenario -->` HTML comment marker (used as a grep
+key) and a `<!-- scenario-NN: <slug> -->` second marker.
+
+Use the existing scenarios as a template:
+
+| # | Slug | Tests |
+|---|------|-------|
+| 04 | `stale-issue` | stale_agent labels + closes after window |
+| 05 | `fixes-cascade` | issue closes when linked PR merges |
+| 06 | `xss-payload` | sanitize_input guardrail |
+| 07 | `deceptive-link` | filter_output guardrail |
+| 09 | `idempotency-comment` | duplicate triage comment dedup |
+| 10 | `empty-pr-body` | triage close test |
+| 11 | `azure-ai-prompt-cache` | prompt cache works through Azure AI |
+
+Reserve the next free number(s) and write each scenario as:
+
+```markdown
+## QA Scenario NN — <one-line title>
+
+**Release validated:** vX.Y.Z (PR #NNN)
+
+**Setup:** <what state must exist for the test, and any one-time
+configuration steps>
+
+**Expected caretaker behavior:**
+1. <observable step 1>
+2. <observable step 2>
+3. <observable step 3, ideally referencing a metric or check-run conclusion>
+
+**Failure modes the scenario catches:**
+- <regression mode 1>
+- <regression mode 2>
+
+**How to verify:**
+```bash
+# concrete commands the QA reviewer can paste to confirm
+gh api /repos/ianlintner/caretaker-qa/actions/runs ...
+```
+
+<!-- caretaker:qa-scenario -->
+<!-- scenario-NN: <slug> -->
+```
+
+A scenario is good if a reasonable reviewer can read it and decide
+PASS/FAIL by inspection — no caretaker-internal knowledge required.
+
+### 4. Trigger a run and watch the invariants
+
+```bash
+# Manually dispatch the caretaker workflow:
+gh workflow run maintainer.yml -R ianlintner/caretaker-qa
+
+# Watch the latest run:
+gh run watch -R ianlintner/caretaker-qa $(gh run list \
+  -R ianlintner/caretaker-qa --workflow maintainer.yml --limit 1 \
+  --json databaseId --jq '.[0].databaseId')
+
+# Inspect the run's artifacts (memory snapshot, scope-gap, digest):
+gh run download <run-id> -R ianlintner/caretaker-qa
+```
+
+Cross-check against the **invariants** in
+`docs/plans/2026-04-25-qa-orchestration-test-plan.md` §9. The most
+load-bearing for autonomy releases are:
+
+- **No double-approve same SHA** — `count(create_review event=APPROVE
+  for pr=N at sha=S) <= 1`
+- **Caretaker PRs only auto-approve** — head ref must start with
+  `caretaker/`, `claude/`, or `copilot/`
+- **Transient-only errors do not fail the run** — exit 0 if all errors
+  in `report.errors` are `RATE_LIMIT` or `TRANSIENT_NETWORK`
+- **Advisory mode never publishes `failure`** — the pr-readiness
+  check-run conclusion is `success | neutral | skipped`, never
+  `failure`, when `pr_agent.merge_authority.mode == advisory`
+- **Idempotency** — replay the same scheduled run on the same head SHA
+  → no new GitHub writes
+
+### 5. Triage findings
+
+For each scenario that doesn't pass:
+
+1. Decide if the bug is in caretaker (fix in main) or in the testbed
+   (fix in caretaker-qa).
+2. If in caretaker: open a PR with a regression unit test in
+   `tests/test_pr_agent/` or `tests/test_orchestrator/` **first**,
+   then the fix. Reference the QA scenario number in the PR.
+3. If in caretaker-qa: open a PR; do not weaken the scenario unless
+   the expected behavior was wrong.
+4. Append the finding to `docs/qa-findings-YYYY-MM-DD.md` (one file
+   per cycle) — this is the long-term scoreboard.
+
+Always finish a cycle by:
+
+- Closing scenarios that pass (label `caretaker:qa-passed`)
+- Leaving open the ones that surfaced bugs until the fix lands
+- Updating the pinned version in caretaker-qa to whatever release
+  shipped the fix
+
+## Common patterns
+
+### Pattern: testing a "PR blocking deadlock" fix (advisory → neutral)
+
+When a release fixes a PR-blocking class of bug (e.g. PR #604), the
+scenario must exercise the **branch-protection-required-check chain**,
+not just the conclusion publisher in isolation:
+
+1. Open a PR on caretaker-qa with a head branch matching `caretaker/*`
+   that fails one transient blocker (e.g. CI red on a flaky test).
+2. Configure branch protection on `main` to require the
+   `caretaker/pr-readiness` check (one-time, document in the
+   scenario).
+3. Schedule two consecutive caretaker runs.
+4. Assert the PR is not blocked indefinitely: either it merges
+   (advisory mode → neutral, no block) or the operator gets a clear
+   `gate_only` failure with an explicit signal.
+
+### Pattern: testing a parent-threading / causal-event fix
+
+Releases that change the causal-event store (e.g. v0.22.0 PR #601)
+need a scenario where **two agent runs share state via a parent_id**:
+
+1. File an issue in caretaker-qa that triggers `issue_agent`.
+2. After issue_agent dispatches a fix to copilot, capture the
+   `CausalEvent.parent_id` from the memory snapshot artifact.
+3. On the next scheduled run, assert that `pr_agent`'s evaluation of
+   the resulting PR has `parent_id` matching the issue's causal id.
+
+If parent_id is null on the second run, the persistence path is broken
+even if unit tests pass.
+
+### Pattern: regression cassette from a real incident
+
+When an incident surfaces, the **post-fix QA scenario** is the
+incident's own event log replayed on the new code. Pull the run id
+from the incident, dump the event log via
+`CARETAKER_RECORD_CASSETTE=path` (when available), and commit the
+cassette as `tests/cassettes/incident-YYYY-MM-DD.jsonl`. Add a layer-4
+test that replays it. The QA scenario in caretaker-qa is then a
+human-readable echo of the cassette.
+
+## Troubleshooting
+
+### Scheduled run isn't picking up the pin bump
+
+The workflow caches `caretaker` from PyPI / git ref by version. After
+bumping `.github/maintainer/.version`, also confirm the workflow's
+`uses:` or `pip install` line resolves the new version. If the bump
+PR was merged but the next run still shows the old version in
+`caretaker --version`, check `actions/cache` keys.
+
+### Self-heal loop fires after a pin bump
+
+The most common cause is a config field that was added in the new
+release and is required (or has a different default). Read the
+`Config error` issue body — it usually quotes the validation error.
+Map that to a `setup-templates/config-default.yml` change in the
+release's PR and apply it to caretaker-qa's config.
+
+### Scenarios marked caretaker:qa-passed re-open the next cycle
+
+If caretaker keeps re-opening a closed scenario, the closing comment
+probably lacked the `caretaker:qa-passed` label or the
+`<!-- caretaker:qa-scenario -->` marker is on a comment instead of
+the issue body. Markers are body-only.
+
+## Related skills
+
+- [caretaker-debug](./caretaker-debug.md) — for diagnosing run
+  failures surfaced by a QA cycle
+- [caretaker-config](./caretaker-config.md) — for tweaking
+  caretaker-qa's `.github/maintainer/config.yml` between cycles
+- [caretaker-upgrade](./caretaker-upgrade.md) — for the
+  honor-the-upgrade-chain alternative in step 2
+
+## References
+
+- `docs/plans/2026-04-25-qa-orchestration-test-plan.md` — full
+  layered test strategy
+- `docs/qa-findings-2026-04-23.md` — example findings doc from a
+  prior cycle
+- `docs/plans/2026-04-22-qa-scenario-11-prompt-cache.md` — example
+  scenario authoring document
+- [caretaker-qa testbed](https://github.com/ianlintner/caretaker-qa)

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,27 @@
 {
   "releases": [
     {
+      "version": "0.22.2",
+      "min_compatible": "0.19.6",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.22.2",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.22.2 -->\n\n## What's Changed\n### Other Changes\n* fix(pr-agent): wire MergeAuthorityConfig + neutral conclusion in advisory mode by @ianlintner in https://github.com/ianlintner/caretaker/pull/604\n* fix(graph): persist CausalEvent.parent_id on Neo4j node so SPA + warm-from-graph see it by @ianlintner\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.22.1...v0.22.2",
+      "breaking": false
+    },
+    {
+      "version": "0.22.1",
+      "min_compatible": "0.19.6",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.22.1",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.22.1 -->\n\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.22.0...v0.22.1",
+      "breaking": false
+    },
+    {
+      "version": "0.22.0",
+      "min_compatible": "0.19.6",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.22.0",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.22.0 -->\n\n## What's Changed\n### Other Changes\n* chore: add v0.21.0 to releases.json by @github-actions[bot] in https://github.com/ianlintner/caretaker/pull/600\n* chore: add v0.20.1 to releases.json by @github-actions[bot] in https://github.com/ianlintner/caretaker/pull/599\n* feat(causal): persistent CausalEventStore + parent threading across agents by @ianlintner in https://github.com/ianlintner/caretaker/pull/601\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.21.0...v0.22.0",
+      "breaking": false
+    },
+    {
       "version": "0.21.0",
       "min_compatible": "0.19.6",
       "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.21.0",
@@ -11,7 +32,7 @@
       "version": "0.20.1",
       "min_compatible": "0.19.6",
       "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.20.1",
-      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.20.1 -->\n\n## What's Changed\n### Other Changes\n* fix(mcp): harden caretaker-mcp against OOM under webhook bursts + GitHub cooldown by @ianlintner in https://github.com/ianlintner/caretaker/pull/596\n* fix(doctor): drop legacy CARETAKER_FLEET_SECRET HMAC check by @ianlintner in https://github.com/ianlintner/caretaker/pull/597\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.20.0...v0.20.1"
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.20.1 -->\n\n## What's Changed\n### Other Changes\n* fix(mcp): harden caretaker-mcp against OOM under webhook bursts + GitHub cooldown by @ianlintner in https://github.com/ianlintner/caretaker/pull/596\n* fix(doctor): drop legacy CARETAKER_FLEET_SECRET HMAC check by @ianlintner in https://github.com/ianlintner/caretaker/pull/597\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.20.0...v0.20.1",
       "breaking": false
     },
     {


### PR DESCRIPTION
## Summary

- **New skill** [`.github/skills/caretaker-qa-cycle.md`](https://github.com/ianlintner/caretaker/blob/claude/nostalgic-lewin-19be09/.github/skills/caretaker-qa-cycle.md) — captures the live-fire QA methodology for validating releases against [caretaker-qa](https://github.com/ianlintner/caretaker-qa). Maps to the §4.5 layer of [docs/plans/2026-04-25-qa-orchestration-test-plan.md](https://github.com/ianlintner/caretaker/blob/main/docs/plans/2026-04-25-qa-orchestration-test-plan.md).
- **Fixed** a pre-existing JSON syntax error in `releases.json` (missing comma after the v0.20.1 entry's `upgrade_notes` string). The file failed to parse on `main`, silently breaking upgrade discovery on every downstream repo — `releases.json` was a no-op input for the upgrade agent.
- **Backfilled** `releases.json` with v0.22.0, v0.22.1, v0.22.2. v0.22.3 isn't here because it hasn't been published as a GitHub release yet — only the pyproject bump (`5e2e76a`).

## Why this matters

The autonomy release line (v0.22.0 + v0.22.1 + v0.22.2) addresses the exact "PR blocking and not achieving goals" class of bug:

- [#601](https://github.com/ianlintner/caretaker/pull/601) — persistent CausalEventStore + parent threading across agents
- [#604](https://github.com/ianlintner/caretaker/pull/604) — wire `MergeAuthorityConfig` + neutral conclusion in advisory mode (the deadlock fix)

Until `releases.json` parses again, no downstream repo (including caretaker-qa) can discover that v0.22.x exists.

## QA scenarios filed (live-fire)

Three scenario issues were authored in caretaker-qa to exercise v0.22.x semantics:

- [caretaker-qa#47](https://github.com/ianlintner/caretaker-qa/issues/47) — qa(scenario-12): advisory mode → neutral conclusion (regression test for #604)
- [caretaker-qa#48](https://github.com/ianlintner/caretaker-qa/issues/48) — qa(scenario-13): persistent CausalEventStore parent threading across runner restarts (validates #601 + the v0.22.1 hotfix)
- [caretaker-qa#49](https://github.com/ianlintner/caretaker-qa/issues/49) — qa(scenario-14): goal-achievement fix-loop end-to-end (issue → PR → review → approve → merge with no operator nudge)

These will start producing pass/fail signal once caretaker-qa is fast-forwarded past v0.19.4 (separate PR there).

## Recurring gap (not addressed in this PR)

The release-publish bot's `releases.json` auto-append step has not been emitting commits for several recent releases. Same gap [docs/qa-findings-2026-04-23.md §2](https://github.com/ianlintner/caretaker/blob/main/docs/qa-findings-2026-04-23.md#2-releasesjson-is-not-updated-automatically-on-release-process-gap) flagged previously and was hand-fixed in commit `89c0d81`. Worth a follow-up to add a CI gate (release tag exists ⇒ entry in releases.json) so this stops being a recurring drift.

## Test plan

- [x] `python3 -c "import json; json.load(open('releases.json'))"` — parses cleanly (was throwing `Expecting ',' delimiter` on `main`)
- [x] First entry is `0.22.2`, full count is 29 entries (was 26 + broken)
- [x] Skill follows the same template as `caretaker-debug.md` and `caretaker-upgrade.md`
- [x] Skill is discoverable from [.github/skills/README.md](https://github.com/ianlintner/caretaker/blob/claude/nostalgic-lewin-19be09/.github/skills/README.md) index

🤖 Generated with [Claude Code](https://claude.com/claude-code)