### PR TITLE
ci(deploy-mcp): use replace --force for the agent-worker Job

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -98,13 +98,20 @@ jobs:
           # ``ServiceAccount "caretaker-mcp" not found``.
           kubectl apply \
             -n "${{ vars.CARETAKER_MCP_NAMESPACE }}" \
-            -f infra/k8s/caretaker-mcp-serviceaccount.yaml \
-            -f infra/k8s/caretaker-agent-worker.yaml
+            -f infra/k8s/caretaker-mcp-serviceaccount.yaml
 
-          # `replace --force` deletes and recreates the Deployment to reconcile
-          # stale unmanaged fields from a prior manual `kubectl apply` — a
-          # regular apply/server-side-apply cannot remove an unmanaged `value`
-          # on an env entry that we now declare via `valueFrom`.
+          # `replace --force` deletes and recreates resources whose specs are
+          # immutable in-place:
+          #   - caretaker-agent-worker.yaml ships a Job (alongside its SA/RBAC),
+          #     and Job.spec.template is immutable, so any pod-spec change
+          #     (e.g. new env vars) fails a plain `kubectl apply`.
+          #   - caretaker-mcp-deployment.yaml is force-replaced to clear
+          #     unmanaged fields from prior manual applies (a regular apply
+          #     can't remove an unmanaged `value` on an env entry that we now
+          #     declare via `valueFrom`).
+          kubectl replace --force \
+            -n "${{ vars.CARETAKER_MCP_NAMESPACE }}" \
+            -f infra/k8s/caretaker-agent-worker.yaml
           kubectl replace --force \
             -n "${{ vars.CARETAKER_MCP_NAMESPACE }}" \
             -f infra/k8s/caretaker-mcp-deployment.yaml


### PR DESCRIPTION
## Summary
- The deploy-mcp workflow was halting at `Apply manifests` whenever a PR changed the agent-worker pod spec (most recently #631's OTel env vars), because `Job.spec.template` is immutable and `kubectl apply` errors out.
- Switch the agent-worker manifest to `kubectl replace --force` — same pattern already used for `caretaker-mcp-deployment.yaml`. The SA-only file stays on a regular apply.

## Test plan
- [x] Repro confirmed in run [25019832593](https://github.com/ianlintner/caretaker/actions/runs/25019832593): apply step failed with `Job ... spec.template: field is immutable`.
- [x] Manual workaround validated: deleting the stale Job let run [25020016119](https://github.com/ianlintner/caretaker/actions/runs/25020016119) succeed and rolled v0.26.0 to the cluster.
- [ ] Next deploy-mcp run after this PR merges should succeed without manual Job deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)