### PR TITLE
feat(byoca): pluggable coding-agent registry + opencode hand-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+BYOCA — Bring Your Own Coding Agent. Generalises the existing Claude Code
+hand-off path into a pluggable registry so opencode (and future agents
+like codex, gemini, hermes) can coexist with Claude Code as first-class
+options.
+
+### Added
+
+- **`caretaker.coding_agents` package** — new module hosting the
+  `CodingAgent` protocol, `HandoffAgent` base class, concrete
+  `ClaudeCodeAgent` / `OpenCodeAgent` subclasses, and
+  `CodingAgentRegistry`. Each hand-off agent owns a unique HTML-comment
+  marker so per-PR attempt counts don't cross-contaminate.
+- **`OpenCodeExecutorConfig`** in `caretaker.config` plus an open-ended
+  `executor.agents: dict[str, HandoffAgentConfig]` map for additional
+  agents declared per repo. `executor.provider` is now an open string
+  (validated at startup against the registry) instead of a closed enum.
+- **`pr_reviewer.complex_reviewer` config field** — selects which
+  hand-off agent the PR reviewer uses for complex PRs (`claude_code`,
+  `opencode`, …). Default keeps existing behaviour.
+- **`pr_reviewer.opencode_label` / `opencode_mention` config fields**
+  paired with the new `OPENCODE_REVIEW_MARKER` so opencode review
+  hand-offs don't collide with Claude review hand-offs.
+- **Generic `agent:<name>` PR labels** — caretaker now resolves
+  `agent:opencode`, `agent:codex`, etc. against the registry instead of
+  only honouring the legacy `agent:custom` alias. `agent:custom` still
+  works.
+- **`RouteOutcome.CUSTOM_AGENT`** + `RouteResult.agent_name` — new
+  generic outcome for any registered hand-off agent. The legacy
+  `RouteOutcome.CLAUDE_CODE` value is preserved for one release as an
+  alias when ``agent_name == "claude_code"``.
+- **`opencode.yml` / `opencode-review.yml` workflow templates** in
+  `setup-templates/templates/workflows/`. The maintainer agent's sync
+  issue lists them in a new "Optional templates" section so consumer
+  repos opt in only when they enable the matching feature.
+- **`doctor` row** validating `executor.provider` and
+  `pr_reviewer.complex_reviewer` resolve to known agents.
+
+### Changed
+
+- **`ExecutorDispatcher` constructor** now takes a `registry:
+  CodingAgentRegistry` argument. The legacy `claude_code_executor=`
+  parameter is kept as a deprecated shim that wraps the executor in a
+  one-entry registry.
+- **`pr_reviewer.routing.RoutingDecision`** gains a `backend: str` field
+  carrying the chosen hand-off agent name when `use_inline=False`.
+- **`pr_reviewer.claude_code_reviewer.dispatch`** is a thin shim that
+  pins the new `handoff_reviewer.dispatch` to `backend="claude_code"`.
+
+### Deprecated
+
+- `caretaker.claude_code_executor.ClaudeCodeExecutor` — alias for
+  `caretaker.coding_agents.ClaudeCodeAgent`. Will be removed in the
+  release after next.
+- `RouteOutcome.CLAUDE_CODE` — alias for `RouteOutcome.CUSTOM_AGENT`
+  with `agent_name == "claude_code"`. Switch consumers to read
+  `agent_name` then drop the alias.
+
 ## [0.19.6] - 2026-04-25
 
 Wires the **fleet registry** into the admin dashboard end-to-end so that

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -37,3 +37,54 @@ If an upgrade introduces regressions:
 - Validation is strict (unknown fields are rejected).
 - Use the CLI to validate config locally:
   - `caretaker validate-config --config .github/maintainer/config.yml`
+
+## BYOCA — opencode and the pluggable coding-agent registry
+
+`caretaker.claude_code_executor.ClaudeCodeExecutor` and the closed
+`executor.provider` enum (`copilot | foundry | claude_code | auto`) are
+now backed by a registry of pluggable coding agents. Behaviour is
+backward-compatible: existing configs keep working byte-identically.
+
+To opt in to opencode as a peer of Claude Code, add an `executor.opencode`
+block to `.github/maintainer/config.yml`:
+
+```yaml
+executor:
+  provider: opencode      # was: claude_code (or copilot/foundry)
+  claude_code:
+    enabled: true         # leave on if you want both available
+  opencode:
+    enabled: true
+    trigger_label: opencode
+    mention: "@opencode-agent"
+    max_attempts: 2
+
+pr_reviewer:
+  complex_reviewer: opencode   # default: claude_code
+```
+
+You will also need the opencode workflow files in your repo:
+
+- `.github/workflows/opencode.yml`
+- `.github/workflows/opencode-review.yml`
+
+The maintainer agent's sync issue lists both alongside the existing
+Claude templates in an "Optional templates" section. Copy them only when
+the matching feature is enabled.
+
+### Per-PR overrides
+
+`agent:opencode` and any other `agent:<registered-name>` label now
+forces routing to that specific agent. The legacy `agent:custom`,
+`agent:copilot`, and `agent:quarantine` labels keep working unchanged.
+
+### Deprecations
+
+These names continue to work for one release and will be removed after:
+
+- `caretaker.claude_code_executor.ClaudeCodeExecutor` →
+  `caretaker.coding_agents.ClaudeCodeAgent`
+- `caretaker.foundry.dispatcher.RouteOutcome.CLAUDE_CODE` →
+  `RouteOutcome.CUSTOM_AGENT` plus `RouteResult.agent_name == "claude_code"`
+- `ExecutorDispatcher(claude_code_executor=...)` constructor argument
+  → `ExecutorDispatcher(registry=...)`

--- a/setup-templates/templates/workflows/claude-code-review.yml
+++ b/setup-templates/templates/workflows/claude-code-review.yml
@@ -1,0 +1,81 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Preflight — check Claude OAuth token availability
+        id: preflight
+        env:
+          OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$OAUTH_TOKEN" ]; then
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN is not set — falling back to Copilot review"
+            echo "claude_available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "claude_available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Claude Code Review
+        id: claude-review
+        if: steps.preflight.outputs.claude_available == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+
+      - name: Fallback — request Copilot review
+        if: |
+          steps.preflight.outputs.claude_available != 'true' ||
+          steps.claude-review.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const reason = '${{ steps.preflight.outputs.claude_available }}' === 'true'
+              ? 'Claude review action failed'
+              : 'Claude OAuth token unavailable';
+            core.info(`${reason} — requesting Copilot review for PR #${prNumber}`);
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                reviewers: ['copilot-pull-request-reviewer'],
+              });
+              core.info(`Requested Copilot review for PR #${prNumber}`);
+            } catch (error) {
+              core.warning(`Copilot review request failed: ${error.message}`);
+            }

--- a/setup-templates/templates/workflows/claude.yml
+++ b/setup-templates/templates/workflows/claude.yml
@@ -1,0 +1,53 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Allow the caretaker bot to trigger this workflow via @claude mentions
+          allowed_bots: 'the-care-taker'
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/setup-templates/templates/workflows/opencode-review.yml
+++ b/setup-templates/templates/workflows/opencode-review.yml
@@ -52,6 +52,11 @@ jobs:
         id: opencode-review
         if: steps.preflight.outputs.opencode_available == 'true'
         continue-on-error: true
+        # Pinning to ``@latest`` is convenient but a supply-chain risk —
+        # any compromise of the upstream tag affects this workflow on the
+        # next run. Recommend pinning to a specific release tag (e.g.
+        # ``sst/opencode/github@v0.1.0``) or commit SHA before relying on
+        # this in production.
         uses: sst/opencode/github@latest
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/setup-templates/templates/workflows/opencode-review.yml
+++ b/setup-templates/templates/workflows/opencode-review.yml
@@ -1,0 +1,92 @@
+name: opencode Review
+
+# Companion to claude-code-review.yml. Runs when caretaker's PR reviewer
+# routes a complex PR to the opencode hand-off path
+# (``pr_reviewer.complex_reviewer = "opencode"`` in caretaker config).
+#
+# opencode picks the model/provider via the workflow inputs below — useful
+# when a repo wants a non-Anthropic backend for code review.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened, labeled]
+
+jobs:
+  opencode-review:
+    # Run when the opencode-review label is applied (caretaker's hand-off
+    # mechanism) or whenever a PR is opened/updated and the operator has
+    # opted in by leaving the workflow enabled.
+    if: |
+      (github.event_name == 'pull_request' && github.event.label.name == 'opencode-review') ||
+      contains(github.event.pull_request.labels.*.name, 'opencode-review')
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Preflight — check opencode provider keys are available
+        id: preflight
+        env:
+          ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GROQ_KEY: ${{ secrets.GROQ_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_KEY" ] && [ -z "$OPENAI_KEY" ] && [ -z "$OPENROUTER_KEY" ] && [ -z "$GROQ_KEY" ]; then
+            echo "::warning::No opencode provider key set — falling back to Copilot review"
+            echo "opencode_available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "opencode_available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run opencode review
+        id: opencode-review
+        if: steps.preflight.outputs.opencode_available == 'true'
+        continue-on-error: true
+        uses: sst/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        with:
+          model: anthropic/claude-sonnet-4
+          # Review mode: a focused prompt asking opencode to review the PR
+          # and post a review summary plus inline comments.
+          prompt: |
+            Review pull request ${{ github.repository }}#${{ github.event.pull_request.number }}.
+            Focus on correctness, security, API contracts, and missing tests.
+            Post a review comment summary and inline comments where applicable.
+
+      - name: Fallback — request Copilot review
+        if: |
+          steps.preflight.outputs.opencode_available != 'true' ||
+          steps.opencode-review.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const reason = '${{ steps.preflight.outputs.opencode_available }}' === 'true'
+              ? 'opencode review action failed'
+              : 'opencode provider keys unavailable';
+            core.info(`${reason} — requesting Copilot review for PR #${prNumber}`);
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                reviewers: ['copilot-pull-request-reviewer'],
+              });
+              core.info(`Requested Copilot review for PR #${prNumber}`);
+            } catch (error) {
+              core.warning(`Copilot review request failed: ${error.message}`);
+            }

--- a/setup-templates/templates/workflows/opencode.yml
+++ b/setup-templates/templates/workflows/opencode.yml
@@ -1,0 +1,64 @@
+name: opencode
+
+# Companion to the Claude Code workflow. Listens for the `opencode` label
+# and `@opencode-agent` mentions that caretaker's BYOCA dispatcher
+# applies when ``executor.provider = "opencode"`` (or a per-PR
+# ``agent:opencode`` label is set).
+#
+# opencode (https://github.com/sst/opencode) supports many providers in
+# agent mode (Anthropic, OpenAI, OpenRouter, local models). The provider
+# / model selection lives in this workflow file, not in caretaker.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [labeled]
+
+jobs:
+  opencode:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@opencode-agent')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@opencode-agent')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@opencode-agent')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@opencode-agent') || contains(github.event.issue.title, '@opencode-agent') || github.event.label.name == 'opencode')) ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run opencode
+        uses: sst/opencode/github@latest
+        env:
+          # Pick whichever provider keys this repo has configured. opencode
+          # picks them up automatically. Add only the keys you intend to
+          # use — empty values are ignored.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        with:
+          # Default model — override per-repo. Any provider/model string
+          # opencode supports works (e.g. ``openrouter/anthropic/claude-sonnet-4``,
+          # ``openai/gpt-4o``, ``anthropic/claude-sonnet-4``).
+          model: anthropic/claude-sonnet-4
+          # Mention string the workflow listens for. Must match
+          # ``executor.opencode.mention`` in caretaker's config.
+          # Default keeps caretaker's hand-off comments triggering work.
+          # mention: '@opencode-agent'

--- a/setup-templates/templates/workflows/opencode.yml
+++ b/setup-templates/templates/workflows/opencode.yml
@@ -44,6 +44,11 @@ jobs:
           fetch-depth: 1
 
       - name: Run opencode
+        # Pinning to ``@latest`` is convenient but a supply-chain risk —
+        # any compromise of the upstream tag affects this workflow on the
+        # next run. Recommend pinning to a specific release tag (e.g.
+        # ``sst/opencode/github@v0.1.0``) or commit SHA before relying on
+        # this in production.
         uses: sst/opencode/github@latest
         env:
           # Pick whichever provider keys this repo has configured. opencode

--- a/src/caretaker/claude_code_executor.py
+++ b/src/caretaker/claude_code_executor.py
@@ -1,203 +1,29 @@
-"""Claude Code hand-off executor.
+"""Backward-compat shim — :class:`ClaudeCodeExecutor` lives in ``coding_agents`` now.
 
-Caretaker's own tool-loop lives in :mod:`caretaker.foundry.executor`. The
-*Claude Code* executor is a thin hand-off: it tags the host PR / issue
-with a configurable trigger label and posts a structured mention comment
-that the upstream `anthropics/claude-code-action`_ workflow picks up.
+The old module-level surface (``ClaudeCodeExecutor`` /
+``CLAUDE_CODE_HANDOFF_MARKER``) is preserved so callers that import from
+``caretaker.claude_code_executor`` keep working through one deprecation
+window. New code should import from :mod:`caretaker.coding_agents`
+directly:
 
-Design choices:
+    from caretaker.coding_agents import ClaudeCodeAgent
 
