### PR TITLE
fix(stream): fall back to default OIDC audience when env var is empty string

### DIFF
--- a/src/caretaker/runs/shipper.py
+++ b/src/caretaker/runs/shipper.py
@@ -60,7 +60,7 @@ def _config_from_env(
     backend = os.environ.get("CARETAKER_BACKEND_URL", "").rstrip("/")
     if not backend:
         raise RuntimeError("CARETAKER_BACKEND_URL is required (e.g. https://caretaker.example.com)")
-    audience = os.environ.get("CARETAKER_OIDC_AUDIENCE", _DEFAULT_AUDIENCE)
+    audience = os.environ.get("CARETAKER_OIDC_AUDIENCE") or _DEFAULT_AUDIENCE
     return StreamConfig(
         backend_url=backend,
         audience=audience,

--- a/templates/maintainer.yml
+++ b/templates/maintainer.yml
@@ -72,8 +72,10 @@ jobs:
     env:
       # Required: the only configuration the workflow needs.
       CARETAKER_BACKEND_URL: ${{ vars.CARETAKER_BACKEND_URL }}
-      # Optional: override the OIDC audience (default: caretaker-backend).
-      CARETAKER_OIDC_AUDIENCE: ${{ vars.CARETAKER_OIDC_AUDIENCE }}
+      # Optional: override the OIDC audience. Leave unset to use the default
+      # ("caretaker-backend"). If you set this as a repo variable, it must
+      # match the audience the backend was configured with.
+      CARETAKER_OIDC_AUDIENCE: ${{ vars.CARETAKER_OIDC_AUDIENCE || 'caretaker-backend' }}
 
     steps:
       - uses: actions/setup-python@v5

--- a/tests/test_runs/test_shipper.py
+++ b/tests/test_runs/test_shipper.py
@@ -1,0 +1,43 @@
+"""Tests for the streaming shipper's config-from-env helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from caretaker.runs.shipper import _DEFAULT_AUDIENCE, _config_from_env
+
+
+@pytest.fixture()
+def _backend_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CARETAKER_BACKEND_URL", "https://caretaker.example.com")
+
+
+@pytest.mark.usefixtures("_backend_url")
+def test_audience_defaults_when_var_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CARETAKER_OIDC_AUDIENCE", raising=False)
+    cfg = _config_from_env(mode="full", tail=True, event_type=None, event_payload=None)
+    assert cfg.audience == _DEFAULT_AUDIENCE
+
+
+@pytest.mark.usefixtures("_backend_url")
+def test_audience_defaults_when_var_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    # GitHub Actions sets the env var to "" when the repo variable is unset.
+    # os.environ.get(KEY, default) would return "" here — the `or` fix prevents that.
+    monkeypatch.setenv("CARETAKER_OIDC_AUDIENCE", "")
+    cfg = _config_from_env(mode="full", tail=True, event_type=None, event_payload=None)
+    assert cfg.audience == _DEFAULT_AUDIENCE
+
+
+@pytest.mark.usefixtures("_backend_url")
+def test_audience_respects_explicit_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CARETAKER_OIDC_AUDIENCE", "my-custom-audience")
+    cfg = _config_from_env(mode="full", tail=True, event_type=None, event_payload=None)
+    assert cfg.audience == "my-custom-audience"
+
+
+@pytest.mark.usefixtures("_backend_url")
+def test_missing_backend_url_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CARETAKER_BACKEND_URL", raising=False)
+    monkeypatch.setenv("CARETAKER_BACKEND_URL", "")
+    with pytest.raises(RuntimeError, match="CARETAKER_BACKEND_URL is required"):
+        _config_from_env(mode="full", tail=True, event_type=None, event_payload=None)


### PR DESCRIPTION
## Summary

- **Root cause**: `ianlintner/space-tycoon` sets `CARETAKER_OIDC_AUDIENCE: ${{ vars.CARETAKER_OIDC_AUDIENCE }}` in its workflow, but the repository variable is not configured. GitHub Actions evaluates an unset repo variable to `""` (empty string), not to an absent env var. `os.environ.get(KEY, default)` only falls back to the default when the key is **absent**, so an empty string was being forwarded as the OIDC audience. The backend rejects this with `401 {"detail":"Invalid token audience"}`, blocking every caretaker run in the repo.
- **Fix in `shipper.py`**: `os.environ.get("CARETAKER_OIDC_AUDIENCE") or _DEFAULT_AUDIENCE` — treats falsy (empty) as absent and uses `"caretaker-backend"`.
- **Fix in `templates/maintainer.yml`**: add `|| 'caretaker-backend'` to the GitHub Actions expression so the env var is always non-empty before caretaker reads it, providing a second layer of defence and fixing all existing deployed streaming workflows that carry this template.

## Changed files

| File | Change |
|------|--------|
| `src/caretaker/runs/shipper.py` | `or _DEFAULT_AUDIENCE` instead of positional default |
| `templates/maintainer.yml` | `${{ vars.CARETAKER_OIDC_AUDIENCE \|\| 'caretaker-backend' }}` + improved comment |
| `tests/test_runs/test_shipper.py` | New — covers absent, empty-string, and explicit-override cases |

## Test plan

- [ ] `PYTHONPATH=src pytest tests/test_runs/test_shipper.py -v` — 4 tests, all green
- [ ] Full suite `PYTHONPATH=src pytest tests/ -q` — 2254 passed, 0 failed
- [ ] After release, verify `ianlintner/space-tycoon` next scheduled run no longer produces `401 Invalid token audience`

## Notes for reviewer

The secondary scope-gap errors in space-tycoon issue #65 (`checks: write`, `security_events: read`) are backend GitHub App permission gaps — they cannot be resolved by editing the runner workflow in streaming mode and are out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)