### PR TITLE
feat(github-app): pre-dispatch comment gate for self-echo + @caretaker triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Pre-dispatch comment gate for the GitHub App webhook receiver.**
+  New module `caretaker.github_app.comment_gate` runs in front of
+  `WebhookDispatcher.dispatch` for `issue_comment`,
+  `pull_request_review`, and `pull_request_review_comment` events. Two
+  jobs:
+
+  *Self-echo loop prevention.* When a webhook delivery comes from a
+  bot actor with a `<!-- caretaker:... -->` marker (caretaker's own
+  output bouncing back), the gate short-circuits with
+  `outcome="self_echo"`. No installation token is minted, no agent
+  runs. Defence in depth on top of the per-agent marker checks that
+  already exist.
+
+  *Explicit human-intent recognition.* When a non-bot actor invokes
+  one of the existing trigger tokens — `@caretaker`, `@the-care-taker`,
+  `/caretaker`, `/maintain` — the gate surfaces a structured log line
+  (`webhook gate outcome=human_intent ...`) and an extra
+  `caretaker_webhook_events_total{outcome="human_intent"}` sample.
+  Operators can grep this to confirm a `@caretaker` mention reached
+  the backend, separate from the generic `outcome="active"` /
+  `"shadow"` rates. Underlying agent dispatch is unchanged.
+
+  Mode is selected by `CARETAKER_WEBHOOK_COMMENT_GATING`:
+  `off` (legacy / instant rollback), `advise` (default — self-echo
+  skip + human-intent observability), `enforce` (also drop comment
+  events with no explicit trigger). `advise` is the safe default
+  because it only changes behaviour for self-echo events, which were
+  already expected to no-op.
+
+  Surfaced after a `@caretaker take this over` comment on PR #630
+  produced no observable backend signal — the gate now makes such
+  triggers loud in the metric stream and lays the groundwork for a
+  future "spawn dedicated takeover worker" path.
+
 ### Fixed
 
 - **`pr_reviewer.handoff_review_consumer` two-bug fix surfaced by the

--- a/src/caretaker/github_app/__init__.py
+++ b/src/caretaker/github_app/__init__.py
@@ -14,6 +14,11 @@ and the FastAPI webhook receiver without circular imports.
 from __future__ import annotations
 
 from .agent_runner import RegistryAgentRunner