-* **No inline execution.** Caretaker does not spawn Claude Code itself.
-  The consumer repo is expected to have the upstream action installed;
-  caretaker just steers tasks at it. This keeps caretaker backend-agnostic
-  and avoids a second model-provider credential to manage.
-* **Async hand-off.** The upstream action runs in its own workflow and
-  posts its own commit + result comment. Caretaker's PR state machine
-  already tracks those via the ``<!-- caretaker:result -->`` markers, so
-  the hand-off looks identical to any other async executor.
-* **COMPLETED on successful hand-off.** We treat the dispatch itself as
-  the unit of work; failures to apply the label / post the comment
-  escalate back to Copilot the same way a Foundry failure does.
-* **Attempt cap.** If caretaker re-routes the same task to Claude Code
-  more than ``config.max_attempts`` times without an upstream resolution,
-  we stop re-triggering and escalate. Prevents the trigger-label →
-  no-op → re-trigger loop if the upstream action is unavailable.
-
-.. _anthropics/claude-code-action: https://github.com/anthropics/claude-code-action
+The name change reflects that the executor is one of several BYOCA
+hand-off agents (Claude Code, opencode, …) sharing a common base.
 """
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING
-
-from caretaker.foundry.executor import (
-    CodingTask,
-    ExecutorOutcome,
-    ExecutorResult,
+from caretaker.coding_agents.handoff import (
+    CLAUDE_CODE_HANDOFF_MARKER,
+    ClaudeCodeAgent,
 )
 
-if TYPE_CHECKING:
-    from caretaker.config import ClaudeCodeExecutorConfig
-    from caretaker.github_client.api import GitHubClient
-    from caretaker.github_client.models import PullRequest
-
-logger = logging.getLogger(__name__)
-
-
-CLAUDE_CODE_HANDOFF_MARKER = "<!-- caretaker:claude-code-handoff -->"
-
-
-def _build_handoff_comment(
-    *, mention: str, task: CodingTask, attempt: int, max_attempts: int
-) -> str:
-    """Format the structured hand-off comment the upstream action consumes."""
-    lines = [
-        CLAUDE_CODE_HANDOFF_MARKER,
-        f"{mention} caretaker is handing this task off to claude-code.",
-        "",
-        f"**task_type**: `{task.task_type.value}`",
-        f"**job**: `{task.job_name}`",
-        f"**attempt**: {attempt}/{max_attempts}",
-        "",
-        "**Instructions:**",
-        task.instructions or "(none)",
-    ]
-    if task.error_output:
-        snippet = task.error_output.strip()
-        if len(snippet) > 4000:
-            snippet = snippet[:4000] + "\n…(truncated)"
-        lines.extend(["", "**Error output:**", "```", snippet, "```"])
-    if task.context:
-        lines.extend(["", "**Additional context:**", task.context.strip()])
-    lines.extend(
-        [
-            "",
-            "_Applied by caretaker's ClaudeCodeExecutor. The upstream "
-            "`anthropics/claude-code-action` workflow will produce the "
-            "fix as its own commit; caretaker's state machine will pick "
-            "up the result from the usual `caretaker:result` markers._",
-        ]
-    )
-    return "\n".join(lines)
-
-
-class ClaudeCodeExecutor:
-    """Hand-off executor that steers tasks at ``anthropics/claude-code-action``.
-
-    The executor conforms to the same ``async run(task, pr) -> ExecutorResult``
-    shape as :class:`caretaker.foundry.executor.FoundryExecutor`, so
-    :class:`~caretaker.foundry.dispatcher.ExecutorDispatcher` can route to
-    either without special-casing.
-    """
-
-    def __init__(
-        self,
-        *,
-        github: GitHubClient,
-        owner: str,
-        repo: str,
-        config: ClaudeCodeExecutorConfig,
-    ) -> None:
-        self._github = github
-        self._owner = owner
-        self._repo = repo
-        self._config = config
-
-    @property
-    def config(self) -> ClaudeCodeExecutorConfig:
-        return self._config
-
-    async def run(self, task: CodingTask, pr: PullRequest) -> ExecutorResult:
-        """Apply the trigger label + post the hand-off comment.
-
-        Returns :class:`ExecutorResult` with outcome:
-
-        * ``COMPLETED`` — label applied and comment posted successfully.
-        * ``ESCALATED`` — attempt cap hit, caller should escalate to Copilot.
-        * ``FAILED``    — GitHub API error; caller should escalate.
-        """
-        if not self._config.enabled:
-            logger.debug("ClaudeCodeExecutor.run called while config.enabled=False; escalating")
-            return ExecutorResult(
-                outcome=ExecutorOutcome.ESCALATED,
-                reason="claude_code.enabled=False",
-            )
-
-        # Attempt cap. We count prior hand-offs via the marker comment on
-        # the PR; a GH API call per dispatch is fine because this path is
-        # low-frequency.
-        attempt = await self._count_prior_handoffs(pr.number) + 1
-        if attempt > self._config.max_attempts:
-            logger.info(
-                "Claude Code hand-off capped on PR #%s (attempt %d > max %d); escalating",
-                pr.number,
-                attempt,
-                self._config.max_attempts,
-            )
-            return ExecutorResult(
-                outcome=ExecutorOutcome.ESCALATED,
-                reason=(
-                    f"claude_code attempt cap hit ({attempt} > "
-                    f"{self._config.max_attempts}); escalating to Copilot"
-                ),
-            )
-
-        body = _build_handoff_comment(
-            mention=self._config.mention,
-            task=task,
-            attempt=attempt,
-            max_attempts=self._config.max_attempts,
-        )
-
-        try:
-            comment = await self._github.add_issue_comment(self._owner, self._repo, pr.number, body)
-        except Exception as exc:  # defensive; escalate rather than raise
-            logger.exception("ClaudeCodeExecutor: add_issue_comment failed: %s", exc)
-            return ExecutorResult(
-                outcome=ExecutorOutcome.FAILED,
-                reason=f"claude_code comment failed: {exc}",
-            )
-
-        try:
-            await self._github.add_labels(
-                self._owner, self._repo, pr.number, [self._config.trigger_label]
-            )
-        except Exception as exc:
-            # Comment is already posted; the upstream action may still
-            # pick up via the mention. Log and continue — treat as COMPLETED
-            # but note the label failure in the reason.
-            logger.warning(
-                "ClaudeCodeExecutor: add_labels(%s) failed on PR #%s: %s",
-                self._config.trigger_label,
-                pr.number,
-                exc,
-            )
-            return ExecutorResult(
-                outcome=ExecutorOutcome.COMPLETED,
-                reason=(f"claude_code dispatched via mention (label apply failed: {exc})"),
-                comment_id=getattr(comment, "id", None),
-                iterations=attempt,
-            )
-
-        return ExecutorResult(
-            outcome=ExecutorOutcome.COMPLETED,
-            reason=f"claude_code dispatched (attempt {attempt}/{self._config.max_attempts})",
-            comment_id=getattr(comment, "id", None),
-            iterations=attempt,
-        )
-
-    async def _count_prior_handoffs(self, pr_number: int) -> int:
-        """Return the number of caretaker claude-code hand-off comments on the PR."""
-        try:
-            comments = await self._github.get_pr_comments(self._owner, self._repo, pr_number)
-        except Exception as exc:
-            logger.debug("ClaudeCodeExecutor: could not list comments: %s", exc)
-            return 0
-        return sum(1 for c in comments if CLAUDE_CODE_HANDOFF_MARKER in (c.body or ""))
-
+# Legacy name kept for one release. Identical to ``ClaudeCodeAgent``.
+ClaudeCodeExecutor = ClaudeCodeAgent
 
 __all__ = [
     "CLAUDE_CODE_HANDOFF_MARKER",
+    "ClaudeCodeAgent",
     "ClaudeCodeExecutor",
 ]

--- a/src/caretaker/coding_agents/__init__.py
+++ b/src/caretaker/coding_agents/__init__.py
@@ -1,0 +1,47 @@
+"""BYOCA — Bring Your Own Coding Agent registry.
+
+This package contains the pluggable coding-agent infrastructure caretaker
+uses to dispatch coding work (lint fixes, test fixes, review-comment fixes)
+and complex PR reviews. Each agent is a concrete implementation of the
+:class:`~caretaker.coding_agents.protocol.CodingAgent` protocol.
+
+Two execution modes ship today:
+
+* ``handoff`` — caretaker tags the host PR / issue with a configurable
+  trigger label and posts a structured ``@mention`` comment. An upstream
+  GitHub Action installed on the consumer repo (``anthropics/claude-code-action``,
+  ``sst/opencode-github-action``, etc.) picks the comment up and produces
+  the work asynchronously. Caretaker treats the dispatch itself as the
+  unit of work.
+* ``inline`` — used today only by ``foundry`` (caretaker's own tool-loop
+  in :mod:`caretaker.foundry.executor`). Future placeholder for inline
+  subprocess agents like ``opencode run``, ``codex …``, ``gemini …``.
+
+The naming ``coding_agents`` is deliberately distinct from the existing
+``caretaker.agents`` package, which holds caretaker's *internal* agents
+(PR agent, issue agent, etc.) — those orchestrate work; these *do* the
+coding work.
+"""
+
+from __future__ import annotations
+
+from caretaker.coding_agents.handoff import (
+    CLAUDE_CODE_HANDOFF_MARKER,
+    OPENCODE_HANDOFF_MARKER,
+    ClaudeCodeAgent,
+    HandoffAgent,
+    OpenCodeAgent,
+)
+from caretaker.coding_agents.protocol import CodingAgent, ExecutionMode
+from caretaker.coding_agents.registry import CodingAgentRegistry
+
+__all__ = [
+    "CLAUDE_CODE_HANDOFF_MARKER",
+    "OPENCODE_HANDOFF_MARKER",
+    "ClaudeCodeAgent",
+    "CodingAgent",
+    "CodingAgentRegistry",
+    "ExecutionMode",
+    "HandoffAgent",
+    "OpenCodeAgent",
+]

--- a/src/caretaker/coding_agents/handoff.py
+++ b/src/caretaker/coding_agents/handoff.py
@@ -1,0 +1,242 @@
+"""Hand-off coding agents — Claude Code, opencode, and friends.
+
+A *hand-off* coding agent does not execute the work itself. It applies a
+configurable trigger label to the host PR / issue and posts a structured
+``@mention`` comment that an upstream GitHub Action workflow picks up.
+
+The pattern was first introduced for ``anthropics/claude-code-action``;
+the same shape works for ``sst/opencode-github-action`` and any future
+agent that ships a label-triggered GitHub Action. Concrete subclasses
+just supply their name, marker, default label, and default mention.
+
+Each agent owns a unique HTML-comment marker in the body of its hand-off
+comment (e.g. ``<!-- caretaker:claude-code-handoff -->``). Markers are
+how :meth:`HandoffAgent._count_prior_handoffs` enforces the per-PR
+attempt cap; reusing a marker across agents would cause cross-talk.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from caretaker.foundry.executor import (
+    CodingTask,
+    ExecutorOutcome,
+    ExecutorResult,
+)
+
+if TYPE_CHECKING:
+    from caretaker.coding_agents.protocol import ExecutionMode
+    from caretaker.config import HandoffAgentConfig
+    from caretaker.github_client.api import GitHubClient
+    from caretaker.github_client.models import PullRequest
+
+logger = logging.getLogger(__name__)
+
+
+CLAUDE_CODE_HANDOFF_MARKER = "<!-- caretaker:claude-code-handoff -->"
+OPENCODE_HANDOFF_MARKER = "<!-- caretaker:opencode-handoff -->"
+
+
+class HandoffAgent:
+    """Base implementation of the hand-off pattern.
+
+    Subclasses set the four class-level attributes below and inherit the
+    full :meth:`run` flow. The hand-off comment body is parameterised by
+    ``mention`` (so each agent gets the trigger string the upstream action
+    expects) and ``trigger_label`` (so consumer-repo workflows can listen
+    on a name they choose).
+    """
+
+    # Subclass-supplied identity. Overridden in concrete subclasses.
+    name: str = ""
+    mode: ExecutionMode = "handoff"
+    marker: str = ""
+    upstream_action_name: str = ""
+
+    # Default config values used when an operator hasn't overridden them
+    # in ``executor.agents.<name>``. Mirrors :class:`HandoffAgentConfig`.
+    default_trigger_label: str = ""
+    default_mention: str = ""
+
+    def __init__(
+        self,
+        *,
+        github: GitHubClient,
+        owner: str,
+        repo: str,
+        config: HandoffAgentConfig,
+    ) -> None:
+        self._github = github
+        self._owner = owner
+        self._repo = repo
+        self._config = config
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    @property
+    def trigger_label(self) -> str:
+        return self._config.trigger_label or self.default_trigger_label
+
+    @property
+    def mention(self) -> str:
+        return self._config.mention or self.default_mention
+
+    @property
+    def max_attempts(self) -> int:
+        return self._config.max_attempts
+
+    @property
+    def config(self) -> HandoffAgentConfig:
+        return self._config
+
+    async def run(self, task: CodingTask, pr: PullRequest) -> ExecutorResult:
+        """Apply the trigger label + post the hand-off comment.
+
+        Returns :class:`ExecutorResult` with outcome:
+
+        * ``COMPLETED`` — label applied and comment posted successfully.
+        * ``ESCALATED`` — attempt cap hit, caller should escalate to Copilot.
+        * ``FAILED``    — GitHub API error; caller should escalate.
+        """
+        if not self._config.enabled:
+            logger.debug(
+                "%sAgent.run called while config.enabled=False; escalating",
+                self.name,
+            )
+            return ExecutorResult(
+                outcome=ExecutorOutcome.ESCALATED,
+                reason=f"{self.name}.enabled=False",
+            )
+
+        attempt = await self._count_prior_handoffs(pr.number) + 1
+        if attempt > self.max_attempts:
+            logger.info(
+                "%s hand-off capped on PR #%s (attempt %d > max %d); escalating",
+                self.name,
+                pr.number,
+                attempt,
+                self.max_attempts,
+            )
+            return ExecutorResult(
+                outcome=ExecutorOutcome.ESCALATED,
+                reason=(
+                    f"{self.name} attempt cap hit ({attempt} > "
+                    f"{self.max_attempts}); escalating to Copilot"
+                ),
+            )
+
+        body = self._build_handoff_comment(task=task, attempt=attempt)
+
+        try:
+            comment = await self._github.add_issue_comment(self._owner, self._repo, pr.number, body)
+        except Exception as exc:
+            logger.exception("%sAgent: add_issue_comment failed: %s", self.name, exc)
+            return ExecutorResult(
+                outcome=ExecutorOutcome.FAILED,
+                reason=f"{self.name} comment failed: {exc}",
+            )
+
+        try:
+            await self._github.add_labels(self._owner, self._repo, pr.number, [self.trigger_label])
+        except Exception as exc:
+            # Comment is already posted; the upstream action may still
+            # pick up via the mention. Log and continue — treat as COMPLETED
+            # but note the label failure in the reason.
+            logger.warning(
+                "%sAgent: add_labels(%s) failed on PR #%s: %s",
+                self.name,
+                self.trigger_label,
+                pr.number,
+                exc,
+            )
+            return ExecutorResult(
+                outcome=ExecutorOutcome.COMPLETED,
+                reason=(f"{self.name} dispatched via mention (label apply failed: {exc})"),
+                comment_id=getattr(comment, "id", None),
+                iterations=attempt,
+            )
+
+        return ExecutorResult(
+            outcome=ExecutorOutcome.COMPLETED,
+            reason=f"{self.name} dispatched (attempt {attempt}/{self.max_attempts})",
+            comment_id=getattr(comment, "id", None),
+            iterations=attempt,
+        )
+
+    def _build_handoff_comment(self, *, task: CodingTask, attempt: int) -> str:
+        """Format the structured hand-off comment the upstream action consumes."""
+        lines = [
+            self.marker,
+            f"{self.mention} caretaker is handing this task off to {self.name}.",
+            "",
+            f"**task_type**: `{task.task_type.value}`",
+            f"**job**: `{task.job_name}`",
+            f"**attempt**: {attempt}/{self.max_attempts}",
+            "",
+            "**Instructions:**",
+            task.instructions or "(none)",
+        ]
+        if task.error_output:
+            snippet = task.error_output.strip()
+            if len(snippet) > 4000:
+                snippet = snippet[:4000] + "\n…(truncated)"
+            lines.extend(["", "**Error output:**", "```", snippet, "```"])
+        if task.context:
+            lines.extend(["", "**Additional context:**", task.context.strip()])
+        action_note = (
+            f"_Applied by caretaker's {self.name} agent. The upstream "
+            f"`{self.upstream_action_name}` workflow will produce the fix as "
+            "its own commit; caretaker's state machine will pick up the "
+            "result from the usual `caretaker:result` markers._"
+        )
+        lines.extend(["", action_note])
+        return "\n".join(lines)
+
+    async def _count_prior_handoffs(self, pr_number: int) -> int:
+        """Return the number of caretaker hand-off comments on the PR for this agent."""
+        try:
+            comments = await self._github.get_pr_comments(self._owner, self._repo, pr_number)
+        except Exception as exc:
+            logger.debug("%sAgent: could not list comments: %s", self.name, exc)
+            return 0
+        return sum(1 for c in comments if self.marker in (c.body or ""))
+
+
+class ClaudeCodeAgent(HandoffAgent):
+    """Hand-off agent for ``anthropics/claude-code-action``."""
+
+    name = "claude_code"
+    marker = CLAUDE_CODE_HANDOFF_MARKER
+    upstream_action_name = "anthropics/claude-code-action"
+    default_trigger_label = "claude-code"
+    default_mention = "@claude"
+
+
+class OpenCodeAgent(HandoffAgent):
+    """Hand-off agent for ``sst/opencode``-style GitHub Actions.
+
+    opencode (https://github.com/sst/opencode) supports many providers in
+    agent mode (Anthropic, OpenAI, OpenRouter, local models). Caretaker
+    treats it as a peer of Claude Code: same hand-off shape, different
+    label / mention / marker so attempts don't cross-count and each
+    upstream workflow can listen on its own trigger.
+    """
+
+    name = "opencode"
+    marker = OPENCODE_HANDOFF_MARKER
+    upstream_action_name = "sst/opencode/github"
+    default_trigger_label = "opencode"
+    default_mention = "@opencode-agent"
+
+
+__all__ = [
+    "CLAUDE_CODE_HANDOFF_MARKER",
+    "OPENCODE_HANDOFF_MARKER",
+    "ClaudeCodeAgent",
+    "HandoffAgent",
+    "OpenCodeAgent",
+]

