### PR TITLE
fix(pr-agent): upgrade-PR dedup picks highest target version (F-6) + qa-findings 2026-04-27 update

### DIFF
--- a/docs/qa-findings-2026-04-27.md
+++ b/docs/qa-findings-2026-04-27.md
@@ -88,30 +88,74 @@ No "comment posted twice" or "two pr-readiness checks at the same SHA from the s
 
 The new Redis-backed config cache (with the `acquire_key_lock(owner, repo)` stampede protection added in the review-fixes commit) sat directly in the hot path of every webhook for caretaker-qa during this cycle (the issue from scenario-15 + the PR from scenario-16 + their associated `issue_comment`, `pull_request_review`, and `check_suite` follow-ups). No `secondary rate limit exceeded` errors surfaced in agent comments, no fallback-to-defaults messages, and the agents that read agent-specific config (pr_reviewer's `min_severity`, pr_agent's `auto_merge`) behaved per the QA repo's configured values. Single-flight is working under real concurrency.
 
+### F-5. `.caretaker.yml` autonomy keys never loaded by server-side dispatch — **REGRESSION, FIXED**
+
+Surfaced when [caretaker#622](https://github.com/ianlintner/caretaker/pull/622) sat at 100% readiness without an APPROVE or merge. The active dispatcher's `GitHubAppContextFactory._load_config` reads `.github/maintainer/config.yml` exclusively. The central caretaker repo's `pr_agent.merge_authority.mode: gate_and_merge` and `pr_agent.review.auto_approve_caretaker_prs: true` lived in `.caretaker.yml` at the repo root — a path no caretaker code path auto-discovers. Result: those keys silently fell back to defaults (`auto_approve_caretaker_prs: False`, `merge_authority.mode: advisory`, agent memory backend = SQLite) and autonomy stopped working.
+
+Fix in [#625](https://github.com/ianlintner/caretaker/pull/625): inlined the four missing keys (`memory_store`, `mongo`, `pr_agent.merge_authority`, `pr_agent.review.auto_approve_caretaker_prs`) into `.github/maintainer/config.yml`, deleted `.caretaker.yml`, updated docstring examples and the qa-cycle skill recipe (F-2). Single source of truth. Verified post-merge by the next webhook tick honoring the autonomy keys.
+
+### F-6. Duplicate-PR dedup picked older over newer target version — **BUG, FIXED**
+
+Symptom: caretaker-qa#67 (target v0.25.0) was closed as "duplicate of #39 (both address pkg:caretaker)" — but #39 was a stale 2-day-old upgrade PR targeting v0.19.4. The retry caretaker-qa#70 was closed for the same reason against caretaker-qa#69 (also v0.25.0, but earlier). The dedup heuristic in `pr_agent/pr_triage.close_duplicate_fix_prs` selected the **oldest** PR by `created_at` as the survivor for **all** group keys, including `pkg:*` (upgrade) groups where the canonical "first PR opened" rationale doesn't apply — newer upgrade PRs target newer versions.
+
+Fix in [#628](https://github.com/ianlintner/caretaker/pull/628): split the survivor selection by group key. CVE groups keep oldest-wins (canonical review history). `pkg:*` groups switch to **highest target version** (parsed from "to vX.Y.Z" in the title), with `created_at` as a tiebreak and PR number as the final deterministic break. Three new regression tests including an explicit replay of the qa#39-vs-qa#70 scenario.
+
+### F-7. Auto-approve handler refused `is_maintainer_bot_pr` PRs — **REGRESSION (pre-existing), FIXED**
+
+Surfaced once F-5 was fixed and [caretaker#626](https://github.com/ianlintner/caretaker/pull/626) (a `chore/releases-json-v0.25.0` PR auto-opened by the `update-releases-json` workflow) sat at 100% readiness without an APPROVE. The state machine in `pr_agent/states.py:530` emits `request_review_approve` when `pr.is_caretaker_pr OR pr.is_maintainer_bot_pr`, but `_handle_auto_approve` at `agent.py:1034` only accepted `is_caretaker_pr` — silently refusing every `chore/releases-json-vX.Y.Z` PR. Pre-F-5 the symptom was masked because nothing auto-approved at all.
+
+Fix in [#627](https://github.com/ianlintner/caretaker/pull/627): relaxed the defensive guard to accept either flag. Both upstream gates already enforce the safety set ("CI passing + caretaker-or-bot-authored + not changes_requested + not already approved + not FIX_REQUESTED"). Live test will fire on the next `chore/releases-json-vX.Y.Z` PR (e.g. v0.26.0 release pipeline).
+
 ## Triage
 
 | Finding | Severity | Action |
 |---|---|---|
 | F-1 | informational | none — expected migration shape |
-| F-2 | minor docs | follow-up PR to the skill's monitor recipe |
+| F-2 | minor docs | fixed in #625 (caretaker-qa-cycle skill monitor recipe) |
 | F-3 | confirms healthy | none |
 | F-4 | confirms healthy | none |
+| F-5 | regression, blocking autonomy | **fixed in #625** |
+| F-6 | bug, stalls upgrade chain | **fixed in #628** |
+| F-7 | pre-existing gap, blocks release pipeline | **fixed in #627** |
 
-**No regressions** were surfaced by this cycle. PR #621 + #620 are validated against live traffic.
+## v0.25.0 release + fleet upgrade
+
+Cycle ended in a clean v0.25.0 cut and full fleet upgrade. Order:
+
+1. F-5 fix landed in [#625](https://github.com/ianlintner/caretaker/pull/625) (autonomy unblocked on the central repo).
+2. `release-prepare` workflow auto-bumped pyproject, tagged `v0.25.0`, pushed the GitHub Release. `release-publish` shipped 2 wheels to PyPI. `update-releases-json` opened [#626](https://github.com/ianlintner/caretaker/pull/626) automatically.
+3. F-7 fix landed in [#627](https://github.com/ianlintner/caretaker/pull/627). Backend redeployed at the F-7 sha.
+4. F-6 fix landed in [#628](https://github.com/ianlintner/caretaker/pull/628).
+5. Fleet upgrade rolled to all 12 known consumer repos in one batch — every repo now pinned to `v0.25.0` with the ~80-line thin streaming workflow:
+
+| Repo | Was | Now |
+|---|---|---|
+| caretaker-qa | 0.24.0 | 0.25.0 |
+| space-tycoon | 0.22.3 | 0.25.0 |
+| rust-oauth2-server | 0.22.3 | 0.25.0 |
+| AI-Pipeline | 0.19.4 | 0.25.0 |
+| Example-React-AI-Chat-App | 0.19.4 | 0.25.0 |
+| algo_functional | 0.19.4 | 0.25.0 |
+| tail_vapor | 0.19.4 | 0.25.0 |
+| portfolio | 0.19.4 | 0.25.0 |
+| flashcards | 0.19.4 | 0.25.0 |
+| python_dsa | 0.19.6 | 0.25.0 |
+| kubernetes-apply-vscode | 0.19.4 | 0.25.0 |
+| audio_engineer | 0.19.6 | 0.25.0 |
+
+Side effect already observed: space-tycoon's failing `Caretaker Maintainer` workflow (401 Invalid token audience from the empty `CARETAKER_OIDC_AUDIENCE` env var) was unblocked by the upgrade because v0.25.0 includes [#619](https://github.com/ianlintner/caretaker/pull/619)'s default-audience fallback.
 
 ## Closures
 
-- [caretaker-qa#64](https://github.com/ianlintner/caretaker-qa/issues/64) closed (scenario-15 PASS).
-- [caretaker-qa#65](https://github.com/ianlintner/caretaker-qa/issues/65) to be closed with `caretaker:qa-passed` label after this doc lands.
-- [caretaker-qa#66](https://github.com/ianlintner/caretaker-qa/pull/66) — to be merged or closed (no behavioral cost either way; the PR's job was to fire the webhook).
+- [caretaker-qa#64](https://github.com/ianlintner/caretaker-qa/issues/64) closed (scenario-15 PASS, `caretaker:qa-passed`).
+- [caretaker-qa#65](https://github.com/ianlintner/caretaker-qa/issues/65) closed (scenario-16 PASS, `caretaker:qa-passed`).
+- [caretaker-qa#66](https://github.com/ianlintner/caretaker-qa/pull/66) — left for QA repo maintainer; verification value already captured.
+- [caretaker-qa#67](https://github.com/ianlintner/caretaker-qa/pull/67) — closed by F-6 dedup; superseded.
+- [caretaker-qa#69](https://github.com/ianlintner/caretaker-qa/pull/69) — caretaker's own auto-bump merged (qa pin to v0.25.0).
+- [caretaker-qa#70](https://github.com/ianlintner/caretaker-qa/pull/70) — closed by F-6 dedup against #69; superseded.
 
 ## Next cycle prep
 
-When the QA repo's pin moves forward to a release containing PR #621 (i.e. the thin streaming workflow), open scenario-17 to verify the consumer-side path:
-
-- `caretaker stream` mints OIDC, calls `/runs/start` → `/runs/{id}/trigger`.
-- `/runs/{id}/trigger` publishes to the bus as a `run_trigger` payload.
-- Consumer body sets the run-scoped contextvars + writes terminal status to the runs store.
-- Self-heal trigger fires on `RunStatus.FAILED` via `runs.self_heal_trigger.publish_self_heal_trigger`.
-
-That scenario will close out the migration story end-to-end on both sides of the wire.
+- Verify the F-7 fix on the next `chore/releases-json-vX.Y.Z` PR (will fire on v0.26.0 release pipeline).
+- Verify the F-6 fix on the next collision in the wild (any future dual-target upgrade PR for the same package).
+- Scenario-17 (consumer-side `caretaker stream` → `/runs/{id}/trigger` → bus path) is unblocked now that the entire fleet runs the thin workflow.

--- a/src/caretaker/pr_agent/pr_triage.py
+++ b/src/caretaker/pr_agent/pr_triage.py
@@ -28,6 +28,41 @@ _PACKAGE_BUMP_RE = re.compile(
     r"\b(?:bump|upgrade|update)\s+(?P<pkg>[a-zA-Z0-9_.-]+)",
     re.IGNORECASE,
 )
+# Match "to vX.Y.Z" (with or without the v) anywhere in a PR title — used to
+# extract the target version of an upgrade PR so dedup prefers the newer
+# target over the older. F-6 from the 2026-04-27 QA cycle: caretaker-qa#67
+# (target v0.25.0) was incorrectly closed as a duplicate of caretaker-qa#39
+# (target v0.19.4) because the dedup heuristic picked oldest-by-created_at,
+# stalling the upgrade chain.
+_TARGET_VERSION_RE = re.compile(
+    r"\bto\s+v?(?P<ver>\d+(?:\.\d+){1,3}(?:[a-zA-Z0-9.+-]*))",
+    re.IGNORECASE,
+)
+
+
+def _parse_target_version(title: str | None) -> tuple[int, ...] | None:
+    """Extract a comparable version tuple from an upgrade PR title.
+
+    Returns ``None`` when the title doesn't carry a "to vX.Y.Z" clause
+    (or it can't be parsed cleanly), so callers can fall back to a
+    timestamp tiebreak. Pre-release / build suffixes after the numeric
+    components are dropped — comparing v1.2.3-rc1 against v1.2.3 as
+    equal is acceptable for dedup purposes.
+    """
+    if not title:
+        return None
+    match = _TARGET_VERSION_RE.search(title)
+    if not match:
+        return None
+    raw = match.group("ver")
+    parts: list[int] = []
+    for chunk in raw.split("."):
+        # Strip any non-numeric trailing junk (e.g. "3-rc1" → "3").
+        digits = re.match(r"\d+", chunk)
+        if not digits:
+            break
+        parts.append(int(digits.group(0)))
+    return tuple(parts) if parts else None
 
 
 @dataclass
@@ -196,17 +231,38 @@ async def close_duplicate_fix_prs(
         if len(prs) < 2:
             continue
 
-        # Survivor: oldest by created_at, falling back to lowest PR number.
-        # PRs with an unknown created_at sort last (never chosen as survivor
-        # over a PR with a real timestamp).
-        def _sort_key(p: PullRequest) -> tuple[float, int]:
-            created = p.created_at.timestamp() if p.created_at else float("inf")
-            return (created, p.number)
+        if key.startswith("pkg:"):
+            # Upgrade PRs: prefer the highest target version, then newest by
+            # created_at as tiebreak. Closing the newer target in favor of
+            # an older stale upgrade PR was F-6 — it stalled the upgrade
+            # chain on caretaker-qa where a v0.19.4 PR sat open for two
+            # days and silently closed every v0.25.0 bump that came after.
+            #
+            # PRs without a parseable target version sort behind any PR
+            # that does parse, so a freshly-titled "upgrade caretaker
+            # pin from v0.24.0 to v0.25.0" beats an unparseable
+            # placeholder title. Lowest PR number breaks the final tie
+            # so two same-target same-time PRs collapse deterministically.
+            def _pkg_sort_key(p: PullRequest) -> tuple[tuple[int, ...], float, int]:
+                version = _parse_target_version(p.title) or ()
+                created = p.created_at.timestamp() if p.created_at else 0.0
+                # Negate so ``min`` selects the highest version + newest.
+                return (
+                    tuple(-c for c in version) if version else (1,),
+                    -created,
+                    p.number,
+                )
 
-        # why oldest wins: mirrors close_duplicate_issues in
-        # issue_agent/issue_triage.py — canonical history lives on the first
-        # PR opened for a given fix.
-        survivor = min(prs, key=_sort_key)
+            survivor = min(prs, key=_pkg_sort_key)
+        else:
+            # CVE / non-upgrade groups: oldest wins, mirroring
+            # issue_agent.issue_triage.close_duplicate_issues — canonical
+            # review history lives on the first PR opened for a given fix.
+            def _oldest_sort_key(p: PullRequest) -> tuple[float, int]:
+                created = p.created_at.timestamp() if p.created_at else float("inf")
+                return (created, p.number)
+
+            survivor = min(prs, key=_oldest_sort_key)
         for pr in prs:
             if pr.number == survivor.number:
                 continue

--- a/tests/test_pr_agent/test_pr_triage.py
+++ b/tests/test_pr_agent/test_pr_triage.py
@@ -102,15 +102,57 @@ async def test_close_duplicate_fix_prs_by_cve() -> None:
 
 
 @pytest.mark.asyncio
-async def test_close_duplicate_fix_prs_package_bump() -> None:
-    # Survivor policy: oldest wins.
+async def test_close_duplicate_fix_prs_package_bump_prefers_higher_target() -> None:
+    """For pkg:* groups (upgrade PRs), the survivor is the one targeting the
+    higher version, not the older PR. F-6 regression — pre-fix this would have
+    closed #21 (target 9.0.3) in favor of #20 (target 9.0.2), stalling the
+    upgrade chain."""
     a = make_pr(number=20, created_at=datetime(2026, 1, 1, tzinfo=UTC))
     a.title = "Bump pytest from 8 to 9.0.2"
     b = make_pr(number=21, created_at=datetime(2026, 1, 2, tzinfo=UTC))
     b.title = "Bump pytest from 8 to 9.0.3"
     gh = _FakeGH()
     closed = await close_duplicate_fix_prs(gh, "o", "r", [a, b])
-    assert closed == [21]
+    assert closed == [20]
+    # Close comment references the survivor (the higher-target PR).
+    assert any("#21" in body for (_, body) in gh.comments)
+
+
+@pytest.mark.asyncio
+async def test_close_duplicate_fix_prs_upgrade_chain_f6_regression() -> None:
+    """F-6 from the 2026-04-27 QA cycle: a stale 2-day-old upgrade PR
+    targeting v0.19.4 silently closed every newer v0.25.0 bump caretaker
+    auto-opened. Pre-fix, oldest-wins-by-created_at made the stale PR the
+    survivor; post-fix, the highest-target survives even when older."""
+    stale = make_pr(number=39, created_at=datetime(2026, 4, 25, 22, tzinfo=UTC))
+    stale.title = "chore: upgrade caretaker pin from v0.19.3 to v0.19.4"
+    fresh = make_pr(number=70, created_at=datetime(2026, 4, 27, 15, tzinfo=UTC))
+    fresh.title = "chore: bump caretaker pin from v0.24.0 to v0.25.0"
+    gh = _FakeGH()
+    closed = await close_duplicate_fix_prs(gh, "o", "r", [stale, fresh])
+    # The stale v0.19.4 PR is closed; the fresh v0.25.0 PR survives.
+    assert closed == [39]
+    assert any("#70" in body for (_, body) in gh.comments)
+
+
+@pytest.mark.asyncio
+async def test_close_duplicate_fix_prs_pkg_dedup_is_input_order_stable() -> None:
+    """Reversing input order must not change the survivor for pkg:* groups
+    (same property as the CVE oldest-wins variant — different selector,
+    same invariant)."""
+    older = make_pr(number=100, created_at=datetime(2026, 1, 1, tzinfo=UTC))
+    older.title = "chore: upgrade caretaker pin from v1.0.0 to v1.1.0"
+    middle = make_pr(number=101, created_at=datetime(2026, 1, 5, tzinfo=UTC))
+    middle.title = "chore: upgrade caretaker pin from v1.1.0 to v1.2.0"
+    newest = make_pr(number=102, created_at=datetime(2026, 1, 10, tzinfo=UTC))
+    newest.title = "chore: upgrade caretaker pin from v1.2.0 to v1.3.0"
+
+    for ordering in ([older, middle, newest], [newest, older, middle]):
+        gh = _FakeGH()
+        closed = await close_duplicate_fix_prs(gh, "o", "r", ordering)
+        # #102 has the highest target (v1.3.0) and survives in every input order.
+        assert sorted(closed) == [100, 101]
+        assert all("#102" in body for (_, body) in gh.comments)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes [F-6](docs/qa-findings-2026-04-27.md) — \`pr_triage.close_duplicate_fix_prs\` was selecting the OLDEST PR by \`created_at\` as the survivor for every group key, including \`pkg:*\` (upgrade) groups where the canonical "first PR opened" rationale doesn't apply. Stale upgrade PRs accumulated and silently closed every newer bump that came after, stalling the fleet upgrade chain.

## Live wild repro

| | repo | created | target |
|---|---|---|---|
| stale | [qa#39](https://github.com/ianlintner/caretaker-qa/pull/39) | 2026-04-25 22:02 | v0.19.4 |
| fresh | [qa#70](https://github.com/ianlintner/caretaker-qa/pull/70) | 2026-04-27 15:02 | v0.25.0 |

Pre-fix: caretaker auto-closed qa#70 with "Closing: duplicate of #39 (both address pkg:caretaker)." → upgrade chain stalls on a 6-versions-behind PR. Post-fix: qa#39 is closed in favor of qa#70, the higher-target survivor.

## Fix

[\`pr_triage.close_duplicate_fix_prs\`](src/caretaker/pr_agent/pr_triage.py): split the survivor selection by group key.

- **CVE / non-upgrade groups** keep oldest-wins (canonical review history lives on the first PR opened — mirrors \`close_duplicate_issues\` in \`issue_agent/issue_triage.py\`).
- **\`pkg:*\` groups** switch to highest-target-version (parsed from "to vX.Y.Z" in the title via the new \`_parse_target_version\` helper), with newest-by-created_at as a tiebreak and lowest PR number as the final deterministic break.

PRs with an unparseable target version sort behind any PR that does parse, so a freshly-titled "upgrade caretaker pin from v0.24.0 to v0.25.0" beats an unparseable placeholder title.

## Tests

- Renamed + flipped existing test to assert the new behavior: \`test_close_duplicate_fix_prs_package_bump_prefers_higher_target\`
- New \`test_close_duplicate_fix_prs_upgrade_chain_f6_regression\` replays the exact qa#39-vs-qa#70 scenario from the wild
- New \`test_close_duplicate_fix_prs_pkg_dedup_is_input_order_stable\` verifies the survivor is invariant across input orderings (catches any future regression hidden by enumeration order)

\`pytest tests/test_pr_agent/test_pr_triage.py\` → 28 passed. Strict mypy clean.

## Findings doc

Same PR ships the \`docs/qa-findings-2026-04-27.md\` update covering F-5/F-6/F-7 resolution + the v0.25.0 fleet upgrade results (12/12 repos to v0.25.0 + thin streaming workflow, side benefit of unblocking space-tycoon's empty-OIDC-audience CI failure).

## Test plan

- [x] All pr_triage unit tests pass with the new selector
- [ ] On the next collision in the wild (e.g. v0.26.0 bump opening before v0.25.0's auto-bump completes), the higher target survives. Tracked in next QA cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)