### PR TITLE
fix(pr-agent): unblock readiness gate — bot approvals, terminal state, polling fallback

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -2,7 +2,15 @@ name: Caretaker
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    # 5-minute cron is the GitHub Actions practical minimum (best-effort).
+    # Webhooks remain the primary low-latency path; this cron is the
+    # polling fallback that recovers from dropped webhook deliveries —
+    # PR #609's status comment stalled at 30% for ~10 minutes despite all
+    # CI completing, because the agent never re-fetched after the missed
+    # webhook. The dispatch-guard cooldown (EVENT_COOLDOWN_MINUTES=3)
+    # serializes runs so the bumped cadence does not pile up duplicate
+    # invocations.
+    - cron: "*/5 * * * *"
   pull_request:
     types: [opened, synchronize, reopened]
   pull_request_review:

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -47,6 +47,34 @@ class ReadinessConfig(StrictBaseModel):
     required_reviews: int = 1
     require_all_checks_passed: bool = True
     require_review_resolution: bool = True
+    # Names of CheckRun jobs whose ``conclusion=success`` count as a bot
+    # approval for the "Required reviews satisfied" gate. The default lists
+    # caretaker's own ``claude-review`` job — which posts its review as a
+    # CheckRun, not a formal Reviews API submission, so without this gate
+    # the readiness comment would forever read "required_review_missing"
+    # even after the bot signed off (PR #609 was the motivating incident).
+    bot_check_names: list[str] = Field(default_factory=lambda: ["claude-review"])
+    # Substrings (case-insensitive) that, when found in a bot-authored review
+    # body or PR issue-comment body, count the comment as an explicit approval.
+    # Used in addition to ``bot_check_names`` so a Claude reply that says
+    # "Approved" or "LGTM" in plain English also satisfies the review gate.
+    bot_approval_markers: list[str] = Field(
+        default_factory=lambda: ["**approved**", "lgtm", "✅ approved", "approved by"]
+    )
+    # CheckRun names produced by caretaker's own supervisor workflow
+    # (``maintainer.yml`` jobs) that should be excluded from the upstream-CI
+    # rollup. Including them would make caretaker self-gate: when caretaker
+    # itself is the running CI, "ci_pending" stays true forever. Always
+    # ignored regardless of ``ci.ignore_jobs``.
+    caretaker_workflow_check_names: list[str] = Field(
+        default_factory=lambda: ["dispatch-guard", "doctor", "maintain", "self-heal-on-failure"]
+    )
+    # Polling cadence used by the long-running ``resync_open_prs`` loop in
+    # the GitHub App webhook server (and any future agent-worker loop). The
+    # GitHub Actions cron path is independent and lives in the workflow
+    # file. Set to 0 to disable in-process polling and rely solely on
+    # webhooks + cron.
+    resync_interval_seconds: int = 60
 
 
 class MergeAuthorityMode(StrEnum):

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -36,8 +36,11 @@ from caretaker.pr_agent.readiness_llm import (
 )
 from caretaker.pr_agent.review import ReviewVerdict, analyze_reviews, assess_review_verdict
 from caretaker.pr_agent.states import (
+    CIEvaluation,
+    CIStatus,
     PRStateEvaluation,
     ReadinessEvaluation,
+    ReviewEvaluation,
     evaluate_pr,
 )
 from caretaker.pr_agent.stuck_pr_llm import (
@@ -212,8 +215,27 @@ class PRAgent:
             # This avoids a full list_pull_requests scan and the O(N) API calls
             # that come with it.
             pr = await self._github.get_pull_request(self._owner, self._repo, pr_number)
-            if pr is None or pr.state != PRState.OPEN:
-                # PR was closed/merged externally — nothing to do
+            if pr is None:
+                return report, tracked_prs
+            if pr.state != PRState.OPEN:
+                # PR is closed/merged. We still want to give the readiness
+                # check a chance to transition to a terminal state (otherwise
+                # the ``caretaker/pr-readiness`` status dangles in_progress
+                # forever, like it did on PR #609). One-shot finalization
+                # gated by ``readiness_check_finalized`` so we don't repost
+                # on every subsequent webhook for the same PR.
+                tracking = tracked_prs.get(pr.number)
+                if tracking is not None and not tracking.readiness_check_finalized:
+                    try:
+                        await self._finalize_readiness_check(pr, tracking)
+                    except Exception as exc:  # noqa: BLE001 — never fail the agent
+                        logger.warning(
+                            "PR #%d: terminal readiness finalization failed (%s: %s)",
+                            pr.number,
+                            type(exc).__name__,
+                            exc,
+                        )
+                    tracked_prs[pr.number] = tracking
                 return report, tracked_prs
             open_prs = [pr]
         else:
@@ -461,6 +483,22 @@ class PRAgent:
         check_runs = await self._github.get_check_runs(self._owner, self._repo, pr.head_ref)
         reviews = await self._github.get_pr_reviews(self._owner, self._repo, pr.number)
 
+        # Issue comments power the bot-approval-marker channel of
+        # ``evaluate_reviews`` (e.g. a Claude reply that says "Approved" in
+        # plain text rather than a formal CheckRun). Fetch defensively —
+        # if the call fails we fall back to the CheckRun + Reviews channels.
+        issue_comments: list[Any] = []
+        try:
+            issue_comments = await self._github.get_pr_comments(self._owner, self._repo, pr.number)
+        except Exception as exc:  # noqa: BLE001 — defensive: never fail the agent
+            logger.debug(
+                "PR #%d: get_pr_comments failed (%s: %s); "
+                "proceeding without comment-based bot approval signal",
+                pr.number,
+                type(exc).__name__,
+                exc,
+            )
+
         # Evaluate PR state (shared by both the stuck-PR gate and the
         # main action ladder below).
         evaluation = evaluate_pr(
@@ -472,6 +510,10 @@ class PRAgent:
             auto_approve_workflows=self._config.ci.auto_approve_workflows,
             required_reviews=self._config.readiness.required_reviews,
             auto_merge=self._config.auto_merge,
+            issue_comments=issue_comments,
+            bot_check_names=self._config.readiness.bot_check_names,
+            bot_approval_markers=self._config.readiness.bot_approval_markers,
+            caretaker_workflow_jobs=self._config.readiness.caretaker_workflow_check_names,
         )
 
         # Phase 2 (2026-Q2 §3.1): shadow-mode migration of readiness. Off
@@ -1339,8 +1381,22 @@ class PRAgent:
         # because those modes explicitly opt in to using the check as a gate.
         conclusion = evaluation.readiness.conclusion
         check_status = "completed"
-        check_conclusion = None
-        if conclusion == "success":
+        check_conclusion: str | None = None
+        # Terminal-state override: once a PR is closed/merged, force the
+        # readiness check to a terminal conclusion regardless of any
+        # outstanding blockers in the in-progress evaluation. Without
+        # this, ``evaluate_readiness`` keeps emitting ``in_progress`` when
+        # any blocker is still present (e.g. ``ci_pending`` because a
+        # post-merge workflow is still queued), so the check dangles
+        # forever — which is exactly what happened on PR #609.
+        pr_state = getattr(pr.state, "value", pr.state)
+        is_merged = bool(getattr(pr, "merged", False)) or pr.merged_at is not None
+        is_closed = pr_state == "closed"
+        if is_merged:
+            check_conclusion = "success"
+        elif is_closed:
+            check_conclusion = "neutral"
+        elif conclusion == "success":
             check_conclusion = "success"
         elif conclusion == "failure":
             if self._config.merge_authority.mode == MergeAuthorityMode.ADVISORY:
@@ -1470,6 +1526,114 @@ class PRAgent:
                 e,
             )
 