--- a/src/caretaker/coding_agents/protocol.py
+++ b/src/caretaker/coding_agents/protocol.py
@@ -1,0 +1,43 @@
+"""Protocol every BYOCA coding agent implements.
+
+The dispatcher routes :class:`~caretaker.foundry.executor.CodingTask`
+items at agents through this contract; nothing in
+:class:`~caretaker.foundry.dispatcher.ExecutorDispatcher` knows about
+the underlying provider (Claude Code, opencode, foundry, …).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from caretaker.foundry.executor import CodingTask, ExecutorResult
+    from caretaker.github_client.models import PullRequest
+
+# ``handoff`` is the only mode wired up in Phase 1. ``inline`` is what the
+# foundry executor uses today (and is what future opencode/codex/gemini
+# subprocess agents will use). ``k8s_job`` is reserved for the planned
+# k8s-job execution path (``infra/k8s/caretaker-agent-worker.yaml``).
+ExecutionMode = Literal["handoff", "inline", "k8s_job"]
+
+
+@runtime_checkable
+class CodingAgent(Protocol):
+    """Minimal contract for a registry-backed coding agent.
+
+    Implementations must expose the four attributes below and an async
+    :meth:`run` method matching the existing executor shape so the
+    dispatcher can fall back to Copilot on ``ESCALATED`` / ``FAILED``
+    without special-casing the agent name.
+    """
+
+    name: str  # registry key — matches ``executor.provider`` and ``agent:<name>`` labels.
+    mode: ExecutionMode
+
+    @property
+    def enabled(self) -> bool: ...
+
+    async def run(self, task: CodingTask, pr: PullRequest) -> ExecutorResult: ...
+
+
+__all__ = ["CodingAgent", "ExecutionMode"]

--- a/src/caretaker/coding_agents/registry.py
+++ b/src/caretaker/coding_agents/registry.py
@@ -1,0 +1,79 @@
+"""BYOCA coding-agent registry.
+
+The registry holds the set of pluggable coding agents available to the
+:class:`~caretaker.foundry.dispatcher.ExecutorDispatcher`. Phase 1 ships
+the ``claude_code`` and ``opencode`` hand-off agents and a placeholder
+slot for ``foundry`` (caretaker's own inline tool-loop). Future phases
+plug in additional agents — codex, gemini, hermes — through the same
+:meth:`register` call.
+
+The registry intentionally does NOT instantiate agents itself. Caretaker
+constructs them in ``Orchestrator._build_executor_dispatcher`` so the
+GitHub client, owner/repo, and per-agent config are wired in from one
+place. The registry just stores them and exposes lookup helpers.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from caretaker.coding_agents.protocol import CodingAgent
+
+logger = logging.getLogger(__name__)
+
+
+class CodingAgentRegistry:
+    """In-memory registry of named :class:`CodingAgent` instances."""
+
+    def __init__(self) -> None:
+        self._agents: dict[str, CodingAgent] = {}
+
+    def register(self, agent: CodingAgent) -> None:
+        """Register an agent under its ``name``.
+
+        Re-registering the same name overwrites the previous entry; this
+        is convenient for tests but should be a warning sign in
+        production. We log at WARNING so it shows up.
+        """
+        if agent.name in self._agents:
+            logger.warning("CodingAgentRegistry: overwriting existing agent %r", agent.name)
+        self._agents[agent.name] = agent
+
+    def get(self, name: str) -> CodingAgent | None:
+        """Return the agent registered under ``name``, or ``None``."""
+        return self._agents.get(name)
+
+    def has(self, name: str) -> bool:
+        return name in self._agents
+
+    def names(self) -> list[str]:
+        """All registered agent names, in insertion order."""
+        return list(self._agents)
+
+    def enabled(self) -> list[CodingAgent]:
+        """Currently-enabled agents, in registration order."""
+        return [a for a in self._agents.values() if a.enabled]
+
+    def fallback_chain(self, primary: str) -> list[CodingAgent]:
+        """Order to try when the primary agent isn't available.
+
+        Returns ``primary`` first (if registered + enabled), then any
+        other enabled custom agents in registration order. Copilot is
+        not represented here — it lives outside the registry as the
+        terminal fallback owned by :class:`ExecutorDispatcher`.
+        """
+        chain: list[CodingAgent] = []
+        primary_agent = self._agents.get(primary)
+        if primary_agent is not None and primary_agent.enabled:
+            chain.append(primary_agent)
+        for name, agent in self._agents.items():
+            if name == primary:
+                continue
+            if agent.enabled:
+                chain.append(agent)
+        return chain
+
+
+__all__ = ["CodingAgentRegistry"]

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -641,11 +641,24 @@ class PRReviewerConfig(StrictBaseModel):
             "ready_for_review",
         ]
     )
-    # Score threshold: score >= threshold → claude-code hand-off; else inline LLM.
+    # Score threshold: score >= threshold → complex hand-off; else inline LLM.
     routing_threshold: int = 40
+    # Which BYOCA coding agent to use for complex PR reviews. Must match
+    # a registered agent name (``claude_code``, ``opencode``, …) or the
+    # special value ``inline`` to keep everything inline. The default
+    # preserves the historical behaviour for existing consumers; switch
+    # to ``opencode`` when you want multi-provider review hand-off.
+    complex_reviewer: str = "claude_code"
     # Label/mention used for the claude-code-action hand-off.
+    # Retained for backward-compatibility — read by the claude_code
+    # reviewer dispatch path. New deployments should configure the
+    # equivalent on the registered agent instead.
     claude_code_label: str = "claude-code"
     claude_code_mention: str = "@claude"
+    # Label/mention used for the opencode hand-off when
+    # ``complex_reviewer = "opencode"``.
+    opencode_label: str = "opencode-review"
+    opencode_mention: str = "@opencode-agent"
     # Maximum diff lines fetched for inline review (excess is truncated).
     max_diff_lines: int = 2000
     # Whether to post per-file inline comments (in addition to the review body).
@@ -1110,38 +1123,75 @@ class FoundryExecutorConfig(StrictBaseModel):
     request_timeout_seconds: float = 120.0
 
 
-class ClaudeCodeExecutorConfig(StrictBaseModel):
-    """Configuration for the opt-in ``claude-code-action`` hand-off executor.
+class HandoffAgentConfig(StrictBaseModel):
+    """Configuration shared by every BYOCA hand-off coding agent.
 
-    Caretaker does not run Claude Code inline; instead, when this executor
-    is selected for a task, it applies a configurable *trigger label* to
-    the host PR / issue, and posts a structured hand-off comment. The
-    upstream [``anthropics/claude-code-action``][cca] workflow, installed
-    separately in the consumer repo, listens for that label (or the `@claude`
-    mention in the comment) and produces the fix asynchronously.
+    Hand-off agents (Claude Code, opencode, …) all behave identically:
+    apply a trigger label to the host PR / issue, post a structured
+    ``@mention`` comment, and let an upstream GitHub Action installed on
+    the consumer repo produce the fix asynchronously. Caretaker tracks
+    the resulting commit / PR through the same ``<!-- caretaker:result -->``
+    markers it already uses for the Copilot + Foundry paths.
 
