### PR TITLE
fix(setup-templates): drop pip cache from thin maintainer workflow

### DIFF
--- a/setup-templates/templates/workflows/maintainer.yml
+++ b/setup-templates/templates/workflows/maintainer.yml
@@ -68,7 +68,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: "pip"
 
       - name: Install caretaker (thin client only)
         run: |


### PR DESCRIPTION
## Summary

- The thin streaming workflow at `setup-templates/templates/workflows/maintainer.yml` deliberately skips `actions/checkout`, so `actions/setup-python@v5` with `cache: "pip"` errors out before pip can run: `No file in <workspace> matched to [**/requirements.txt or **/pyproject.toml]`.
- Drop the `cache: "pip"` line. Caretaker installs exactly one wheel per run on a 6-hour cron; pip caching adds negligible value, and adding a checkout / synthetic dependency file purely to enable cache would be more code for no benefit.
- This fixes new installs. Already-bootstrapped repos (e.g. `space-tycoon`) still have the broken file and will get separate one-line PRs.

Failing run that surfaced this: https://github.com/ianlintner/space-tycoon/actions/runs/25028462523/job/73304781723

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('setup-templates/templates/workflows/maintainer.yml'))"` parses cleanly.
- [x] `pytest tests/test_bootstrap_agent.py tests/test_review_fixes.py -q` → 23 passed.
- [ ] Post-merge: cut a patch release and confirm `space-tycoon`'s next scheduled `Caretaker` run succeeds (after its own one-line PR lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)