+from .comment_gate import (
+    CommentGateDecision,
+    CommentGateMode,
+    evaluate_comment_gate,
+)
 from .context_factory import GitHubAppContextFactory
 from .dispatch_guard import (
     DispatchEvent,
@@ -50,20 +55,23 @@ from .webhooks import (
 __all__ = [
     "EVENT_AGENT_MAP",
     "AppJWTSigner",
-    "GitHubAppContextFactory",
-    "RegistryAgentRunner",
+    "CommentGateDecision",
+    "CommentGateMode",
     "DispatchEvent",
     "DispatchMode",
     "DispatchResult",
     "DispatchVerdict",
+    "GitHubAppContextFactory",
     "GitHubAppCredentialsProvider",
     "InstallationToken",
     "InstallationTokenCache",
     "InstallationTokenMinter",
+    "RegistryAgentRunner",
     "WebhookDispatcher",
     "WebhookSignatureError",
     "agents_for_event",
     "dispatch_in_background",
+    "evaluate_comment_gate",
     "evaluate_dispatch",
     "judge_dispatch",
     "judge_dispatch_llm",

--- a/src/caretaker/github_app/comment_gate.py
+++ b/src/caretaker/github_app/comment_gate.py
@@ -1,0 +1,251 @@
+"""Pre-dispatch gate for comment-carrying webhook events.
+
+Today the :class:`~caretaker.github_app.dispatcher.WebhookDispatcher`
+resolves agents purely from the event type. That works for state-driven
+events (PR opened, CI finished, push) but it has two failure modes for
+comment-driven events:
+
+1. **Self-echo loops.** When caretaker posts a comment, GitHub fires an
+   ``issue_comment.created`` webhook back at us. Without a guard, that
+   bounce dispatches ``["issue", "pr"]`` agents which may post another
+   comment, ad infinitum. Today the agents themselves are expected to
+   no-op on caretaker's own marker — but the dispatcher has no defence
+   in depth.
+
+2. **Silent ``@caretaker`` requests.** A user types ``@caretaker take
+   this over`` and gets no feedback. Today the comment is delivered to
+   the same ``["issue", "pr"]`` agents that fire on every PR comment,
+   so there's no signal in metrics or logs distinguishing "human asked
+   for caretaker" from generic comment traffic. Operators can't tell
+   whether the trigger was even received.
+
+This module solves both with a tiny, deterministic gate that runs *in
+front of* the dispatcher's agent resolution. It re-uses
+:func:`~caretaker.github_app.dispatch_guard.legacy_dispatch_verdict` so
+the trigger-string set stays in one place.
+
+Behaviour is controlled by :envvar:`CARETAKER_WEBHOOK_COMMENT_GATING`:
+
+* ``off`` — no gating; matches behaviour prior to this module.
+* ``advise`` (default) — self-echo events are skipped; human-intent
+  events are tagged in logs + metrics (``outcome="human_intent"``) and
+  then proceed to normal agent dispatch. Other comment events behave as
+  before.
+* ``enforce`` — self-echo events are skipped; comment events that
+  carry no explicit human intent are also skipped. Only human-intent
+  or non-comment events run agents.
+
+Skips are *not* errors — they record ``outcome="self_echo"`` /
+``outcome="no_human_intent"`` and return success ack to GitHub.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from caretaker.github_app.dispatch_guard import (
+    DispatchEvent,
+    DispatchVerdict,
+    legacy_dispatch_verdict,
+)
+
+if TYPE_CHECKING:
+    from caretaker.github_app.webhooks import ParsedWebhook
+
+logger = logging.getLogger(__name__)
+
+
+# Webhook event types whose payload carries a comment body that should
+# be inspected for trigger strings / self-echo markers. Other event
+# types (``pull_request``, ``push``, ``check_run``, …) are state-driven
+# and never gated — their agents fire unconditionally.
+_COMMENT_EVENTS: frozenset[str] = frozenset(
+    {
+        "issue_comment",
+        "pull_request_review",
+        "pull_request_review_comment",
+    }
+)
+
+
+class CommentGateMode(StrEnum):
+    """Operational mode for the comment gate.
+
+    Values match the ``CARETAKER_WEBHOOK_COMMENT_GATING`` env var.
+    """
+
+    OFF = "off"
+    ADVISE = "advise"
+    ENFORCE = "enforce"
+
+    @classmethod
+    def parse(cls, raw: str | None) -> CommentGateMode:
+        """Parse ``raw`` into a mode, defaulting to :attr:`ADVISE`.
+
+        Unknown values resolve to :attr:`ADVISE` — the gate's safe
+        default skips self-echo loops without changing agent dispatch
+        for non-self-echo events. Operators set ``off`` to revert
+        entirely or ``enforce`` to require explicit triggers.
+        """
+        if not raw:
+            return cls.ADVISE
+        try:
+            return cls(raw.strip().lower())
+        except ValueError:
+            logger.warning(
+                "Unknown CARETAKER_WEBHOOK_COMMENT_GATING %r; defaulting to 'advise'",
+                raw,
+            )
+            return cls.ADVISE
+
+
+@dataclass(frozen=True, slots=True)
+class CommentGateDecision:
+    """Outcome of evaluating the gate for a single webhook delivery.
+
+    Attributes:
+        skip: ``True`` when the dispatcher should short-circuit and not
+            resolve agents. The caller still records a metric and acks
+            the delivery.
+        outcome: Bounded label suitable for the
+            ``caretaker_webhook_events_total{outcome=...}`` metric.
+            One of ``"self_echo"``, ``"no_human_intent"``,
+            ``"human_intent"``, or ``"proceed"``.
+        verdict: The underlying :class:`DispatchVerdict` (or ``None``
+            when the event was not comment-gated, e.g. ``push``).
+        reason: Short human-readable rationale, mirroring
+            ``verdict.reason`` when present. Empty string for plain
+            proceed paths.
+    """
+
+    skip: bool
+    outcome: str
+    verdict: DispatchVerdict | None
+    reason: str
+
+
+_PROCEED = CommentGateDecision(
+    skip=False,
+    outcome="proceed",
+    verdict=None,
+    reason="",
+)
+
+
+def _extract_actor_and_body(parsed: ParsedWebhook) -> tuple[str, str | None]:
+    """Pull ``(actor_login, comment_body)`` out of a comment-event payload.
+
+    The comment object lives under different keys per event:
+
+    * ``issue_comment`` / ``pull_request_review_comment`` →
+      ``payload["comment"]``
+    * ``pull_request_review`` → ``payload["review"]``
+
+    Both shapes carry ``{"body": str, "user": {"login": str}}``. We fall
+    back to the top-level ``"sender"`` for the actor when the nested
+    user is missing (which only happens on synthetic test payloads).
+    Empty strings are returned for missing fields — callers treat
+    those as "no signal", matching :func:`legacy_dispatch_verdict`.
+    """
+    payload = parsed.payload
+    actor = ""
+    body: str | None = None
+
+    obj = payload.get("comment") or payload.get("review")
+    if isinstance(obj, dict):
+        raw_body = obj.get("body")
+        if isinstance(raw_body, str):
+            body = raw_body
+        user = obj.get("user")
+        if isinstance(user, dict):
+            login = user.get("login")
+            if isinstance(login, str):
+                actor = login
+
+    if not actor:
+        sender = payload.get("sender")
+        if isinstance(sender, dict):
+            login = sender.get("login")
+            if isinstance(login, str):
+                actor = login
+
+    return actor, body
+
+
+def evaluate_comment_gate(
+    parsed: ParsedWebhook,
+    *,
+    mode: CommentGateMode | None = None,
+) -> CommentGateDecision:
+    """Decide whether a parsed webhook should reach the agent dispatcher.
+
+    Returns :data:`_PROCEED` (``skip=False, outcome="proceed"``) for any
+    event that is not comment-gated, or when the gate is ``off``. Other
+    decisions:
+
+    * Self-echo (any mode except ``off``) →
+      ``skip=True, outcome="self_echo"``.
+    * Human intent (``advise`` or ``enforce``) →
+      ``skip=False, outcome="human_intent"`` (still runs agents, but
+      surfaces the trigger to logs/metrics).
+    * No-human-intent on a comment event in ``enforce`` mode →
+      ``skip=True, outcome="no_human_intent"``.
+    * No-human-intent on a comment event in ``advise`` mode →
+      ``skip=False, outcome="proceed"`` (no behavior change).
+
+    The optional ``mode`` argument is for tests; production reads the
+    env var via :meth:`CommentGateMode.parse`.
+    """
+    resolved_mode = mode or CommentGateMode.parse(
+        os.environ.get("CARETAKER_WEBHOOK_COMMENT_GATING")
+    )
+    if resolved_mode is CommentGateMode.OFF:
+        return _PROCEED
+    if parsed.event_type not in _COMMENT_EVENTS:
+        return _PROCEED
+
+    actor, body = _extract_actor_and_body(parsed)
+    verdict = legacy_dispatch_verdict(
+        DispatchEvent(
+            event_type=parsed.event_type,
+            actor_login=actor,
+            comment_body=body,
+        )
+    )
+
+    if verdict.is_self_echo:
+        return CommentGateDecision(
+            skip=True,
+            outcome="self_echo",
+            verdict=verdict,
+            reason=verdict.reason,
+        )
+
+    if verdict.is_human_intent:
+        return CommentGateDecision(
+            skip=False,
+            outcome="human_intent",
+            verdict=verdict,
+            reason=verdict.reason,
+        )
+
+    if resolved_mode is CommentGateMode.ENFORCE:
+        return CommentGateDecision(
+            skip=True,
+            outcome="no_human_intent",
+            verdict=verdict,
+            reason=verdict.reason,
+        )
+
+    return _PROCEED
+
+
+__all__ = [
+    "CommentGateDecision",
+    "CommentGateMode",
+    "evaluate_comment_gate",
+]

--- a/src/caretaker/github_app/dispatcher.py
+++ b/src/caretaker/github_app/dispatcher.py
@@ -48,6 +48,10 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
 
+from caretaker.github_app.comment_gate import (
+    CommentGateDecision,
+    evaluate_comment_gate,
+)
 from caretaker.github_app.events import agents_for_event
 from caretaker.observability.metrics import (
     record_error,
@@ -191,7 +195,18 @@ class WebhookDispatcher:
 
         try:
             agents = tuple(agents_for_event(parsed.event_type))
-            if self._mode is DispatchMode.OFF:
+
+            # Comment-gate runs before agent resolution: it short-circuits
+            # self-echo loops and (in ``enforce`` mode) drops comment events
+            # without an explicit ``@caretaker`` / ``/caretaker`` mention.
+            # In ``advise`` mode it flags human-intent events so operators
+            # can verify the trigger landed without changing dispatch.
+            gate = evaluate_comment_gate(parsed)
+            if gate.skip:
+                self._log_gate(parsed, gate, agents)
+                outcome = gate.outcome
+                detail = gate.reason or f"gate skipped event ({gate.outcome})"
+            elif self._mode is DispatchMode.OFF:
                 outcome = "off"
                 detail = "dispatcher disabled"
             elif not agents:
@@ -206,6 +221,19 @@ class WebhookDispatcher:
             else:  # pragma: no cover — enum exhaustive above
                 outcome = "error"
                 detail = f"unhandled dispatch mode: {self._mode}"
+
+            # Surface the human-intent trigger as its own observability
+            # signal — independently of the mode-specific outcome. Lets
+            # operators grep ``outcome="human_intent"`` to confirm
+            # ``@caretaker`` mentions are reaching the backend, without
+            # mixing them into the generic ``active`` / ``shadow`` rates.
+            if not gate.skip and gate.outcome == "human_intent":
+                self._log_gate(parsed, gate, agents)
+                record_webhook_event(
+                    event=parsed.event_type,
+                    mode=self._mode.value,
+                    outcome="human_intent",
+                )
         except Exception as exc:  # defensive; dispatch must never raise
             logger.exception(
                 "webhook dispatch failed event=%s delivery=%s: %s",
@@ -370,6 +398,33 @@ class WebhookDispatcher:
             parsed.installation_id,
             parsed.repository_full_name,
             list(agents),
+        )
+
+    def _log_gate(
+        self,
+        parsed: ParsedWebhook,
+        gate: CommentGateDecision,
+        agents: tuple[str, ...],
+    ) -> None:
+        """Emit the comment-gate verdict as a structured log line.
+
+        Fires for both skip outcomes (``self_echo``, ``no_human_intent``)
+        and the proceed-with-flag outcome (``human_intent``). The
+        ``reason`` is the short rationale from
+        :class:`~caretaker.github_app.dispatch_guard.DispatchVerdict`.
+        """
+        logger.info(
+            "webhook gate outcome=%s skip=%s event=%s action=%s "
+            "delivery=%s installation=%s repository=%s agents=%s reason=%r",
+            gate.outcome,
+            gate.skip,
+            parsed.event_type,
+            parsed.action,
+            parsed.delivery_id,
+            parsed.installation_id,
+            parsed.repository_full_name,
+            list(agents),
+            gate.reason,
         )
 
     def _log_agent_would_run(self, parsed: ParsedWebhook, agent: str) -> None:

--- a/tests/test_github_app/test_comment_gate.py
+++ b/tests/test_github_app/test_comment_gate.py
@@ -1,0 +1,214 @@
+"""Tests for the pre-dispatch comment gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from caretaker.github_app.comment_gate import (
+    CommentGateMode,
+    evaluate_comment_gate,
+)
+from caretaker.github_app.webhooks import ParsedWebhook
+
+
+def _parsed(
+    *,
+    event: str = "issue_comment",
+    body: str | None = None,
+    actor: str = "alice",
+    action: str = "created",
+) -> ParsedWebhook:
+    """Build a minimal ParsedWebhook with a comment payload."""
+    payload: dict[str, object] = {
+        "action": action,
+        "sender": {"login": actor},
+    }
+    if body is not None:
+        # ``pull_request_review`` carries the body under ``review`` and
+        # the others under ``comment`` — synthesise both shapes here so
+        # this helper works for every comment-event type the gate
+        # inspects.
+        if event == "pull_request_review":
+            payload["review"] = {"body": body, "user": {"login": actor}}
+        else:
+            payload["comment"] = {"body": body, "user": {"login": actor}}
+    return ParsedWebhook(
+        event_type=event,
+        delivery_id="00000000-0000-0000-0000-000000000001",
+        action=action,
+        installation_id=1,
+        repository_full_name="ianlintner/caretaker",
+        payload=payload,
+    )
+
+
+# ── CommentGateMode parsing ────────────────────────────────────────────
+
+
+def test_mode_parse_known_values() -> None:
+    assert CommentGateMode.parse("off") is CommentGateMode.OFF
+    assert CommentGateMode.parse("advise") is CommentGateMode.ADVISE
+    assert CommentGateMode.parse("enforce") is CommentGateMode.ENFORCE
+
+
+def test_mode_parse_defaults_to_advise() -> None:
+    # Empty / None / unknown → ADVISE so a fresh deploy gets self-echo
+    # safety without the stricter dispatch-cut.
+    assert CommentGateMode.parse(None) is CommentGateMode.ADVISE
+    assert CommentGateMode.parse("") is CommentGateMode.ADVISE
+    assert CommentGateMode.parse("strict") is CommentGateMode.ADVISE
+
+
+# ── Non-comment events bypass the gate entirely ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "event",
+    ["pull_request", "push", "check_run", "workflow_run", "ping"],
+)
+def test_non_comment_events_proceed_in_every_mode(event: str) -> None:
+    parsed = _parsed(event=event, body="@caretaker take this over")
+    for mode in CommentGateMode:
+        decision = evaluate_comment_gate(parsed, mode=mode)
+        assert decision.skip is False
+        assert decision.outcome == "proceed"
+        assert decision.verdict is None
+
+
+# ── off mode ──────────────────────────────────────────────────────────
+
+
+def test_off_mode_proceeds_even_for_self_echo() -> None:
+    parsed = _parsed(
+        body="caretaker says hi <!-- caretaker:review-result -->",
+        actor="caretaker[bot]",
+    )
+    decision = evaluate_comment_gate(parsed, mode=CommentGateMode.OFF)
+    assert decision.skip is False
+    assert decision.outcome == "proceed"
+
+
+# ── self-echo skip (advise + enforce) ─────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [CommentGateMode.ADVISE, CommentGateMode.ENFORCE],
+)
+def test_self_echo_skipped(mode: CommentGateMode) -> None:
+    """Bot actor + caretaker marker → skip with outcome=self_echo."""
+    parsed = _parsed(
+        body=("Caretaker review summary: looks good\n<!-- caretaker:review-result -->"),
+        actor="caretaker[bot]",
+    )
+    decision = evaluate_comment_gate(parsed, mode=mode)
+    assert decision.skip is True
+    assert decision.outcome == "self_echo"
+    assert decision.verdict is not None
+    assert decision.verdict.is_self_echo is True
+
+
+# ── human-intent path ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "trigger",
+    [
+        "@caretaker take this over",
+        "@the-care-taker please look",
+        "/caretaker help",
+        "/maintain ASAP",
+        "Could you take a look @CareTaker",  # case-insensitive
+    ],
+)
+def test_human_intent_recognised_in_advise(trigger: str) -> None:
+    parsed = _parsed(body=trigger, actor="alice")
+    decision = evaluate_comment_gate(parsed, mode=CommentGateMode.ADVISE)
+    assert decision.skip is False
+    assert decision.outcome == "human_intent"
+    assert decision.verdict is not None
+    assert decision.verdict.is_human_intent is True
+
+
+def test_human_intent_recognised_in_enforce() -> None:
+    parsed = _parsed(body="@caretaker take this over", actor="alice")
+    decision = evaluate_comment_gate(parsed, mode=CommentGateMode.ENFORCE)
+    assert decision.skip is False
+    assert decision.outcome == "human_intent"
+
+
+# ── no-intent (plain comment) ─────────────────────────────────────────
+
+
+def test_no_intent_advise_proceeds() -> None:
+    """Plain PR comment in advise mode → unchanged behaviour."""
+    parsed = _parsed(body="LGTM, merging soon", actor="alice")
+    decision = evaluate_comment_gate(parsed, mode=CommentGateMode.ADVISE)
+    assert decision.skip is False
+    assert decision.outcome == "proceed"
+
+
+def test_no_intent_enforce_skipped() -> None:
+    """Plain PR comment in enforce mode → drop, outcome=no_human_intent."""
+    parsed = _parsed(body="LGTM, merging soon", actor="alice")
+    decision = evaluate_comment_gate(parsed, mode=CommentGateMode.ENFORCE)
+    assert decision.skip is True
+    assert decision.outcome == "no_human_intent"
+
+
+# ── pull_request_review carries body under "review" ───────────────────
+
+
+def test_pull_request_review_body_extraction() -> None:
+    """Reviews put the body under ``review`` instead of ``comment``."""
+    parsed = _parsed(
+        event="pull_request_review",
+        body="@caretaker please address this",
+        actor="alice",
+        action="submitted",
+    )
+    decision = evaluate_comment_gate(parsed, mode=CommentGateMode.ADVISE)
+    assert decision.skip is False
+    assert decision.outcome == "human_intent"
+
+
+# ── env var read path (production default) ────────────────────────────
+
+
+def test_env_var_read_when_mode_omitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Production callers omit ``mode`` and the helper reads the env var."""
+    monkeypatch.setenv("CARETAKER_WEBHOOK_COMMENT_GATING", "enforce")
+    parsed = _parsed(body="LGTM", actor="alice")
+    decision = evaluate_comment_gate(parsed)
+    assert decision.skip is True
+    assert decision.outcome == "no_human_intent"
+
+
+def test_env_var_default_is_advise(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CARETAKER_WEBHOOK_COMMENT_GATING", raising=False)
+    parsed = _parsed(body="LGTM", actor="alice")
+    decision = evaluate_comment_gate(parsed)
+    # advise + no-intent → proceed (current behaviour preserved).
+    assert decision.skip is False
+    assert decision.outcome == "proceed"
+
+
+# ── missing payload fields fall through cleanly ───────────────────────
+
+
+def test_missing_comment_object_treated_as_no_signal() -> None:
+    """A malformed payload with no ``comment``/``review`` returns proceed
+    in advise mode — no body means no trigger and no marker, so the
+    legacy verdict is ``no_self_echo / no_human_intent``.
+    """
+    parsed = ParsedWebhook(
+        event_type="issue_comment",
+        delivery_id="00000000-0000-0000-0000-000000000001",
+        action="created",
+        installation_id=1,
+        repository_full_name="ianlintner/caretaker",
+        payload={"action": "created"},
+    )
+    decision = evaluate_comment_gate(parsed, mode=CommentGateMode.ADVISE)
+    assert decision.skip is False
+    assert decision.outcome == "proceed"

--- a/tests/test_github_app/test_dispatcher.py
+++ b/tests/test_github_app/test_dispatcher.py
@@ -432,3 +432,193 @@ async def test_dispatch_in_background_drops_when_in_flight_cap_reached(
     # The done callback runs on the next event-loop tick.
     await asyncio.sleep(0)
     assert in_flight_count() == starting
+
+
+# ── comment gate (self-echo / human-intent) ──────────────────────────
+
+
+def _make_comment_parsed(
+    *,
+    body: str,
+    actor: str,
+    event: str = "issue_comment",
+    delivery: str = "00000000-0000-0000-0000-000000aaaa01",
+) -> ParsedWebhook:
+    """ParsedWebhook with a realistic ``issue_comment`` payload shape."""
+    return ParsedWebhook(
+        event_type=event,
+        delivery_id=delivery,
+        action="created",
+        installation_id=42,
+        repository_full_name="ianlintner/caretaker",
+        payload={
+            "action": "created",
+            "comment": {"body": body, "user": {"login": actor}},
+            "sender": {"login": actor},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_self_echo_short_circuits_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caretaker's own bot-authored comment with the marker → skip.
+
+    No agents resolve, no factory build, no runner call. The result
+    envelope carries ``outcome="self_echo"`` so operators can see it on
+    the metric and structured log.
+    """
+    monkeypatch.setenv("CARETAKER_WEBHOOK_COMMENT_GATING", "advise")
+
+    factory = _FakeFactory()
+    runner = _RecordingRunner(outcomes={})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+    )
+
+    parsed = _make_comment_parsed(
+        body="Caretaker review: LGTM\n<!-- caretaker:review-result -->",
+        actor="caretaker[bot]",
+    )
+    result = await dispatcher.dispatch(parsed)
+
+    assert result.outcome == "self_echo"
+    # Critically: no agent ran, no installation token was minted.
+    assert factory.builds == []
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_human_intent_proceeds_in_advise_and_emits_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``@caretaker take this over`` from a human → agents still run,
+    but a structured ``webhook gate outcome=human_intent`` log line
+    fires so operators can confirm the trigger landed."""
+    monkeypatch.setenv("CARETAKER_WEBHOOK_COMMENT_GATING", "advise")
+
+    factory = _FakeFactory()
+    runner = _RecordingRunner(outcomes={"issue": "success", "pr": "success"})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+    )
+
+    parsed = _make_comment_parsed(
+        body="@caretaker take this over",
+        actor="alice",
+    )
+
+    with caplog.at_level("INFO", logger="caretaker.github_app.dispatcher"):
+        result = await dispatcher.dispatch(parsed)
+
+    # Underlying dispatch ran agents normally.
+    assert result.outcome == "active"
+    assert runner.calls == ["issue", "pr"]
+    # Plus the gate logged its verdict — operators grep this in production.
+    gate_lines = [
+        r.message for r in caplog.records if "webhook gate outcome=human_intent" in r.message
+    ]
+    assert len(gate_lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_advise_mode_no_intent_proceeds_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A regular PR comment (no @caretaker) in advise mode dispatches
+    agents exactly as before — the gate is purely additive."""
+    monkeypatch.setenv("CARETAKER_WEBHOOK_COMMENT_GATING", "advise")
+
+    factory = _FakeFactory()
+    runner = _RecordingRunner(outcomes={"issue": "success", "pr": "success"})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+    )
+
+    parsed = _make_comment_parsed(body="LGTM, merging soon", actor="alice")
+    result = await dispatcher.dispatch(parsed)
+
+    assert result.outcome == "active"
+    assert runner.calls == ["issue", "pr"]
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_drops_comments_without_explicit_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In enforce mode, plain comments don't dispatch agents at all —
+    only ``@caretaker``/``/caretaker`` mentions do."""
+    monkeypatch.setenv("CARETAKER_WEBHOOK_COMMENT_GATING", "enforce")
+
+    factory = _FakeFactory()
+    runner = _RecordingRunner(outcomes={})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+    )
+
+    parsed = _make_comment_parsed(body="LGTM, merging soon", actor="alice")
+    result = await dispatcher.dispatch(parsed)
+
+    assert result.outcome == "no_human_intent"
+    assert factory.builds == []
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_off_mode_disables_gate_entirely(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CARETAKER_WEBHOOK_COMMENT_GATING=off`` reverts to legacy: even
+    self-echoes dispatch agents (which then no-op via their own marker
+    checks). Provides an instant rollback knob if the gate misbehaves."""
+    monkeypatch.setenv("CARETAKER_WEBHOOK_COMMENT_GATING", "off")
+
+    factory = _FakeFactory()
+    runner = _RecordingRunner(outcomes={"issue": "success", "pr": "success"})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+    )
+
+    parsed = _make_comment_parsed(
+        body="LGTM <!-- caretaker:review-result -->",
+        actor="caretaker[bot]",
+    )
+    result = await dispatcher.dispatch(parsed)
+
+    # off mode: gate is bypassed → agents run as today.
+    assert result.outcome == "active"
+    assert runner.calls == ["issue", "pr"]
+
+
+@pytest.mark.asyncio
+async def test_non_comment_event_unaffected_by_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``pull_request.opened`` is state-driven; the gate must never
+    short-circuit it even in enforce mode."""
+    monkeypatch.setenv("CARETAKER_WEBHOOK_COMMENT_GATING", "enforce")
+
+    factory = _FakeFactory()
+    runner = _RecordingRunner(outcomes={"pr": "success", "pr-reviewer": "success"})
+    dispatcher = WebhookDispatcher(
+        mode=DispatchMode.ACTIVE,
+        context_factory=factory,  # type: ignore[arg-type]
+        agent_runner=runner,  # type: ignore[arg-type]
+    )
+
+    result = await dispatcher.dispatch(_make_parsed(event="pull_request"))
+
+    assert result.outcome == "active"
+    assert runner.calls == ["pr", "pr-reviewer"]


### PR DESCRIPTION
## Summary

Adds a tiny pre-dispatch gate for `issue_comment` / `pull_request_review` / `pull_request_review_comment` webhook events. Solves two real problems surfaced while debugging [#630](https://github.com/ianlintner/caretaker/pull/630):

1. **Self-echo loops.** When caretaker posts a comment, GitHub fires an `issue_comment.created` webhook back at us. Today the dispatcher fan-outs `["issue", "pr"]` agents on those bounces — defence-in-depth on top of each agent's own marker check is missing. The gate now short-circuits at the dispatcher level with `outcome="self_echo"`, no installation token minted, no agent run.

2. **Silent `@caretaker` requests.** A user typed `@caretaker take this over` on #630 and there was no signal anywhere in production that the trigger had been received. Now an explicit `@caretaker` / `@the-care-taker` / `/caretaker` / `/maintain` from a non-bot actor emits a structured `webhook gate outcome=human_intent ...` log line plus an extra `caretaker_webhook_events_total{outcome=\"human_intent\"}` metric sample. Operators can grep the metric to confirm a trigger landed, separate from the generic active/shadow rates.

The gate re-uses the existing `legacy_dispatch_verdict` from `dispatch_guard.py` — there's no new trigger-string source of truth.

## Mode selection

`CARETAKER_WEBHOOK_COMMENT_GATING`:

| Value | Behavior |
|---|---|
| `off` | No gating; legacy behavior. Instant rollback knob. |
| `advise` (default) | Self-echo skipped; human-intent observed (log + extra metric); plain comments dispatch as today. |
| `enforce` | Also drop comment events with no explicit trigger. |

`advise` is the safe default because the only behavior change is on self-echo events — and those were already expected to no-op via per-agent marker checks. We're just doing it earlier and saving a token mint + agent fan-out.

## Files

- New: [src/caretaker/github_app/comment_gate.py](src/caretaker/github_app/comment_gate.py) — 220 lines, fully documented, pure stdlib + existing `dispatch_guard`.
- Modified: [src/caretaker/github_app/dispatcher.py](src/caretaker/github_app/dispatcher.py) — calls `evaluate_comment_gate` before agent resolution; new `_log_gate` helper.
- Modified: [src/caretaker/github_app/__init__.py](src/caretaker/github_app/__init__.py) — re-exports `CommentGateDecision`, `CommentGateMode`, `evaluate_comment_gate`.
- New: [tests/test_github_app/test_comment_gate.py](tests/test_github_app/test_comment_gate.py) — 22 unit tests.
- Modified: [tests/test_github_app/test_dispatcher.py](tests/test_github_app/test_dispatcher.py) — 6 integration tests that exercise the gate through `WebhookDispatcher.dispatch`.
- [CHANGELOG.md](CHANGELOG.md) — Unreleased / Added entry.

## Test plan

- [x] `pytest tests/test_github_app/ tests/test_runs_trigger_eventbus.py tests/test_eventbus_webhook_integration.py tests/test_metrics.py` — **171 passed** locally.
- [x] Pre-commit: ruff format, ruff check, mypy strict (261 source files) all clean.
- [x] Self-echo case (verbatim from a real caretaker review comment) → `factory.builds == [] and runner.calls == []`. No installation token minted on caretaker's own bounces.
- [x] Human-intent case (`@caretaker take this over` from a non-bot actor) → agents still run, plus the structured log line fires. Asserted via `caplog`.
- [ ] Post-deploy: verify `caretaker_webhook_events_total{outcome=\"self_echo\"}` and `{outcome=\"human_intent\"}` samples appear in Prometheus once a real comment lands. (This is the metric that #632 unblocked — the two PRs are companions.)

## Companion to #632

[#632](https://github.com/ianlintner/caretaker/pull/632) restores the `caretaker_http_server_*` and `caretaker_webhook_events_total` middleware that's been silently broken since #631 deployed. **This PR puts useful signal into that metric stream.** Without #632 the new `outcome=\"human_intent\"` / `outcome=\"self_echo\"` labels wouldn't be visible in production.

## Out of scope (deliberate)

This PR does **not** spawn a dedicated takeover worker, post an acknowledgment comment, or wire `@caretaker` to `runs_dispatch.run_trigger`. Those are separate behavior-change PRs that need product decisions (what should the takeover do? does it post an ACK? what idempotency guarantees?). The gate established here is the foundation those PRs will build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)