### PR TITLE
feat(fleet): server-side dispatch heartbeat — keeps /api/admin/fleet live post-v0.25.0

### DIFF
--- a/src/caretaker/eventbus/consumer.py
+++ b/src/caretaker/eventbus/consumer.py
@@ -216,6 +216,28 @@ async def _handle_webhook(*, parsed: ParsedWebhook, dispatcher: WebhookDispatche
         mode=dispatcher.mode.value,
         outcome=f"bus_{result.outcome}",
     )
+
+    # Server-side fleet touch — keeps /api/admin/fleet live now that the
+    # v0.25.0 thin streaming workflow no longer runs ``caretaker run`` in
+    # consumer CI (so consumer-side ``emit_heartbeat`` never fires for any
+    # fleet repo anymore). Best-effort; failures never propagate.
+    if parsed.repository_full_name and result.outcome != "off":
+        try:
+            from caretaker.fleet import record_dispatch_activity
+
+            await record_dispatch_activity(
+                repo=parsed.repository_full_name,
+                event_type=parsed.event_type,
+                agents_fired=list(result.agents),
+                outcome=result.outcome,
+            )
+        except Exception:
+            logger.debug(
+                "fleet record_dispatch_activity failed for %s",
+                parsed.repository_full_name,
+                exc_info=True,
+            )
+
     if result.outcome == "error":
         raise RuntimeError(f"dispatch error: {result.detail or 'unknown'}")
 

