### PR TITLE
fix(scope-gap): auto-close resolved issues when tracker is empty

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -45,6 +45,13 @@ Skills are specialized knowledge modules that provide:
    - Plan migration
    - Execute upgrade
 
+6. **[caretaker-qa-cycle](./caretaker-qa-cycle.md)** - Run a live-fire QA cycle against caretaker-qa
+   - Decide whether a release warrants a live-fire QA cycle
+   - Author scenario issues that exercise specific behaviors
+   - Fast-forward the testbed pin to the release under test
+   - Watch a scheduled run and assert against documented invariants
+   - Triage findings and ship the fix
+
 ## How to Use Skills
 
 ### For Human Developers

--- a/.github/skills/caretaker-qa-cycle.md
+++ b/.github/skills/caretaker-qa-cycle.md
@@ -1,0 +1,281 @@
+# Skill: caretaker-qa-cycle
+
+## Purpose
+
+Run a structured QA test cycle of caretaker against the live
+[ianlintner/caretaker-qa](https://github.com/ianlintner/caretaker-qa)
+testbed. Use this when validating a release end-to-end (especially
+releases that change orchestrator/PR-agent behavior, autonomy posture,
+or the merge-authority surface).
+
+This is the **live-fire layer** described in
+`docs/plans/2026-04-25-qa-orchestration-test-plan.md` §4.5. Unit and
+state-machine tests cover individual transitions; this skill exercises
+the real LLM, real GitHub permissions, real webhook timing, and real
+multi-actor concurrency by driving caretaker through purpose-built
+scenarios on a real repo.
+
+## Capabilities
+
+- Decide whether a release warrants a live-fire QA cycle
+- Author QA scenario issues that exercise specific behaviors
+- Fast-forward the testbed's pin to the release under test
+- Watch a scheduled run and assert against the documented invariants
+- Triage findings and either fix in caretaker or record as a known gap
+
+## When to Use
+
+Trigger this skill when **any** of the following are true:
+
+- A release touches `pr_agent/`, `orchestrator/`, `pr_reviewer/`,
+  `merge_authority/`, `executor/`, or the readiness check publisher
+- A release changes default config values (autonomy / merge / review)
+- A release introduces a new external write (GitHub API call, label,
+  comment marker, check-run conclusion)
+- An incident's root-cause was not catchable by unit tests alone (i.e.
+  required event ordering, idempotency, or cross-agent state to surface)
+- The user asks to "test caretaker", "QA the release", "exercise
+  caretaker against caretaker-qa", or similar
+
+Do **not** trigger for purely internal refactors with no observable
+behavior change, or for doc-only PRs.
+
+## Prerequisites
+
+- `gh` authenticated as a user with write access to both
+  `ianlintner/caretaker` and `ianlintner/caretaker-qa`
+- Latest release tag exists (`gh release list -R ianlintner/caretaker`)
+- caretaker-qa workflow secrets present: `COPILOT_PAT`,
+  `ANTHROPIC_API_KEY` (or `AZURE_AI_API_KEY` + `AZURE_AI_API_BASE`),
+  optionally `CARETAKER_FLEET_SECRET` / OAuth2 fleet creds
+
+## QA cycle (5 steps)
+
+### 1. Identify the release surface
+
+Before writing scenarios, identify what behavior changed:
+
+```bash
+# What's the latest tag?
+gh release list -R ianlintner/caretaker --limit 5
+
+# What did it touch?
+gh pr list -R ianlintner/caretaker --search "merged:>=$(date -v-7d +%F)" \
+  --json number,title,files --limit 20
+
+# For a specific PR:
+gh pr view 604 -R ianlintner/caretaker --json files --jq '.files[].path'
+```
+
+Map each changed file to the user-observable behavior it controls. The
+scenarios in step 3 should exercise those behaviors — not the code
+paths, but the **outcomes** an operator would notice.
+
+### 2. Verify the testbed is current enough to exercise the release
+
+```bash
+# Pinned version on caretaker-qa:
+gh api /repos/ianlintner/caretaker-qa/contents/.github/maintainer/.version \
+  --jq '.content' | base64 -d
+```
+
+If the pin is older than the release under test, the testbed is not
+running the new code at all. Two options:
+
+- **Fast-forward** (recommended for QA cycles): open a PR bumping
+  `.github/maintainer/.version` to the release tag. The bump PR itself
+  is a live test of the autonomy / advisory-merge surface — if the
+  fixed pr-readiness check would have blocked it, that's the regression
+  signal.
+- **Honor the upgrade chain**: let the existing
+  `[Maintainer] Upgrade to vX.Y.Z` issues drive the bump organically.
+  Slower but tests the upgrade agent path. Use this if the release
+  changed upgrade-agent semantics.
+
+### 3. Author scenario issues in caretaker-qa
+
+Each scenario is one GitHub issue in caretaker-qa with a
+`<!-- caretaker:qa-scenario -->` HTML comment marker (used as a grep
+key) and a `<!-- scenario-NN: <slug> -->` second marker.
+
+Use the existing scenarios as a template:
+
+| # | Slug | Tests |
+|---|------|-------|
+| 04 | `stale-issue` | stale_agent labels + closes after window |
+| 05 | `fixes-cascade` | issue closes when linked PR merges |
+| 06 | `xss-payload` | sanitize_input guardrail |
+| 07 | `deceptive-link` | filter_output guardrail |
+| 09 | `idempotency-comment` | duplicate triage comment dedup |
+| 10 | `empty-pr-body` | triage close test |
+| 11 | `azure-ai-prompt-cache` | prompt cache works through Azure AI |
+
+Reserve the next free number(s) and write each scenario as:
+
+```markdown
+## QA Scenario NN — <one-line title>
+
+**Release validated:** vX.Y.Z (PR #NNN)
+
+**Setup:** <what state must exist for the test, and any one-time
+configuration steps>
+
+**Expected caretaker behavior:**
+1. <observable step 1>
+2. <observable step 2>
+3. <observable step 3, ideally referencing a metric or check-run conclusion>
+
+**Failure modes the scenario catches:**
+- <regression mode 1>
+- <regression mode 2>
+
+**How to verify:**
+```bash
+# concrete commands the QA reviewer can paste to confirm
+gh api /repos/ianlintner/caretaker-qa/actions/runs ...
+```
+
+<!-- caretaker:qa-scenario -->
+<!-- scenario-NN: <slug> -->
+```
+
+A scenario is good if a reasonable reviewer can read it and decide
+PASS/FAIL by inspection — no caretaker-internal knowledge required.
+
+### 4. Trigger a run and watch the invariants
+
+```bash
+# Manually dispatch the caretaker workflow:
+gh workflow run maintainer.yml -R ianlintner/caretaker-qa
+
+# Watch the latest run:
+gh run watch -R ianlintner/caretaker-qa $(gh run list \
+  -R ianlintner/caretaker-qa --workflow maintainer.yml --limit 1 \
+  --json databaseId --jq '.[0].databaseId')
+
+# Inspect the run's artifacts (memory snapshot, scope-gap, digest):
+gh run download <run-id> -R ianlintner/caretaker-qa
+```
+
+Cross-check against the **invariants** in
+`docs/plans/2026-04-25-qa-orchestration-test-plan.md` §9. The most
+load-bearing for autonomy releases are:
+
+- **No double-approve same SHA** — `count(create_review event=APPROVE
+  for pr=N at sha=S) <= 1`
+- **Caretaker PRs only auto-approve** — head ref must start with
+  `caretaker/`, `claude/`, or `copilot/`
+- **Transient-only errors do not fail the run** — exit 0 if all errors
+  in `report.errors` are `RATE_LIMIT` or `TRANSIENT_NETWORK`
+- **Advisory mode never publishes `failure`** — the pr-readiness
+  check-run conclusion is `success | neutral | skipped`, never
+  `failure`, when `pr_agent.merge_authority.mode == advisory`
+- **Idempotency** — replay the same scheduled run on the same head SHA
+  → no new GitHub writes
+
+### 5. Triage findings
+
+For each scenario that doesn't pass:
+
+1. Decide if the bug is in caretaker (fix in main) or in the testbed
+   (fix in caretaker-qa).
+2. If in caretaker: open a PR with a regression unit test in
+   `tests/test_pr_agent/` or `tests/test_orchestrator/` **first**,
+   then the fix. Reference the QA scenario number in the PR.
+3. If in caretaker-qa: open a PR; do not weaken the scenario unless
+   the expected behavior was wrong.
+4. Append the finding to `docs/qa-findings-YYYY-MM-DD.md` (one file
+   per cycle) — this is the long-term scoreboard.
+
+Always finish a cycle by:
+
+- Closing scenarios that pass (label `caretaker:qa-passed`)
+- Leaving open the ones that surfaced bugs until the fix lands
+- Updating the pinned version in caretaker-qa to whatever release
+  shipped the fix
+
+## Common patterns
+
+### Pattern: testing a "PR blocking deadlock" fix (advisory → neutral)
+
+When a release fixes a PR-blocking class of bug (e.g. PR #604), the
+scenario must exercise the **branch-protection-required-check chain**,
+not just the conclusion publisher in isolation:
+
+1. Open a PR on caretaker-qa with a head branch matching `caretaker/*`
+   that fails one transient blocker (e.g. CI red on a flaky test).
+2. Configure branch protection on `main` to require the
+   `caretaker/pr-readiness` check (one-time, document in the
+   scenario).
+3. Schedule two consecutive caretaker runs.
+4. Assert the PR is not blocked indefinitely: either it merges
+   (advisory mode → neutral, no block) or the operator gets a clear
+   `gate_only` failure with an explicit signal.
+
+### Pattern: testing a parent-threading / causal-event fix
+
+Releases that change the causal-event store (e.g. v0.22.0 PR #601)
+need a scenario where **two agent runs share state via a parent_id**:
+
+1. File an issue in caretaker-qa that triggers `issue_agent`.
+2. After issue_agent dispatches a fix to copilot, capture the
+   `CausalEvent.parent_id` from the memory snapshot artifact.
+3. On the next scheduled run, assert that `pr_agent`'s evaluation of
+   the resulting PR has `parent_id` matching the issue's causal id.
+
+If parent_id is null on the second run, the persistence path is broken
+even if unit tests pass.
+
+### Pattern: regression cassette from a real incident
+
+When an incident surfaces, the **post-fix QA scenario** is the
+incident's own event log replayed on the new code. Pull the run id
+from the incident, dump the event log via
+`CARETAKER_RECORD_CASSETTE=path` (when available), and commit the
+cassette as `tests/cassettes/incident-YYYY-MM-DD.jsonl`. Add a layer-4
+test that replays it. The QA scenario in caretaker-qa is then a
+human-readable echo of the cassette.
+
+## Troubleshooting
+
+### Scheduled run isn't picking up the pin bump
+
+The workflow caches `caretaker` from PyPI / git ref by version. After
+bumping `.github/maintainer/.version`, also confirm the workflow's
+`uses:` or `pip install` line resolves the new version. If the bump
+PR was merged but the next run still shows the old version in
+`caretaker --version`, check `actions/cache` keys.
+
+### Self-heal loop fires after a pin bump
+
+The most common cause is a config field that was added in the new
+release and is required (or has a different default). Read the
+`Config error` issue body — it usually quotes the validation error.
+Map that to a `setup-templates/config-default.yml` change in the
+release's PR and apply it to caretaker-qa's config.
+
+### Scenarios marked caretaker:qa-passed re-open the next cycle
+
+If caretaker keeps re-opening a closed scenario, the closing comment
+probably lacked the `caretaker:qa-passed` label or the
+`<!-- caretaker:qa-scenario -->` marker is on a comment instead of
+the issue body. Markers are body-only.
+
+## Related skills
+
+- [caretaker-debug](./caretaker-debug.md) — for diagnosing run
+  failures surfaced by a QA cycle
+- [caretaker-config](./caretaker-config.md) — for tweaking
+  caretaker-qa's `.github/maintainer/config.yml` between cycles
+- [caretaker-upgrade](./caretaker-upgrade.md) — for the
+  honor-the-upgrade-chain alternative in step 2
+
+## References
+
+- `docs/plans/2026-04-25-qa-orchestration-test-plan.md` — full
+  layered test strategy
+- `docs/qa-findings-2026-04-23.md` — example findings doc from a
+  prior cycle
+- `docs/plans/2026-04-22-qa-scenario-11-prompt-cache.md` — example
+  scenario authoring document
+- [caretaker-qa testbed](https://github.com/ianlintner/caretaker-qa)

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,27 @@
 {
   "releases": [
     {
+      "version": "0.22.2",
+      "min_compatible": "0.19.6",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.22.2",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.22.2 -->\n\n## What's Changed\n### Other Changes\n* fix(pr-agent): wire MergeAuthorityConfig + neutral conclusion in advisory mode by @ianlintner in https://github.com/ianlintner/caretaker/pull/604\n* fix(graph): persist CausalEvent.parent_id on Neo4j node so SPA + warm-from-graph see it by @ianlintner\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.22.1...v0.22.2",
+      "breaking": false
+    },
+    {
+      "version": "0.22.1",
+      "min_compatible": "0.19.6",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.22.1",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.22.1 -->\n\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.22.0...v0.22.1",
+      "breaking": false
+    },
+    {
+      "version": "0.22.0",
+      "min_compatible": "0.19.6",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.22.0",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.22.0 -->\n\n## What's Changed\n### Other Changes\n* chore: add v0.21.0 to releases.json by @github-actions[bot] in https://github.com/ianlintner/caretaker/pull/600\n* chore: add v0.20.1 to releases.json by @github-actions[bot] in https://github.com/ianlintner/caretaker/pull/599\n* feat(causal): persistent CausalEventStore + parent threading across agents by @ianlintner in https://github.com/ianlintner/caretaker/pull/601\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.21.0...v0.22.0",
+      "breaking": false
+    },
+    {
       "version": "0.21.0",
       "min_compatible": "0.19.6",
       "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.21.0",
@@ -11,7 +32,7 @@
       "version": "0.20.1",
       "min_compatible": "0.19.6",
       "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.20.1",
-      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.20.1 -->\n\n## What's Changed\n### Other Changes\n* fix(mcp): harden caretaker-mcp against OOM under webhook bursts + GitHub cooldown by @ianlintner in https://github.com/ianlintner/caretaker/pull/596\n* fix(doctor): drop legacy CARETAKER_FLEET_SECRET HMAC check by @ianlintner in https://github.com/ianlintner/caretaker/pull/597\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.20.0...v0.20.1"
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.20.1 -->\n\n## What's Changed\n### Other Changes\n* fix(mcp): harden caretaker-mcp against OOM under webhook bursts + GitHub cooldown by @ianlintner in https://github.com/ianlintner/caretaker/pull/596\n* fix(doctor): drop legacy CARETAKER_FLEET_SECRET HMAC check by @ianlintner in https://github.com/ianlintner/caretaker/pull/597\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.20.0...v0.20.1",
       "breaking": false
     },
     {

--- a/src/caretaker/github_client/scope_gap_reporter.py
+++ b/src/caretaker/github_client/scope_gap_reporter.py
@@ -166,10 +166,61 @@ async def publish_scope_gap_issue(
     The function never raises — callers tend to invoke it from the
     orchestrator's tail cleanup where nothing upstream has a handle
     to recover, so any failure is logged at WARNING and swallowed.
+
+    When the tracker is empty AND a previous run filed an open
+    scope-gap issue, the issue is closed automatically. This closes
+    the loop with consumers who fixed the underlying ``permissions:``
+    block and lets ``maintainer:action-required`` clear without
+    manual housekeeping.
     """
     tracker = tracker or get_tracker()
     if tracker.is_empty():
-        return None
+        if dry_run:
+            return None
+        try:
+            existing = await _find_existing_issue(github, owner, repo)
+        except Exception as exc:
+            logger.warning(
+                "Unable to look up existing scope-gap issue in %s/%s during resolve-close: %s",
+                owner,
+                repo,
+                exc,
+            )
+            return None
+        if existing is None:
+            return None
+        try:
+            resolved_body = existing.body.rstrip() + (
+                "\n\n---\n\n_Closed automatically: caretaker observed no "
+                "scope-gap 403s on the most recent run, so this issue is "
+                "considered resolved. Caretaker will re-open a fresh "
+                "scope-gap issue if any GITHUB_TOKEN scope is missing on "
+                "a future run._"
+            )
+            await github.update_issue(
+                owner,
+                repo,
+                existing.number,
+                body=resolved_body,
+                state="closed",
+                state_reason="completed",
+            )
+            logger.info(
+                "Closed scope-gap issue #%d in %s/%s — gap resolved on this run",
+                existing.number,
+                owner,
+                repo,
+            )
+            return existing.number
+        except Exception as exc:  # pragma: no cover - defensive tail
+            logger.warning(
+                "Failed to close resolved scope-gap issue #%d in %s/%s: %s",
+                existing.number,
+                owner,
+                repo,
+                exc,
+            )
+            return None
 
     incidents = tracker.snapshot()
     body = render_issue_body(incidents, owner=owner, repo=repo)

--- a/src/caretaker/observability/otel.py
+++ b/src/caretaker/observability/otel.py
@@ -62,13 +62,13 @@ _TracerProvider: Any
 _BatchSpanProcessor: Any
 
 try:  # pragma: no cover - exercised by the fallback path in tests
-    from opentelemetry import trace as _otel_trace
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    from opentelemetry import trace as _otel_trace  # type: ignore[no-redef]
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # type: ignore[no-redef]
         OTLPSpanExporter as _OTLPSpanExporter,
     )
-    from opentelemetry.sdk.resources import Resource as _OTelResource
-    from opentelemetry.sdk.trace import TracerProvider as _TracerProvider
-    from opentelemetry.sdk.trace.export import (
+    from opentelemetry.sdk.resources import Resource as _OTelResource  # type: ignore[no-redef]
+    from opentelemetry.sdk.trace import TracerProvider as _TracerProvider  # type: ignore[no-redef]
+    from opentelemetry.sdk.trace.export import (  # type: ignore[no-redef]
         BatchSpanProcessor as _BatchSpanProcessor,
     )
 

--- a/src/caretaker/observability/otel.py
+++ b/src/caretaker/observability/otel.py
@@ -62,13 +62,13 @@ _TracerProvider: Any
 _BatchSpanProcessor: Any
 
 try:  # pragma: no cover - exercised by the fallback path in tests
-    from opentelemetry import trace as _otel_trace  # type: ignore[no-redef]
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # type: ignore[no-redef]
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
         OTLPSpanExporter as _OTLPSpanExporter,
     )
-    from opentelemetry.sdk.resources import Resource as _OTelResource  # type: ignore[no-redef]
-    from opentelemetry.sdk.trace import TracerProvider as _TracerProvider  # type: ignore[no-redef]
-    from opentelemetry.sdk.trace.export import (  # type: ignore[no-redef]
+    from opentelemetry.sdk.resources import Resource as _OTelResource
+    from opentelemetry.sdk.trace import TracerProvider as _TracerProvider
+    from opentelemetry.sdk.trace.export import (
         BatchSpanProcessor as _BatchSpanProcessor,
     )
 

--- a/tests/test_scope_gap.py
+++ b/tests/test_scope_gap.py
@@ -404,3 +404,58 @@ async def test_publish_dry_run_skips_write() -> None:
     assert result is None
     assert gh.create_calls == []
     assert gh.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_closes_existing_issue_when_gap_resolves() -> None:
+    """When the tracker is empty AND a prior run filed an open scope-gap
+    issue, the next run closes it automatically with a resolution note.
+    Surfaced live on caretaker-qa#53 — operator widened the workflow
+    perms but the issue stayed open across subsequent green runs."""
+    gh = FakeGitHub()
+    gh.existing_issues[SCOPE_GAP_LABEL] = [
+        _issue(
+            17,
+            f"{SCOPE_GAP_ISSUE_MARKER}\n\nold body about missing checks: write",
+            labels=[SCOPE_GAP_LABEL],
+        )
+    ]
+
+    # Tracker is empty (no 403s observed this run).
+    result = await publish_scope_gap_issue(gh, "o", "r")
+
+    assert result == 17
+    assert gh.create_calls == []
+    assert len(gh.update_calls) == 1
+    upd = gh.update_calls[0]
+    assert upd["number"] == 17
+    assert upd["state"] == "closed"
+    assert upd.get("state_reason") == "completed"
+    assert "Closed automatically" in upd["body"]
+    assert SCOPE_GAP_ISSUE_MARKER in upd["body"]
+
+
+@pytest.mark.asyncio
+async def test_publish_resolve_close_is_noop_when_no_existing_issue() -> None:
+    """Empty tracker + no prior issue → still a clean no-op."""
+    gh = FakeGitHub()
+    result = await publish_scope_gap_issue(gh, "o", "r")
+    assert result is None
+    assert gh.create_calls == []
+    assert gh.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_resolve_close_respects_dry_run() -> None:
+    """Dry-run must never close the existing issue, even if the gap is gone."""
+    gh = FakeGitHub()
+    gh.existing_issues[SCOPE_GAP_LABEL] = [
+        _issue(
+            17,
+            f"{SCOPE_GAP_ISSUE_MARKER}\n\nbody",
+            labels=[SCOPE_GAP_LABEL],
+        )
+    ]
+    result = await publish_scope_gap_issue(gh, "o", "r", dry_run=True)
+    assert result is None
+    assert gh.update_calls == []

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "caretaker-github"
-version = "0.22.2"
+version = "0.22.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Closes the open-forever loop on `[caretaker] Workflow token is missing required scopes` issues. When an operator widens the permissions block, the next run sees zero 403s and `ScopeGapTracker.is_empty()` returns true — but `publish_scope_gap_issue` was returning early on that path, leaving the previous run's issue (with `maintainer:action-required` label) open across every subsequent green run.

Now: empty tracker + existing open scope-gap issue → close it (`state=closed, state_reason=completed`) with a resolution note appended. The body still gets rewritten in place every cycle the gap persists, same contract as before. Caretaker re-opens a fresh issue on any future 403, so this is purely additive cleanup.

## Surfaced live

- [caretaker-qa#53](https://github.com/ianlintner/caretaker-qa/issues/53) — bot filed scope-gap on the first v0.22.3 run (5x 403s on `POST/PATCH /check-runs`)
- [caretaker-qa#54](https://github.com/ianlintner/caretaker-qa/pull/54) — operator (this session, automated) widened `checks: write` + `security-events: read`
- Two subsequent runs ([24963544377](https://github.com/ianlintner/caretaker-qa/actions/runs/24963544377), [24963662593](https://github.com/ianlintner/caretaker-qa/actions/runs/24963662593)) had **zero** scope-gap 403s, but #53 stayed `OPEN` — the close path didn't exist

## Changes

| File | Change |
|---|---|
| `src/caretaker/github_client/scope_gap_reporter.py` | Add empty-tracker resolve-close branch in `publish_scope_gap_issue` |
| `tests/test_scope_gap.py` | 3 new tests: full close path, no-op fallthrough, dry-run safety |
| `src/caretaker/observability/otel.py` | Drive-by: drop 5 stale `# type: ignore[no-redef]` blocking pre-commit mypy (introduced in #604) |
| `uv.lock` | Bump to caretaker-github 0.22.3 |

## Test plan

- [x] `pytest tests/test_scope_gap.py` — 43 passed (40 existing + 3 new)
- [x] `mypy src/caretaker` (strict) — clean
- [x] `ruff format --check` + `ruff check` — clean
- [ ] After merge: caretaker-qa#53 auto-closes on the next run (no manual close required)
- [ ] Dry-run path verified to never close (regression test in suite)

## Methodology

Surfaced via the [caretaker-qa-cycle](https://github.com/ianlintner/caretaker/blob/main/.github/skills/caretaker-qa-cycle.md) skill (added in [#605](https://github.com/ianlintner/caretaker/pull/605)). This fix is the kind of "issue auto-close on resolve" gap the cycle is designed to surface — one of three stale-on-resolve issues observed on caretaker-qa post-v0.22.3 (#53 scope-gap, #51 CI failure, #41 stale upgrade target). Fixing #53 here; #51 and #41 are different code paths and can be follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)