### PR TITLE
fix(observability): register HTTP metrics middleware at app construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **`caretaker-mcp` Prometheus HTTP middleware no longer silently fails
+  to register at startup.** `init_metrics(app, ...)` was being called
+  from inside the FastAPI lifespan handler, which Starlette rejects with
+  `RuntimeError: Cannot add middleware after an application has started`.
+  The error was swallowed by a `try/except` that demoted it to a warning,
+  so pods stayed up — but `caretaker_http_server_requests_total` and
+  `caretaker_http_server_request_duration_seconds` never incremented in
+  production, leaving the RED-floor dashboards empty. The middleware now
+  registers at module import time (right after `app = FastAPI(...)`),
+  matching the layout that `tests/test_metrics.py` has had all along; the
+  `/metrics` ASGI sidecar — which legitimately needs an event loop —
+  stays in lifespan. Regression test in
+  `tests/test_mcp_backend_metrics_wired.py` asserts the counter
+  increments after a `TestClient` hits `/health`. Surfaced while
+  debugging an unrelated `@caretaker` PR-takeover question (PR #630)
+  where the empty counters made it impossible to tell whether the
+  webhook dispatcher had run.
+
 - **`pr_reviewer.handoff_review_consumer` two-bug fix surfaced by the
   v0.24.0 live QA cycle on caretaker-qa#63.**
 

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -85,21 +85,21 @@ async def _lifespan(application: FastAPI):  # type: ignore[no-untyped-def]
     except Exception:
         logger.debug("OpenTelemetry bootstrap skipped", exc_info=True)
 
-    # Prometheus metrics (paved-path SKILL §1-§10). RED-floor HTTP
-    # metrics + http_client_* + db_client_* + worker_* are emitted
-    # unconditionally; /metrics is served on a separate cluster-internal
-    # port (default 9090) so scraping never contends with user traffic.
+    # Prometheus /metrics ASGI sidecar — owns a uvicorn task on the
+    # event loop, so it has to start in lifespan. The middleware that
+    # populates the counters it scrapes is registered at module scope
+    # (right after ``app = FastAPI(...)`` below) because Starlette
+    # rejects ``add_middleware`` once startup begins.
     try:
-        from caretaker.observability import init_metrics, start_metrics_server
+        from caretaker.observability import start_metrics_server
 
-        init_metrics(application, service="caretaker-mcp")
         metrics_port = int(os.environ.get("CARETAKER_METRICS_PORT", "9090"))
         # Opt out by setting the port to 0 — useful for in-process
         # tests that don't want a background asyncio server.
         if metrics_port > 0:
             application.state.metrics_server_task = start_metrics_server(port=metrics_port)
     except Exception:
-        logger.warning("Prometheus metrics init failed", exc_info=True)
+        logger.warning("Prometheus metrics server start failed", exc_info=True)
 
     # Configure shared OAuth2 bearer-token auth used by the fleet
     # heartbeat endpoint (and any future authenticated public
@@ -572,6 +572,19 @@ app = FastAPI(
     version=_PKG_VERSION,
     lifespan=_lifespan,
 )
+
+# Prometheus RED-floor HTTP middleware (paved-path SKILL §1-§10). Must
+# register at app construction — Starlette rejects ``add_middleware``
+# after lifespan startup begins, so calling this from inside ``_lifespan``
+# raises ``RuntimeError: Cannot add middleware after an application has
+# started``. The /metrics ASGI sidecar that scrapes the counters this
+# middleware populates is started from lifespan instead (see above).
+try:
+    from caretaker.observability import init_metrics
+
+    init_metrics(app, service="caretaker-mcp")
+except Exception:
+    logger.warning("Prometheus metrics init failed", exc_info=True)
 
 
 # ── Delivery dedup ───────────────────────────────────────────────

--- a/tests/test_eventbus_webhook_integration.py
+++ b/tests/test_eventbus_webhook_integration.py
@@ -64,6 +64,12 @@ def _clean_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(backend_main, "_dedup", LocalDedup())
 
 
+@pytest.fixture(autouse=True)
+def _disable_metrics_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent metrics server from starting on port 9090 during tests."""
+    monkeypatch.setenv("CARETAKER_METRICS_PORT", "0")
+
+
 @pytest.fixture()
 def with_secret(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CARETAKER_GITHUB_APP_WEBHOOK_SECRET", WEBHOOK_SECRET)

--- a/tests/test_mcp_backend_metrics_wired.py
+++ b/tests/test_mcp_backend_metrics_wired.py
@@ -1,0 +1,48 @@
+"""Regression test: HTTP RED-floor metrics middleware is registered at
+module import for the production ``caretaker-mcp`` app.
+
+If ``init_metrics`` ever moves back inside the FastAPI lifespan handler,
+Starlette will reject the late ``add_middleware`` call with
+``RuntimeError: Cannot add middleware after an application has started``.
+The existing ``mcp_backend.main`` masks that error as a warning, so the
+pod stays up but ``caretaker_http_server_requests_total`` never
+increments. This test catches that regression by hitting ``/health``
+through a TestClient (which exercises the real lifespan) and asserting
+the counter actually moved.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi.testclient import TestClient
+
+
+def test_health_request_increments_caretaker_mcp_counter() -> None:
+    """A live request to the production app advances the RED counter."""
+    # Disable the background /metrics uvicorn sidecar — it would try to
+    # bind 9090 and fight any other test runner.
+    os.environ["CARETAKER_METRICS_PORT"] = "0"
+
+    from caretaker.mcp_backend.main import app
+    from caretaker.observability.metrics import HTTP_SERVER_REQUESTS_TOTAL
+
+    series = HTTP_SERVER_REQUESTS_TOTAL.labels(
+        service="caretaker-mcp",
+        http_method="GET",
+        http_route="/health",
+        http_status_code="200",
+    )
+    before = series._value.get()
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    after = series._value.get()
+    assert after == before + 1, (
+        "HTTP_SERVER_REQUESTS_TOTAL did not increment after GET /health — "
+        "the metrics middleware is probably not registered. Check that "
+        "caretaker.mcp_backend.main calls init_metrics(app, ...) at module "
+        "scope (not from inside _lifespan)."
+    )


### PR DESCRIPTION
## Summary

- `init_metrics(app, ...)` was being called from inside the FastAPI lifespan handler in [src/caretaker/mcp_backend/main.py](src/caretaker/mcp_backend/main.py); Starlette rejects late `add_middleware` with `RuntimeError: Cannot add middleware after an application has started`. The existing `try/except` swallowed it as a warning, so pods stayed up but the RED-floor HTTP middleware never registered and `caretaker_http_server_requests_total` / `caretaker_http_server_request_duration_seconds` never incremented in production.
- Move `init_metrics(app, "caretaker-mcp")` to module scope, right after `app = FastAPI(...)`. Keep the async `/metrics` sidecar (`start_metrics_server`) inside `_lifespan` because it legitimately needs the running event loop.
- Add `tests/test_mcp_backend_metrics_wired.py` — a `TestClient(app)` round-trip on `/health` must advance the counter, otherwise the assertion fails with a pointer to this fix.

## Why this slipped past CI

The existing fixture in [tests/test_metrics.py:29-38](tests/test_metrics.py:29) already calls `init_metrics(app, ...)` *outside* any lifespan (the test comment notes this is deliberate), so it bypassed the bug entirely. Other `mcp_backend` tests entered lifespan via `TestClient` but didn't assert on the demoted warning. Regression was introduced by #631 (e2e OpenTelemetry tracing).

## Reproduction (pre-fix)

Production pod logs (every restart, post-#631 deploy):
```
File ".../caretaker/mcp_backend/main.py", line 94, in _lifespan
    init_metrics(application, service="caretaker-mcp")
File ".../caretaker/observability/metrics.py", line 476, in init_metrics
    @app.middleware("http")
File ".../starlette/applications.py", line 125, in add_middleware
    raise RuntimeError("Cannot add middleware after an application has started")
```

Surfaced while debugging an unrelated `@caretaker` PR-takeover question on #630 — the empty counters made it impossible to tell whether the webhook dispatcher had run.

## Test plan

- [x] `pytest tests/test_metrics.py tests/test_mcp_backend_auth.py tests/test_mcp_backend_github_app.py tests/test_mcp_backend_metrics_wired.py` — all 29 pass locally.
- [x] `python -c "from caretaker.mcp_backend.main import app"` — no warning printed (was previously printing `Prometheus metrics init failed` + traceback).
- [x] `pre-commit` (ruff, ruff-format, mypy strict) clean.
- [ ] Post-deploy: confirm `kubectl logs -n caretaker -l app=caretaker-mcp` no longer shows `Cannot add middleware after an application has started` and `curl localhost:9090/metrics` exposes `caretaker_http_server_requests_total`.

## Out of scope

There's a separate, unrelated finding from the same diagnosis: the `@caretaker` / `/caretaker` comment trigger isn't wired into the webhook dispatch path because [.github/workflows/maintainer.yml](.github/workflows/maintainer.yml) was gutted to cron + `workflow_dispatch` only and [dispatch_guard.py](src/caretaker/github_app/dispatch_guard.py)'s `legacy_dispatch_verdict` is no longer called from [dispatcher.py](src/caretaker/github_app/dispatcher.py). That's a feature-completeness gap rather than a regression — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)