### PR TITLE
fix(thin-workflow): use correct PyPI dist name caretaker-github

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -58,11 +58,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: "pip"
 
       - name: Install caretaker (thin client only)
         run: |
-          pip install --quiet -e .
+          # Match the published-template form so dogfood validates the
+          # exact path consumer repos run. PyPI dist name is
+          # "caretaker-github"; the console script is `caretaker`.
+          pip install --quiet "caretaker-github"
 
       - name: Stream a backend-executed run
         run: |

--- a/docs/fleet-qa-2026-04-28.md
+++ b/docs/fleet-qa-2026-04-28.md
@@ -1,0 +1,306 @@
+# Fleet QA Report — 2026-04-28
+
+Research pass over runs in the caretaker-managed fleet, with prioritized fixes
+toward the stated goal: **"autonomous repo automation with minimal human
+interaction until needed."**
+
+Approach matches the project's research philosophy: **let the AI misbehave in
+safe places (caretaker-qa, dogfood), observe, then add guardrails**.
+
+## 1. Fleet snapshot
+
+| Repo | Latest run | Open PRs | Open issues | Notable |
+| --- | --- | --- | --- | --- |
+| `caretaker` (dogfood) | failure (every run since 2026-04-27 18:59) | — | — | thin workflow broken |
+| `space-tycoon` | failure (since 2026-04-27 18:59) | 15 | 2 | scope-gap closed; 14 human PRs in flight |
+| `caretaker-qa` | mixed (cron success, agent runs cancelled) | 8 | 7 | QA scenarios working as designed |
+| `audio_engineer` | failure | 5 | 5 | self-heal issues piling up (#83, #95) |
+| `flashcards` | failure | 1 | 5 | self-heal #29, #16, build-failure #11 |
+| `AI-Pipeline` | failure | 1 | 10 | **7 stuck upgrade issues** (v0.9.0 → v0.19.2) |
+| `rust-oauth2-server` | failure | 1 | 2 | clean otherwise |
+
+## 2. Findings
+
+### F1 (P0, fleet-wide outage) — Wrong PyPI package in thin workflow
+
+Every scheduled `Caretaker` workflow run across the fleet has been failing since
+the v0.20.0 thin-workflow migration with:
+
+```
+caretaker: command not found
+exit code 127
+```
+
+Root cause: `setup-templates/templates/workflows/maintainer.yml:78`
+
+```yaml
+pip install --quiet "caretaker"
+```
+
+The PyPI distribution is named **`caretaker-github`** (per `pyproject.toml`).
+There is an unrelated project on PyPI literally named `caretaker` ("Technology
+demonstrator self-adapting code") which gets silently installed instead and
+provides no `caretaker` console script.
+
+The pre-migration line was `pip install "git+...caretaker.git@v${VERSION}"`,
+which worked because git installs use the package's distribution name from
+`pyproject.toml`. The PyPI rewrite hard-coded the wrong name.
+
+The dogfood file `.github/workflows/maintainer.yml` has a *different* version
+of the same bug: it does `pip install --quiet -e .` with no `actions/checkout`
+step before it, so there's no source tree to install — plus `cache: "pip"` was
+re-introduced after #636 dropped it from the template (see F1b).
+
+**Webhook path is unaffected** — the backend executes everything; only the
+sparse 6-hour cron + manual `workflow_dispatch` is broken. So the impact is
+"safety net is broken, not the primary path." Still P0 because operator
+trigger and webhook-miss recovery are both compromised.
+
+### F1b — `cda5851` cache fix did not propagate to dogfood
+
+PR #636 removed `cache: "pip"` from the template, but the dogfood
+`.github/workflows/maintainer.yml` still has it on line 61. Fixing one without
+the other is a marker that the dogfood file isn't generated from the template
+or referenced by tests.
+
+### F2 (P1) — Upgrade-issue accumulation
+
+`AI-Pipeline` has **7 open `[Maintainer] Upgrade ...` issues** for versions
+spanning v0.9.0 → v0.19.2. Each new upgrade target opens a new issue without
+closing the prior one. The fleet has been bumped to v0.26.1 since.
+
+```
+#26 [Maintainer] Upgrade to v0.19.2
+#23 [Maintainer] Upgrade to v0.19.1
+#21 [Maintainer] Upgrade to v0.17.0
+#20 [Maintainer] Upgrade to v0.14.0  (breaking)
+#18 [Maintainer] Upgrade to v0.10.2
+#16 [Maintainer] Upgrade to v0.10.0  (breaking)
+#14 [Maintainer] Upgrade to v0.9.0
+```
+
+The upgrade comment marker `<!-- caretaker:upgrade target=X.Y.Z -->` is
+present but the agent doesn't grep prior issues by marker and supersede.
+
+### F3 (P1) — Self-heal issue lifecycle
+
+`audio_engineer` and `flashcards` accumulate `caretaker:self-heal` issues that
+never close even after subsequent runs succeed. Examples:
+
+* `audio_engineer` #83 "Unknown caretaker failure" + #95 "Config error"
+* `flashcards` #16 "Unknown caretaker failure" + #29 "Config error"
+
+The self-heal path opens a bug per failure event. There's PR-side close logic
+in `charlie_agent` (closes self-heal issues when the PR fixing them merges),
+but no **issue-side reaper** for "the failure has stopped recurring for N
+runs." Plus the migration to backend-side `self_heal_trigger` (per #621)
+left old, Actions-era self-heal issues orphaned — they're never re-evaluated.
+
+### F4 (P1) — `scope-gap` issue points at the wrong file
+
+The `scope-gap` issue body (e.g. `space-tycoon` #65, `flashcards` #27)
+recommends pasting a `permissions:` block into `.github/workflows/maintainer.yml`.
+After the v0.20.0 migration, **the runner workflow no longer makes those API
+calls** — the backend does, with the GitHub App's installation token. Adding
+permissions to the runner's `GITHUB_TOKEN` won't help; the App installation
+needs the scopes.
+
+Excellent pattern (clear ask, observed evidence, concrete fix block) but
+pointing at the wrong knob post-migration.
+
+### F5 (P2) — Escalation calibration: can't tell "didn't try" from "gave up"
+
+`caretaker-qa` PR #3 was escalated with reason `"Open >24h with no human
+approval"`. The debug dump shows:
+
+```json
+{ "copilot_attempts": 0, "fix_cycles": 0,
+  "stuck_reason": "abandoned", "stuck_confidence": 0.5 }
+```
+
+Zero attempts and zero cycles, but escalated as "abandoned." For a human
+reviewer this is ambiguous — did caretaker try and fail, or never engage?
+The label `maintainer:escalated` is overloaded.
+
+This particular PR is *intentionally* abandoned (a QA scenario), so the
+behavior isn't wrong — but the **labeling** doesn't surface that distinction.
+
+### F6 (works as designed)
+
+* **Bot CHANGELOG PRs** (`docs: reconcile CHANGELOG — 2026-W18`) — well
+  formatted, list all merges, propose entries. Working.
+* **Upgrade PRs** (`copilot-swe-agent` opens draft, requests owner review,
+  pins version) — working as designed.
+* **caretaker-qa scenarios** — purposely-broken PRs sit, get escalated,
+  surface in weekly digest. This *is* the safe-misbehavior loop.
+* **Backend health** — `/health` 200, v0.26.0 (one minor behind v0.26.1
+  client release; no impact).
+* **Causal-id annotation** in agent comments — every comment carries
+  `caretaker:causal id=...` which makes after-the-fact tracing tractable.
+
+## 3. Goal alignment
+
+Stated goal: **autonomous repo automation, minimal human interaction until
+needed**.
+
+| Sub-goal | Status |
+| --- | --- |
+| Real-time webhook execution | ✅ working (per backend `dispatch_mode: active`) |
+| Sparse cron safety net | ❌ broken fleet-wide (F1) |
+| Self-bootstrap on install | ✅ idempotent, working |
+| Self-upgrade | ⚠️ opens PRs but accumulates stale upgrade issues (F2) |
+| Self-heal | ⚠️ opens issues, doesn't reap (F3) |
+| Escalation digest (weekly) | ✅ surfacing items, well-formatted |
+| Scope-gap detection | ⚠️ correct detection, wrong remediation text (F4) |
+| Escalation calibration | ⚠️ no signal for "tried-and-failed" vs "untried" (F5) |
+| Backend observability | ⚠️ admin SPA exists, no public digest endpoint |
+
+Net: the **happy path works**; the **failure-recovery and stale-state paths**
+are where guardrails are missing. This matches the user's "let it misbehave,
+then guardrail" philosophy — the misbehavior is now well-cataloged.
+
+## 4. Plan — prioritized fixes
+
+### P0 — Restore fleet cron/dispatch (today)
+
+**4.1** In `setup-templates/templates/workflows/maintainer.yml:78`, change
+`pip install --quiet "caretaker"` → `pip install --quiet "caretaker-github"`.
+*Optional hardening:* pin to `>=0.26.1,<1.0` so the runner can't silently
+get a much newer client than the backend supports.
+
+**4.2** Fix dogfood `.github/workflows/maintainer.yml`:
+* drop `cache: "pip"` (consistency with #636)
+* either add an `actions/checkout` step before `pip install -e .`, OR
+  switch to `pip install --quiet "caretaker-github"` like the template
+* recommended: switch to the template form and **delete the dogfood
+  divergence** — dogfood should literally use the template
+
+**4.3** Fleet rollout. Bootstrap agent skips repos with the marker (by
+design). Two viable paths:
+
+* **A.** Add a one-shot **template-drift agent** that diffs the deployed
+  `maintainer.yml` against the current template and opens a PR if the install
+  line / install command has materially diverged. Runs on the backend cron.
+* **B.** Hand-curated one-line PRs to each fleet repo (faster, less code).
+
+Both are reasonable. A is closer to the system's autonomy goal; B is faster.
+**See "Decisions for review" §5.**
+
+### P1 — Stale-state guardrails (next)
+
+**4.4** Upgrade-issue supersession. In `upgrade_agent`, before opening a new
+`[Maintainer] Upgrade to vX.Y.Z` issue, search open issues by the
+`<!-- caretaker:upgrade -->` marker. If the older target is now
+satisfied (current version >= older target), close the older issue with a
+`superseded by #N` comment. Add a smoke test in caretaker-qa for this.
+
+**4.5** Self-heal issue reaper. In `stale_agent` (which already lists
+`caretaker:self-heal` in its label set), add a rule: if no failed run with
+the same root-cause hash has occurred in N=3 consecutive runs, close the
+issue with a "no-recurrence" comment. Hash on the run's failure signature,
+not the rendered title (so renames don't fool it).
+
+**4.6** Rewrite `scope-gap` issue body for the App-installation reality.
+Detect whether the repo is on the thin workflow (no permissions: block has
+the listed scopes) and direct to:
+
+```
+Open https://github.com/settings/installations/<id> →
+"Permissions" → grant: Checks (write), Code scanning alerts (read),
+Secret scanning alerts (read).
+```
+
+Plus a one-liner to re-open the issue if the App still gets 403 next run.
+
+### P2 — Calibration & ergonomics
+
+**4.7** Split `maintainer:escalated` into two labels:
+
+* `maintainer:escalated:exhausted` — tried and gave up (`copilot_attempts > 0`
+  or `fix_cycles > 0`)
+* `maintainer:escalated:untouched` — sat past threshold without any agent
+  engagement
+
+Update the weekly digest to render them in separate buckets. Reviewer can
+prioritize "the system tried hard and is stuck" before "the system never
+looked."
+
+**4.8** Per-PR comment rate limit. Cap any single agent at N comments per
+PR per 24h, exponential backoff on retries. Detected via causal-id parent
+chain. (Pure preventive guardrail; no observed runaway yet, but it's
+cheap insurance.)
+
+### P3 — Observability for the human-review loop
+
+**4.9** Public `/api/fleet/digest.json` endpoint on the backend that
+aggregates per-repo open work, run-success rate, last-failure timestamp.
+Becomes the canonical "weekly work report" the human reads — replaces
+poking at GitHub UI repo by repo.
+
+**4.10** Refresh the per-repo orchestrator-state issue body on every run
+(it currently says only "Do not close or modify"). Make it a live status
+card: last 5 runs, current open caretaker-owned PRs/issues, current goal
+scores. Then opening that issue *is* the report.
+
+## 5. Decisions for review
+
+These are the choices where the call shapes the system materially. **In
+learning mode: I've described trade-offs and want your input** before
+implementing P0.4.3, P1.4.4, and P2.4.7.
+
+### D1 — Fleet rollout strategy (relates to §4.3)
+
+> **A. Template-drift agent** — backend cron compares deployed
+> `maintainer.yml` against template, opens an "update workflow" PR per drift.
+> Cost: new agent + tests. Benefit: scales to every future template change
+> without a per-incident scramble.
+>
+> **B. Hand-curated one-line PRs** — open ~9 PRs today, done. Cost: zero
+> code. Benefit: instant. Drawback: same problem next time the template
+> changes.
+>
+> **Recommendation:** A long-term, B today. Land B as one PR-per-repo via
+> a small script, then build A as the proper guardrail. (Matches the
+> philosophy: stop the bleeding, then write the guardrail.)
+
+**Your call:** A only / B only / B-then-A?
+
+### D2 — Upgrade-issue supersession granularity (relates to §4.4)
+
+> **a)** Close older upgrade issues silently with a comment.
+> **b)** Close them and link the new issue ("subsumes #14, #16, #18, ...").
+> **c)** Don't open a new issue at all if N>0 prior upgrade issues exist;
+> instead, edit-in-place the latest one and bump its target.
+>
+> (c) is the most "minimal human noise" but loses history. (b) is the
+> most legible. (a) is simplest.
+>
+> **Recommendation:** (b). Causal-id chain already supports parent links;
+> use those.
+
+**Your call:** a / b / c / different?
+
+### D3 — Escalation label split (relates to §4.7)
+
+> Adding two labels increases label-cardinality. Worth it?
+>
+> **Recommendation:** yes — current label hides the most actionable
+> distinction (exhausted = needs design judgment from human; untouched =
+> probably config gap, much faster to triage).
+
+**Your call:** ship as proposed / single label with a body field instead /
+skip?
+
+## 6. Out of scope (called out, not flagged for action)
+
+* QA scenarios in `caretaker-qa` (PR #3, #6, #19, #61, #63, #66) — these
+  are deliberate misbehavior tests; their staleness is the point.
+* `space-tycoon` 14 human-authored PRs — user is mid-feature-sprint; not
+  a caretaker concern.
+* Backend version skew (`v0.26.0` running, `v0.26.1` published) — within
+  one patch; no breaking changes; will resolve next deploy.
+* `rust-oauth2-server` issue #284 — looks human-filed, no caretaker label.
+
+---
+
+Generated 2026-04-28 from a one-pass survey across the fleet.

--- a/setup-templates/templates/workflows/maintainer.yml
+++ b/setup-templates/templates/workflows/maintainer.yml
@@ -72,10 +72,11 @@ jobs:
       - name: Install caretaker (thin client only)
         run: |
           # The thin client needs only the runs shipper; no agent code,
-          # no orchestrator, no LLM dependencies. The version is pinned
-          # to the latest published release so the runner does not run
-          # ahead of the backend.
-          pip install --quiet "caretaker"
+          # no orchestrator, no LLM dependencies. The PyPI distribution
+          # is "caretaker-github" (the package name "caretaker" is taken
+          # by an unrelated project). The console script it ships is
+          # still `caretaker`, matching what the next step invokes.
+          pip install --quiet "caretaker-github"
 
       - name: Stream a backend-executed run
         run: |


### PR DESCRIPTION
## Summary

- Thin streaming workflow installed `caretaker` from PyPI, which is an unrelated project ("Technology demonstrator self-adapting code"). Actual distribution name is **`caretaker-github`**; console script it ships is still `caretaker`.
- Every scheduled / dispatch run across the fleet has been failing since the v0.20 thin-workflow migration with `caretaker: command not found` (exit 127).
- Webhook execution path is unaffected (backend executes everything); this broke the **safety net** (sparse cron + `workflow_dispatch`), not the primary path. Still P0 because operator-trigger + webhook-miss recovery are both compromised.
- Dogfood `.github/workflows/maintainer.yml` had a sibling bug — re-introduced `cache: "pip"` after #636 dropped it, plus `pip install -e .` with no checkout step. Replaced with the canonical template form so dogfood validates the exact path consumer repos run.

## Fleet QA report

Full findings and prioritized plan in `docs/fleet-qa-2026-04-28.md`. Headlines:

| | |
|---|---|
| **P0** | this PR — wrong PyPI package |
| **P1** | upgrade-issue accumulation (AI-Pipeline has 7 stuck), self-heal issue reaper missing, `scope-gap` remediation text points at wrong knob post-migration |
| **P2** | escalation label `maintainer:escalated` overloads "tried-and-failed" with "untouched" |

## Test plan

- [ ] CI on this PR passes (lint, tests, the maintain job — which now actually runs)
- [ ] After merge + release: kick a `workflow_dispatch` run on `caretaker` itself and confirm `caretaker stream` resolves
- [ ] Per-repo one-line PRs follow for every fleet repo with the broken thin workflow (separate PRs in each downstream)
- [ ] Re-check fleet `Caretaker` runs 6h after rollout — failure rate should drop to baseline

## Already-deployed copies

The bootstrap agent is idempotent and skips repos that already have the marker, so deployed templates won't auto-update. Per-repo PRs are being opened separately. A future template-drift agent (P1 in the QA report) is the structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)