--- a/src/caretaker/fleet/__init__.py
+++ b/src/caretaker/fleet/__init__.py
@@ -19,6 +19,7 @@ from caretaker.fleet.emitter import (
     FleetOAuthClientCache,
     build_heartbeat,
     emit_heartbeat,
+    record_dispatch_activity,
 )
 from caretaker.fleet.graph import (
     GraphBackedGlobalSkillReader,
@@ -79,6 +80,7 @@ __all__ = [
     "get_store",
     "promote_global_skills",
     "public_router",
+    "record_dispatch_activity",
     "reset_alert_store_for_tests",
     "reset_store_for_tests",
     "resolve_db_path",

--- a/src/caretaker/fleet/emitter.py
+++ b/src/caretaker/fleet/emitter.py
@@ -313,6 +313,71 @@ def build_heartbeat(
     )
 
 
+async def record_dispatch_activity(
+    *,
+    repo: str,
+    event_type: str,
+    agents_fired: list[str] | None = None,
+    outcome: str = "success",
+) -> bool:
+    """Server-side fleet "touch" — write a minimal heartbeat to the local fleet store.
+
+    Bypasses the HTTP / OAuth2 emit-to-self loop that the consumer-side
+    ``emit_heartbeat`` uses; talks directly to the in-process
+    :func:`caretaker.fleet.store.get_store`. This is what keeps
+    ``/api/admin/fleet`` live now that the v0.25.0 thin streaming workflow
+    no longer runs ``caretaker run`` in consumer CI (so the legacy
+    consumer-side heartbeat never fires anymore).
+
+    Records a tiny payload — repo + caretaker version + event type +
+    agents fired + outcome — so the admin SPA's "last seen" / "active
+    fleet" view stays fresh without the heavyweight RunSummary block.
+    Each successful dispatch upserts the FleetClient row and appends one
+    bounded entry to the heartbeat history ring buffer (32 per repo).
+
+    Returns ``True`` on a successful write, ``False`` if the store
+    rejected the payload or raised. Fail-open by design: never raises
+    into the dispatcher.
+    """
+    if not repo or "/" not in repo:
+        return False
+
+    from caretaker.fleet.store import get_store
+
+    payload: dict[str, Any] = {
+        "repo": repo,
+        "caretaker_version": _caretaker_version(),
+        "run_at": datetime.now(UTC).isoformat(),
+        # ``mode`` field is part of the FleetHeartbeat schema; encode the
+        # webhook event there so the admin dashboard's "last activity"
+        # column carries useful context (e.g. ``webhook:pull_request``).
+        "mode": f"webhook:{event_type}" if event_type else "webhook",
+        "enabled_agents": list(agents_fired or []),
+        "goal_health": None,
+        # The dispatcher returns bounded outcome labels: "active",
+        # "active_partial", "shadow", "off", "no_agents", "error", and
+        # the "deferred_cooldown" / "dropped_overload" variants. Only
+        # "error" reflects a true dispatch failure. Match the bounded
+        # set explicitly rather than negating "success" (which the
+        # dispatcher never emits).
+        "error_count": 1 if outcome in {"error", "active_partial"} else 0,
+        "counters": {},
+        "summary": {"event_type": event_type, "outcome": outcome},
+    }
+    try:
+        store = get_store()
+        await store.record_heartbeat(payload)
+        return True
+    except Exception:
+        logger.warning(
+            "record_dispatch_activity failed for repo=%s event=%s",
+            repo,
+            event_type,
+            exc_info=True,
+        )
+        return False
+
+
 async def emit_heartbeat(
     config: MaintainerConfig,
     summary: RunSummary,

--- a/tests/test_fleet_dispatch_activity.py
+++ b/tests/test_fleet_dispatch_activity.py
@@ -1,0 +1,218 @@
+"""Tests for the server-side fleet dispatch-touch (post-v0.25.0 fleet upgrade).
+
+After PR #621 + the v0.25.0 fleet rollout removed ``caretaker run`` from
+every consumer-side workflow, no consumer process emits the legacy
+``emit_heartbeat`` HTTP POST anymore. The ``/api/admin/fleet`` view
+would have gone stale-frozen at the pre-migration snapshot. This test
+suite covers the new ``record_dispatch_activity`` helper and confirms
+the eventbus consumer wires it on every successful webhook dispatch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from caretaker.fleet import record_dispatch_activity
+from caretaker.fleet.store import FleetRegistryStore, reset_store_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _isolated_fleet_store() -> None:
+    """Each test starts with a fresh in-memory fleet store."""
+    store = FleetRegistryStore()
+    reset_store_for_tests(store)
+    yield
+    reset_store_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_record_dispatch_activity_writes_minimal_heartbeat() -> None:
+    ok = await record_dispatch_activity(
+        repo="acme/demo",
+        event_type="pull_request",
+        agents_fired=["pr", "pr-reviewer"],
+        outcome="active",
+    )
+    assert ok is True
+
+    from caretaker.fleet.store import get_store
+
+    store = get_store()
+    client = await store.get_client("acme/demo")
+    assert client is not None
+    assert client.repo == "acme/demo"
+    assert client.last_mode == "webhook:pull_request"
+    assert sorted(client.enabled_agents) == ["pr", "pr-reviewer"]
+    assert client.last_error_count == 0
+
+
+@pytest.mark.asyncio
+async def test_record_dispatch_activity_marks_error_count_on_failure() -> None:
+    await record_dispatch_activity(
+        repo="acme/demo",
+        event_type="issues",
+        agents_fired=["issue"],
+        outcome="error",
+    )
+    from caretaker.fleet.store import get_store
+
+    client = await (get_store()).get_client("acme/demo")
+    assert client is not None
+    assert client.last_error_count == 1
+
+
+@pytest.mark.asyncio
+async def test_record_dispatch_activity_partial_dispatch_counts_as_error() -> None:
+    """`active_partial` (one agent failed but siblings succeeded) is a
+    legitimate dispatch failure — the registry should reflect it so the
+    admin SPA can highlight repos with degraded agent runs."""
+    await record_dispatch_activity(
+        repo="acme/demo",
+        event_type="pull_request",
+        agents_fired=["pr", "pr-reviewer"],
+        outcome="active_partial",
+    )
+    from caretaker.fleet.store import get_store
+
+    client = await (get_store()).get_client("acme/demo")
+    assert client is not None
+    assert client.last_error_count == 1
+
+
+@pytest.mark.asyncio
+async def test_record_dispatch_activity_shadow_mode_is_clean() -> None:
+    """Shadow mode is observation-only — must not look like an error in
+    the fleet registry."""
+    await record_dispatch_activity(
+        repo="acme/demo",
+        event_type="pull_request",
+        agents_fired=["pr"],
+        outcome="shadow",
+    )
+    from caretaker.fleet.store import get_store
+
+    client = await (get_store()).get_client("acme/demo")
+    assert client is not None
+    assert client.last_error_count == 0
+
+
+@pytest.mark.asyncio
+async def test_record_dispatch_activity_rejects_invalid_repo() -> None:
+    """Mis-shaped slugs are no-ops, not errors."""
+    assert await record_dispatch_activity(repo="", event_type="x") is False
+    assert await record_dispatch_activity(repo="not-a-slug", event_type="x") is False
+
+
+@pytest.mark.asyncio
+async def test_record_dispatch_activity_swallows_store_errors() -> None:
+    """A failing store backend must not propagate into the dispatcher."""
+
+    class _BrokenStore:
+        async def record_heartbeat(self, payload: dict[str, Any]) -> Any:
+            raise RuntimeError("simulated mongo outage")
+
+    reset_store_for_tests(_BrokenStore())  # type: ignore[arg-type]
+    ok = await record_dispatch_activity(repo="acme/demo", event_type="pull_request")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_record_dispatch_activity_increments_heartbeats_seen() -> None:
+    """Consecutive dispatches for the same repo upsert the same row."""
+    for _ in range(3):
+        await record_dispatch_activity(repo="acme/demo", event_type="push")
+
+    from caretaker.fleet.store import get_store
+
+    client = await (get_store()).get_client("acme/demo")
+    assert client is not None
+    assert client.heartbeats_seen == 3
+
+
+# ── Eventbus integration ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_consumer_webhook_handler_records_dispatch_activity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The eventbus consumer's ``_handle_webhook`` must call the new
+    ``record_dispatch_activity`` after a successful dispatch so the
+    fleet registry stays live without the legacy consumer-side emitter."""
+    from caretaker.eventbus.consumer import _handle_webhook
+    from caretaker.github_app.dispatcher import DispatchMode, DispatchResult
+    from caretaker.github_app.webhooks import ParsedWebhook
+
+    parsed = ParsedWebhook(
+        event_type="pull_request",
+        delivery_id="d-1",
+        action="opened",
+        installation_id=42,
+        repository_full_name="acme/demo",
+        payload={},
+    )
+    dispatcher = AsyncMock()
+    dispatcher.mode = DispatchMode.ACTIVE
+    dispatcher.dispatch = AsyncMock(
+        return_value=DispatchResult(
+            mode=DispatchMode.ACTIVE,
+            event="pull_request",
+            delivery_id="d-1",
+            agents=("pr", "pr-reviewer"),
+            outcome="active",
+            duration_seconds=0.1,
+        )
+    )
+
+    await _handle_webhook(parsed=parsed, dispatcher=dispatcher)
+
+    # Fleet store should now know about acme/demo.
+    from caretaker.fleet.store import get_store
+
+    client = await (get_store()).get_client("acme/demo")
+    assert client is not None
+    assert client.last_mode == "webhook:pull_request"
+    assert sorted(client.enabled_agents) == ["pr", "pr-reviewer"]
+
+
+@pytest.mark.asyncio
+async def test_consumer_webhook_handler_skips_record_when_dispatcher_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When dispatcher.mode is OFF, the consumer should NOT record a
+    fleet activity (otherwise mere webhook receipt looks like dispatch
+    activity and inflates the fleet view)."""
+    from caretaker.eventbus.consumer import _handle_webhook
+    from caretaker.github_app.dispatcher import DispatchMode, DispatchResult
+    from caretaker.github_app.webhooks import ParsedWebhook
+
+    parsed = ParsedWebhook(
+        event_type="pull_request",
+        delivery_id="d-1",
+        action="opened",
+        installation_id=42,
+        repository_full_name="acme/demo",
+        payload={},
+    )
+    dispatcher = AsyncMock()
+    dispatcher.mode = DispatchMode.OFF
+    dispatcher.dispatch = AsyncMock(
+        return_value=DispatchResult(
+            mode=DispatchMode.OFF,
+            event="pull_request",
+            delivery_id="d-1",
+            agents=(),
+            outcome="off",
+            duration_seconds=0.0,
+        )
+    )
+
+    await _handle_webhook(parsed=parsed, dispatcher=dispatcher)
+
+    from caretaker.fleet.store import get_store
+
+    client = await (get_store()).get_client("acme/demo")
+    assert client is None


### PR DESCRIPTION
## Summary

Closes the fleet-registry-stale gap surfaced during today's data-reporting validation of the v0.25.0 fleet upgrade.

After PR #621 + the v0.25.0 fleet rollout to all 12 consumer repos, **no consumer-side \`caretaker run\` process exists anymore** — the thin streaming workflow only invokes \`caretaker stream\` (mints OIDC + tails SSE). The legacy fleet heartbeat call lives in \`orchestrator.py:809,855\`, which only fires inside a consumer Python process. So \`/api/admin/fleet\` would have stayed frozen at the pre-migration snapshot indefinitely, even though the backend processes real webhook traffic against the same repos every minute.

## Fix

New \`caretaker.fleet.emitter.record_dispatch_activity\` helper that writes a minimal heartbeat directly to the in-process FleetRegistryStore (no HTTP, no OAuth2 emit-to-self loop). The eventbus consumer's \`_handle_webhook\` calls it after every successful \`dispatcher.dispatch()\`. Mongo-backed in production (already wired); SQLite for single-pod dev; in-memory fallback for tests.

Skipped when \`dispatcher.mode is OFF\` so mere webhook receipt doesn't inflate the fleet view with non-acted-on traffic.

Payload encodes the webhook event in the \`mode\` field (\`webhook:pull_request\`, \`webhook:issues\`, …) so the admin SPA's "last activity" column carries useful context. \`error_count\` only flips on the bounded outcome labels the dispatcher actually emits (\`error\`, \`active_partial\`); \`shadow\` stays clean so the observation phase doesn't show as unhealthy.

Best-effort by design: store failures log and swallow, never propagate into the dispatcher.

## Behavior change

| Before | After |
|---|---|
| \`/api/admin/fleet\` frozen at pre-v0.25.0 snapshot | Live, updated on every webhook the dispatcher processes |
| Consumer-side \`emit_heartbeat\` had to fire | Server-side write, no consumer dependency |
| Heartbeat semantics tied to RunSummary counters | Lightweight "activity" record (event_type + agents fired + outcome) |

The legacy consumer-side \`emit_heartbeat\` path is preserved unchanged for any repo that still runs the heavy workflow (currently none in this fleet, but a future opt-in scenario could).

## Tests

7 new in \`tests/test_fleet_dispatch_activity.py\`:
- \`record_dispatch_activity\` writes minimal heartbeat
- error counting on \`error\`, \`active_partial\` outcomes
- \`shadow\` outcome stays clean
- mis-shaped repo slug is a no-op (not an exception)
- store-backend exceptions swallow
- \`heartbeats_seen\` increments across consecutive dispatches
- consumer's \`_handle_webhook\` integration: dispatch outcome = \`active\` → fleet write happens
- \`OFF\` mode skip

\`pytest tests/test_fleet_dispatch_activity.py tests/test_eventbus.py tests/test_eventbus_webhook_integration.py tests/test_fleet_registry.py\` → 33 passed. Strict mypy clean.

## Verification

After merge + redeploy, the next webhook to caretaker-qa (or any fleet repo) will populate \`fleet_clients\` in Mongo. \`/api/admin/fleet\` will start showing live "last seen" timestamps for every repo the backend dispatches against. The deploy can roll without operator action — the change is additive and backward-compatible.

## Test plan

- [x] All unit tests pass with the new helper + integration
- [ ] Post-redeploy: open a webhook event on a fleet repo, confirm \`fleet_clients\` row appears in Mongo with \`last_mode=webhook:<event>\`. Tracked in next QA cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)