### PR TITLE
fix(pr-agent): allow auto-approve for maintainer-bot PRs (releases.json) [F-7]

### DIFF
--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -1028,12 +1028,23 @@ class PRAgent:
         advances ``pr.head_sha`` and re-arms the gate naturally.
 
         Defensive guard: refuse to approve PRs that aren't caretaker-owned
-        even if a state-machine bug routed us here. ``is_caretaker_pr``
-        keys off the ``claude/`` / ``caretaker/`` head-branch prefix.
+        OR maintainer-bot-authored (e.g. ``chore/releases-json-*`` from the
+        update-releases-json workflow). The state machine in ``states.py``
+        emits ``request_review_approve`` for either flag (see
+        ``pr_agent.states`` line 530), so the handler must accept both —
+        otherwise PRs that are eligible per the state-machine condition
+        are silently refused here, which is the F-7 regression: every
+        post-release ``chore/releases-json-vX.Y.Z`` PR sat un-approved
+        until a human merged it by hand (see #616, #618). ``is_caretaker_pr``
+        keys off the ``claude/`` / ``caretaker/`` head-branch prefix;
+        ``is_maintainer_bot_pr`` keys off ``chore/releases-json-*`` and
+        ``chore/*`` from ``github-actions[bot]``.
         """
-        if not getattr(pr, "is_caretaker_pr", False):
+        if not (
+            getattr(pr, "is_caretaker_pr", False) or getattr(pr, "is_maintainer_bot_pr", False)
+        ):
             logger.warning(
-                "PR #%d: refusing auto-approve — not a caretaker PR (head_ref=%r)",
+                "PR #%d: refusing auto-approve — not a caretaker / maintainer-bot PR (head_ref=%r)",
                 pr.number,
                 getattr(pr, "head_ref", ""),
             )

--- a/tests/test_pr_agent/test_agent.py
+++ b/tests/test_pr_agent/test_agent.py
@@ -1686,6 +1686,24 @@ class TestHandleReviewApprove:
         assert updated.last_approved_sha is None
         assert 4 in report.waiting
 
+    async def test_approves_maintainer_bot_releases_json_pr(self) -> None:
+        """F-7 regression: ``chore/releases-json-*`` is opened by the
+        update-releases-json workflow after every release. The state
+        machine routes it to ``request_review_approve`` (states.py:530),
+        so the handler must accept it. Pre-fix it was refused on the
+        ``is_caretaker_pr`` head-ref check, which is why every past
+        v0.X.Y bump (#616, #618, ...) had to be merged manually."""
+        pr = make_pr(number=8, head_ref="chore/releases-json-v0.25.0")
+        pr.head_sha = "deadbeef"
+        tracking = TrackedPR(number=8)
+
+        updated, report, github = await self._run(pr, tracking)
+
+        github.create_review.assert_awaited_once()
+        assert updated.state == PRTrackingState.MERGE_READY
+        assert updated.last_approved_sha == "deadbeef"
+        assert 8 in report.approved
+
     async def test_disabled_flag_skips(self) -> None:
         pr = make_pr(number=5, head_ref="caretaker/x")
         pr.head_sha = "abc123"


### PR DESCRIPTION
## Summary

Fixes the F-7 gap exposed by [PR #626](https://github.com/ianlintner/caretaker/pull/626) — the v0.25.0 \`chore/releases-json-*\` bump PR sat un-approved despite all checks green and the status comment showing 100% readiness, because the executor refuses to auto-approve maintainer-bot PRs even though the state machine routes them as eligible.

## Bug

The state machine in [\`pr_agent/states.py:530\`](src/caretaker/pr_agent/states.py:530) emits \`request_review_approve\` when:

\`\`\`python
ci.status == CIStatus.PASSING
and (pr.is_caretaker_pr or pr.is_maintainer_bot_pr)
and not review_eval.changes_requested
and not review_eval.approved
and current_state != PRTrackingState.FIX_REQUESTED
\`\`\`

But the executor [\`pr_agent/agent.py:1034\`](src/caretaker/pr_agent/agent.py:1034) only accepts \`is_caretaker_pr\`:

\`\`\`python
if not getattr(pr, "is_caretaker_pr", False):
    logger.warning("PR #%d: refusing auto-approve — not a caretaker PR ...", ...)
    report.waiting.append(pr.number)
    return tracking
\`\`\`

So every \`chore/releases-json-vX.Y.Z\` PR opened by the \`update-releases-json\` workflow after a release is silently refused. Pre-PR-625 the symptom was masked (config-path bug F-5 meant \`auto_approve_caretaker_prs\` was always False at runtime, so nothing auto-approved); now that F-5 is fixed, the maintainer-bot gap is the visible failure.

## Why this matters

Past releases.json PRs (#616 v0.23.0, #618 v0.24.0, #626 v0.25.0) all merged via human hand, never via caretaker. The release pipeline isn't autonomous end-to-end. After this fix, the chain is:

\`release-prepare\` → tag → \`release-publish\` (PyPI) → \`update-releases-json\` opens \`chore/releases-json-*\` PR → caretaker auto-approves + merges → fleet upgrade-agent picks up the new version on next run.

## Fix

Relax the defensive guard at [\`agent.py:1034\`](src/caretaker/pr_agent/agent.py:1034) to accept either \`is_caretaker_pr\` OR \`is_maintainer_bot_pr\`. The state-machine condition upstream already enforces the full safety set ("CI passing + caretaker-or-bot-authored + not changes_requested + not already approved + not FIX_REQUESTED"), so no invariant weakens.

\`is_maintainer_bot_pr\` is bounded:
- head ref \`chore/releases-json-*\` (the workflow we care about), OR
- head ref \`chore/*\` AND author is \`github-actions[bot]\` (future-proofing)

Both ship from the central repo's own automation, so the security model is identical to \`is_caretaker_pr\`.

## Tests

- New regression test \`TestAutoApproveCaretakerPRs::test_approves_maintainer_bot_releases_json_pr\` in [tests/test_pr_agent/test_agent.py](tests/test_pr_agent/test_agent.py).
- Existing tests still pass (\`pytest tests/test_pr_agent/test_agent.py -k "auto_approve or approve"\` → 11 passed).
- mypy strict clean, ruff clean.

## Verification

After this lands and the cache TTL flips, [PR #626](https://github.com/ianlintner/caretaker/pull/626) (or its successor if it gets merged manually first) will be the live test — caretaker should self-approve + auto-merge.

Findings F-6 (caretaker-qa#67 closed by stale dedup against #39) is a separate cycle; will land in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)