### PR TITLE
fix(pr-agent): finalize readiness check for untracked closed PRs

### DIFF
--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -224,8 +224,17 @@ class PRAgent:
                 # forever, like it did on PR #609). One-shot finalization
                 # gated by ``readiness_check_finalized`` so we don't repost
                 # on every subsequent webhook for the same PR.
+                #
+                # Synthesise tracking when none exists so a PR that closed
+                # before the first agent run could persist tracking still
+                # gets its readiness check terminated. caretaker-qa#79 hit
+                # this: opened 2026-04-28T08:53Z, merged 23:18Z, never
+                # appeared in tracked_prs, and the readiness check at the
+                # head SHA stayed ``in_progress`` indefinitely.
                 tracking = tracked_prs.get(pr.number)
-                if tracking is not None and not tracking.readiness_check_finalized:
+                if tracking is None:
+                    tracking = TrackedPR(number=pr.number)
+                if not tracking.readiness_check_finalized:
                     try:
                         await self._finalize_readiness_check(pr, tracking)
                     except Exception as exc:  # noqa: BLE001 — never fail the agent
@@ -235,7 +244,7 @@ class PRAgent:
                             type(exc).__name__,
                             exc,
                         )
-                    tracked_prs[pr.number] = tracking
+                tracked_prs[pr.number] = tracking
                 return report, tracked_prs
             open_prs = [pr]
         else:

--- a/tests/test_pr_agent/test_agent.py
+++ b/tests/test_pr_agent/test_agent.py
@@ -2208,6 +2208,54 @@ class TestTerminalReadinessOnCloseMerge:
         report2, tracked2 = await agent.run(tracked, pr_number=609)
         github.create_check_run.assert_not_awaited()
 
+    async def test_run_finalizes_readiness_check_for_untracked_merged_pr(self) -> None:
+        """run() with pr_number for a merged PR that was never tracked
+        (state save lost between open and merge, or the PR closed before
+        the first agent run could persist tracking) must still finalize
+        the readiness check — otherwise it dangles ``in_progress`` forever.
+
+        Live incident: caretaker-qa#79. Opened 2026-04-28T08:53Z, merged
+        2026-04-28T23:18Z. Never appeared in ``tracked_prs`` (the state
+        snapshot at 00:15Z next day had 36 entries, none for #79). The
+        ``caretaker/pr-readiness`` check at the head SHA stayed
+        ``in_progress`` with no terminal conclusion because the merge-time
+        finalize gate at ``_run`` line 228 was guarded by
+        ``tracking is not None and not tracking.readiness_check_finalized``.
+        """
+        from datetime import UTC, datetime
+
+        github = AsyncMock()
+        merged_pr = make_pr(
+            number=79,
+            head_ref="copilot/upgrade",
+            merged=True,
+            state=PRState.CLOSED,
+        )
+        merged_pr.head_sha = "b23447de"
+        merged_pr.merged_at = datetime(2026, 4, 28, 23, 18, tzinfo=UTC)
+        github.get_pull_request = AsyncMock(return_value=merged_pr)
+        github.find_check_run = AsyncMock(return_value=None)
+        github.create_check_run = AsyncMock(return_value={"id": 7})
+
+        agent = self._agent(github)
+        # Critical: tracked_prs is EMPTY — this PR was never tracked.
+        tracked: dict[int, TrackedPR] = {}
+
+        report, tracked = await agent.run(tracked, pr_number=79)
+
+        # Finalization must happen even though tracking didn't exist on entry.
+        github.create_check_run.assert_awaited_once()
+        assert github.create_check_run.call_args.kwargs["conclusion"] == "success"
+        # A tracking entry should have been lazily created and marked finalized
+        # so a subsequent run() is a no-op (idempotency preserved).
+        assert 79 in tracked
+        assert tracked[79].readiness_check_finalized is True
+
+        # Replay the merge event: must NOT re-publish the check.
+        github.create_check_run.reset_mock()
+        await agent.run(tracked, pr_number=79)
+        github.create_check_run.assert_not_awaited()
+
 
 class TestTerminalReadinessOnEscalation:
     """An escalated PR has been handed off to humans — the readiness


### PR DESCRIPTION
## Summary

A PR that closes/merges before the first agent run could persist its `TrackedPR` entry was being skipped at the post-close finalize gate ([`pr_agent/agent.py:228`](src/caretaker/pr_agent/agent.py:228)), leaving its `caretaker/pr-readiness` GitHub Check stuck `in_progress` indefinitely.

## Root cause

```python
# Before
tracking = tracked_prs.get(pr.number)
if tracking is not None and not tracking.readiness_check_finalized:
    await self._finalize_readiness_check(pr, tracking)
```

When `tracking is None`, the gate skips. `_finalize_readiness_check` actually only needs `tracking.readiness_score` / `readiness_blockers` / `readiness_summary` (all default to `0` / `[]` / `None`) to build the synthetic evaluation, and `_publish_readiness_check` short-circuits to `success` (merged) / `neutral` (closed) on the terminal-state branch regardless of those fields. So the missing-tracking case was preventable by lazy-init.

## Fix

```python
# After
tracking = tracked_prs.get(pr.number)
if tracking is None:
    tracking = TrackedPR(number=pr.number)
if not tracking.readiness_check_finalized:
    await self._finalize_readiness_check(pr, tracking)
tracked_prs[pr.number] = tracking
```

The lazily-created entry is folded into `tracked_prs` and marked `readiness_check_finalized=True` so the next webhook for the same closed PR remains a no-op — idempotency preserved.

## Live incident

`caretaker-qa#79`:
- Opened 2026-04-28T08:53Z by Copilot (upgrade pin v0.25.0 → v0.26.1)
- `caretaker/pr-readiness` check created at 08:55:54Z (head SHA `b23447de`)
- Merged 2026-04-28T23:18Z
- Never appeared in the orchestrator state snapshot at 00:15Z next day (36 tracked PRs, none for #79)
- Readiness check at the head SHA stayed `in_progress` with no terminal conclusion through the un-draft, merge, and the linked-issue (#77) auto-close — all the events that should have triggered finalization.

## Tests

`tests/test_pr_agent/test_agent.py` adds `test_run_finalizes_readiness_check_for_untracked_merged_pr`:

- `run(tracked={}, pr_number=79)` on a merged PR creates a check_run with `conclusion=success`
- A tracking entry is lazily created with `readiness_check_finalized=True`
- Replaying the same merge event is a no-op (no second `create_check_run`)

## Test plan

- [x] `uv run pytest tests/` — 2343 passed, 3 skipped
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/caretaker` (strict) — clean
- [ ] Post-merge: PR #79's readiness check should not be revived (it's still on `b23447de`, but no future webhook will fire); next merged caretaker-qa PR exercises the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)