+    async def _finalize_readiness_check(self, pr: PullRequest, tracking: TrackedPR) -> None:
+        """Publish the terminal ``caretaker/pr-readiness`` conclusion for a
+        closed/merged PR.
+
+        Called from the ``run()`` early-exit path that previously dropped
+        closed PRs entirely. Builds a minimal :class:`PRStateEvaluation` so
+        :meth:`_publish_readiness_check` can run its terminal-state branch
+        — we do NOT re-fetch reviews/checks because the conclusion is
+        determined by the PR's terminal state, not by re-evaluating
+        upstream signals.
+        """
+        if not self._config.readiness.enabled:
+            tracking.readiness_check_finalized = True
+            return
+        # Build a synthetic evaluation. The readiness body fields don't
+        # matter for the terminal branch — ``_publish_readiness_check``
+        # short-circuits to ``success`` (merged) or ``neutral`` (closed)
+        # regardless of conclusion/score. We still pass an in_progress
+        # placeholder so the function runs to completion.
+        pseudo_ci = CIEvaluation(
+            status=CIStatus.PASSING,
+            failed_runs=[],
+            pending_runs=[],
+            passed_runs=[],
+            action_required_runs=[],
+            all_completed=True,
+        )
+        pseudo_reviews = ReviewEvaluation(
+            approved=True,
+            changes_requested=False,
+            pending=False,
+            approving_reviews=[],
+            blocking_reviews=[],
+        )
+        pseudo_readiness = ReadinessEvaluation(
+            score=tracking.readiness_score,
+            blockers=list(tracking.readiness_blockers),
+            summary=tracking.readiness_summary or "PR closed",
+            conclusion="success" if pr.merged or pr.merged_at else "failure",
+        )
+        eval_obj = PRStateEvaluation(
+            pr=pr,
+            ci=pseudo_ci,
+            reviews=pseudo_reviews,
+            readiness=pseudo_readiness,
+            recommended_state=(
+                PRTrackingState.MERGED if (pr.merged or pr.merged_at) else PRTrackingState.CLOSED
+            ),
+            recommended_action="none",
+        )
+        await self._publish_readiness_check(pr, tracking, eval_obj)
+        tracking.readiness_check_finalized = True
+        logger.info(
+            "PR #%d: finalized %s check (terminal=%s)",
+            pr.number,
+            self._config.readiness.check_name,
+            "merged" if (pr.merged or pr.merged_at) else "closed",
+        )
+
+    async def resync_open_prs(
+        self, tracked_prs: dict[int, TrackedPR]
+    ) -> tuple[PRAgentReport, dict[int, TrackedPR]]:
+        """Re-evaluate every open PR and force the readiness comment + check
+        to reflect current GitHub state.
+
+        This is the polling fallback for when webhooks have dropped or
+        delivery is delayed. It calls the same ``_process_pr`` path that
+        webhooks take, so the resulting state is identical — the only
+        difference is that the cron / long-running loop guarantees a
+        re-evaluation cadence regardless of webhook reliability.
+
+        Returns the same ``(report, tracked_prs)`` tuple as :meth:`run` so
+        callers can treat it as a drop-in alternative. Failures on a single
+        PR are logged and the loop continues, matching :meth:`run`'s
+        per-PR error isolation.
+        """
+        report = PRAgentReport()
+        try:
+            open_prs = await self._github.list_pull_requests(self._owner, self._repo)
+        except Exception as exc:  # noqa: BLE001 — defensive: never crash the resync
+            logger.warning("resync_open_prs: list_pull_requests failed: %s", exc)
+            return report, tracked_prs
+
+        report.monitored = len(open_prs)
+        for pr in open_prs:
+            try:
+                tracking = tracked_prs.get(pr.number, TrackedPR(number=pr.number))
+                prior_score = tracking.readiness_score
+                prior_blockers = list(tracking.readiness_blockers)
+                tracking = await self._process_pr(pr, tracking, report)
+                tracking.last_checked = datetime.now(UTC)
+                tracked_prs[pr.number] = tracking
+                if (
+                    tracking.readiness_score != prior_score
+                    or list(tracking.readiness_blockers) != prior_blockers
+                ):
+                    logger.info(
+                        "PR #%d: resync updated readiness %.0f%%→%.0f%% (blockers: %s)",
+                        pr.number,
+                        prior_score * 100,
+                        tracking.readiness_score * 100,
+                        ",".join(tracking.readiness_blockers) or "none",
+                    )
+            except Exception as exc:  # noqa: BLE001 — match run()'s per-PR isolation
+                logger.error("resync_open_prs: PR #%d failed: %s", pr.number, exc)
+                report.errors.append(f"PR #{pr.number}: {exc}")
+        return report, tracked_prs
+
     async def _handle_ownership(
         self,
         pr: PullRequest,
@@ -1494,6 +1658,19 @@ class PRAgent:
         tracking.readiness_score = evaluation.readiness.score
         tracking.readiness_blockers = evaluation.readiness.blockers
         tracking.readiness_summary = evaluation.readiness.summary
+
+        # Capture bot-approver names so the status comment can render the
+        # ``(bot)`` label on the Reviews row. CheckRun-based approvals
+        # surface as the job name; comment-based approvals surface as the
+        # bot login.
+        bot_names: list[str] = []
+        bot_names.extend(cr.name for cr in evaluation.reviews.bot_check_approvals)
+        for entry in evaluation.reviews.bot_comment_approvals:
+            user = getattr(entry, "user", None)
+            login = getattr(user, "login", "") if user else ""
+            if login and login not in bot_names:
+                bot_names.append(login)
+        tracking.bot_approvers = bot_names
 
         # Handle ownership state transitions. Each branch that calls out
         # to GitHub counts as a write action for attribution telemetry.

--- a/src/caretaker/pr_agent/ownership.py
+++ b/src/caretaker/pr_agent/ownership.py
@@ -388,6 +388,15 @@ def build_status_comment(
     ci_points = 0 if {"ci_pending", "ci_failing"} & blockers else 40
     total_pct = int(tracking.readiness_score * 100)
 
+    # When the review-points came solely from a bot approval (CheckRun or
+    # comment marker), annotate the row so a human reader can tell the
+    # green check came from a bot, not a person. Empty list → no bot
+    # approvals counted → render the row exactly as before.
+    review_label = "Reviews approved"
+    if tracking.bot_approvers and review_points > 0:
+        approvers = ", ".join(tracking.bot_approvers)
+        review_label = f"Reviews approved (bot: {approvers})"
+
     blockers_section = _render_blockers_section(tracking, readiness_verdict)
 
     ownership_lines = [f"- **Owner:** {tracking.owned_by}"]
@@ -418,7 +427,7 @@ def build_status_comment(
 |-----------|-------|
 | Mergeable & non-draft | {mergeability_points}% |
 | Automated feedback | {automated_points}% |
-| Reviews approved | {review_points}% |
+| {review_label} | {review_points}% |
 | CI passing | {ci_points}% |
 | **Total** | **{total_pct}%** |
 

--- a/src/caretaker/pr_agent/states.py
+++ b/src/caretaker/pr_agent/states.py
@@ -11,6 +11,7 @@ from caretaker.github_client.models import (
     CheckConclusion,
     CheckRun,
     CheckStatus,
+    Comment,
     PullRequest,
     Review,
     ReviewState,
@@ -52,10 +53,23 @@ class ReviewEvaluation:
     # Reviews with COMMENTED state from automated reviewer bots that contain
     # actionable feedback (e.g. copilot-pull-request-reviewer).
     automated_review_comments: list[Review] = field(default_factory=list)
+    # Successful CheckRuns from configured bot reviewers (e.g. ``claude-review``)
+    # that count as an approval for the readiness gate. Empty when no bot
+    # CheckRun signed off. Surfaced separately from ``approving_reviews`` so
+    # the status comment can render the row as "(bot)".
+    bot_check_approvals: list[CheckRun] = field(default_factory=list)
+    # Bot-authored review comments / issue comments whose body matched a
+    # configured approval marker (e.g. "Approved", "LGTM"). Treated the
+    # same as ``bot_check_approvals`` for the gate.
+    bot_comment_approvals: list[Review | Comment] = field(default_factory=list)
 
     @property
     def has_automated_comments(self) -> bool:
         return len(self.automated_review_comments) > 0
+
+    @property
+    def has_bot_approval(self) -> bool:
+        return bool(self.bot_check_approvals) or bool(self.bot_comment_approvals)
 
 
 @dataclass
@@ -96,9 +110,22 @@ _ALWAYS_IGNORED_CHECK_NAMES: frozenset[str] = frozenset(
 )
 
 
-def evaluate_ci(check_runs: list[CheckRun], ignore_jobs: list[str] | None = None) -> CIEvaluation:
-    """Evaluate CI status from check runs."""
-    ignore = set(ignore_jobs or []) | _ALWAYS_IGNORED_CHECK_NAMES
+def evaluate_ci(
+    check_runs: list[CheckRun],
+    ignore_jobs: list[str] | None = None,
+    caretaker_workflow_jobs: list[str] | None = None,
+) -> CIEvaluation:
+    """Evaluate CI status from check runs.
+
+    ``caretaker_workflow_jobs`` carries the names of caretaker's own
+    supervisor jobs (``maintainer.yml``: dispatch-guard / doctor /
+    maintain / self-heal-on-failure). They are excluded from the upstream
+    rollup for the same reason ``caretaker/pr-readiness`` is: caretaker
+    must not gate itself.
+    """
+    ignore = (
+        set(ignore_jobs or []) | set(caretaker_workflow_jobs or []) | _ALWAYS_IGNORED_CHECK_NAMES
+    )
     relevant = [cr for cr in check_runs if cr.name not in ignore]
 
     if not relevant:
@@ -154,8 +181,43 @@ def evaluate_ci(check_runs: list[CheckRun], ignore_jobs: list[str] | None = None
     )
 
 
-def evaluate_reviews(reviews: list[Review]) -> ReviewEvaluation:
-    """Evaluate review status — uses latest review per reviewer."""
+def _body_has_marker(body: str | None, markers: list[str]) -> bool:
+    """Return True when ``body`` contains any case-insensitive marker.
+
+    Markers default to common Claude / bot phrasing (``approved``, ``lgtm``).
+    Match is substring, not whole-word, so phrasings like "✅ Approved!" or
+    "**Approved**" both fire.
+    """
+    if not body or not markers:
+        return False
+    needle = body.lower()
+    return any(m.lower() in needle for m in markers)
+
+
+def evaluate_reviews(
+    reviews: list[Review],
+    check_runs: list[CheckRun] | None = None,
+    issue_comments: list[Comment] | None = None,
+    bot_check_names: list[str] | None = None,
+    bot_approval_markers: list[str] | None = None,
+) -> ReviewEvaluation:
+    """Evaluate review status — uses latest review per reviewer.
+
+    Bot approvals are surfaced through three independent channels, any of
+    which on its own satisfies the readiness review-gate:
+
+    1. A formal Reviews API submission with state APPROVED — the existing
+       human + caretaker-app path.
+    2. A successful CheckRun whose name is listed in ``bot_check_names``
+       (default: ``claude-review``). This is the channel caretaker's own
+       review workflow uses; without it PR #609's comment kept reporting
+       ``required_review_missing`` even though the bot had signed off.
+    3. A bot-authored review (state COMMENTED) or PR issue-comment whose
+       body contains an approval marker like "Approved" or "LGTM".
+
+    A formal CHANGES_REQUESTED from any reviewer still blocks regardless
+    of bot approval — only humans should be able to veto.
+    """
     latest_by_user: dict[str, Review] = {}
     for review in reviews:
         existing = latest_by_user.get(review.user.login)
@@ -168,21 +230,53 @@ def evaluate_reviews(reviews: list[Review]) -> ReviewEvaluation:
 
     approvals = [r for r in latest_by_user.values() if r.state == ReviewState.APPROVED]
     blockers = [r for r in latest_by_user.values() if r.state == ReviewState.CHANGES_REQUESTED]
-    automated = [
-        r
-        for r in latest_by_user.values()
-        if r.state == ReviewState.COMMENTED
-        and is_automated(r.user.login)
-        and r.body  # only reviews that carry a summary body
-    ]
+
+    # COMMENTED reviews from bots split two ways: those carrying an explicit
+    # approval marker in their body land in ``bot_comment_approvals`` and
+    # gate ``approved=True``; the rest stay in ``automated_review_comments``
+    # and continue to flag ``automated_feedback_unaddressed`` as a blocker.
+    markers = list(bot_approval_markers or [])
+    automated: list[Review] = []
+    bot_comment_approvals: list[Review | Comment] = []
+    for r in latest_by_user.values():
+        if r.state != ReviewState.COMMENTED or not is_automated(r.user.login) or not r.body:
+            continue
+        if _body_has_marker(r.body, markers):
+            bot_comment_approvals.append(r)
+        else:
+            automated.append(r)
+
+    # Issue comments (separate from the Reviews API) from bots can also
+    # carry an approval marker — e.g. when a bot replies inline rather
+    # than via a formal review.
+    for comment in issue_comments or []:
+        login = comment.user.login if comment.user else ""
+        if not login or not is_automated(login):
+            continue
+        if _body_has_marker(comment.body, markers):
+            bot_comment_approvals.append(comment)
+
+    # CheckRun-based bot approvals: any successful run whose name is in
+    # the configured allowlist counts as a single bot approval.
+    bot_names = set(bot_check_names or [])
+    bot_check_approvals: list[CheckRun] = []
+    for cr in check_runs or []:
+        if cr.name not in bot_names:
+            continue
+        if cr.status == CheckStatus.COMPLETED and cr.conclusion == CheckConclusion.SUCCESS:
+            bot_check_approvals.append(cr)
+
+    has_bot_approval = bool(bot_check_approvals) or bool(bot_comment_approvals)
 
     return ReviewEvaluation(
-        approved=len(approvals) > 0 and len(blockers) == 0,
+        approved=(len(approvals) > 0 or has_bot_approval) and len(blockers) == 0,
         changes_requested=len(blockers) > 0,
-        pending=len(latest_by_user) == 0,
+        pending=len(latest_by_user) == 0 and not has_bot_approval,
         approving_reviews=approvals,
         blocking_reviews=blockers,
         automated_review_comments=automated,
+        bot_check_approvals=bot_check_approvals,
+        bot_comment_approvals=bot_comment_approvals,
     )
 
 
@@ -300,6 +394,10 @@ def evaluate_pr(
     auto_approve_workflows: bool = False,
     required_reviews: int = 1,
     auto_merge: AutoMergeConfig | None = None,
+    issue_comments: list[Comment] | None = None,
+    bot_check_names: list[str] | None = None,
+    bot_approval_markers: list[str] | None = None,
+    caretaker_workflow_jobs: list[str] | None = None,
 ) -> PRStateEvaluation:
     """Full PR evaluation — determines next state and action.
 
@@ -308,9 +406,23 @@ def evaluate_pr(
     reject (e.g. ``human_prs=false``). The PR falls back to ``CI_PASSING`` with
     ``await_review``, which correctly renders as "awaiting review" in the
     status comment instead of the misleading "ready for merge".
+
+    ``bot_check_names`` / ``bot_approval_markers`` / ``issue_comments``: see
+    :func:`evaluate_reviews` — let bot CheckRun successes (e.g. ``claude-review``)
+    and bot comment markers ("Approved", "LGTM") satisfy the review gate.
+
+    ``caretaker_workflow_jobs``: see :func:`evaluate_ci` — exclude caretaker's
+    own supervisor-workflow jobs from the upstream-CI rollup so the agent
+    cannot self-gate.
     """
-    ci = evaluate_ci(check_runs, ignore_jobs)
-    review_eval = evaluate_reviews(reviews)
+    ci = evaluate_ci(check_runs, ignore_jobs, caretaker_workflow_jobs)
+    review_eval = evaluate_reviews(
+        reviews,
+        check_runs=check_runs,
+        issue_comments=issue_comments,
+        bot_check_names=bot_check_names,
+        bot_approval_markers=bot_approval_markers,
+    )
     readiness = evaluate_readiness(pr, ci, review_eval, current_state, required_reviews)
 
     # State transitions

--- a/src/caretaker/state/models.py
+++ b/src/caretaker/state/models.py
@@ -85,6 +85,22 @@ class TrackedPR(BaseModel):
     # caretaker:status comment.
     legacy_comments_compacted: bool = False
 
+    # One-shot terminal-state finalization for the ``caretaker/pr-readiness``
+    # check. Once a PR is merged or closed, caretaker publishes a final
+    # ``success`` / ``neutral`` conclusion so the check stops dangling
+    # ``in_progress`` (PR #609 was the motivating incident — its readiness
+    # check stayed in_progress for hours after merge). The flag prevents
+    # republishing on every subsequent webhook for the same closed PR.
+    readiness_check_finalized: bool = False
+
+    # Names of bot reviewers (CheckRun jobs or comment authors) whose
+    # approval was counted toward the "Required reviews satisfied" gate.
+    # Populated from :class:`ReviewEvaluation`. Drives the ``(bot)`` label
+    # rendered in the status-comment Reviews row so a human reader can
+    # tell at a glance whether the green checkmark came from a bot or a
+    # person.
+    bot_approvers: list[str] = Field(default_factory=list)
+
     # ── Attribution telemetry (R&D workstream A2) ────────────────────────
     # Answer "did caretaker actually save human toil on this PR?" — a
     # per-PR audit trail that the weekly rollup aggregates into

--- a/tests/test_pr_agent/test_agent.py
+++ b/tests/test_pr_agent/test_agent.py
@@ -2072,3 +2072,186 @@ class TestAdvisoryModeNeutralConclusion:
         github.create_check_run.assert_awaited_once()
         conclusion_arg = github.create_check_run.call_args.kwargs["conclusion"]
         assert conclusion_arg == "success"
+
+
+class TestTerminalReadinessOnCloseMerge:
+    """Once a PR is merged or closed, ``caretaker/pr-readiness`` must transition
+    to a terminal conclusion regardless of any in-progress blockers in the
+    evaluation. PR #609 was the motivating incident — the check stayed
+    in_progress for hours after the human merged it.
+    """
+
+    def _agent(self, github):
+        from caretaker.pr_agent.agent import PRAgent
+
+        config = make_config()
+        config.readiness.enabled = True
+        return PRAgent(github=github, owner="o", repo="r", config=config)
+
+    def _in_progress_eval(self, pr):
+        from caretaker.pr_agent.states import (
+            CIEvaluation,
+            CIStatus,
+            PRStateEvaluation,
+            ReadinessEvaluation,
+            ReviewEvaluation,
+        )
+
+        return PRStateEvaluation(
+            pr=pr,
+            ci=CIEvaluation(
+                status=CIStatus.PENDING,
+                failed_runs=[],
+                pending_runs=[],
+                passed_runs=[],
+                action_required_runs=[],
+                all_completed=False,
+            ),
+            reviews=ReviewEvaluation(
+                approved=False,
+                changes_requested=False,
+                pending=True,
+                approving_reviews=[],
+                blocking_reviews=[],
+            ),
+            readiness=ReadinessEvaluation(
+                score=0.3,
+                blockers=["ci_pending", "required_review_missing"],
+                summary="In progress",
+                conclusion="in_progress",
+            ),
+        )
+
+    async def test_merged_pr_publishes_success_even_with_pending_blockers(self) -> None:
+        github = AsyncMock()
+        github.find_check_run = AsyncMock(return_value=None)
+        github.create_check_run = AsyncMock(return_value={"id": 1})
+
+        agent = self._agent(github)
+        pr = make_pr(number=609, head_ref="feat/x", merged=True, state=PRState.CLOSED)
+        pr.head_sha = "abc123"
+        from datetime import UTC, datetime
+
+        pr.merged_at = datetime(2026, 4, 26, 21, 30, tzinfo=UTC)
+        tracking = TrackedPR(number=609)
+
+        await agent._publish_readiness_check(pr, tracking, self._in_progress_eval(pr))
+
+        github.create_check_run.assert_awaited_once()
+        kwargs = github.create_check_run.call_args.kwargs
+        assert kwargs["conclusion"] == "success"
+        assert kwargs["status"] == "completed"
+
+    async def test_closed_unmerged_pr_publishes_neutral(self) -> None:
+        github = AsyncMock()
+        github.find_check_run = AsyncMock(return_value=None)
+        github.create_check_run = AsyncMock(return_value={"id": 2})
+
+        agent = self._agent(github)
+        pr = make_pr(number=42, head_ref="feat/x", merged=False, state=PRState.CLOSED)
+        pr.head_sha = "abc123"
+        tracking = TrackedPR(number=42)
+
+        await agent._publish_readiness_check(pr, tracking, self._in_progress_eval(pr))
+
+        github.create_check_run.assert_awaited_once()
+        kwargs = github.create_check_run.call_args.kwargs
+        assert kwargs["conclusion"] == "neutral"
+        assert kwargs["status"] == "completed"
+
+    async def test_run_finalizes_readiness_check_for_externally_merged_pr(self) -> None:
+        """run() with pr_number for a PR that's been closed/merged externally
+        must still finalize the readiness check (one-shot, idempotent via
+        ``readiness_check_finalized``).
+        """
+        from datetime import UTC, datetime
+
+        github = AsyncMock()
+        merged_pr = make_pr(number=609, head_ref="feat/x", merged=True, state=PRState.CLOSED)
+        merged_pr.head_sha = "abc123"
+        merged_pr.merged_at = datetime(2026, 4, 26, 21, 30, tzinfo=UTC)
+        github.get_pull_request = AsyncMock(return_value=merged_pr)
+        github.find_check_run = AsyncMock(return_value=None)
+        github.create_check_run = AsyncMock(return_value={"id": 5})
+
+        agent = self._agent(github)
+        tracking = TrackedPR(number=609)
+        tracked = {609: tracking}
+
+        report, tracked = await agent.run(tracked, pr_number=609)
+
+        # Finalization happened
+        assert tracked[609].readiness_check_finalized is True
+        github.create_check_run.assert_awaited_once()
+        assert github.create_check_run.call_args.kwargs["conclusion"] == "success"
+
+        # Second run() with same closed PR is a no-op (one-shot)
+        github.create_check_run.reset_mock()
+        report2, tracked2 = await agent.run(tracked, pr_number=609)
+        github.create_check_run.assert_not_awaited()
+
+
+class TestResyncOpenPRs:
+    """The resync method is the polling fallback for dropped webhooks. It
+    must call _process_pr for each open PR and update tracking.
+    """
+
+    async def test_resync_processes_each_open_pr(self) -> None:
+        from caretaker.pr_agent.agent import PRAgent
+
+        pr1 = make_pr(number=1, head_ref="feat/a")
+        pr2 = make_pr(number=2, head_ref="feat/b")
+
+        github = AsyncMock()
+        github.list_pull_requests = AsyncMock(return_value=[pr1, pr2])
+
+        config = make_config()
+        agent = PRAgent(github=github, owner="o", repo="r", config=config)
+
+        # Stub _process_pr so we don't have to wire every downstream call
+        seen: list[int] = []
+
+        async def fake_process(pr, tracking, report):
+            seen.append(pr.number)
+            tracking.readiness_score = 1.0
+            return tracking
+
+        agent._process_pr = fake_process  # type: ignore[method-assign]
+
+        tracked: dict = {}
+        report, tracked = await agent.resync_open_prs(tracked)
+
+        assert sorted(seen) == [1, 2]
+        assert report.monitored == 2
+        assert tracked[1].readiness_score == 1.0
+        assert tracked[2].readiness_score == 1.0
+        assert tracked[1].last_checked is not None
+
+    async def test_resync_continues_after_per_pr_error(self) -> None:
+        from caretaker.pr_agent.agent import PRAgent
+
+        pr1 = make_pr(number=1, head_ref="feat/a")
+        pr2 = make_pr(number=2, head_ref="feat/b")
+
+        github = AsyncMock()
+        github.list_pull_requests = AsyncMock(return_value=[pr1, pr2])
+
+        config = make_config()
+        agent = PRAgent(github=github, owner="o", repo="r", config=config)
+
+        seen: list[int] = []
+
+        async def fake_process(pr, tracking, report):
+            seen.append(pr.number)
+            if pr.number == 1:
+                raise RuntimeError("simulated transient")
+            tracking.readiness_score = 1.0
+            return tracking
+
+        agent._process_pr = fake_process  # type: ignore[method-assign]
+
+        report, tracked = await agent.resync_open_prs({})
+
+        assert sorted(seen) == [1, 2]  # both attempted
+        assert any("PR #1" in e for e in report.errors)
+        assert tracked[2].readiness_score == 1.0  # PR #2 still processed

--- a/tests/test_pr_agent/test_states.py
+++ b/tests/test_pr_agent/test_states.py
@@ -731,3 +731,175 @@ class TestRequestReviewApprove:
 
         pr = make_pr(head_ref="chore/releases-json-v0.19.5")
         assert _auto_merge_allows(pr, AutoMergeConfig(maintainer_bot_prs=False)) is False
+
+
+# ── Bot CheckRun + comment-marker approvals (PR #609 regression) ─────
+
+
+class TestBotApprovalChannels:
+    """Bot reviewers signal approval through three channels — all should
+    satisfy the readiness review-gate. See PR #609 incident: claude-review
+    posted a SUCCESS CheckRun, but the comment forever read
+    "required_review_missing" because only formal Reviews counted.
+    """
+
+    def test_bot_check_run_counts_as_approval(self) -> None:
+        """A configured bot CheckRun (e.g. claude-review) success satisfies the gate."""
+        from caretaker.github_client.models import CheckConclusion, CheckStatus
+
+        checks = [
+            make_check_run(
+                name="claude-review",
+                status=CheckStatus.COMPLETED,
+                conclusion=CheckConclusion.SUCCESS,
+            )
+        ]
+        result = evaluate_reviews([], check_runs=checks, bot_check_names=["claude-review"])
+        assert result.approved is True
+        assert len(result.bot_check_approvals) == 1
+        assert result.has_bot_approval is True
+
+    def test_bot_check_run_pending_does_not_approve(self) -> None:
+        """An in-progress bot CheckRun does not pre-approve the PR."""
+        from caretaker.github_client.models import CheckStatus
+
+        checks = [
+            make_check_run(name="claude-review", status=CheckStatus.IN_PROGRESS, conclusion=None)
+        ]
+        result = evaluate_reviews([], check_runs=checks, bot_check_names=["claude-review"])
+        assert result.approved is False
+        assert len(result.bot_check_approvals) == 0
+
+    def test_bot_review_with_marker_counts_as_approval(self) -> None:
+        """A bot COMMENTED review whose body matches an approval marker satisfies the gate."""
+        from caretaker.github_client.models import User
+
+        bot = User(login="claude[bot]", id=99, type="Bot")
+        rev = make_review(user=bot, state=ReviewState.COMMENTED, body="**Approved** — looks good!")
+        result = evaluate_reviews([rev], bot_approval_markers=["**approved**", "lgtm"])
+        assert result.approved is True
+        assert len(result.bot_comment_approvals) == 1
+
+    def test_bot_review_without_marker_stays_automated_feedback(self) -> None:
+        """A bot COMMENTED review without a marker remains feedback, not approval."""
+        from caretaker.github_client.models import User
+
+        bot = User(login="copilot-pull-request-reviewer[bot]", id=99, type="Bot")
+        rev = make_review(user=bot, state=ReviewState.COMMENTED, body="Consider X")
+        result = evaluate_reviews([rev], bot_approval_markers=["**approved**"])
+        assert result.approved is False
+        assert len(result.automated_review_comments) == 1
+        assert len(result.bot_comment_approvals) == 0
+        assert result.has_automated_comments is True
+
+    def test_bot_issue_comment_with_marker_counts_as_approval(self) -> None:
+        """A bot-authored issue comment with 'LGTM' satisfies the gate even without a Review."""
+        from caretaker.github_client.models import User
+        from tests.conftest import make_comment
+
+        ic = make_comment(body="LGTM!", user=User(login="claude[bot]", id=99, type="Bot"))
+        result = evaluate_reviews([], issue_comments=[ic], bot_approval_markers=["lgtm"])
+        assert result.approved is True
+
+    def test_changes_requested_overrides_bot_approval(self) -> None:
+        """Human CHANGES_REQUESTED still blocks even when a bot CheckRun signed off."""
+        from caretaker.github_client.models import CheckConclusion, CheckStatus
+
+        rev_block = make_review(state=ReviewState.CHANGES_REQUESTED, body="Nope")
+        checks = [
+            make_check_run(
+                name="claude-review",
+                status=CheckStatus.COMPLETED,
+                conclusion=CheckConclusion.SUCCESS,
+            )
+        ]
+        result = evaluate_reviews([rev_block], check_runs=checks, bot_check_names=["claude-review"])
+        assert result.approved is False
+        assert result.changes_requested is True
+
+
+class TestCaretakerWorkflowExclusion:
+    """Caretaker's own supervisor workflow jobs (dispatch-guard, doctor, etc.)
+    must not gate the readiness CI rollup — including them would create the
+    same self-deadlock that ``caretaker/pr-readiness`` already avoids.
+    """
+
+    def test_pending_caretaker_workflow_job_does_not_block_ci(self) -> None:
+        """An in-progress dispatch-guard does not flag ci_pending."""
+        from caretaker.github_client.models import CheckStatus
+
+        runs = [
+            make_check_run(name="lint"),  # SUCCESS
+            make_check_run(name="dispatch-guard", status=CheckStatus.IN_PROGRESS, conclusion=None),
+        ]
+        ci = evaluate_ci(
+            runs,
+            caretaker_workflow_jobs=[
+                "dispatch-guard",
+                "doctor",
+                "maintain",
+                "self-heal-on-failure",
+            ],
+        )
+        assert ci.status == CIStatus.PASSING
+        assert ci.all_completed is True
+        assert len(ci.pending_runs) == 0
+
+    def test_failing_caretaker_workflow_job_does_not_fail_ci(self) -> None:
+        """A failing maintain job does not flag ci_failing — it's caretaker's own job."""
+        runs = [
+            make_check_run(name="test"),  # SUCCESS
+            make_check_run(name="maintain", conclusion=CheckConclusion.FAILURE),
+        ]
+        ci = evaluate_ci(runs, caretaker_workflow_jobs=["maintain"])
+        assert ci.status == CIStatus.PASSING
+        assert len(ci.failed_runs) == 0
+
+
+class TestPR609Regression:
+    """End-to-end regression for PR #609: human PR, claude-review CheckRun
+    SUCCESS, all real CI green, caretaker workflow jobs running, no formal
+    Reviews API submission. Old behavior gave 70% with required_review_missing.
+    New behavior gives 100% ready.
+    """
+
+    def test_pr609_scenario_reaches_100_percent(self) -> None:
+        from caretaker.github_client.models import CheckConclusion, CheckStatus
+
+        pr = make_pr()
+        checks = [
+            make_check_run(name="lint"),
+            make_check_run(name="test"),
+            make_check_run(
+                name="claude-review",
+                status=CheckStatus.COMPLETED,
+                conclusion=CheckConclusion.SUCCESS,
+            ),
+            # caretaker workflow jobs that should be ignored
+            make_check_run(name="dispatch-guard"),
+            make_check_run(name="doctor"),
+            make_check_run(name="maintain"),
+            # caretaker's own readiness check (already in _ALWAYS_IGNORED)
+            make_check_run(
+                name="caretaker/pr-readiness", status=CheckStatus.IN_PROGRESS, conclusion=None
+            ),
+        ]
+        result = evaluate_pr(
+            pr,
+            checks,
+            [],  # no formal reviews
+            PRTrackingState.DISCOVERED,
+            required_reviews=1,
+            bot_check_names=["claude-review"],
+            caretaker_workflow_jobs=[
+                "dispatch-guard",
+                "doctor",
+                "maintain",
+                "self-heal-on-failure",
+            ],
+        )
+        assert result.readiness is not None
+        assert result.readiness.score == 1.0
+        assert result.readiness.conclusion == "success"
+        assert result.readiness.blockers == []
+        assert result.reviews.has_bot_approval is True


### PR DESCRIPTION
## Why

Caretaker acted as a bottleneck on [#609](https://github.com/ianlintner/caretaker/pull/609): the status comment stalled at **30% readiness** with `required_review_missing` + `ci_pending` blockers despite every CI job passing and the bot review completing. The user had to merge manually. Worse, `caretaker/pr-readiness` dangled `IN_PROGRESS` *after* merge — it never transitioned to a terminal state.

Three independent root causes compounded into one bad UX. This PR fixes all three plus adds a polling fallback so a dropped webhook can no longer freeze the comment indefinitely.

## What changed

### Accuracy fixes (states.py, agent.py, ownership.py)

- **`claude-review` CheckRun now satisfies the review gate.** `evaluate_reviews` only inspected formal Reviews API submissions; the Claude review workflow posts a CheckRun, so its approval was invisible. New `readiness.bot_check_names` config (default `["claude-review"]`).
- **Claude approving via a comment now counts.** Bot-authored review or issue comments matching `bot_approval_markers` (default: `**approved**`, `lgtm`, `✅ approved`, `approved by`) satisfy the gate. Bots can approve; only humans can `CHANGES_REQUESTED`.
- **Caretaker's own supervisor workflow no longer self-gates.** `dispatch-guard`, `doctor`, `maintain`, `self-heal-on-failure` are now excluded from the upstream-CI rollup — same self-deadlock that's already prevented for `caretaker/pr-readiness`. Configurable via `readiness.caretaker_workflow_check_names`.
- **`caretaker/pr-readiness` transitions to a terminal state on merge/close.** New early branch in `_publish_readiness_check` publishes `success` on merge / `neutral` on close regardless of in-progress blockers in the evaluation. One-shot, idempotent via `tracking.readiness_check_finalized`. `run()` with `pr_number` finalizes externally-closed PRs instead of dropping them.
- **Status comment labels bot approvals.** `Reviews approved (bot: claude-review)` — a reader can tell at a glance whether the green check came from a bot.

### Polling fallback

- **`PRAgent.resync_open_prs()`** re-runs the full evaluate + publish path for every open PR. Logs `PR #X: resync updated readiness 30%→100%` when state changes — easy to confirm the cron is doing useful work, easy to set the interval back if it isn't.
- **`maintainer.yml` cron bumped** from `0 * * * *` (hourly) to `*/5 * * * *` (GH Actions practical minimum). Existing `EVENT_COOLDOWN_MINUTES=3` still serializes runs cleanly.

## What this is NOT

- **Not promoting `caretaker/pr-readiness` to a required gate yet.** The user's words "make it the roadblock" are tempting, but flipping that switch with the accuracy bugs in place would have made #609 *unmergeable* instead of just confusing. Promotion is a follow-up after a week of clean resync metrics.
- **Not rewriting the webhook routing.** The polling fallback makes webhook reliability no longer load-bearing for correctness, which is the right invariant regardless.

## Verification

- All 2150 existing tests pass; +14 new tests cover every behavior change including the full PR #609 scenario going from 70% blocked to 100% ready.
- Lint (ruff) clean; mypy strict clean across all 226 source files (verified by pre-commit hook).
- New tests:
  - `TestBotApprovalChannels` — CheckRun, comment marker, issue comment, changes_requested override
  - `TestCaretakerWorkflowExclusion` — pending and failing supervisor jobs no longer gate CI
  - `TestPR609Regression` — full end-to-end reproduction
  - `TestTerminalReadinessOnCloseMerge` — merged → success, closed → neutral, one-shot finalization
  - `TestResyncOpenPRs` — happy path + per-PR error isolation

## Rollout

- Defaults are conservative: `bot_check_names=["claude-review"]`, `bot_approval_markers` are common phrases, `caretaker_workflow_check_names` matches the names in `maintainer.yml`. Existing repos pick up the fix automatically; non-caretaker repos see no behavior change.
- Watch `caretaker.readiness.resync.changed` (well, the log line in `resync_open_prs`) for 24-48h. If it's consistently >0 we know the webhook path was dropping updates and the cron is correcting them; if it's 0 we can raise the interval to lower API load.

## Test plan

- [ ] Open a sandbox PR; confirm comment shows 100% ready within 1 cron tick after CI completes
- [ ] Merge it; confirm `caretaker/pr-readiness` flips to `success` (not stuck `IN_PROGRESS`)
- [ ] Verify the new "(bot: claude-review)" label appears in the Reviews row
- [ ] Watch `*/5 cron` runs serialize without piling up

🤖 Generated with [Claude Code](https://claude.com/claude-code)