-    The caretaker state machine then tracks the resulting commit / PR
-    through the same ``<!-- caretaker:result -->`` markers it already uses
-    for the Copilot + Foundry paths.
-
-    Feature is entirely opt-in: ``enabled = False`` by default; in addition
-    the consumer repo must have the upstream action installed and
-    authorised on its own.
-
-    [cca]: https://github.com/anthropics/claude-code-action
+    Each concrete agent supplies its own defaults for ``trigger_label`` /
+    ``mention``; operators can override them per repo via the
+    ``executor.agents.<name>`` config block.
     """
 
     enabled: bool = False
-    # Label caretaker applies to trigger the upstream workflow.
-    trigger_label: str = "claude-code"
+    # Execution mode. Phase 1 only ships ``handoff``; ``inline`` and
+    # ``k8s_job`` are reserved for future phases. Validated at startup
+    # against the agent class — opencode/claude_code are hand-off only.
+    mode: Literal["handoff", "inline", "k8s_job"] = "handoff"
+    # Label caretaker applies to trigger the upstream workflow. Empty
+    # string falls through to the agent class's ``default_trigger_label``.
+    trigger_label: str = ""
     # Mention string included in the hand-off comment so the upstream
     # auto-detector can pick it up even if a repo has a different label
-    # listener name configured.
-    mention: str = "@claude"
+    # listener name configured. Empty string falls through to the agent
+    # class's ``default_mention``.
+    mention: str = ""
     # Maximum attempts per task before caretaker stops re-applying the
     # trigger label; prevents ping-pong if the upstream action can't
     # complete the work.
     max_attempts: int = 2
+
+
+class ClaudeCodeExecutorConfig(HandoffAgentConfig):
+    """Configuration for the ``anthropics/claude-code-action`` hand-off agent.
+
+    Identical shape to :class:`HandoffAgentConfig`; subclassed only so
+    legacy ``executor.claude_code: …`` YAML keeps working without an
+    ``extra="forbid"`` validation error during the deprecation window.
+    The defaults match what shipped before the BYOCA refactor.
+
+    See https://github.com/anthropics/claude-code-action for the upstream
+    action this agent dispatches to.
+    """
+
+    trigger_label: str = "claude-code"
+    mention: str = "@claude"
+
+
+class OpenCodeExecutorConfig(HandoffAgentConfig):
+    """Configuration for the ``sst/opencode``-style hand-off agent.
+
+    opencode (https://github.com/sst/opencode) supports many providers in
+    agent mode — useful when caretaker is dispatching coding work in repos
+    that need a non-Anthropic backend. Caretaker treats it as a peer of
+    Claude Code: same hand-off shape, different label / mention so each
+    upstream workflow can listen on its own trigger and per-PR attempt
+    counts don't cross-contaminate.
+
+    Feature is opt-in (``enabled = False`` by default); the consumer repo
+    must have the upstream opencode action installed and authorised on
+    its own. The maintainer agent's template installer can write the
+    ``.github/workflows/opencode.yml`` workflow into consumer repos when
+    they opt in; see ``setup-templates/templates/.github/workflows/``.
+    """
+
+    trigger_label: str = "opencode"
+    mention: str = "@opencode-agent"
 
 
 class K8sAgentWorkerConfig(StrictBaseModel):
@@ -1178,12 +1228,33 @@ class K8sAgentWorkerConfig(StrictBaseModel):
 
 
 class ExecutorConfig(StrictBaseModel):
-    """Top-level switch deciding how coding tasks are executed."""
+    """Top-level switch deciding how coding tasks are executed.
 
-    provider: Literal["copilot", "foundry", "claude_code", "auto"] = "copilot"
+    BYOCA — Bring Your Own Coding Agent. ``provider`` is a string naming
+    a registered :class:`~caretaker.coding_agents.protocol.CodingAgent`
+    plus the legacy reserved values ``copilot`` (always available; never
+    in the registry) and ``auto`` (try the registered custom agents in
+    order, fall back to Copilot).
+
+    Built-in registered names today: ``foundry``, ``claude_code``,
+    ``opencode``. Operators can register additional agents (codex,
+    gemini, hermes, …) by populating the ``agents`` map below. Unknown
+    ``provider`` values are diagnosed at orchestrator startup with the
+    full list of registered names — not at config-parse time, so
+    operators get a useful error.
+    """
+
+    provider: str = "copilot"
     foundry: FoundryExecutorConfig = Field(default_factory=FoundryExecutorConfig)
     claude_code: ClaudeCodeExecutorConfig = Field(default_factory=ClaudeCodeExecutorConfig)
+    opencode: OpenCodeExecutorConfig = Field(default_factory=OpenCodeExecutorConfig)
     k8s_worker: K8sAgentWorkerConfig = Field(default_factory=K8sAgentWorkerConfig)
+    # Per-repo overrides for additional registered agents. Keys are agent
+    # names (matching the agent's ``CodingAgent.name``); values follow
+    # :class:`HandoffAgentConfig`. Use this for agents that aren't built
+    # in (codex, gemini, hermes, …) without breaking the existing typed
+    # ``claude_code`` / ``opencode`` blocks.
+    agents: dict[str, HandoffAgentConfig] = Field(default_factory=dict)
 
 
 class AgenticEnforceGateConfig(StrictBaseModel):

--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -1045,6 +1045,93 @@ def check_external_services(
 # ── Orchestration ──────────────────────────────────────────────────────
 
 
+def check_coding_agent_config(config: MaintainerConfig) -> list[CheckResult]:
+    """Validate ``executor.provider`` resolves to a registered coding agent.
+
+    The dispatcher tolerates an unknown provider at runtime (logs and falls
+    back to Copilot) so a typo doesn't crash the orchestrator. ``doctor``
+    surfaces the misconfiguration as a row so operators can spot it before
+    they wonder why every task is going to Copilot.
+    """
+    rows: list[CheckResult] = []
+    cfg = config.executor
+
+    # Names always known to the registry-construction code in
+    # ``Orchestrator._build_executor_dispatcher``. Built-ins plus any
+    # extra agents declared in ``executor.agents``. ``copilot`` / ``auto``
+    # / ``foundry`` are always-valid reserved provider values.
+    known: set[str] = {"copilot", "auto", "foundry"}
+    if cfg.claude_code.enabled:
+        known.add("claude_code")
+    if cfg.opencode.enabled:
+        known.add("opencode")
+    for name, agent_cfg in cfg.agents.items():
+        if agent_cfg.enabled:
+            known.add(name)
+
+    if cfg.provider not in known:
+        # Distinguish between "named agent isn't enabled" and "provider
+        # doesn't exist at all" — the first is a common misconfig where
+        # the operator pasted ``provider: opencode`` but forgot
+        # ``opencode.enabled: true``.
+        is_typed_disabled = (cfg.provider == "claude_code" and not cfg.claude_code.enabled) or (
+            cfg.provider == "opencode" and not cfg.opencode.enabled
+        )
+        detail = (
+            f"executor.provider={cfg.provider!r} is set but the "
+            f"corresponding agent block has enabled=False — caretaker will "
+            "route to Copilot instead. Set the matching ``.enabled = true``."
+            if is_typed_disabled
+            else (
+                f"executor.provider={cfg.provider!r} does not match any "
+                f"registered coding agent (known: {', '.join(sorted(known))}). "
+                "Tasks will silently route to Copilot."
+            )
+        )
+        rows.append(
+            CheckResult(
+                category="executor",
+                name="provider",
+                severity=Severity.WARN,
+                detail=detail,
+                hint="executor.provider",
+            )
+        )
+
+    # Validate per-PR ``complex_reviewer`` matches a known reviewer backend.
+    pr_cfg = config.pr_reviewer
+    valid_reviewers = {"inline", "claude_code", "opencode"}
+    if pr_cfg.complex_reviewer not in valid_reviewers:
+        rows.append(
+            CheckResult(
+                category="executor",
+                name="pr-reviewer backend",
+                severity=Severity.WARN,
+                detail=(
+                    f"pr_reviewer.complex_reviewer={pr_cfg.complex_reviewer!r} "
+                    f"is not a recognized hand-off backend "
+                    f"(known: {', '.join(sorted(valid_reviewers))}). "
+                    "Caretaker falls back to claude_code."
+                ),
+                hint="pr_reviewer.complex_reviewer",
+            )
+        )
+
+    if not rows:
+        rows.append(
+            CheckResult(
+                category="executor",
+                name="provider",
+                severity=Severity.OK,
+                detail=(
+                    f"executor.provider={cfg.provider!r}, "
+                    f"pr_reviewer.complex_reviewer={pr_cfg.complex_reviewer!r}"
+                ),
+            )
+        )
+    return rows
+
+
 async def run_doctor(
     config: MaintainerConfig,
     *,
@@ -1092,6 +1179,9 @@ async def run_doctor(
                     await github.close()
 
     for result in check_external_services(config, env, strict=strict):
+        report.add(result)
+
+    for result in check_coding_agent_config(config):
         report.add(result)
 
     return report

--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -1057,10 +1057,14 @@ def check_coding_agent_config(config: MaintainerConfig) -> list[CheckResult]:
     cfg = config.executor
 
     # Names always known to the registry-construction code in
-    # ``Orchestrator._build_executor_dispatcher``. Built-ins plus any
-    # extra agents declared in ``executor.agents``. ``copilot`` / ``auto``
-    # / ``foundry`` are always-valid reserved provider values.
-    known: set[str] = {"copilot", "auto", "foundry"}
+    # ``Orchestrator._build_executor_dispatcher``. ``copilot`` and
+    # ``auto`` are reserved router-only values that don't need a
+    # corresponding enabled feature; ``foundry`` is gated on its own
+    # ``enabled`` flag so a typo'd ``provider: foundry`` without
+    # ``foundry.enabled = true`` surfaces here as a WARN row.
+    known: set[str] = {"copilot", "auto"}
+    if cfg.foundry.enabled:
+        known.add("foundry")
     if cfg.claude_code.enabled:
         known.add("claude_code")
     if cfg.opencode.enabled:
@@ -1074,8 +1078,10 @@ def check_coding_agent_config(config: MaintainerConfig) -> list[CheckResult]:
         # doesn't exist at all" — the first is a common misconfig where
         # the operator pasted ``provider: opencode`` but forgot
         # ``opencode.enabled: true``.
-        is_typed_disabled = (cfg.provider == "claude_code" and not cfg.claude_code.enabled) or (
-            cfg.provider == "opencode" and not cfg.opencode.enabled
+        is_typed_disabled = (
+            (cfg.provider == "claude_code" and not cfg.claude_code.enabled)
+            or (cfg.provider == "opencode" and not cfg.opencode.enabled)
+            or (cfg.provider == "foundry" and not cfg.foundry.enabled)
         )
         detail = (
             f"executor.provider={cfg.provider!r} is set but the "
@@ -1098,9 +1104,14 @@ def check_coding_agent_config(config: MaintainerConfig) -> list[CheckResult]:
             )
         )
 
-    # Validate per-PR ``complex_reviewer`` matches a known reviewer backend.
+    # Validate per-PR ``complex_reviewer`` matches a known reviewer
+    # backend. Pull the hand-off backend list from the canonical source
+    # (``handoff_reviewer.known_backends``) so adding a new backend
+    # there doesn't silently desync this check.
+    from caretaker.pr_reviewer.handoff_reviewer import known_backends
+
     pr_cfg = config.pr_reviewer
-    valid_reviewers = {"inline", "claude_code", "opencode"}
+    valid_reviewers = {"inline", *known_backends()}
     if pr_cfg.complex_reviewer not in valid_reviewers:
         rows.append(
             CheckResult(

--- a/src/caretaker/foundry/dispatcher.py
+++ b/src/caretaker/foundry/dispatcher.py
@@ -1,23 +1,34 @@
-"""Executor dispatcher — picks between Foundry and Copilot per task.
+"""Executor dispatcher — picks between BYOCA coding agents and Copilot per task.
 
 Existing agent bridges ask the dispatcher for a :class:`RouteResult` for each
 task. The dispatcher's decision tree (highest-priority first):
 
-0. **Label override** on the host PR / issue (see :data:`ROUTING_LABELS`):
-   * ``agent:quarantine`` — refuse dispatch entirely (``RouteOutcome.REFUSED``).
-   * ``agent:custom``     — force the custom executor (Foundry today).
-   * ``agent:copilot``    — force the legacy Copilot path.
-1. Config ``provider == "copilot"`` → always post the Copilot task (legacy).
-2. Config ``provider == "foundry"`` → try Foundry; fall back to Copilot on
-   ``ESCALATED`` or ``FAILED``.
-3. Config ``provider == "auto"`` → try Foundry when eligible (task type
-   allowed and provider credentials present), else Copilot.
+0. **Label override** on the host PR / issue:
 
-The dispatcher is a thin coordinator — it never opens a workspace itself.
+   * ``agent:quarantine`` — refuse dispatch entirely (``RouteOutcome.REFUSED``).
+   * ``agent:<name>``     — force the named registered agent (e.g.
+     ``agent:opencode``, ``agent:claude_code``). Falls back to Copilot if
+     the named agent is unregistered or disabled.
+   * ``agent:custom``     — *deprecated* alias for the configured
+     ``executor.provider`` agent.
+   * ``agent:copilot``    — force the legacy Copilot path.
+
+1. Config ``provider == "copilot"`` → always post the Copilot task (legacy).
+2. Config ``provider == "<registered name>"`` → run that agent. On
+   ``ESCALATED`` / ``FAILED``, fall back to Copilot. ``foundry`` follows
+   the eligibility gate (task type + size); hand-off agents follow their
+   per-agent attempt cap.
+3. Config ``provider == "auto"`` → try Foundry when eligible, then any
+   other enabled custom agent in registration order, then Copilot.
+
+The dispatcher itself never opens a workspace and never calls a model
+provider — it just routes. All the per-agent details live in
+:mod:`caretaker.coding_agents`.
 """
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -27,7 +38,7 @@ from caretaker.foundry.executor import CodingTask, ExecutorOutcome, ExecutorResu
 from caretaker.llm.copilot import CopilotTask, TaskType
 
 if TYPE_CHECKING:
-    from caretaker.claude_code_executor import ClaudeCodeExecutor
+    from caretaker.coding_agents.registry import CodingAgentRegistry
     from caretaker.config import ExecutorConfig
     from caretaker.foundry.executor import FoundryExecutor
     from caretaker.github_client.models import Comment, PullRequest
@@ -40,7 +51,11 @@ class RouteOutcome(StrEnum):
     """How a task was actually dispatched."""
 
     FOUNDRY = "FOUNDRY"  # Foundry handled it end-to-end
-    CLAUDE_CODE = "CLAUDE_CODE"  # claude-code-action hand-off dispatched
+    CUSTOM_AGENT = "CUSTOM_AGENT"  # any registered hand-off agent dispatched
+    # Deprecated: kept for one release so downstream observability that
+    # filters on ``CLAUDE_CODE`` keeps working. New routing assigns
+    # ``CUSTOM_AGENT`` plus ``agent_name`` instead.
+    CLAUDE_CODE = "CLAUDE_CODE"
     COPILOT = "COPILOT"  # Copilot comment was posted (legacy path)
     COPILOT_FALLBACK = "COPILOT_FALLBACK"  # custom executor escalated; Copilot posted
     REFUSED = "REFUSED"  # Label-based quarantine refused dispatch
@@ -53,7 +68,14 @@ class RouteOutcome(StrEnum):
 LABEL_AGENT_CUSTOM = "agent:custom"
 LABEL_AGENT_COPILOT = "agent:copilot"
 LABEL_AGENT_QUARANTINE = "agent:quarantine"
+LABEL_AGENT_PREFIX = "agent:"
 ROUTING_LABELS = frozenset({LABEL_AGENT_CUSTOM, LABEL_AGENT_COPILOT, LABEL_AGENT_QUARANTINE})
+
+# Reserved agent-label suffixes that don't resolve to a registry entry —
+# these are caretaker's hand-rolled overrides and must not collide with a
+# registered agent name. Any other ``agent:<x>`` looks up ``x`` in the
+# registry.
+_RESERVED_AGENT_SUFFIXES = frozenset({"custom", "copilot", "quarantine"})
 
 
 def _label_names(labels: object) -> set[str]:
@@ -83,12 +105,29 @@ def _label_names(labels: object) -> set[str]:
 def routing_override(labels: object) -> str | None:
     """Return the routing override dictated by labels, or ``None``.
 
-    Precedence is: quarantine > custom > copilot. Caller decides how to
-    act on each value; see :class:`ExecutorDispatcher.route`.
+    Precedence is: quarantine > copilot > specific agent (``agent:<name>``)
+    > legacy ``custom`` alias. Caller decides how to act on each value;
+    see :class:`ExecutorDispatcher.route`.
+
+    Returns either one of the legacy constants
+    (:data:`LABEL_AGENT_QUARANTINE` / :data:`LABEL_AGENT_COPILOT` /
+    :data:`LABEL_AGENT_CUSTOM`) or a bare ``agent:<name>`` string for the
+    caller to resolve against the registry.
     """
     names = _label_names(labels)
     if LABEL_AGENT_QUARANTINE in names:
         return LABEL_AGENT_QUARANTINE
+    # Specific ``agent:<name>`` labels (other than reserved suffixes) win
+    # over the legacy ``agent:custom`` alias so operators can target a
+    # particular registered agent on a per-PR basis. Sorted for
+    # determinism when an operator stacks multiple ``agent:<name>``
+    # labels (rare; surfaced as a config smell elsewhere).
+    for label in sorted(names):
+        if not label.startswith(LABEL_AGENT_PREFIX):
+            continue
+        suffix = label[len(LABEL_AGENT_PREFIX) :]
+        if suffix and suffix not in _RESERVED_AGENT_SUFFIXES:
+            return label
     if LABEL_AGENT_CUSTOM in names:
         return LABEL_AGENT_CUSTOM
     if LABEL_AGENT_COPILOT in names:
@@ -101,14 +140,31 @@ class RouteResult:
     outcome: RouteOutcome
     # Set when a Copilot task comment was posted.
     copilot_comment: Comment | None = None
-    # Set when Foundry actually ran (either COMPLETED or ESCALATED).
+    # Set when any custom executor (Foundry or a hand-off agent) actually ran.
+    # Field name preserved for backward compatibility — historically only
+    # Foundry populated it. Now also populated by hand-off agents so
+    # callers can read ``foundry_result.outcome`` uniformly.
     foundry_result: ExecutorResult | None = None
     reason: str = ""
     errors: list[str] = field(default_factory=list)
+    # When ``outcome == CUSTOM_AGENT`` (or the deprecated CLAUDE_CODE
+    # alias), the registered agent name that handled the task. Empty for
+    # Foundry, Copilot, refusal.
+    agent_name: str = ""
 
 
 class ExecutorDispatcher:
-    """Routes tasks between the Foundry executor and the Copilot protocol."""
+    """Routes tasks between registered coding agents and the Copilot protocol.
+
+    The dispatcher does NOT instantiate agents — they're constructed by
+    :meth:`Orchestrator._build_executor_dispatcher` and passed in via the
+    ``registry`` argument. Foundry remains a separate parameter (rather
+    than a registry entry) because its eligibility check is more
+    elaborate than the registry's simple ``enabled`` flag — it inspects
+    task type and per-task size budget. The dispatcher promotes Foundry
+    to the registry surface only for the ``auto`` provider's fallback
+    chain.
+    """
 
     def __init__(
         self,
@@ -116,38 +172,61 @@ class ExecutorDispatcher:
         config: ExecutorConfig,
         foundry_executor: FoundryExecutor | None,
         copilot_protocol: CopilotProtocol,
-        claude_code_executor: ClaudeCodeExecutor | None = None,
+        registry: CodingAgentRegistry | None = None,
+        claude_code_executor: object = None,
     ) -> None:
         self._config = config
         self._foundry = foundry_executor
-        self._claude_code = claude_code_executor
         self._copilot = copilot_protocol
+        # Back-compat: tests and older callers passed
+        # ``claude_code_executor=...`` directly. Build a single-entry
+        # registry so they keep working through the deprecation window.
+        if registry is None:
+            from caretaker.coding_agents.registry import CodingAgentRegistry as _Registry
+
+            registry = _Registry()
+            if claude_code_executor is not None:
+                # The legacy parameter pinned this to the claude_code
+                # agent — pin the name/enabled so a bare MagicMock works
+                # as a stand-in.
+                with contextlib.suppress(Exception):
+                    claude_code_executor.name = "claude_code"  # type: ignore[attr-defined]
+                with contextlib.suppress(Exception):
+                    if not isinstance(getattr(claude_code_executor, "enabled", None), bool):
+                        claude_code_executor.enabled = config.claude_code.enabled  # type: ignore[attr-defined]
+                registry.register(claude_code_executor)  # type: ignore[arg-type]
+        self._registry = registry
 
     @property
     def provider(self) -> str:
         return self._config.provider
 
-    def foundry_eligible(self, coding_task: CodingTask) -> bool:
-        """Return True if the task is a candidate for Foundry routing.
+    @property
+    def registry(self) -> CodingAgentRegistry:
+        return self._registry
 
-        Callers that only have a :class:`CopilotTask` can build an equivalent
-        :class:`CodingTask` and pass it here.
-        """
+    def foundry_eligible(self, coding_task: CodingTask) -> bool:
+        """Return True if the task is a candidate for Foundry routing."""
         if self._foundry is None:
             return False
         if not self._config.foundry.enabled:
             return False
         return coding_task.task_type.value in self._config.foundry.allowed_task_types
 
+    def agent_eligible(self, name: str) -> bool:
+        """Return True if a registered hand-off agent is available and enabled."""
+        agent = self._registry.get(name)
+        return agent is not None and agent.enabled
+
+    # Back-compat alias used by older callers / tests.
     def claude_code_eligible(self) -> bool:
-        """Return True if a Claude Code hand-off is configured and available."""
-        return self._claude_code is not None and self._config.claude_code.enabled
+        return self.agent_eligible("claude_code")
 
     def _custom_executor_available(self) -> bool:
         """Is at least one non-Copilot executor wired up?"""
-        return (
-            self._foundry is not None and self._config.foundry.enabled
-        ) or self.claude_code_eligible()
+        if self._foundry is not None and self._config.foundry.enabled:
+            return True
+        return bool(self._registry.enabled())
 
     async def route(
         self,
@@ -157,15 +236,7 @@ class ExecutorDispatcher:
         coding_task: CodingTask | None = None,
         labels: object = None,
     ) -> RouteResult:
-        """Dispatch a task, handling provider selection + Copilot fallback.
-
-        ``copilot_task`` is required so the Copilot path (legacy or fallback)
-        has the exact payload it needs.  ``coding_task`` — if supplied — is
-        handed to the Foundry executor; otherwise a CodingTask is derived from
-        ``copilot_task``. ``labels`` are the labels currently applied to the
-        host PR / issue and participate in the routing decision per
-        :data:`ROUTING_LABELS`.
-        """
+        """Dispatch a task, handling provider selection + Copilot fallback."""
         effective_task = coding_task or self._to_coding_task(copilot_task)
 
         # 0. Label overrides trump every config knob. Operators use these
@@ -178,118 +249,191 @@ class ExecutorDispatcher:
                 outcome=RouteOutcome.REFUSED,
                 reason="agent:quarantine label present",
             )
-        if override == LABEL_AGENT_CUSTOM:
-            if not self._custom_executor_available():
+        if override == LABEL_AGENT_COPILOT:
+            return await self._post_copilot(pr, copilot_task, reason="agent:copilot label")
+        if override and override.startswith(LABEL_AGENT_PREFIX) and override != LABEL_AGENT_CUSTOM:
+            target = override[len(LABEL_AGENT_PREFIX) :]
+            if not self.agent_eligible(target):
                 logger.warning(
-                    "agent:custom label on PR #%s but no custom executor "
-                    "is enabled; falling back to Copilot",
+                    "%s label on PR #%s but agent %r is not registered/enabled; "
+                    "falling back to Copilot",
+                    override,
                     pr.number,
+                    target,
                 )
                 return await self._post_copilot(
                     pr,
                     copilot_task,
-                    reason="agent:custom label set but custom executor unavailable",
+                    reason=f"{override} label but {target} unavailable",
                     is_fallback=True,
                 )
