### PR TITLE
fix(devops,upgrade): auto-close stale issues when underlying condition resolves

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -45,6 +45,13 @@ Skills are specialized knowledge modules that provide:
    - Plan migration
    - Execute upgrade
 
+6. **[caretaker-qa-cycle](./caretaker-qa-cycle.md)** - Run a live-fire QA cycle against caretaker-qa
+   - Decide whether a release warrants a live-fire QA cycle
+   - Author scenario issues that exercise specific behaviors
+   - Fast-forward the testbed pin to the release under test
+   - Watch a scheduled run and assert against documented invariants
+   - Triage findings and ship the fix
+
 ## How to Use Skills
 
 ### For Human Developers

--- a/.github/skills/caretaker-qa-cycle.md
+++ b/.github/skills/caretaker-qa-cycle.md
@@ -1,0 +1,281 @@
+# Skill: caretaker-qa-cycle
+
+## Purpose
+
+Run a structured QA test cycle of caretaker against the live
+[ianlintner/caretaker-qa](https://github.com/ianlintner/caretaker-qa)
+testbed. Use this when validating a release end-to-end (especially
+releases that change orchestrator/PR-agent behavior, autonomy posture,
+or the merge-authority surface).
+
+This is the **live-fire layer** described in
+`docs/plans/2026-04-25-qa-orchestration-test-plan.md` §4.5. Unit and
+state-machine tests cover individual transitions; this skill exercises
+the real LLM, real GitHub permissions, real webhook timing, and real
+multi-actor concurrency by driving caretaker through purpose-built
+scenarios on a real repo.
+
+## Capabilities
+
+- Decide whether a release warrants a live-fire QA cycle
+- Author QA scenario issues that exercise specific behaviors
+- Fast-forward the testbed's pin to the release under test
+- Watch a scheduled run and assert against the documented invariants
+- Triage findings and either fix in caretaker or record as a known gap
+
+## When to Use
+
+Trigger this skill when **any** of the following are true:
+
+- A release touches `pr_agent/`, `orchestrator/`, `pr_reviewer/`,
+  `merge_authority/`, `executor/`, or the readiness check publisher
+- A release changes default config values (autonomy / merge / review)
+- A release introduces a new external write (GitHub API call, label,
+  comment marker, check-run conclusion)
+- An incident's root-cause was not catchable by unit tests alone (i.e.
+  required event ordering, idempotency, or cross-agent state to surface)
+- The user asks to "test caretaker", "QA the release", "exercise
+  caretaker against caretaker-qa", or similar
+
+Do **not** trigger for purely internal refactors with no observable
+behavior change, or for doc-only PRs.
+
+## Prerequisites
+
+- `gh` authenticated as a user with write access to both
+  `ianlintner/caretaker` and `ianlintner/caretaker-qa`
+- Latest release tag exists (`gh release list -R ianlintner/caretaker`)
+- caretaker-qa workflow secrets present: `COPILOT_PAT`,
+  `ANTHROPIC_API_KEY` (or `AZURE_AI_API_KEY` + `AZURE_AI_API_BASE`),
+  optionally `CARETAKER_FLEET_SECRET` / OAuth2 fleet creds
+
+## QA cycle (5 steps)
+
+### 1. Identify the release surface
+
+Before writing scenarios, identify what behavior changed:
+
+```bash
+# What's the latest tag?
+gh release list -R ianlintner/caretaker --limit 5
+
+# What did it touch?
+gh pr list -R ianlintner/caretaker --search "merged:>=$(date -v-7d +%F)" \
+  --json number,title,files --limit 20
+
+# For a specific PR:
+gh pr view 604 -R ianlintner/caretaker --json files --jq '.files[].path'
+```
+
+Map each changed file to the user-observable behavior it controls. The
+scenarios in step 3 should exercise those behaviors — not the code
+paths, but the **outcomes** an operator would notice.
+
+### 2. Verify the testbed is current enough to exercise the release
+
+```bash
+# Pinned version on caretaker-qa:
+gh api /repos/ianlintner/caretaker-qa/contents/.github/maintainer/.version \
+  --jq '.content' | base64 -d
+```
+
+If the pin is older than the release under test, the testbed is not
+running the new code at all. Two options:
+
+- **Fast-forward** (recommended for QA cycles): open a PR bumping
+  `.github/maintainer/.version` to the release tag. The bump PR itself
+  is a live test of the autonomy / advisory-merge surface — if the
+  fixed pr-readiness check would have blocked it, that's the regression
+  signal.
+- **Honor the upgrade chain**: let the existing
+  `[Maintainer] Upgrade to vX.Y.Z` issues drive the bump organically.
+  Slower but tests the upgrade agent path. Use this if the release
+  changed upgrade-agent semantics.
+
+### 3. Author scenario issues in caretaker-qa
+
+Each scenario is one GitHub issue in caretaker-qa with a
+`<!-- caretaker:qa-scenario -->` HTML comment marker (used as a grep
+key) and a `<!-- scenario-NN: <slug> -->` second marker.
+
+Use the existing scenarios as a template:
+
+| # | Slug | Tests |
+|---|------|-------|
+| 04 | `stale-issue` | stale_agent labels + closes after window |
+| 05 | `fixes-cascade` | issue closes when linked PR merges |
+| 06 | `xss-payload` | sanitize_input guardrail |
+| 07 | `deceptive-link` | filter_output guardrail |
+| 09 | `idempotency-comment` | duplicate triage comment dedup |
+| 10 | `empty-pr-body` | triage close test |
+| 11 | `azure-ai-prompt-cache` | prompt cache works through Azure AI |
+
+Reserve the next free number(s) and write each scenario as:
+
+```markdown
+## QA Scenario NN — <one-line title>
+
+**Release validated:** vX.Y.Z (PR #NNN)
+
+**Setup:** <what state must exist for the test, and any one-time
+configuration steps>
+
+**Expected caretaker behavior:**
+1. <observable step 1>
+2. <observable step 2>
+3. <observable step 3, ideally referencing a metric or check-run conclusion>
+
+**Failure modes the scenario catches:**
+- <regression mode 1>
+- <regression mode 2>
+
+**How to verify:**
+```bash
+# concrete commands the QA reviewer can paste to confirm
+gh api /repos/ianlintner/caretaker-qa/actions/runs ...
+```
+
+<!-- caretaker:qa-scenario -->
+<!-- scenario-NN: <slug> -->
+```
+
+A scenario is good if a reasonable reviewer can read it and decide
+PASS/FAIL by inspection — no caretaker-internal knowledge required.
+
+### 4. Trigger a run and watch the invariants
+
+```bash
+# Manually dispatch the caretaker workflow:
+gh workflow run maintainer.yml -R ianlintner/caretaker-qa
+
+# Watch the latest run:
+gh run watch -R ianlintner/caretaker-qa $(gh run list \
+  -R ianlintner/caretaker-qa --workflow maintainer.yml --limit 1 \
+  --json databaseId --jq '.[0].databaseId')
+
+# Inspect the run's artifacts (memory snapshot, scope-gap, digest):
+gh run download <run-id> -R ianlintner/caretaker-qa
+```
+
+Cross-check against the **invariants** in
+`docs/plans/2026-04-25-qa-orchestration-test-plan.md` §9. The most
+load-bearing for autonomy releases are:
+
+- **No double-approve same SHA** — `count(create_review event=APPROVE
+  for pr=N at sha=S) <= 1`
+- **Caretaker PRs only auto-approve** — head ref must start with
+  `caretaker/`, `claude/`, or `copilot/`
+- **Transient-only errors do not fail the run** — exit 0 if all errors
+  in `report.errors` are `RATE_LIMIT` or `TRANSIENT_NETWORK`
+- **Advisory mode never publishes `failure`** — the pr-readiness
+  check-run conclusion is `success | neutral | skipped`, never
+  `failure`, when `pr_agent.merge_authority.mode == advisory`
+- **Idempotency** — replay the same scheduled run on the same head SHA
+  → no new GitHub writes
+
+### 5. Triage findings
+
+For each scenario that doesn't pass:
+
+1. Decide if the bug is in caretaker (fix in main) or in the testbed
+   (fix in caretaker-qa).
+2. If in caretaker: open a PR with a regression unit test in
+   `tests/test_pr_agent/` or `tests/test_orchestrator/` **first**,
+   then the fix. Reference the QA scenario number in the PR.
+3. If in caretaker-qa: open a PR; do not weaken the scenario unless
+   the expected behavior was wrong.
+4. Append the finding to `docs/qa-findings-YYYY-MM-DD.md` (one file
+   per cycle) — this is the long-term scoreboard.
+
+Always finish a cycle by:
+
+- Closing scenarios that pass (label `caretaker:qa-passed`)
+- Leaving open the ones that surfaced bugs until the fix lands
+- Updating the pinned version in caretaker-qa to whatever release
+  shipped the fix
+
+## Common patterns
+
+### Pattern: testing a "PR blocking deadlock" fix (advisory → neutral)
+
+When a release fixes a PR-blocking class of bug (e.g. PR #604), the
+scenario must exercise the **branch-protection-required-check chain**,
+not just the conclusion publisher in isolation:
+
+1. Open a PR on caretaker-qa with a head branch matching `caretaker/*`
+   that fails one transient blocker (e.g. CI red on a flaky test).
+2. Configure branch protection on `main` to require the
+   `caretaker/pr-readiness` check (one-time, document in the
+   scenario).
+3. Schedule two consecutive caretaker runs.
+4. Assert the PR is not blocked indefinitely: either it merges
+   (advisory mode → neutral, no block) or the operator gets a clear
+   `gate_only` failure with an explicit signal.
+
+### Pattern: testing a parent-threading / causal-event fix
+
+Releases that change the causal-event store (e.g. v0.22.0 PR #601)
+need a scenario where **two agent runs share state via a parent_id**:
+
+1. File an issue in caretaker-qa that triggers `issue_agent`.
+2. After issue_agent dispatches a fix to copilot, capture the
+   `CausalEvent.parent_id` from the memory snapshot artifact.
+3. On the next scheduled run, assert that `pr_agent`'s evaluation of
+   the resulting PR has `parent_id` matching the issue's causal id.
+
+If parent_id is null on the second run, the persistence path is broken
+even if unit tests pass.
+
+### Pattern: regression cassette from a real incident
+
+When an incident surfaces, the **post-fix QA scenario** is the
+incident's own event log replayed on the new code. Pull the run id
+from the incident, dump the event log via
+`CARETAKER_RECORD_CASSETTE=path` (when available), and commit the
+cassette as `tests/cassettes/incident-YYYY-MM-DD.jsonl`. Add a layer-4
+test that replays it. The QA scenario in caretaker-qa is then a
+human-readable echo of the cassette.
+
+## Troubleshooting
+
+### Scheduled run isn't picking up the pin bump
+
+The workflow caches `caretaker` from PyPI / git ref by version. After
+bumping `.github/maintainer/.version`, also confirm the workflow's
+`uses:` or `pip install` line resolves the new version. If the bump
+PR was merged but the next run still shows the old version in
+`caretaker --version`, check `actions/cache` keys.
+
+### Self-heal loop fires after a pin bump
+
+The most common cause is a config field that was added in the new
+release and is required (or has a different default). Read the
+`Config error` issue body — it usually quotes the validation error.
+Map that to a `setup-templates/config-default.yml` change in the
+release's PR and apply it to caretaker-qa's config.
+
+### Scenarios marked caretaker:qa-passed re-open the next cycle
+
+If caretaker keeps re-opening a closed scenario, the closing comment
+probably lacked the `caretaker:qa-passed` label or the
+`<!-- caretaker:qa-scenario -->` marker is on a comment instead of
+the issue body. Markers are body-only.
+
+## Related skills
+
+- [caretaker-debug](./caretaker-debug.md) — for diagnosing run
+  failures surfaced by a QA cycle
+- [caretaker-config](./caretaker-config.md) — for tweaking
+  caretaker-qa's `.github/maintainer/config.yml` between cycles
+- [caretaker-upgrade](./caretaker-upgrade.md) — for the
+  honor-the-upgrade-chain alternative in step 2
+
+## References
+
+- `docs/plans/2026-04-25-qa-orchestration-test-plan.md` — full
+  layered test strategy
+- `docs/qa-findings-2026-04-23.md` — example findings doc from a
+  prior cycle
+- `docs/plans/2026-04-22-qa-scenario-11-prompt-cache.md` — example
+  scenario authoring document
+- [caretaker-qa testbed](https://github.com/ianlintner/caretaker-qa)

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,27 @@
 {
   "releases": [
     {
+      "version": "0.22.2",
+      "min_compatible": "0.19.6",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.22.2",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.22.2 -->\n\n## What's Changed\n### Other Changes\n* fix(pr-agent): wire MergeAuthorityConfig + neutral conclusion in advisory mode by @ianlintner in https://github.com/ianlintner/caretaker/pull/604\n* fix(graph): persist CausalEvent.parent_id on Neo4j node so SPA + warm-from-graph see it by @ianlintner\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.22.1...v0.22.2",
+      "breaking": false
+    },
+    {
+      "version": "0.22.1",
+      "min_compatible": "0.19.6",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.22.1",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.22.1 -->\n\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.22.0...v0.22.1",
+      "breaking": false
+    },
+    {
+      "version": "0.22.0",
+      "min_compatible": "0.19.6",
+      "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.22.0",
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.22.0 -->\n\n## What's Changed\n### Other Changes\n* chore: add v0.21.0 to releases.json by @github-actions[bot] in https://github.com/ianlintner/caretaker/pull/600\n* chore: add v0.20.1 to releases.json by @github-actions[bot] in https://github.com/ianlintner/caretaker/pull/599\n* feat(causal): persistent CausalEventStore + parent threading across agents by @ianlintner in https://github.com/ianlintner/caretaker/pull/601\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.21.0...v0.22.0",
+      "breaking": false
+    },
+    {
       "version": "0.21.0",
       "min_compatible": "0.19.6",
       "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.21.0",
@@ -11,7 +32,7 @@
       "version": "0.20.1",
       "min_compatible": "0.19.6",
       "changelog_url": "https://github.com/ianlintner/caretaker/releases/tag/v0.20.1",
-      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.20.1 -->\n\n## What's Changed\n### Other Changes\n* fix(mcp): harden caretaker-mcp against OOM under webhook bursts + GitHub cooldown by @ianlintner in https://github.com/ianlintner/caretaker/pull/596\n* fix(doctor): drop legacy CARETAKER_FLEET_SECRET HMAC check by @ianlintner in https://github.com/ianlintner/caretaker/pull/597\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.20.0...v0.20.1"
+      "upgrade_notes": "<!-- Release notes generated using configuration in .github/release.yml at v0.20.1 -->\n\n## What's Changed\n### Other Changes\n* fix(mcp): harden caretaker-mcp against OOM under webhook bursts + GitHub cooldown by @ianlintner in https://github.com/ianlintner/caretaker/pull/596\n* fix(doctor): drop legacy CARETAKER_FLEET_SECRET HMAC check by @ianlintner in https://github.com/ianlintner/caretaker/pull/597\n\n\n**Full Changelog**: https://github.com/ianlintner/caretaker/compare/v0.20.0...v0.20.1",
       "breaking": false
     },
     {

--- a/src/caretaker/devops_agent/agent.py
+++ b/src/caretaker/devops_agent/agent.py
@@ -32,6 +32,7 @@ class DevOpsReport:
     failures_detected: int = 0
     issues_created: list[int] = field(default_factory=list)
     issues_skipped: int = 0  # duplicate detection
+    issues_closed_resolved: list[int] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     # Sigs actioned this run — used to update persisted state dedup
     actioned_sigs: list[str] = field(default_factory=list)
@@ -83,6 +84,16 @@ class DevOpsAgent:
 
         if not failing_jobs:
             logger.info("DevOps agent: no failing CI jobs on %s", self._default_branch)
+            # Sweep open build-failure issues — anything still open
+            # corresponds to a failure that no longer reproduces. Close
+            # them so `maintainer:action-required` clears without manual
+            # housekeeping.
+            try:
+                report.issues_closed_resolved = await self._close_resolved_failure_issues(
+                    active_sigs=set()
+                )
+            except Exception as e:
+                logger.warning("DevOps agent: resolved-failure close pass failed: %s", e)
             return report
 
         report.failures_detected = len(failing_jobs)
@@ -135,6 +146,17 @@ class DevOpsAgent:
             except Exception as e:
                 logger.error("DevOps agent: failed to create issue: %s", e)
                 report.errors.append(str(e))
+
+        # Close any open build-failure issues whose signature is no longer
+        # reproducing this run. Subset of failing_jobs may have been fixed
+        # in main while others remain — close the resolved ones.
+        active_sigs = {_failure_signature(s) for s in failing_jobs}
+        try:
+            report.issues_closed_resolved = await self._close_resolved_failure_issues(
+                active_sigs=active_sigs
+            )
+        except Exception as e:
+            logger.warning("DevOps agent: resolved-failure close pass failed: %s", e)
 
         report.updated_cooldowns = dict(self._issue_cooldowns)
         return report
@@ -266,6 +288,64 @@ class DevOpsAgent:
                 base_branch=self._default_branch,
             ),
         )
+
+    async def _close_resolved_failure_issues(self, *, active_sigs: set[str]) -> list[int]:
+        """Close open build-failure issues whose signature is no longer firing.
+
+        Surfaced live on caretaker-qa#51: an old transient
+        ``maintain (unknown)`` failure was tracked, the underlying
+        problem (broken bootstrap-check) was fixed via caretaker-qa#50
+        + #54, every subsequent run had ``no failing CI jobs on main``
+        — but the issue stayed ``OPEN`` with ``bug, devops:build-failure``
+        labels because devops_agent had no resolved-close path.
+
+        ``active_sigs`` is the set of failure signatures still firing on
+        the current run. Issues whose embedded ``sig:<hex>`` is NOT in
+        that set are considered resolved and closed (with a comment).
+
+        Returns the list of issue numbers closed.
+        """
+        try:
+            issues = await self._issues.list(state="open", labels=BUILD_FAILURE_LABEL)
+        except Exception as e:
+            logger.warning("Failed to list open build-failure issues: %s", e)
+            return []
+
+        closed: list[int] = []
+        for issue in issues:
+            if DEVOPS_AGENT_MARKER not in (issue.body or ""):
+                continue
+            sig: str | None = None
+            for line in (issue.body or "").splitlines():
+                if line.startswith(DEVOPS_AGENT_MARKER):
+                    match = re.search(r"\bsig:([0-9a-f]+)\b", line)
+                    if match:
+                        sig = match.group(1)
+                        break
+            if sig is None or sig in active_sigs:
+                continue
+            logger.info(
+                "Closing resolved build-failure issue #%d (sig %s no longer firing on %s)",
+                issue.number,
+                sig,
+                self._default_branch,
+            )
+            try:
+                await self._issues.comment(
+                    issue.number,
+                    f"Closed automatically: caretaker observed no failing CI jobs "
+                    f"on `{self._default_branch}` matching this signature on the "
+                    f"most recent run, so the build failure is considered "
+                    f"resolved. Caretaker will re-open a fresh issue if the "
+                    f"failure reappears.",
+                )
+                await self._issues.update(issue.number, state="closed")
+                closed.append(issue.number)
+            except Exception as e:
+                logger.warning(
+                    "Failed to close resolved build-failure issue #%d: %s", issue.number, e
+                )
+        return closed
 
     async def _ensure_label(self, name: str, color: str, description: str) -> None:
         """Create the label if it does not already exist (best-effort)."""

--- a/src/caretaker/github_client/scope_gap_reporter.py
+++ b/src/caretaker/github_client/scope_gap_reporter.py
@@ -166,10 +166,61 @@ async def publish_scope_gap_issue(
     The function never raises — callers tend to invoke it from the
     orchestrator's tail cleanup where nothing upstream has a handle
     to recover, so any failure is logged at WARNING and swallowed.
+
+    When the tracker is empty AND a previous run filed an open
+    scope-gap issue, the issue is closed automatically. This closes
+    the loop with consumers who fixed the underlying ``permissions:``
+    block and lets ``maintainer:action-required`` clear without
+    manual housekeeping.
     """
     tracker = tracker or get_tracker()
     if tracker.is_empty():
-        return None
+        if dry_run:
+            return None
+        try:
+            existing = await _find_existing_issue(github, owner, repo)
+        except Exception as exc:
+            logger.warning(
+                "Unable to look up existing scope-gap issue in %s/%s during resolve-close: %s",
+                owner,
+                repo,
+                exc,
+            )
+            return None
+        if existing is None:
+            return None
+        try:
+            resolved_body = existing.body.rstrip() + (
+                "\n\n---\n\n_Closed automatically: caretaker observed no "
+                "scope-gap 403s on the most recent run, so this issue is "
+                "considered resolved. Caretaker will re-open a fresh "
+                "scope-gap issue if any GITHUB_TOKEN scope is missing on "
+                "a future run._"
+            )
+            await github.update_issue(
+                owner,
+                repo,
+                existing.number,
+                body=resolved_body,
+                state="closed",
+                state_reason="completed",
+            )
+            logger.info(
+                "Closed scope-gap issue #%d in %s/%s — gap resolved on this run",
+                existing.number,
+                owner,
+                repo,
+            )
+            return existing.number
+        except Exception as exc:  # pragma: no cover - defensive tail
+            logger.warning(
+                "Failed to close resolved scope-gap issue #%d in %s/%s: %s",
+                existing.number,
+                owner,
+                repo,
+                exc,
+            )
+            return None
 
     incidents = tracker.snapshot()
     body = render_issue_body(incidents, owner=owner, repo=repo)

--- a/src/caretaker/observability/otel.py
+++ b/src/caretaker/observability/otel.py
@@ -62,13 +62,13 @@ _TracerProvider: Any
 _BatchSpanProcessor: Any
 
 try:  # pragma: no cover - exercised by the fallback path in tests
-    from opentelemetry import trace as _otel_trace  # type: ignore[no-redef]
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # type: ignore[no-redef]
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
         OTLPSpanExporter as _OTLPSpanExporter,
     )
-    from opentelemetry.sdk.resources import Resource as _OTelResource  # type: ignore[no-redef]
-    from opentelemetry.sdk.trace import TracerProvider as _TracerProvider  # type: ignore[no-redef]
-    from opentelemetry.sdk.trace.export import (  # type: ignore[no-redef]
+    from opentelemetry.sdk.resources import Resource as _OTelResource
+    from opentelemetry.sdk.trace import TracerProvider as _TracerProvider
+    from opentelemetry.sdk.trace.export import (
         BatchSpanProcessor as _BatchSpanProcessor,
     )
 

--- a/src/caretaker/observability/otel.py
+++ b/src/caretaker/observability/otel.py
@@ -62,13 +62,17 @@ _TracerProvider: Any
 _BatchSpanProcessor: Any
 
 try:  # pragma: no cover - exercised by the fallback path in tests
-    from opentelemetry import trace as _otel_trace
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    from opentelemetry import trace as _otel_trace  # type: ignore[no-redef, unused-ignore]
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # type: ignore[no-redef, unused-ignore]
         OTLPSpanExporter as _OTLPSpanExporter,
     )
-    from opentelemetry.sdk.resources import Resource as _OTelResource
-    from opentelemetry.sdk.trace import TracerProvider as _TracerProvider
-    from opentelemetry.sdk.trace.export import (
+    from opentelemetry.sdk.resources import (  # type: ignore[no-redef, unused-ignore]
+        Resource as _OTelResource,
+    )
+    from opentelemetry.sdk.trace import (  # type: ignore[no-redef, unused-ignore]
+        TracerProvider as _TracerProvider,
+    )
+    from opentelemetry.sdk.trace.export import (  # type: ignore[no-redef, unused-ignore]
         BatchSpanProcessor as _BatchSpanProcessor,
     )
 

--- a/src/caretaker/upgrade_agent/agent.py
+++ b/src/caretaker/upgrade_agent/agent.py
@@ -26,6 +26,7 @@ class UpgradeAgentReport:
     upgrade_issue: int | None = None
     superseded_prs: list[int] = field(default_factory=list)
     readied_draft_prs: list[int] = field(default_factory=list)
+    closed_stale_upgrade_issues: list[int] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
 
@@ -84,6 +85,21 @@ class UpgradeAgent:
                 )
             else:
                 logger.info("Already on latest version %s", self._current_version)
+                # Even when no upgrade is needed, sweep stale upgrade
+                # issues whose targets the consumer has already moved past.
+                # Otherwise every "[Maintainer] Upgrade to vX.Y.Z" issue
+                # stays OPEN forever once the pin is bumped past it.
+                try:
+                    closed = await self._planner.close_stale_upgrade_issues(self._current_version)
+                    report.closed_stale_upgrade_issues = closed
+                    if closed:
+                        logger.info(
+                            "Closed %d stale upgrade issue(s): %s",
+                            len(closed),
+                            closed,
+                        )
+                except Exception as e:
+                    logger.warning("Stale upgrade issue cleanup failed: %s", e)
 
         except Exception as e:
             logger.error("Upgrade check failed: %s", e)

--- a/src/caretaker/upgrade_agent/planner.py
+++ b/src/caretaker/upgrade_agent/planner.py
@@ -330,6 +330,70 @@ class UpgradePlanner:
         logger.info("Created upgrade issue #%d for v%s", issue.number, target.version)
         return issue.number
 
+    async def close_stale_upgrade_issues(self, current_version: str) -> list[int]:
+        """Close open upgrade issues whose target is at or below ``current_version``.
+
+        When a consumer repo upgrades past an issue's target (either via
+        the upgrade flow or a manual jump), the issue is stale — there's
+        nothing left to do. Without this cleanup, every prior ``[Maintainer]
+        Upgrade to vX.Y.Z`` issue stays ``OPEN`` forever even though
+        ``Already on latest version $current_version`` is true on every run.
+
+        Surfaced live on caretaker-qa#41 (``Upgrade to v0.19.6`` open
+        while the repo is on v0.22.3 — pin was fast-forwarded past v0.19.6
+        in caretaker-qa#50, but the upgrade issue never closed).
+
+        Returns the list of issue numbers closed.
+        """
+        from packaging.version import InvalidVersion, Version
+
+        try:
+            current = Version(current_version)
+        except InvalidVersion:
+            logger.warning(
+                "close_stale_upgrade_issues: invalid current_version %r — skipping",
+                current_version,
+            )
+            return []
+
+        issues = await self._issues.list(state="open")
+        closed: list[int] = []
+        for issue in issues:
+            marker_match = _UPGRADE_MARKER_RE.search(issue.body or "")
+            if not marker_match:
+                continue
+            target_version_str = marker_match.group(1)
+            try:
+                target_version = Version(target_version_str)
+            except InvalidVersion:
+                continue
+            if target_version > current:
+                # Future upgrade target — leave it open.
+                continue
+            logger.info(
+                "Closing stale upgrade issue #%d (target v%s ≤ current v%s)",
+                issue.number,
+                target_version_str,
+                current_version,
+            )
+            try:
+                await self._issues.comment(
+                    issue.number,
+                    f"Closed automatically: caretaker is already on "
+                    f"`v{current_version}`, which is at or past the target "
+                    f"`v{target_version_str}`. Caretaker will re-open a "
+                    f"fresh upgrade issue when a newer release is available.",
+                )
+                await self._issues.update(issue.number, state="closed")
+                closed.append(issue.number)
+            except Exception as e:
+                logger.warning(
+                    "Failed to close stale upgrade issue #%d: %s",
+                    issue.number,
+                    e,
+                )
+        return closed
+
     async def close_superseded_upgrade_prs(self, version: str) -> list[int]:
         """Close older open upgrade PRs for the same target version.
 

--- a/tests/test_devops_agent.py
+++ b/tests/test_devops_agent.py
@@ -29,6 +29,87 @@ def _issue_with_signature(number: int, sig: str) -> Issue:
     )
 
 
+class TestDevOpsAgentResolvedFailureClose:
+    """The resolved-failure auto-close path keeps stale `devops:build-failure`
+    issues from piling up after the underlying CI bug is fixed.
+
+    Surfaced live on caretaker-qa#51 — the bootstrap-check failure was
+    fixed via caretaker-qa#50 + #54, every subsequent run logged
+    `no failing CI jobs on main`, but #51 stayed OPEN because there was
+    no resolved-failure cleanup pass."""
+
+    @pytest.mark.asyncio
+    async def test_closes_open_issue_when_no_failures_this_run(self) -> None:
+        """Empty failing_jobs + open build-failure issue → close the issue."""
+        gh = AsyncMock()
+        # First list_issues call (resolved-close pass) returns the stale issue.
+        gh.list_issues.return_value = [_issue_with_signature(51, "deadbeefcafe")]
+
+        agent = DevOpsAgent(github=gh, owner="o", repo="r")
+        agent._discover_failing_jobs = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        report = await agent.run()
+
+        assert report.failures_detected == 0
+        assert report.issues_closed_resolved == [51]
+        # Confirm we actually patched + commented.
+        gh.update_issue.assert_awaited()
+        gh.add_issue_comment.assert_awaited()
+        update_call = gh.update_issue.await_args
+        assert update_call.kwargs.get("state") == "closed"
+
+    @pytest.mark.asyncio
+    async def test_keeps_issue_open_when_signature_still_firing(self) -> None:
+        """Issue's signature matches a current failing job → leave it OPEN."""
+        summary = FailureSummary(
+            job_name="lint",
+            conclusion="failure",
+            suspected_files=["src/caretaker/config.py"],
+            category="lint",
+        )
+        sig = _failure_signature(summary)
+
+        gh = AsyncMock()
+        gh.list_issues.return_value = [_issue_with_signature(51, sig)]
+        agent = DevOpsAgent(github=gh, owner="o", repo="r")
+        agent._discover_failing_jobs = AsyncMock(return_value=[summary])  # type: ignore[method-assign]
+        agent._create_fix_issue = AsyncMock()  # type: ignore[method-assign]
+
+        report = await agent.run()
+
+        # Sig is currently firing → we skipped creating (dedup) AND did not close.
+        assert report.issues_skipped == 1
+        assert report.issues_closed_resolved == []
+        # update_issue should not have been called with state=closed.
+        for call in gh.update_issue.await_args_list:
+            assert call.kwargs.get("state") != "closed"
+
+    @pytest.mark.asyncio
+    async def test_closes_subset_when_some_failures_resolve(self) -> None:
+        """Two open issues, only one signature still firing → close the other."""
+        active_summary = FailureSummary(
+            job_name="lint",
+            conclusion="failure",
+            suspected_files=["src/caretaker/config.py"],
+            category="lint",
+        )
+        active_sig = _failure_signature(active_summary)
+        stale_sig = "1111aaaa2222"
+
+        gh = AsyncMock()
+        gh.list_issues.return_value = [
+            _issue_with_signature(51, stale_sig),
+            _issue_with_signature(52, active_sig),
+        ]
+        agent = DevOpsAgent(github=gh, owner="o", repo="r")
+        agent._discover_failing_jobs = AsyncMock(return_value=[active_summary])  # type: ignore[method-assign]
+        agent._create_fix_issue = AsyncMock()  # type: ignore[method-assign]
+
+        report = await agent.run()
+
+        assert report.issues_closed_resolved == [51]
+
+
 class TestDevOpsAgentDuplicateSuppression:
     @pytest.mark.asyncio
     async def test_extracts_raw_signature_from_existing_issue_marker(self) -> None:

--- a/tests/test_scope_gap.py
+++ b/tests/test_scope_gap.py
@@ -404,3 +404,58 @@ async def test_publish_dry_run_skips_write() -> None:
     assert result is None
     assert gh.create_calls == []
     assert gh.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_closes_existing_issue_when_gap_resolves() -> None:
+    """When the tracker is empty AND a prior run filed an open scope-gap
+    issue, the next run closes it automatically with a resolution note.
+    Surfaced live on caretaker-qa#53 — operator widened the workflow
+    perms but the issue stayed open across subsequent green runs."""
+    gh = FakeGitHub()
+    gh.existing_issues[SCOPE_GAP_LABEL] = [
+        _issue(
+            17,
+            f"{SCOPE_GAP_ISSUE_MARKER}\n\nold body about missing checks: write",
+            labels=[SCOPE_GAP_LABEL],
+        )
+    ]
+
+    # Tracker is empty (no 403s observed this run).
+    result = await publish_scope_gap_issue(gh, "o", "r")
+
+    assert result == 17
+    assert gh.create_calls == []
+    assert len(gh.update_calls) == 1
+    upd = gh.update_calls[0]
+    assert upd["number"] == 17
+    assert upd["state"] == "closed"
+    assert upd.get("state_reason") == "completed"
+    assert "Closed automatically" in upd["body"]
+    assert SCOPE_GAP_ISSUE_MARKER in upd["body"]
+
+
+@pytest.mark.asyncio
+async def test_publish_resolve_close_is_noop_when_no_existing_issue() -> None:
+    """Empty tracker + no prior issue → still a clean no-op."""
+    gh = FakeGitHub()
+    result = await publish_scope_gap_issue(gh, "o", "r")
+    assert result is None
+    assert gh.create_calls == []
+    assert gh.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_resolve_close_respects_dry_run() -> None:
+    """Dry-run must never close the existing issue, even if the gap is gone."""
+    gh = FakeGitHub()
+    gh.existing_issues[SCOPE_GAP_LABEL] = [
+        _issue(
+            17,
+            f"{SCOPE_GAP_ISSUE_MARKER}\n\nbody",
+            labels=[SCOPE_GAP_LABEL],
+        )
+    ]
+    result = await publish_scope_gap_issue(gh, "o", "r", dry_run=True)
+    assert result is None
+    assert gh.update_calls == []

--- a/tests/test_upgrade_agent/test_agent.py
+++ b/tests/test_upgrade_agent/test_agent.py
@@ -83,6 +83,42 @@ class TestUpgradeAgent:
         assert report.upgrade_needed is False
         assert report.upgrade_issue is None
 
+    async def test_no_upgrade_path_sweeps_stale_upgrade_issues(self) -> None:
+        """Regression for caretaker-qa#41 — when no upgrade is needed, the
+        agent must still sweep open upgrade issues whose targets the repo
+        has already moved past."""
+        from caretaker.github_client.models import Issue, User
+
+        github = AsyncMock()
+
+        stale = Issue(
+            number=41,
+            title="[Maintainer] Upgrade to v0.19.6",
+            body="<!-- caretaker:upgrade target=0.19.6 -->",
+            state="open",
+            user=User(login="bot", id=1, type="Bot"),
+        )
+        github.list_issues.return_value = [stale]
+
+        agent = UpgradeAgent(
+            github=github,
+            owner="o",
+            repo="r",
+            config=UpgradeAgentConfig(enabled=True),
+            current_version="0.22.3",
+        )
+        release = Release(
+            version="0.22.3",
+            min_compatible="0.22.0",
+            changelog_url="https://example.com/changelog",
+        )
+        releases_mock = AsyncMock(return_value=[release])
+        with patch("caretaker.upgrade_agent.agent.fetch_releases", new=releases_mock):
+            report = await agent.run()
+
+        assert report.upgrade_needed is False
+        assert report.closed_stale_upgrade_issues == [41]
+
     async def test_auto_ready_drafts_default_is_true(self) -> None:
         cfg = UpgradeAgentConfig()
         assert cfg.auto_ready_drafts is True

--- a/tests/test_upgrade_agent/test_planner.py
+++ b/tests/test_upgrade_agent/test_planner.py
@@ -165,6 +165,85 @@ class TestUpgradePlanner:
         github.update_issue.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+class TestCloseStaleUpgradeIssues:
+    """Sweep open upgrade issues whose target ≤ current version.
+
+    Surfaced live on caretaker-qa#41 — pin was fast-forwarded from
+    v0.19.4 to v0.22.3 in caretaker-qa#50, but the v0.19.6 upgrade
+    issue stayed OPEN because the agent's "no upgrade needed" branch
+    didn't sweep stale issues."""
+
+    async def test_closes_issue_when_target_is_below_current(self) -> None:
+        github = AsyncMock()
+        planner = UpgradePlanner(github=github, owner="o", repo="r")
+        stale = make_issue(41, "Upgrade to v0.19.6", maintainer=True)
+        stale.body = "<!-- caretaker:upgrade target=0.19.6 -->"
+        stale.state = "open"
+        github.list_issues.return_value = [stale]
+
+        closed = await planner.close_stale_upgrade_issues("0.22.3")
+
+        assert closed == [41]
+        github.update_issue.assert_awaited_with("o", "r", 41, state="closed")
+        github.add_issue_comment.assert_awaited()
+
+    async def test_closes_issue_when_target_equals_current(self) -> None:
+        """target == current is also stale — there's nothing to upgrade to."""
+        github = AsyncMock()
+        planner = UpgradePlanner(github=github, owner="o", repo="r")
+        stale = make_issue(41, "Upgrade to v0.22.3", maintainer=True)
+        stale.body = "<!-- caretaker:upgrade target=0.22.3 -->"
+        stale.state = "open"
+        github.list_issues.return_value = [stale]
+
+        closed = await planner.close_stale_upgrade_issues("0.22.3")
+
+        assert closed == [41]
+
+    async def test_keeps_issue_open_when_target_is_above_current(self) -> None:
+        """Future-target issues are NOT stale — leave them OPEN."""
+        github = AsyncMock()
+        planner = UpgradePlanner(github=github, owner="o", repo="r")
+        future = make_issue(41, "Upgrade to v0.23.0", maintainer=True)
+        future.body = "<!-- caretaker:upgrade target=0.23.0 -->"
+        future.state = "open"
+        github.list_issues.return_value = [future]
+
+        closed = await planner.close_stale_upgrade_issues("0.22.3")
+
+        assert closed == []
+        github.update_issue.assert_not_awaited()
+
+    async def test_skips_issues_without_marker(self) -> None:
+        """Issues that aren't upgrade-marked are out of scope."""
+        github = AsyncMock()
+        planner = UpgradePlanner(github=github, owner="o", repo="r")
+        unrelated = make_issue(42, "Some unrelated issue", maintainer=False)
+        unrelated.body = "no caretaker marker here"
+        unrelated.state = "open"
+        github.list_issues.return_value = [unrelated]
+
+        closed = await planner.close_stale_upgrade_issues("0.22.3")
+
+        assert closed == []
+        github.update_issue.assert_not_awaited()
+
+    async def test_skips_when_current_version_unparseable(self) -> None:
+        """Don't go around closing things with garbage version inputs."""
+        github = AsyncMock()
+        planner = UpgradePlanner(github=github, owner="o", repo="r")
+        stale = make_issue(41, "Upgrade to v0.19.6", maintainer=True)
+        stale.body = "<!-- caretaker:upgrade target=0.19.6 -->"
+        stale.state = "open"
+        github.list_issues.return_value = [stale]
+
+        closed = await planner.close_stale_upgrade_issues("not-a-version")
+
+        assert closed == []
+        github.update_issue.assert_not_awaited()
+
+
 class TestBuildSyncIssueBody:
     def test_body_contains_version_and_marker(self) -> None:
         body = build_sync_issue_body("1.5.0")

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "caretaker-github"
-version = "0.22.2"
+version = "0.22.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Two parallel "open-forever" issue patterns in `devops_agent` and `upgrade_agent`, both surfaced live on caretaker-qa post-v0.22.3. They share the same shape as the scope-gap fix in [#607](https://github.com/ianlintner/caretaker/pull/607): the agent silently early-returned when nothing matched, never reconsidering open issues for cleanup.

This PR is the follow-up [#607](https://github.com/ianlintner/caretaker/pull/607) flagged.

## DevOps agent — closes [caretaker-qa#51](https://github.com/ianlintner/caretaker-qa/issues/51)

`devops_agent` filed a `🔧 CI failure on main: maintain (unknown)` issue from a transient bootstrap-check failure. The underlying problem was fixed via [caretaker-qa#50](https://github.com/ianlintner/caretaker-qa/pull/50) + [#54](https://github.com/ianlintner/caretaker-qa/pull/54), every subsequent run logged `no failing CI jobs on main` — but the issue stayed `OPEN` with `bug, devops:build-failure` labels because there was no resolved-failure cleanup pass.

**Fix:** after evaluating failing jobs, sweep open `devops:build-failure` issues whose embedded `sig:<hex>` is no longer firing (or all of them, when no failures reproduce at all). Close with a comment explaining the resolution. Re-opens automatically if the failure reappears.

## Upgrade agent — closes [caretaker-qa#41](https://github.com/ianlintner/caretaker-qa/issues/41)

`upgrade_agent` filed `[Maintainer] Upgrade to v0.19.6` when the pin was on v0.19.4. The pin then jumped to v0.22.3 in [caretaker-qa#50](https://github.com/ianlintner/caretaker-qa/pull/50), making v0.19.6 a target the repo had already moved past. The agent logged `Already on latest version 0.22.3` on every run thereafter but never closed the stale v0.19.6 issue — its "Already on latest" branch was a pure no-op.

**Fix:** when no upgrade is needed, sweep open issues with the `<!-- caretaker:upgrade target=X.Y.Z -->` marker, parse the version, and close any whose target is at or below `current_version`. Future-target issues stay open.

## Tests

| Suite | Cases added |
|---|---|
| `TestDevOpsAgentResolvedFailureClose` | 3 — full close, active-sig held open, partial close (subset resolves) |
| `TestCloseStaleUpgradeIssues` | 5 — target<current, target==current, target>current, no marker, garbage current_version |
| `test_no_upgrade_path_sweeps_stale_upgrade_issues` | 1 — agent-level integration confirming sweep fires from "Already on latest" |

**100 passed total** across `tests/test_devops_agent.py`, `tests/test_upgrade_agent/`, and `tests/test_scope_gap.py` (the related #607 suite).

## Pre-commit

- [x] `ruff format --check` clean
- [x] `ruff check` clean
- [x] `mypy src/caretaker` (strict) — no issues found in 226 source files

## Why this matters

Closes a class of bug behind "PR blocking and not achieving goals": issues filed by caretaker that never auto-clear contribute to the operator-attention queue (`maintainer:action-required` etc.) and make the autonomous loop look like it's not converging — the operator sees stale red issues pile up, concludes caretaker is stuck, and intervenes manually. With this PR + [#607](https://github.com/ianlintner/caretaker/pull/607) merged, caretaker's three most common per-run informational issues (scope-gap, build-failure, stale-upgrade) all auto-close on resolve.

Surfaced via the [caretaker-qa-cycle](https://github.com/ianlintner/caretaker/blob/main/.github/skills/caretaker-qa-cycle.md) skill (added in [#605](https://github.com/ianlintner/caretaker/pull/605)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)