-            # When both Foundry and Claude Code are configured, respect the
-            # ``executor.provider`` setting to decide which wins. If the
-            # provider is ``copilot`` (the original default) but the label
-            # says custom, prefer whichever custom executor is enabled.
-            if self.provider == "claude_code" and self.claude_code_eligible():
-                return await self._run_claude_code(
-                    pr, copilot_task, effective_task, reason="agent:custom label"
-                )
-            if self._foundry is not None and self._config.foundry.enabled:
-                return await self._run_foundry(
-                    pr, copilot_task, effective_task, reason="agent:custom label"
-                )
-            return await self._run_claude_code(
-                pr, copilot_task, effective_task, reason="agent:custom label"
+            return await self._run_agent(
+                target, pr, copilot_task, effective_task, reason=f"{override} label"
             )
-        if override == LABEL_AGENT_COPILOT:
-            return await self._post_copilot(pr, copilot_task, reason="agent:copilot label")
+        if override == LABEL_AGENT_CUSTOM:
+            return await self._handle_custom_label(pr, copilot_task, effective_task)
 
-        # Claude Code provider — dispatch via label + mention comment.
-        if self.provider == "claude_code":
-            if not self.claude_code_eligible():
-                logger.warning(
-                    "executor.provider='claude_code' but claude_code.enabled=False "
-                    "or executor missing; routing to Copilot"
-                )
-                return await self._post_copilot(pr, copilot_task, reason="claude_code disabled")
-            return await self._run_claude_code(
-                pr, copilot_task, effective_task, reason="provider=claude_code"
-            )
-
-        if self.provider == "copilot" or self._foundry is None:
+        # 1. Provider == copilot — short-circuit to legacy path.
+        if self.provider == "copilot":
             return await self._post_copilot(pr, copilot_task, reason="provider=copilot")
 
-        if self.provider == "auto" and not self.foundry_eligible(effective_task):
-            # When auto-routing and Foundry is ineligible, try Claude Code
-            # as the next-cheapest custom executor before falling to Copilot.
-            if self.claude_code_eligible():
-                return await self._run_claude_code(
+        # 2. Provider names a registered agent (claude_code, opencode, …).
+        if self._registry.has(self.provider):
+            if not self.agent_eligible(self.provider):
+                logger.warning(
+                    "executor.provider=%r but that agent is disabled or "
+                    "unavailable; routing to Copilot",
+                    self.provider,
+                )
+                return await self._post_copilot(
+                    pr, copilot_task, reason=f"{self.provider} disabled"
+                )
+            return await self._run_agent(
+                self.provider,
+                pr,
+                copilot_task,
+                effective_task,
+                reason=f"provider={self.provider}",
+            )
+
+        # 3. Provider == foundry / auto / unknown.
+        if self.provider == "foundry":
+            if self._foundry is None or not self._config.foundry.enabled:
+                logger.warning(
+                    "executor.provider='foundry' but foundry.enabled=False; routing to Copilot"
+                )
+                return await self._post_copilot(pr, copilot_task, reason="foundry disabled")
+            return await self._run_foundry(
+                pr, copilot_task, effective_task, reason=f"provider={self.provider}"
+            )
+
+        if self.provider == "auto":
+            if self._foundry is not None and self.foundry_eligible(effective_task):
+                return await self._run_foundry(
+                    pr, copilot_task, effective_task, reason="auto: foundry eligible"
+                )
+            # Foundry ineligible — try registered custom agents (Claude
+            # Code, opencode, …) in registration order before Copilot.
+            for agent in self._registry.enabled():
+                return await self._run_agent(
+                    agent.name,
                     pr,
                     copilot_task,
                     effective_task,
-                    reason="auto: foundry ineligible, claude_code eligible",
+                    reason=f"auto: foundry ineligible, {agent.name} eligible",
                 )
             return await self._post_copilot(
-                pr, copilot_task, reason="auto: task not Foundry-eligible"
+                pr, copilot_task, reason="auto: no custom agent eligible"
             )
 
-        if self.provider == "foundry" and not self._config.foundry.enabled:
-            # Misconfiguration: provider set to foundry but feature disabled.
-            logger.warning(
-                "executor.provider='foundry' but foundry.enabled=False; routing to Copilot"
-            )
-            return await self._post_copilot(pr, copilot_task, reason="foundry disabled")
-
-        return await self._run_foundry(
-            pr, copilot_task, effective_task, reason=f"provider={self.provider}"
+        # Unknown provider name — log and fall back to Copilot. We don't
+        # crash the dispatcher because the same config is loaded by
+        # multiple agents and a typo shouldn't take the whole orchestrator
+        # down. ``caretaker doctor`` surfaces the misconfiguration.
+        logger.warning(
+            "executor.provider=%r is not registered (known agents: %s); routing to Copilot",
+            self.provider,
+            ", ".join(self._registry.names()) or "(none)",
+        )
+        return await self._post_copilot(
+            pr, copilot_task, reason=f"unknown provider {self.provider!r}"
         )
 
-    async def _run_claude_code(
+    async def _handle_custom_label(
         self,
+        pr: PullRequest,
+        copilot_task: CopilotTask,
+        effective_task: CodingTask,
+    ) -> RouteResult:
+        """Resolve the deprecated ``agent:custom`` label.
+
+        Preference order: configured ``provider`` (if it names a custom
+        agent), then Foundry, then the first enabled hand-off agent.
+        Falls back to Copilot when nothing is wired up.
+        """
+        if not self._custom_executor_available():
+            logger.warning(
+                "agent:custom label on PR #%s but no custom executor "
+                "is enabled; falling back to Copilot",
+                pr.number,
+            )
+            return await self._post_copilot(
+                pr,
+                copilot_task,
+                reason="agent:custom label set but custom executor unavailable",
+                is_fallback=True,
+            )
+        # If provider names a registered agent, prefer it.
+        if self.agent_eligible(self.provider):
+            return await self._run_agent(
+                self.provider, pr, copilot_task, effective_task, reason="agent:custom label"
+            )
+        if self._foundry is not None and self._config.foundry.enabled:
+            return await self._run_foundry(
+                pr, copilot_task, effective_task, reason="agent:custom label"
+            )
+        # Last resort: first enabled registered agent.
+        for agent in self._registry.enabled():
+            return await self._run_agent(
+                agent.name, pr, copilot_task, effective_task, reason="agent:custom label"
+            )
+        return await self._post_copilot(
+            pr, copilot_task, reason="agent:custom label but nothing eligible", is_fallback=True
+        )
+
+    async def _run_agent(
+        self,
+        name: str,
         pr: PullRequest,
         copilot_task: CopilotTask,
         effective_task: CodingTask,
         *,
         reason: str,
     ) -> RouteResult:
-        """Invoke the Claude Code hand-off executor and handle fallback."""
-        assert self._claude_code is not None
+        """Invoke a registered hand-off agent and handle fallback."""
+        agent = self._registry.get(name)
+        assert agent is not None, f"agent {name!r} not registered"
         try:
-            cc_result = await self._claude_code.run(effective_task, pr)
+            agent_result = await agent.run(effective_task, pr)
         except Exception as exc:
-            logger.exception("ClaudeCodeExecutor.run raised: %s", exc)
+            logger.exception("%sAgent.run raised: %s", name, exc)
             return await self._post_copilot(
                 pr,
                 copilot_task,
-                reason=f"claude_code raised: {exc}",
+                reason=f"{name} raised: {exc}",
                 is_fallback=True,
             )
 
-        if cc_result.outcome == ExecutorOutcome.COMPLETED:
+        if agent_result.outcome == ExecutorOutcome.COMPLETED:
+            # ``CLAUDE_CODE`` is a deprecated alias of ``CUSTOM_AGENT``;
+            # we surface the legacy value for ``claude_code`` so existing
+            # observability filters keep working through the deprecation
+            # window. Switch all consumers to read ``agent_name`` and
+            # then drop the alias in a follow-up.
+            outcome = (
+                RouteOutcome.CLAUDE_CODE if name == "claude_code" else RouteOutcome.CUSTOM_AGENT
+            )
             return RouteResult(
-                outcome=RouteOutcome.CLAUDE_CODE,
-                foundry_result=cc_result,  # reuse field; same shape
-                reason=f"{reason}: claude_code dispatched",
+                outcome=outcome,
+                foundry_result=agent_result,
+                reason=f"{reason}: {name} dispatched",
+                agent_name=name,
             )
 
         # ESCALATED / FAILED → fall back to Copilot.
         logger.info(
-            "ClaudeCode outcome=%s reason=%s — falling back to Copilot",
-            cc_result.outcome,
-            cc_result.reason,
+            "%s outcome=%s reason=%s — falling back to Copilot",
+            name,
+            agent_result.outcome,
+            agent_result.reason,
         )
-        fallback_task = self._augment_copilot_task(copilot_task, cc_result)
+        fallback_task = self._augment_copilot_task(copilot_task, agent_result)
         return await self._post_copilot(
             pr,
             fallback_task,
-            reason=f"{reason}: claude_code {cc_result.outcome.value}: {cc_result.reason}",
+            reason=f"{reason}: {name} {agent_result.outcome.value}: {agent_result.reason}",
             is_fallback=True,
-            foundry_result=cc_result,
+            foundry_result=agent_result,
         )
 
     async def _run_foundry(
@@ -315,6 +459,7 @@ class ExecutorDispatcher:
                 outcome=RouteOutcome.FOUNDRY,
                 foundry_result=foundry_result,
                 reason=f"{reason}: foundry completed",
+                agent_name="foundry",
             )
 
         # ESCALATED / FAILED → fall back to Copilot.
@@ -334,13 +479,7 @@ class ExecutorDispatcher:
 
     @staticmethod
     def _pr_labels(pr: PullRequest) -> object:
-        """Return whatever label container the PR object carries.
-
-        ``PullRequest.labels`` is currently a ``list[str]`` but callers may
-        be running against older fixtures that don't populate it. We defer
-        normalisation to :func:`_label_names` so the dispatcher stays
-        tolerant of schema drift.
-        """
+        """Return whatever label container the PR object carries."""
         return getattr(pr, "labels", None)
 
     async def _post_copilot(
@@ -389,10 +528,10 @@ class ExecutorDispatcher:
 
     @staticmethod
     def _augment_copilot_task(base: CopilotTask, foundry_result: ExecutorResult) -> CopilotTask:
-        """Append Foundry's escalation context to the Copilot task's context field.
+        """Append the prior agent's escalation context to the Copilot task's context field.
 
-        Giving Copilot visibility into why Foundry escalated lets it skip
-        approaches that already failed.
+        Giving Copilot visibility into why the prior agent escalated lets
+        it skip approaches that already failed.
         """
         extra = (
             "\n\n---\n"

--- a/src/caretaker/foundry/dispatcher.py
+++ b/src/caretaker/foundry/dispatcher.py
@@ -186,9 +186,16 @@ class ExecutorDispatcher:
 
             registry = _Registry()
             if claude_code_executor is not None:
-                # The legacy parameter pinned this to the claude_code
-                # agent — pin the name/enabled so a bare MagicMock works
-                # as a stand-in.
+                # NOTE: this branch *mutates the caller's object* so a
+                # bare ``MagicMock()`` (which is what every legacy test
+                # passes) satisfies the registry's ``name`` / ``enabled``
+                # contract. Real ``ClaudeCodeAgent`` instances already
+                # carry the correct values so the assignments are no-ops
+                # on them. The mutation only matters for test-only mocks
+                # and is bounded to the deprecation window — production
+                # callers should switch to the ``registry=`` argument
+                # which avoids the in-place mutation entirely. See
+                # CHANGELOG / UPGRADE_GUIDE for the deprecation timeline.
                 with contextlib.suppress(Exception):
                     claude_code_executor.name = "claude_code"  # type: ignore[attr-defined]
                 with contextlib.suppress(Exception):
@@ -312,15 +319,22 @@ class ExecutorDispatcher:
                 return await self._run_foundry(
                     pr, copilot_task, effective_task, reason="auto: foundry eligible"
                 )
-            # Foundry ineligible — try registered custom agents (Claude
-            # Code, opencode, …) in registration order before Copilot.
-            for agent in self._registry.enabled():
+            # Foundry ineligible — pick the first enabled hand-off agent
+            # in registration order. ``_run_agent`` already falls back to
+            # Copilot on ESCALATED / FAILED, so a real chain through
+            # multiple custom agents would require restructuring that
+            # method to not bail to Copilot internally. Phase 1 keeps the
+            # legacy single-shot behaviour (Claude Code was always tried
+            # alone here) and operators can still target a specific agent
+            # via the ``agent:<name>`` PR label.
+            primary = next(iter(self._registry.enabled()), None)
+            if primary is not None:
                 return await self._run_agent(
-                    agent.name,
+                    primary.name,
                     pr,
                     copilot_task,
                     effective_task,
-                    reason=f"auto: foundry ineligible, {agent.name} eligible",
+                    reason=f"auto: foundry ineligible, {primary.name} eligible",
                 )
             return await self._post_copilot(
                 pr, copilot_task, reason="auto: no custom agent eligible"
@@ -372,10 +386,13 @@ class ExecutorDispatcher:
             return await self._run_foundry(
                 pr, copilot_task, effective_task, reason="agent:custom label"
             )
-        # Last resort: first enabled registered agent.
-        for agent in self._registry.enabled():
+        # Last resort: first enabled registered agent in registration
+        # order. ``agent:custom`` is the deprecated alias — operators
+        # who want a specific agent should use ``agent:<name>``.
+        primary = next(iter(self._registry.enabled()), None)
+        if primary is not None:
             return await self._run_agent(
-                agent.name, pr, copilot_task, effective_task, reason="agent:custom label"
+                primary.name, pr, copilot_task, effective_task, reason="agent:custom label"
             )
         return await self._post_copilot(
             pr, copilot_task, reason="agent:custom label but nothing eligible", is_fallback=True

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -42,6 +42,7 @@ from caretaker.state.models import (
 from caretaker.state.tracker import StateTracker
 
 if TYPE_CHECKING:
+    from caretaker.coding_agents.registry import CodingAgentRegistry
     from caretaker.evolution.insight_store import InsightStore
     from caretaker.goals.models import GoalEvaluation
     from caretaker.llm.claude import ClaudeClient
@@ -385,6 +386,8 @@ class Orchestrator:
             executor_cfg.provider == "copilot"
             and not executor_cfg.foundry.enabled
             and not executor_cfg.claude_code.enabled
+            and not executor_cfg.opencode.enabled
+            and not any(a.enabled for a in executor_cfg.agents.values())
         ):
             return None
 
@@ -423,28 +426,98 @@ class Orchestrator:
                     executor_cfg.foundry.allowed_task_types,
                 )
 
-        claude_code_executor = None
-        if executor_cfg.claude_code.enabled:
-            from caretaker.claude_code_executor import ClaudeCodeExecutor
-
-            claude_code_executor = ClaudeCodeExecutor(
-                github=github,
-                owner=owner,
-                repo=repo,
-                config=executor_cfg.claude_code,
-            )
-            logger.info(
-                "ClaudeCodeExecutor ready: trigger_label=%s mention=%s",
-                executor_cfg.claude_code.trigger_label,
-                executor_cfg.claude_code.mention,
-            )
+        registry = self._build_coding_agent_registry(
+            github=github, owner=owner, repo=repo, executor_cfg=executor_cfg
+        )
 
         return ExecutorDispatcher(
             config=executor_cfg,
             foundry_executor=foundry_executor,
             copilot_protocol=copilot_protocol,
-            claude_code_executor=claude_code_executor,
+            registry=registry,
         )
+
+    @staticmethod
+    def _build_coding_agent_registry(
+        *,
+        github: GitHubClient,
+        owner: str,
+        repo: str,
+        executor_cfg: Any,
+    ) -> CodingAgentRegistry:
+        """Construct the BYOCA registry from ``executor_cfg``.
+
+        Built-in hand-off agents (claude_code, opencode) are always
+        registered when their config block has ``enabled=True``. Extra
+        agents declared in ``executor_cfg.agents`` are registered as
+        ``HandoffAgent`` instances; non-handoff modes are reserved for
+        Phase 2/3 and a warning is logged today.
+        """
+        from caretaker.coding_agents import (
+            ClaudeCodeAgent,
+            CodingAgentRegistry,
+            HandoffAgent,
+            OpenCodeAgent,
+        )
+
+        registry = CodingAgentRegistry()
+        if executor_cfg.claude_code.enabled:
+            registry.register(
+                ClaudeCodeAgent(
+                    github=github, owner=owner, repo=repo, config=executor_cfg.claude_code
+                )
+            )
+            logger.info(
+                "ClaudeCodeAgent ready: trigger_label=%s mention=%s",
+                executor_cfg.claude_code.trigger_label,
+                executor_cfg.claude_code.mention,
+            )
+        if executor_cfg.opencode.enabled:
+            registry.register(
+                OpenCodeAgent(github=github, owner=owner, repo=repo, config=executor_cfg.opencode)
+            )
+            logger.info(
+                "OpenCodeAgent ready: trigger_label=%s mention=%s",
+                executor_cfg.opencode.trigger_label,
+                executor_cfg.opencode.mention,
+            )
+        # Extra registered agents (codex, gemini, hermes, …). These all
+        # share the generic HandoffAgent surface today; Phase 2 adds
+        # InlineSubprocessAgent and Phase 3 adds K8sJobAgent.
+        for name, agent_cfg in executor_cfg.agents.items():
+            if not agent_cfg.enabled:
+                continue
+            if registry.has(name):
+                # The typed claude_code / opencode blocks already
+                # registered this name. Operator pasted the same name
+                # into ``agents`` — log once and keep the typed entry.
+                logger.warning(
+                    "executor.agents[%r] duplicates a typed config block; typed block wins",
+                    name,
+                )
+                continue
+            if agent_cfg.mode != "handoff":
+                logger.warning(
+                    "executor.agents[%r] mode=%r is not yet supported "
+                    "(only 'handoff' ships in Phase 1); skipping registration",
+                    name,
+                    agent_cfg.mode,
+                )
+                continue
+            extra = type(
+                f"_Custom{name.title().replace('_', '')}Agent",
+                (HandoffAgent,),
+                {
+                    "name": name,
+                    "marker": f"<!-- caretaker:{name}-handoff -->",
+                    "upstream_action_name": name,
+                    "default_trigger_label": name,
+                    "default_mention": f"@{name}",
+                },
+            )
+            registry.register(extra(github=github, owner=owner, repo=repo, config=agent_cfg))
+            logger.info("Registered custom hand-off agent: %s", name)
+        return registry
 
     @classmethod
     def from_config_path(cls, path: str) -> Orchestrator:

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from caretaker import __version__
 from caretaker.agent_protocol import AgentContext
 from caretaker.agents import EVENT_AGENT_MAP, build_registry
-from caretaker.config import MaintainerConfig
+from caretaker.config import ExecutorConfig, MaintainerConfig
 from caretaker.evolution.backends.factory import build_evolution_store
 from caretaker.evolution.crystallizer import SkillCrystallizer
 from caretaker.evolution.mutator import StrategyMutator
@@ -443,7 +443,7 @@ class Orchestrator:
         github: GitHubClient,
         owner: str,
         repo: str,
-        executor_cfg: Any,
+        executor_cfg: ExecutorConfig,
     ) -> CodingAgentRegistry:
         """Construct the BYOCA registry from ``executor_cfg``.
 
@@ -484,6 +484,16 @@ class Orchestrator:
         # Extra registered agents (codex, gemini, hermes, …). These all
         # share the generic HandoffAgent surface today; Phase 2 adds
         # InlineSubprocessAgent and Phase 3 adds K8sJobAgent.
+        #
+        # Names are interpolated into HTML-comment markers
+        # (``<!-- caretaker:<name>-handoff -->``) and into the
+        # ``agent:<name>`` PR label. Anything outside the kebab/snake
+        # alphabet would either produce malformed markers (breaking the
+        # attempt-count detection) or labels GitHub rejects, so we
+        # validate up-front rather than register a broken agent.
+        import re
+
+        agent_name_pattern = re.compile(r"^[a-z][a-z0-9_-]*$")
         for name, agent_cfg in executor_cfg.agents.items():
             if not agent_cfg.enabled:
                 continue
@@ -493,6 +503,13 @@ class Orchestrator:
                 # into ``agents`` — log once and keep the typed entry.
                 logger.warning(
                     "executor.agents[%r] duplicates a typed config block; typed block wins",
+                    name,
+                )
+                continue
+            if not agent_name_pattern.match(name):
+                logger.warning(
+                    "executor.agents[%r] is not a valid agent name "
+                    "(must match ^[a-z][a-z0-9_-]*$); skipping registration",
                     name,
                 )
                 continue

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -33,7 +33,7 @@ from caretaker.evolution.executor_routing import (
     route_from_pr_reviewer_legacy,
 )
 from caretaker.evolution.shadow import shadow_decision
-from caretaker.pr_reviewer import claude_code_reviewer, inline_reviewer
+from caretaker.pr_reviewer import handoff_reviewer, inline_reviewer
 from caretaker.pr_reviewer.github_review import post_review
 from caretaker.pr_reviewer.routing import decide
 
@@ -186,6 +186,7 @@ class PRReviewerAgent(BaseAgent):
             file_paths=file_paths,
             pr_labels=pr_labels,
             threshold=cfg.routing_threshold,
+            backend=cfg.complex_reviewer,
         )
         logger.info("pr-reviewer: #%d routing — %s", pr_number, decision.reason)
 
@@ -270,8 +271,21 @@ class PRReviewerAgent(BaseAgent):
                     report.reviewed.append(pr_number)
                     return
 
-        # Claude-code hand-off path
-        success = await claude_code_reviewer.dispatch(
+        # Hand-off path — backend chosen by ``complex_reviewer`` (Claude
+        # Code, opencode, …). Falls back to claude_code if the configured
+        # backend isn't recognized so misconfiguration doesn't silently
+        # skip review entirely.
+        backend = decision.backend or cfg.complex_reviewer or "claude_code"
+        if backend not in handoff_reviewer.known_backends():
+            logger.warning(
+                "pr-reviewer: complex_reviewer=%r is not a known hand-off backend "
+                "(known: %s); falling back to claude_code",
+                backend,
+                ", ".join(handoff_reviewer.known_backends()),
+            )
+            backend = "claude_code"
+        success = await handoff_reviewer.dispatch(
+            backend=backend,
             github=self._ctx.github,
             owner=owner,
             repo=repo,
@@ -282,7 +296,7 @@ class PRReviewerAgent(BaseAgent):
         if success:
             report.dispatched.append(pr_number)
         else:
-            report.errors.append(f"claude-code dispatch failed for #{pr_number}")
+            report.errors.append(f"{backend} dispatch failed for #{pr_number}")
 
     async def _route_via_shadow(
         self,

--- a/src/caretaker/pr_reviewer/claude_code_reviewer.py
+++ b/src/caretaker/pr_reviewer/claude_code_reviewer.py
@@ -1,54 +1,26 @@
-"""Claude Code reviewer — slow path for complex PRs.
+"""Backward-compat shim — the generic dispatcher lives in ``handoff_reviewer``.
 
-Instead of running a review inline, this applies the configured trigger label
-and posts a structured ``@claude`` hand-off comment requesting a full code review.
-The ``anthropics/claude-code-action`` workflow picks that up asynchronously.
-
-This is intentionally thin: we delegate the hard work to the action so caretaker
-doesn't need to manage execution context or tool-loop budget for large diffs.
+Existing call sites that use ``await claude_code_reviewer.dispatch(...)``
+keep working through one deprecation window. New code should call
+:func:`caretaker.pr_reviewer.handoff_reviewer.dispatch` directly with an
+explicit ``backend`` argument so the same path serves Claude Code,
+opencode, and any future hand-off reviewer.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
+
+from caretaker.pr_reviewer.handoff_reviewer import (
+    CLAUDE_CODE_REVIEW_MARKER as _HANDOFF_MARKER,
+)
+from caretaker.pr_reviewer.handoff_reviewer import (
+    dispatch as _generic_dispatch,
+)
 
 if TYPE_CHECKING:
     from caretaker.config import PRReviewerConfig
     from caretaker.github_client.api import GitHubClient
-
-logger = logging.getLogger(__name__)
-
-_HANDOFF_MARKER = "<!-- caretaker:pr-reviewer-handoff -->"
-
-
-def _build_handoff_comment(
-    *,
-    mention: str,
-    pr_number: int,
-    owner: str,
-    repo: str,
-    routing_reason: str,
-) -> str:
-    lines = [
-        _HANDOFF_MARKER,
-        f"{mention} caretaker is requesting a full code review for this PR.",
-        "",
-        f"**Repo:** `{owner}/{repo}` · **PR:** #{pr_number}",
-        f"**Routing reason:** {routing_reason}",
-        "",
-        "Please review this pull request for:",
-        "- Correctness and logic errors",
-        "- Security vulnerabilities or unsafe patterns",
-        "- API contract and backward-compatibility concerns",
-        "- Test coverage gaps",
-        "- Any blocking issues before merge",
-        "",
-        "Post a review comment summary and inline comments where applicable.",
-        "",
-        "_Delegated by caretaker's PRReviewerAgent via ClaudeCodeExecutor hand-off._",
-    ]
-    return "\n".join(lines)
 
 
 async def dispatch(
@@ -60,56 +32,16 @@ async def dispatch(
     config: PRReviewerConfig,
     routing_reason: str,
 ) -> bool:
-    """Apply trigger label + post hand-off comment. Returns True on success."""
-    label = config.claude_code_label
-    mention = config.claude_code_mention
-
-    try:
-        await github.ensure_label(
-            owner, repo, label, color="7057ff", description="claude-code-action trigger"
-        )
-        await github.add_labels(owner, repo, pr_number, [label])
-    except Exception as exc:
-        logger.warning(
-            "pr-reviewer: failed to apply trigger label %r to %s/%s#%d: %s",
-            label,
-            owner,
-            repo,
-            pr_number,
-            exc,
-        )
-        return False
-
-    comment_body = _build_handoff_comment(
-        mention=mention,
-        pr_number=pr_number,
+    """Pin to the ``claude_code`` backend; preserved for legacy callers."""
+    return await _generic_dispatch(
+        backend="claude_code",
+        github=github,
         owner=owner,
         repo=repo,
+        pr_number=pr_number,
+        config=config,
         routing_reason=routing_reason,
     )
-    try:
-        await github.upsert_issue_comment(
-            owner,
-            repo,
-            pr_number,
-            marker=_HANDOFF_MARKER,
-            body=comment_body,
-        )
-    except Exception as exc:
-        logger.warning(
-            "pr-reviewer: failed to post hand-off comment on %s/%s#%d: %s",
-            owner,
-            repo,
-            pr_number,
-            exc,
-        )
-        return False
 
-    logger.info(
-        "pr-reviewer: claude-code hand-off dispatched for %s/%s#%d (%s)",
-        owner,
-        repo,
-        pr_number,
-        routing_reason,
-    )
-    return True
+
+__all__ = ["_HANDOFF_MARKER", "dispatch"]

--- a/src/caretaker/pr_reviewer/handoff_reviewer.py
+++ b/src/caretaker/pr_reviewer/handoff_reviewer.py
@@ -1,0 +1,200 @@
+"""Hand-off PR reviewer — slow path for complex PRs.
+
+Generalised from the original ``claude_code_reviewer`` so that the same
+shape works for any registered coding agent (Claude Code, opencode, …).
+The ``PRReviewerAgent`` selects which backend dispatches based on
+``PRReviewerConfig.complex_reviewer``.
+
+Each backend gets its own marker (so re-runs don't cross-count attempts)
+and its own label/mention pair (so each upstream workflow listens on its
+own trigger).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from caretaker.config import PRReviewerConfig
+    from caretaker.github_client.api import GitHubClient
+
+logger = logging.getLogger(__name__)
+
+
+# Markers per backend. Re-using a marker across backends would mean
+# attempts cross-count and a re-review request can't be retargeted at a
+# different agent without confusion.
+CLAUDE_CODE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-handoff -->"
+OPENCODE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-opencode-handoff -->"
+
+
+@dataclass(frozen=True)
+class HandoffReviewerSpec:
+    """Per-backend strings used to compose the hand-off comment."""
+
+    backend: str  # "claude_code" | "opencode" | …
+    marker: str
+    upstream_action_name: str  # human-readable name for the closing note
+    label_color: str
+    label_description: str
+
+
+_CLAUDE_CODE = HandoffReviewerSpec(
+    backend="claude_code",
+    marker=CLAUDE_CODE_REVIEW_MARKER,
+    upstream_action_name="anthropics/claude-code-action",
+    label_color="7057ff",
+    label_description="claude-code-action trigger",
+)
+_OPENCODE = HandoffReviewerSpec(
+    backend="opencode",
+    marker=OPENCODE_REVIEW_MARKER,
+    upstream_action_name="sst/opencode/github",
+    label_color="d04a02",
+    label_description="opencode review trigger",
+)
+
+_SPECS: dict[str, HandoffReviewerSpec] = {
+    _CLAUDE_CODE.backend: _CLAUDE_CODE,
+    _OPENCODE.backend: _OPENCODE,
+}
+
+
+def _build_handoff_comment(
+    *,
+    spec: HandoffReviewerSpec,
+    mention: str,
+    pr_number: int,
+    owner: str,
+    repo: str,
+    routing_reason: str,
+) -> str:
+    lines = [
+        spec.marker,
+        f"{mention} caretaker is requesting a full code review for this PR.",
+        "",
+        f"**Repo:** `{owner}/{repo}` · **PR:** #{pr_number}",
+        f"**Routing reason:** {routing_reason}",
+        "",
+        "Please review this pull request for:",
+        "- Correctness and logic errors",
+        "- Security vulnerabilities or unsafe patterns",
+        "- API contract and backward-compatibility concerns",
+        "- Test coverage gaps",
+        "- Any blocking issues before merge",
+        "",
+        "Post a review comment summary and inline comments where applicable.",
+        "",
+        f"_Delegated by caretaker's PRReviewerAgent via {spec.upstream_action_name} hand-off._",
+    ]
+    return "\n".join(lines)
+
+
+def _resolve(backend: str, config: PRReviewerConfig) -> tuple[HandoffReviewerSpec, str, str]:
+    """Return the (spec, label, mention) tuple for a given backend.
+
+    Reads the per-backend label/mention from :class:`PRReviewerConfig`
+    (``claude_code_label`` / ``opencode_label`` / etc.), falling back to
+    the agent's spec defaults when the operator hasn't customised them.
+    """
+    spec = _SPECS.get(backend)
+    if spec is None:
+        raise ValueError(
+            f"Unsupported PR reviewer backend {backend!r}. Known backends: {', '.join(_SPECS)}"
+        )
+    if backend == "claude_code":
+        return spec, config.claude_code_label, config.claude_code_mention
+    if backend == "opencode":
+        return spec, config.opencode_label, config.opencode_mention
+    # Future backends would extend PRReviewerConfig with their own
+    # label/mention pair; until then ``_resolve`` only knows about
+    # claude_code and opencode.
+    raise AssertionError(f"backend {backend!r} listed in _SPECS but no config mapping")
+
+
+async def dispatch(
+    *,
+    backend: str,
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    config: PRReviewerConfig,
+    routing_reason: str,
+) -> bool:
+    """Apply trigger label + post hand-off comment. Returns True on success."""
+    try:
+        spec, label, mention = _resolve(backend, config)
+    except ValueError as exc:
+        logger.warning("pr-reviewer: %s", exc)
+        return False
+
+    try:
+        await github.ensure_label(
+            owner, repo, label, color=spec.label_color, description=spec.label_description
+        )
+        await github.add_labels(owner, repo, pr_number, [label])
+    except Exception as exc:
+        logger.warning(
+            "pr-reviewer(%s): failed to apply trigger label %r to %s/%s#%d: %s",
+            backend,
+            label,
+            owner,
+            repo,
+            pr_number,
+            exc,
+        )
+        return False
+
+    comment_body = _build_handoff_comment(
+        spec=spec,
+        mention=mention,
+        pr_number=pr_number,
+        owner=owner,
+        repo=repo,
+        routing_reason=routing_reason,
+    )
+    try:
+        await github.upsert_issue_comment(
+            owner,
+            repo,
+            pr_number,
+            marker=spec.marker,
+            body=comment_body,
+        )
+    except Exception as exc:
+        logger.warning(
+            "pr-reviewer(%s): failed to post hand-off comment on %s/%s#%d: %s",
+            backend,
+            owner,
+            repo,
+            pr_number,
+            exc,
+        )
+        return False
+
+    logger.info(
+        "pr-reviewer: %s hand-off dispatched for %s/%s#%d (%s)",
+        backend,
+        owner,
+        repo,
+        pr_number,
+        routing_reason,
+    )
+    return True
+
+
+def known_backends() -> list[str]:
+    """Return the set of supported PR-reviewer backend names."""
+    return list(_SPECS)
+
+
+__all__ = [
+    "CLAUDE_CODE_REVIEW_MARKER",
+    "OPENCODE_REVIEW_MARKER",
+    "HandoffReviewerSpec",
+    "dispatch",
+    "known_backends",
+]

--- a/src/caretaker/pr_reviewer/routing.py
+++ b/src/caretaker/pr_reviewer/routing.py
@@ -1,4 +1,4 @@
-"""Routing decider — score-based selection between inline LLM and claude-code hand-off.
+"""Routing decider — score-based selection between inline LLM and a hand-off reviewer.
 
 Score breakdown (0-100):
   - LOC bucket:        0-30 pts  (additions + deletions)
@@ -7,8 +7,12 @@ Score breakdown (0-100):
   - Architecture:      0-15 pts  (config changes, many packages touched)
   - Label signals:     0-10 pts  (operator-applied labels)
 
-Score >= threshold (default 40) → ClaudeCode hand-off (complex review).
+Score >= threshold (default 40) → hand-off backend (complex review).
 Score <  threshold              → inline LLM review  (fast path).
+
+The hand-off backend (``claude_code``, ``opencode``, …) is picked by the
+caller from :class:`PRReviewerConfig.complex_reviewer`; this module
+returns the ``inline``/``handoff`` decision and the chosen backend name.
 """
 
 from __future__ import annotations
@@ -40,6 +44,11 @@ class RoutingDecision:
     score: int
     use_inline: bool
     reason: str
+    # Hand-off backend to dispatch to when ``use_inline`` is False.
+    # Empty string means "the caller decides" — preserved for the inline
+    # path (where backend is irrelevant) and for backwards compatibility
+    # with existing test fixtures that don't care about the field.
+    backend: str = ""
 
 
 def decide(
@@ -50,6 +59,7 @@ def decide(
     file_paths: list[str],
     pr_labels: list[str],
     threshold: int = 40,
+    backend: str = "claude_code",
 ) -> RoutingDecision:
     """Return a routing decision for a PR."""
     score = 0
@@ -123,8 +133,10 @@ def decide(
     score = min(100, max(0, score))
     use_inline = score < threshold
     path_str = ", ".join(reasons) if reasons else "low-complexity"
+    chosen = "inline" if use_inline else backend
     return RoutingDecision(
         score=score,
         use_inline=use_inline,
-        reason=f"score={score} [{path_str}] → {'inline' if use_inline else 'claude-code'}",
+        reason=f"score={score} [{path_str}] → {chosen}",
+        backend="" if use_inline else backend,
     )

--- a/src/caretaker/upgrade_agent/planner.py
+++ b/src/caretaker/upgrade_agent/planner.py
@@ -130,6 +130,34 @@ SYNC_FILES: list[tuple[str, str]] = [
     ),
 ]
 
+# BYOCA workflow templates — optional installs. Each entry pairs the local
+# install path with the canonical template path and the config-side flag
+# that gates whether the consumer wants this workflow installed.
+# Sync issues list these in a separate "Optional templates" section so
+# Copilot only writes them when the corresponding feature is enabled.
+OPTIONAL_TEMPLATES: list[tuple[str, str, str]] = [
+    (
+        ".github/workflows/claude.yml",
+        "setup-templates/templates/workflows/claude.yml",
+        "executor.claude_code.enabled",
+    ),
+    (
+        ".github/workflows/claude-code-review.yml",
+        "setup-templates/templates/workflows/claude-code-review.yml",
+        "executor.claude_code.enabled or pr_reviewer.complex_reviewer == 'claude_code'",
+    ),
+    (
+        ".github/workflows/opencode.yml",
+        "setup-templates/templates/workflows/opencode.yml",
+        "executor.opencode.enabled",
+    ),
+    (
+        ".github/workflows/opencode-review.yml",
+        "setup-templates/templates/workflows/opencode-review.yml",
+        "executor.opencode.enabled or pr_reviewer.complex_reviewer == 'opencode'",
+    ),
+]
+
 
 def build_sync_issue_body(version: str) -> str:
     """Build the body for a workflow/file sync issue.
@@ -166,6 +194,23 @@ def build_sync_issue_body(version: str) -> str:
     for local_path, template_path in SYNC_FILES:
         url = f"{_REPO_BASE}/{tag_ref}/{template_path}"
         lines.append(f"- **`{local_path}`**")
+        lines.append(f"  Source: {url}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "### Optional templates (BYOCA coding agents)",
+            "",
+            "Sync these only when the matching feature is enabled in "
+            "`.github/maintainer/config.yml`. If the file does not exist locally "
+            "and the gate condition is false, leave it absent. If it exists "
+            "locally, sync it to the canonical version.",
+            "",
+        ]
+    )
+    for local_path, template_path, gate in OPTIONAL_TEMPLATES:
+        url = f"{_REPO_BASE}/{tag_ref}/{template_path}"
+        lines.append(f"- **`{local_path}`** — install when `{gate}`")
         lines.append(f"  Source: {url}")
         lines.append("")
 

--- a/tests/test_coding_agents/test_dispatcher_byoca.py
+++ b/tests/test_coding_agents/test_dispatcher_byoca.py
@@ -1,0 +1,153 @@
+"""BYOCA-specific dispatcher tests.
+
+The classic dispatcher tests live in ``tests/test_foundry/test_dispatcher.py``
+and ``tests/test_claude_code_executor.py`` (which now exercise the
+registry path through the back-compat shim). These tests cover the
+new opencode-aware behaviour and the generic ``agent:<name>`` label
+override.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from caretaker.coding_agents.handoff import OpenCodeAgent
+from caretaker.coding_agents.registry import CodingAgentRegistry
+from caretaker.config import (
+    ExecutorConfig,
+    FoundryExecutorConfig,
+    OpenCodeExecutorConfig,
+)
+from caretaker.foundry.dispatcher import ExecutorDispatcher, RouteOutcome
+from caretaker.foundry.executor import ExecutorOutcome, ExecutorResult
+from caretaker.github_client.models import Comment, Label, PullRequest, User
+from caretaker.llm.copilot import CopilotTask, TaskType
+
+
+def _pr(labels: list[str] | None = None) -> PullRequest:
+    return PullRequest(
+        number=42,
+        title="t",
+        body="",
+        state="open",
+        user=User(login="dev", id=1),
+        head_ref="feat",
+        head_sha="abc",
+        base_ref="main",
+        labels=[Label(name=n) for n in (labels or [])],
+    )
+
+
+def _copilot_task() -> CopilotTask:
+    return CopilotTask(
+        task_type=TaskType.LINT_FAILURE,
+        job_name="lint",
+        error_output="E501",
+        instructions="fix",
+        attempt=1,
+        max_attempts=2,
+    )
+
+
+def _comment() -> Comment:
+    from datetime import UTC, datetime
+
+    return Comment(
+        id=1,
+        user=User(login="bot", id=2, type="Bot"),
+        body="",
+        created_at=datetime(2026, 4, 21, tzinfo=UTC),
+    )
+
+
+def _build(
+    *,
+    provider: str,
+    opencode_enabled: bool = True,
+    foundry_enabled: bool = False,
+) -> tuple[ExecutorDispatcher, MagicMock, MagicMock]:
+    cfg = ExecutorConfig(
+        provider=provider,
+        foundry=FoundryExecutorConfig(enabled=foundry_enabled),
+        opencode=OpenCodeExecutorConfig(enabled=opencode_enabled),
+    )
+    copilot = MagicMock()
+    copilot.post_task = AsyncMock(return_value=_comment())
+    registry = CodingAgentRegistry()
+    opencode_agent = MagicMock(spec=OpenCodeAgent)
+    opencode_agent.name = "opencode"
+    opencode_agent.enabled = opencode_enabled
+    opencode_agent.run = AsyncMock(
+        return_value=ExecutorResult(
+            outcome=ExecutorOutcome.COMPLETED, reason="dispatched", comment_id=1
+        )
+    )
+    if opencode_enabled:
+        registry.register(opencode_agent)
+    foundry = None
+    dispatcher = ExecutorDispatcher(
+        config=cfg,
+        foundry_executor=foundry,
+        copilot_protocol=copilot,
+        registry=registry,
+    )
+    return dispatcher, copilot, opencode_agent
+
+
+@pytest.mark.asyncio
+async def test_provider_opencode_routes_to_opencode_agent() -> None:
+    dispatcher, copilot, agent = _build(provider="opencode")
+    route = await dispatcher.route(pr=_pr(), copilot_task=_copilot_task())
+    assert route.outcome == RouteOutcome.CUSTOM_AGENT
+    assert route.agent_name == "opencode"
+    agent.run.assert_awaited_once()
+    copilot.post_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_label_override_agent_opencode() -> None:
+    # provider=copilot but `agent:opencode` label forces the registered
+    # opencode agent.
+    dispatcher, copilot, agent = _build(provider="copilot")
+    route = await dispatcher.route(
+        pr=_pr(labels=["agent:opencode"]),
+        copilot_task=_copilot_task(),
+    )
+    assert route.outcome == RouteOutcome.CUSTOM_AGENT
+    assert route.agent_name == "opencode"
+    agent.run.assert_awaited_once()
+    copilot.post_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_agent_label_falls_back_to_copilot() -> None:
+    # `agent:gemini` on a PR but gemini isn't registered → Copilot fallback,
+    # not a crash.
+    dispatcher, copilot, agent = _build(provider="copilot")
+    route = await dispatcher.route(
+        pr=_pr(labels=["agent:gemini"]),
+        copilot_task=_copilot_task(),
+    )
+    assert route.outcome == RouteOutcome.COPILOT_FALLBACK
+    copilot.post_task.assert_awaited_once()
+    agent.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_logs_and_routes_to_copilot() -> None:
+    dispatcher, copilot, agent = _build(provider="hermes")
+    route = await dispatcher.route(pr=_pr(), copilot_task=_copilot_task())
+    assert route.outcome == RouteOutcome.COPILOT
+    copilot.post_task.assert_awaited_once()
+    agent.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_opencode_disabled_falls_to_copilot_when_named() -> None:
+    dispatcher, copilot, agent = _build(provider="opencode", opencode_enabled=False)
+    route = await dispatcher.route(pr=_pr(), copilot_task=_copilot_task())
+    assert route.outcome == RouteOutcome.COPILOT
+    copilot.post_task.assert_awaited_once()
+    agent.run.assert_not_called()

--- a/tests/test_coding_agents/test_dispatcher_byoca.py
+++ b/tests/test_coding_agents/test_dispatcher_byoca.py
@@ -151,3 +151,77 @@ async def test_opencode_disabled_falls_to_copilot_when_named() -> None:
     assert route.outcome == RouteOutcome.COPILOT
     copilot.post_task.assert_awaited_once()
     agent.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_provider_picks_first_registered_agent() -> None:
+    """``auto`` with multiple agents picks the first in registration order.
+
+    Documents the single-shot fallthrough behaviour: ``_run_agent``
+    already falls back to Copilot internally on ESCALATED/FAILED, so a
+    real chain through every enabled agent would require a deeper
+    refactor (Phase 2). For now the contract is: try one custom agent,
+    then Copilot.
+    """
+    cfg = ExecutorConfig(
+        provider="auto",
+        foundry=FoundryExecutorConfig(enabled=False),
+        opencode=OpenCodeExecutorConfig(enabled=True),
+    )
+    copilot = MagicMock()
+    copilot.post_task = AsyncMock(return_value=_comment())
+    registry = CodingAgentRegistry()
+
+    # Register two agents — opencode first (registration order matters).
+    opencode_agent = MagicMock(spec=OpenCodeAgent)
+    opencode_agent.name = "opencode"
+    opencode_agent.enabled = True
+    opencode_agent.run = AsyncMock(
+        return_value=ExecutorResult(
+            outcome=ExecutorOutcome.COMPLETED, reason="dispatched", comment_id=1
+        )
+    )
+    registry.register(opencode_agent)
+
+    second = MagicMock()
+    second.name = "claude_code"
+    second.enabled = True
+    second.run = AsyncMock(
+        return_value=ExecutorResult(
+            outcome=ExecutorOutcome.COMPLETED, reason="dispatched", comment_id=2
+        )
+    )
+    registry.register(second)
+
+    dispatcher = ExecutorDispatcher(
+        config=cfg,
+        foundry_executor=None,
+        copilot_protocol=copilot,
+        registry=registry,
+    )
+    route = await dispatcher.route(pr=_pr(), copilot_task=_copilot_task())
+    # First-registered (opencode) wins; the second agent is not called.
+    assert route.outcome == RouteOutcome.CUSTOM_AGENT
+    assert route.agent_name == "opencode"
+    opencode_agent.run.assert_awaited_once()
+    second.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_custom_label_with_byoca_provider_routes_to_provider() -> None:
+    """Legacy ``agent:custom`` resolves to the configured provider.
+
+    When ``provider`` names a registered BYOCA agent (opencode), the
+    ``agent:custom`` deprecated alias should still route to it rather
+    than falling through to Copilot. New code should use
+    ``agent:opencode`` directly.
+    """
+    dispatcher, copilot, agent = _build(provider="opencode")
+    route = await dispatcher.route(
+        pr=_pr(labels=["agent:custom"]),
+        copilot_task=_copilot_task(),
+    )
+    assert route.outcome == RouteOutcome.CUSTOM_AGENT
+    assert route.agent_name == "opencode"
+    agent.run.assert_awaited_once()
+    copilot.post_task.assert_not_called()

--- a/tests/test_coding_agents/test_doctor_byoca.py
+++ b/tests/test_coding_agents/test_doctor_byoca.py
@@ -1,0 +1,60 @@
+"""Doctor check for BYOCA executor / PR-reviewer config validity."""
+
+from __future__ import annotations
+
+from caretaker.config import (
+    ExecutorConfig,
+    MaintainerConfig,
+    OpenCodeExecutorConfig,
+    PRReviewerConfig,
+)
+from caretaker.doctor import Severity, check_coding_agent_config
+
+
+def _maintainer_config(
+    *,
+    executor: ExecutorConfig,
+    pr_reviewer: PRReviewerConfig | None = None,
+) -> MaintainerConfig:
+    cfg = MaintainerConfig()
+    cfg.executor = executor
+    if pr_reviewer is not None:
+        cfg.pr_reviewer = pr_reviewer
+    return cfg
+
+
+def test_default_config_is_ok() -> None:
+    rows = check_coding_agent_config(_maintainer_config(executor=ExecutorConfig()))
+    assert all(r.severity == Severity.OK for r in rows)
+
+
+def test_provider_set_but_disabled_warns() -> None:
+    cfg = _maintainer_config(
+        executor=ExecutorConfig(provider="opencode", opencode=OpenCodeExecutorConfig(enabled=False))
+    )
+    rows = check_coding_agent_config(cfg)
+    assert any(r.severity == Severity.WARN and "enabled=False" in r.detail for r in rows)
+
+
+def test_unknown_provider_warns() -> None:
+    cfg = _maintainer_config(executor=ExecutorConfig(provider="hermes"))
+    rows = check_coding_agent_config(cfg)
+    assert any(r.severity == Severity.WARN and "does not match any" in r.detail for r in rows)
+
+
+def test_unknown_complex_reviewer_warns() -> None:
+    cfg = _maintainer_config(
+        executor=ExecutorConfig(),
+        pr_reviewer=PRReviewerConfig(complex_reviewer="hermes"),
+    )
+    rows = check_coding_agent_config(cfg)
+    assert any(r.severity == Severity.WARN and "complex_reviewer" in r.detail for r in rows)
+
+
+def test_opencode_enabled_is_ok() -> None:
+    cfg = _maintainer_config(
+        executor=ExecutorConfig(provider="opencode", opencode=OpenCodeExecutorConfig(enabled=True)),
+        pr_reviewer=PRReviewerConfig(complex_reviewer="opencode"),
+    )
+    rows = check_coding_agent_config(cfg)
+    assert all(r.severity == Severity.OK for r in rows)

--- a/tests/test_coding_agents/test_handoff.py
+++ b/tests/test_coding_agents/test_handoff.py
@@ -1,0 +1,158 @@
+"""Tests for the BYOCA hand-off agents (Claude Code + opencode)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from caretaker.coding_agents.handoff import (
+    CLAUDE_CODE_HANDOFF_MARKER,
+    OPENCODE_HANDOFF_MARKER,
+    ClaudeCodeAgent,
+    OpenCodeAgent,
+)
+from caretaker.config import (
+    ClaudeCodeExecutorConfig,
+    OpenCodeExecutorConfig,
+)
+from caretaker.foundry.executor import (
+    CodingTask,
+    ExecutorOutcome,
+)
+from caretaker.github_client.models import Comment, Label, PullRequest, User
+from caretaker.llm.copilot import TaskType
+
+
+def _coding_task() -> CodingTask:
+    return CodingTask(
+        task_type=TaskType.LINT_FAILURE,
+        job_name="lint",
+        error_output="E501",
+        instructions="fix line length",
+    )
+
+
+def _pr() -> PullRequest:
+    return PullRequest(
+        number=42,
+        title="test",
+        body="",
+        state="open",
+        user=User(login="dev", id=1),
+        head_ref="feat",
+        head_sha="abc",
+        base_ref="main",
+        labels=[],
+    )
+
+
+def _comment(marker: str, cid: int = 1) -> Comment:
+    return Comment(
+        id=cid,
+        user=User(login="caretaker-bot", id=99, type="Bot"),
+        body=marker,
+        created_at=datetime(2026, 4, 21, tzinfo=UTC),
+    )
+
+
+# Markers must be unique per agent so attempt-counts don't cross-contaminate.
+def test_markers_distinct() -> None:
+    assert CLAUDE_CODE_HANDOFF_MARKER != OPENCODE_HANDOFF_MARKER
+
+
+# ── OpenCodeAgent ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_opencode_posts_comment_and_applies_label() -> None:
+    github = MagicMock()
+    github.add_issue_comment = AsyncMock(return_value=_comment(OPENCODE_HANDOFF_MARKER, cid=777))
+    github.add_labels = AsyncMock(return_value=[Label(name="opencode")])
+    github.get_pr_comments = AsyncMock(return_value=[])
+    agent = OpenCodeAgent(
+        github=github,
+        owner="o",
+        repo="r",
+        config=OpenCodeExecutorConfig(enabled=True),
+    )
+    result = await agent.run(_coding_task(), _pr())
+    assert result.outcome == ExecutorOutcome.COMPLETED
+    assert result.comment_id == 777
+    body = github.add_issue_comment.await_args.args[3]
+    # The body must carry the opencode marker AND the opencode mention,
+    # not the Claude marker — protects against accidental marker reuse.
+    assert OPENCODE_HANDOFF_MARKER in body
+    assert CLAUDE_CODE_HANDOFF_MARKER not in body
+    assert "@opencode-agent" in body
+    github.add_labels.assert_awaited_once_with("o", "r", 42, ["opencode"])
+
+
+@pytest.mark.asyncio
+async def test_opencode_disabled_escalates() -> None:
+    github = MagicMock()
+    github.get_pr_comments = AsyncMock(return_value=[])
+    github.add_issue_comment = AsyncMock()
+    github.add_labels = AsyncMock()
+    agent = OpenCodeAgent(
+        github=github, owner="o", repo="r", config=OpenCodeExecutorConfig(enabled=False)
+    )
+    result = await agent.run(_coding_task(), _pr())
+    assert result.outcome == ExecutorOutcome.ESCALATED
+    github.add_issue_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_opencode_attempt_cap_uses_own_marker() -> None:
+    # Claude-code prior comments must NOT count toward opencode's cap.
+    prior_claude = [
+        _comment(CLAUDE_CODE_HANDOFF_MARKER, cid=1),
+        _comment(CLAUDE_CODE_HANDOFF_MARKER, cid=2),
+    ]
+    prior_opencode = [_comment(OPENCODE_HANDOFF_MARKER, cid=3)]
+    github = MagicMock()
+    github.get_pr_comments = AsyncMock(return_value=prior_claude + prior_opencode)
+    github.add_issue_comment = AsyncMock(return_value=_comment(OPENCODE_HANDOFF_MARKER, cid=99))
+    github.add_labels = AsyncMock(return_value=[])
+    agent = OpenCodeAgent(
+        github=github,
+        owner="o",
+        repo="r",
+        config=OpenCodeExecutorConfig(enabled=True, max_attempts=2),
+    )
+    # Only 1 prior opencode hand-off → attempt 2 → still under cap.
+    result = await agent.run(_coding_task(), _pr())
+    assert result.outcome == ExecutorOutcome.COMPLETED
+    assert result.iterations == 2
+
+
+# ── ClaudeCodeAgent — backward-compat sanity ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_claude_code_uses_legacy_marker() -> None:
+    github = MagicMock()
+    github.add_issue_comment = AsyncMock(return_value=_comment(CLAUDE_CODE_HANDOFF_MARKER, cid=11))
+    github.add_labels = AsyncMock(return_value=[])
+    github.get_pr_comments = AsyncMock(return_value=[])
+    agent = ClaudeCodeAgent(
+        github=github,
+        owner="o",
+        repo="r",
+        config=ClaudeCodeExecutorConfig(enabled=True),
+    )
+    result = await agent.run(_coding_task(), _pr())
+    assert result.outcome == ExecutorOutcome.COMPLETED
+    body = github.add_issue_comment.await_args.args[3]
+    assert CLAUDE_CODE_HANDOFF_MARKER in body
+    assert OPENCODE_HANDOFF_MARKER not in body
+    assert "@claude" in body
+
+
+def test_claude_code_executor_legacy_alias() -> None:
+    """``ClaudeCodeExecutor`` is a deprecation alias for ``ClaudeCodeAgent``."""
+    from caretaker.claude_code_executor import ClaudeCodeAgent as Aliased
+    from caretaker.claude_code_executor import ClaudeCodeExecutor
+
+    assert ClaudeCodeExecutor is Aliased

--- a/tests/test_coding_agents/test_orchestrator_registry.py
+++ b/tests/test_coding_agents/test_orchestrator_registry.py
@@ -1,0 +1,120 @@
+"""Tests for ``Orchestrator._build_coding_agent_registry``.
+
+The interesting behaviours are name validation and the typed-block
+priority over the open ``executor.agents`` map.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from caretaker.config import (
+    ClaudeCodeExecutorConfig,
+    ExecutorConfig,
+    HandoffAgentConfig,
+    OpenCodeExecutorConfig,
+)
+from caretaker.orchestrator import Orchestrator
+
+
+def _build(executor_cfg: ExecutorConfig):
+    """Stub-friendly registry builder — the helper only needs strings."""
+    return Orchestrator._build_coding_agent_registry(
+        github=None,  # type: ignore[arg-type] — HandoffAgent stores it but we never call .run()
+        owner="o",
+        repo="r",
+        executor_cfg=executor_cfg,
+    )
+
+
+def test_typed_blocks_register_when_enabled() -> None:
+    cfg = ExecutorConfig(
+        claude_code=ClaudeCodeExecutorConfig(enabled=True),
+        opencode=OpenCodeExecutorConfig(enabled=True),
+    )
+    registry = _build(cfg)
+    assert registry.has("claude_code")
+    assert registry.has("opencode")
+
+
+def test_extra_agent_registers_with_handoff_mode() -> None:
+    cfg = ExecutorConfig(
+        agents={"hermes": HandoffAgentConfig(enabled=True, mode="handoff")},
+    )
+    registry = _build(cfg)
+    assert registry.has("hermes")
+    agent = registry.get("hermes")
+    assert agent is not None
+    assert agent.name == "hermes"
+    # Marker is interpolated from the validated name.
+    assert agent.marker == "<!-- caretaker:hermes-handoff -->"  # type: ignore[attr-defined]
+
+
+def test_extra_agent_skipped_when_disabled() -> None:
+    cfg = ExecutorConfig(
+        agents={"hermes": HandoffAgentConfig(enabled=False, mode="handoff")},
+    )
+    registry = _build(cfg)
+    assert not registry.has("hermes")
+
+
+def test_extra_agent_skipped_for_non_handoff_mode(caplog: pytest.LogCaptureFixture) -> None:
+    """Phase 1 only ships ``handoff``; ``inline`` / ``k8s_job`` are reserved."""
+    cfg = ExecutorConfig(
+        agents={"future_agent": HandoffAgentConfig(enabled=True, mode="inline")},
+    )
+    with caplog.at_level("WARNING"):
+        registry = _build(cfg)
+    assert not registry.has("future_agent")
+    assert any("not yet supported" in rec.message for rec in caplog.records)
+
+
+def test_typed_block_wins_over_open_agents_map(caplog: pytest.LogCaptureFixture) -> None:
+    """Operator pasted ``opencode`` into both blocks — typed wins."""
+    cfg = ExecutorConfig(
+        opencode=OpenCodeExecutorConfig(enabled=True, trigger_label="opencode-typed"),
+        agents={"opencode": HandoffAgentConfig(enabled=True, trigger_label="opencode-loose")},
+    )
+    with caplog.at_level("WARNING"):
+        registry = _build(cfg)
+    agent = registry.get("opencode")
+    assert agent is not None
+    # Typed block is the one that survived.
+    assert agent.trigger_label == "opencode-typed"  # type: ignore[attr-defined]
+    assert any("duplicates a typed config block" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "Bad-Name",  # uppercase rejected
+        "1agent",  # leading digit rejected
+        "agent name",  # whitespace rejected
+        "agent>",  # HTML metacharacter rejected
+        "--agent",  # leading dash rejected
+        "",  # empty rejected
+    ],
+)
+def test_invalid_custom_agent_name_skipped(bad_name: str, caplog: pytest.LogCaptureFixture) -> None:
+    """Names that would produce malformed markers / labels are rejected.
+
+    The pattern is ``^[a-z][a-z0-9_-]*$`` — anything else either breaks
+    the HTML-comment marker (``<!-- caretaker:<name>-handoff -->``) or
+    produces a GitHub label that gets rejected at apply time.
+    """
+    cfg = ExecutorConfig(
+        agents={bad_name: HandoffAgentConfig(enabled=True, mode="handoff")},
+    )
+    with caplog.at_level("WARNING"):
+        registry = _build(cfg)
+    assert not registry.has(bad_name)
+    assert any("not a valid agent name" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize("good_name", ["hermes", "codex", "agent-1", "my_agent", "a"])
+def test_valid_custom_agent_name_registers(good_name: str) -> None:
+    cfg = ExecutorConfig(
+        agents={good_name: HandoffAgentConfig(enabled=True, mode="handoff")},
+    )
+    registry = _build(cfg)
+    assert registry.has(good_name)

--- a/tests/test_coding_agents/test_pr_reviewer_backend.py
+++ b/tests/test_coding_agents/test_pr_reviewer_backend.py
@@ -1,0 +1,108 @@
+"""PR reviewer routing now exposes a ``backend`` field for BYOCA selection."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from caretaker.config import PRReviewerConfig
+from caretaker.pr_reviewer import handoff_reviewer
+from caretaker.pr_reviewer.handoff_reviewer import (
+    CLAUDE_CODE_REVIEW_MARKER,
+    OPENCODE_REVIEW_MARKER,
+)
+from caretaker.pr_reviewer.routing import decide
+
+
+def test_inline_decision_has_empty_backend() -> None:
+    d = decide(
+        additions=10,
+        deletions=5,
+        file_count=1,
+        file_paths=["src/foo.py"],
+        pr_labels=[],
+        threshold=40,
+        backend="opencode",
+    )
+    assert d.use_inline is True
+    assert d.backend == ""
+
+
+def test_handoff_decision_records_chosen_backend() -> None:
+    # Big PR triggers hand-off; backend selection is preserved.
+    d = decide(
+        additions=900,
+        deletions=200,
+        file_count=30,
+        file_paths=["src/auth/secret_key.py"],
+        pr_labels=["architecture"],
+        threshold=40,
+        backend="opencode",
+    )
+    assert d.use_inline is False
+    assert d.backend == "opencode"
+    assert "opencode" in d.reason
+
+
+def test_default_backend_is_claude_code() -> None:
+    d = decide(
+        additions=900,
+        deletions=200,
+        file_count=30,
+        file_paths=[],
+        pr_labels=[],
+        threshold=40,
+    )
+    assert d.use_inline is False
+    assert d.backend == "claude_code"
+
+
+def test_known_backends_includes_both() -> None:
+    backends = handoff_reviewer.known_backends()
+    assert "claude_code" in backends
+    assert "opencode" in backends
+
+
+@pytest.mark.asyncio
+async def test_dispatch_opencode_uses_distinct_marker() -> None:
+    github = MagicMock()
+    github.ensure_label = AsyncMock()
+    github.add_labels = AsyncMock()
+    github.upsert_issue_comment = AsyncMock()
+    cfg = PRReviewerConfig()  # defaults
+    ok = await handoff_reviewer.dispatch(
+        backend="opencode",
+        github=github,
+        owner="o",
+        repo="r",
+        pr_number=1,
+        config=cfg,
+        routing_reason="test",
+    )
+    assert ok is True
+    # Label string comes from PRReviewerConfig.opencode_label, not claude_code_label.
+    github.add_labels.assert_awaited_once()
+    label_args = github.add_labels.await_args.args
+    assert label_args[3] == [cfg.opencode_label]
+    # Marker passed to upsert is the opencode marker, not the claude one.
+    upsert_kwargs = github.upsert_issue_comment.await_args.kwargs
+    assert upsert_kwargs["marker"] == OPENCODE_REVIEW_MARKER
+    assert OPENCODE_REVIEW_MARKER in upsert_kwargs["body"]
+    assert CLAUDE_CODE_REVIEW_MARKER not in upsert_kwargs["body"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_backend_returns_false() -> None:
+    github = MagicMock()
+    cfg = PRReviewerConfig()
+    ok = await handoff_reviewer.dispatch(
+        backend="hermes",
+        github=github,
+        owner="o",
+        repo="r",
+        pr_number=1,
+        config=cfg,
+        routing_reason="test",
+    )
+    assert ok is False

--- a/tests/test_coding_agents/test_registry.py
+++ b/tests/test_coding_agents/test_registry.py
@@ -1,0 +1,71 @@
+"""Tests for :class:`CodingAgentRegistry`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from caretaker.coding_agents.registry import CodingAgentRegistry
+
+if TYPE_CHECKING:
+    import pytest
+
+
+@dataclass
+class _StubAgent:
+    name: str
+    enabled: bool = True
+    mode: str = "handoff"
+
+    async def run(self, task, pr):  # pragma: no cover — never called here
+        raise NotImplementedError
+
+
+def test_register_and_get() -> None:
+    reg = CodingAgentRegistry()
+    a = _StubAgent(name="claude_code")
+    reg.register(a)
+    assert reg.get("claude_code") is a
+    assert reg.has("claude_code") is True
+    assert reg.get("missing") is None
+    assert reg.has("missing") is False
+
+
+def test_names_preserves_insertion_order() -> None:
+    reg = CodingAgentRegistry()
+    reg.register(_StubAgent(name="claude_code"))
+    reg.register(_StubAgent(name="opencode"))
+    reg.register(_StubAgent(name="codex"))
+    assert reg.names() == ["claude_code", "opencode", "codex"]
+
+
+def test_enabled_filters_disabled_agents() -> None:
+    reg = CodingAgentRegistry()
+    reg.register(_StubAgent(name="claude_code", enabled=True))
+    reg.register(_StubAgent(name="opencode", enabled=False))
+    reg.register(_StubAgent(name="codex", enabled=True))
+    assert [a.name for a in reg.enabled()] == ["claude_code", "codex"]
+
+
+def test_fallback_chain_puts_primary_first() -> None:
+    reg = CodingAgentRegistry()
+    reg.register(_StubAgent(name="claude_code", enabled=True))
+    reg.register(_StubAgent(name="opencode", enabled=True))
+    chain = reg.fallback_chain("opencode")
+    assert [a.name for a in chain] == ["opencode", "claude_code"]
+
+
+def test_fallback_chain_skips_disabled_primary() -> None:
+    reg = CodingAgentRegistry()
+    reg.register(_StubAgent(name="opencode", enabled=False))
+    reg.register(_StubAgent(name="claude_code", enabled=True))
+    chain = reg.fallback_chain("opencode")
+    assert [a.name for a in chain] == ["claude_code"]
+
+
+def test_register_overwrite_warns(caplog: pytest.LogCaptureFixture) -> None:
+    reg = CodingAgentRegistry()
+    reg.register(_StubAgent(name="opencode"))
+    with caplog.at_level("WARNING"):
+        reg.register(_StubAgent(name="opencode"))
+    assert any("overwriting existing agent" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

- BYOCA — Bring Your Own Coding Agent. Generalises the existing Claude Code hand-off into a pluggable registry of coding agents so **opencode** (sst/opencode, multi-provider in agent mode) ships as a peer of Claude Code.
- Abstractions are shaped for future BYOCA additions (codex, gemini, hermes, k8s Jobs, inline subprocess) — only the hand-off ``mode`` is wired up in this PR.
- Behaviour-preserving: existing zero-config Copilot deployments and existing Claude Code consumers see no functional change. All 2178 existing tests still pass.

## What's new

- ``caretaker.coding_agents`` package with ``CodingAgent`` protocol, ``HandoffAgent`` base class, concrete ``ClaudeCodeAgent`` / ``OpenCodeAgent`` subclasses, and a ``CodingAgentRegistry``.
- ``executor.provider`` opens up from a closed enum to a registry-validated string. New ``OpenCodeExecutorConfig`` typed block plus an open ``executor.agents: dict`` for declaring extra agents per repo without a typed schema.
- New ``RouteOutcome.CUSTOM_AGENT`` + ``RouteResult.agent_name``. Generic ``agent:<name>`` PR labels (``agent:opencode``, etc.) resolved against the registry alongside the legacy ``agent:custom`` / ``agent:copilot`` / ``agent:quarantine`` overrides.
- PR reviewer generalised: ``handoff_reviewer.dispatch(backend=...)`` with per-agent markers, ``pr_reviewer.complex_reviewer`` selector, ``RoutingDecision.backend`` field. ``claude_code_reviewer.dispatch`` becomes a thin shim.
- New workflow templates ``setup-templates/templates/workflows/{opencode,opencode-review}.yml`` (plus the previously local Claude templates moved here for symmetry). Maintainer agent's sync issue lists them in a new "Optional templates" section gated on config flags.
- ``caretaker doctor`` validates ``executor.provider`` and ``pr_reviewer.complex_reviewer`` resolve to known agents.
- 28 new unit tests in ``tests/test_coding_agents/`` exercising the registry, hand-off attempt-cap isolation, dispatcher BYOCA paths, PR-reviewer backend selection, and the new doctor row.

## Backward compatibility

These names continue to work for one release; deprecation notes are in [CHANGELOG.md](CHANGELOG.md) and [UPGRADE_GUIDE.md](UPGRADE_GUIDE.md):

- ``caretaker.claude_code_executor.ClaudeCodeExecutor`` → ``caretaker.coding_agents.ClaudeCodeAgent``
- ``RouteOutcome.CLAUDE_CODE`` → ``RouteOutcome.CUSTOM_AGENT`` + ``RouteResult.agent_name``
- ``ExecutorDispatcher(claude_code_executor=...)`` ctor arg → ``ExecutorDispatcher(registry=...)``

## Phasing

This PR is **Phase 1 of three**. The ``mode: handoff | inline | k8s_job`` field is already in the schema so neither future phase needs a config break:

- **Phase 2** (future) — inline subprocess agents (``opencode run``, ``codex ...``, ``gemini ...``) running in caretaker's worktree like FoundryExecutor.
- **Phase 3** (future) — k8s Job agents using the existing ``caretaker.k8s_worker`` plumbing for long-running tasks.

## Notes for reviewers

- The exact upstream opencode GitHub Action slug used in the new templates is ``sst/opencode/github@latest``. That can be tweaked per-repo (it's plain YAML) and Phase 2's inline mode would let caretaker bypass the upstream action entirely. Confirmed acceptable for Phase 1.
- ``ExecutorDispatcher.__init__`` accepts both ``registry=`` (new) and ``claude_code_executor=`` (legacy). The shim wraps the legacy executor in a one-entry registry, which is why every existing dispatcher test passes through the new code path with no test changes.
- Each hand-off agent owns a unique HTML-comment marker (``<!-- caretaker:claude-code-handoff -->`` vs ``<!-- caretaker:opencode-handoff -->``). This is load-bearing — sharing a marker would cross-count attempts and break the per-agent cap.

## Test plan

- [x] ``uv run python -m pytest tests/`` — 2178 passed (no failures, no regressions)
- [x] ``uv run python -m pytest tests/test_coding_agents/`` — 28 new tests pass
- [x] ``uv run mypy src/caretaker`` — strict, no errors
- [x] ``uv run ruff format --check`` and ``uv run ruff check`` — clean
- [x] Smoke-tested ``check_coding_agent_config`` against good/bad YAML (opencode enabled vs ``provider: opencode`` with ``opencode.enabled: false``, plus an unknown ``hermes`` reviewer backend) — produces the expected OK / WARN rows
- [ ] Reviewer to sanity-check the upstream action slug ``sst/opencode/github@latest`` in [opencode.yml](setup-templates/templates/workflows/opencode.yml) and [opencode-review.yml](setup-templates/templates/workflows/opencode-review.yml) before any consumer repo opts in

🤖 Generated with [Claude Code](https://claude.com/claude-code)