### PR TITLE
feat(pr-reviewer): pluggable third-party backends + pr-agent integration

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -624,14 +624,44 @@ class ReviewAgentConfig(StrictBaseModel):
     use_llm_for_retro: bool = True
 
 
+class PRAgentBackendConfig(StrictBaseModel):
+    """Configuration for the ``pr_agent`` complex-reviewer backend.
+
+    Caretaker invokes the open-source PR-Agent CLI
+    (https://github.com/The-PR-Agent/pr-agent) as a subprocess to produce
+    a review for high-complexity PRs. PR-Agent is AGPL-3.0; running it as
+    a separate process keeps the licence boundary at "aggregation" — no
+    Python imports, no in-process linking. Tighten ``cli_path`` to a
+    pinned path in production deployments where you control the binary.
+    """
+
+    cli_path: str = "pr-agent"
+    command: str = "review"
+    timeout_seconds: int = 180
+    # Extra environment variables passed through to the pr-agent
+    # subprocess (e.g. ``OPENAI_KEY``, ``ANTHROPIC_KEY``, ``GITHUB_TOKEN``,
+    # ``CONFIG.MODEL``). Caretaker does NOT inject defaults here so
+    # operators stay in explicit control of which credentials reach the
+    # third-party process.
+    extra_env: dict[str, str] = Field(default_factory=dict)
+    # When True, also post pr-agent's raw markdown output as an issue
+    # comment (in addition to the formal Reviews-tab entry) so reviewers
+    # can see pr-agent's full reasoning. Off by default to keep the PR
+    # thread tidy.
+    post_raw_output_comment: bool = False
+
+
 class PRReviewerConfig(StrictBaseModel):
     """Configuration for the dual-path PR code reviewer.
 
     When ``enabled`` is ``True``, caretaker reviews opened/updated PRs:
     - Low-complexity PRs (score < ``routing_threshold``) get an inline
       LLM review posted as a GitHub pull-request review.
-    - High-complexity PRs get handed off to the ``claude-code-action``
-      workflow via a trigger label + structured ``@claude`` comment.
+    - High-complexity PRs get handed off to a configurable backend
+      (``claude_code``, ``opencode``, ``pr_agent``, …). ``claude_code``
+      and ``opencode`` use the comment-trigger pattern (label + mention,
+      reply harvested next cycle); ``pr_agent`` runs the third-party CLI
+      in-process and posts the formal review directly.
 
     Set ``enabled = false`` to disable. By default the agent also runs on
     polling-only deployments (``webhook_only = false``) so it works out of
@@ -676,6 +706,21 @@ class PRReviewerConfig(StrictBaseModel):
     # ``complex_reviewer = "opencode"``.
     opencode_label: str = "opencode-review"
     opencode_mention: str = "@opencode-agent"
+    # Label/mention used for the CodeRabbit comment-trigger stub. The
+    # CodeRabbit GitHub App reads ``@coderabbitai`` mentions; caretaker
+    # only posts the trigger and harvests the response (parser stub).
+    coderabbit_label: str = "coderabbit-review"
+    coderabbit_mention: str = "@coderabbitai review"
+    # Settings for the pr-agent CLI backend (``complex_reviewer = "pr_agent"``).
+    pr_agent: PRAgentBackendConfig = Field(default_factory=PRAgentBackendConfig)
+    # Backends caretaker is allowed to dispatch to. Only specs in this
+    # list can be selected via ``complex_reviewer``; misconfiguration
+    # surfaces at startup rather than at PR-review time. Stub backends
+    # (``coderabbit``, ``greptile``) are registered in the spec registry
+    # but absent here by default — opt them in explicitly.
+    enabled_backends: list[str] = Field(
+        default_factory=lambda: ["claude_code", "opencode", "pr_agent"]
+    )
     # Maximum diff lines fetched for inline review (excess is truncated).
     max_diff_lines: int = 2000
     # Whether to post per-file inline comments (in addition to the review body).

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -58,6 +58,12 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_HANDLED_ACTIONS = frozenset({"opened", "synchronize", "reopened"})
 
+# Sentinel passed to local-subprocess runners that have no per-backend
+# config block yet (e.g. the greptile stub). Using a frozen empty
+# dataclass instance — not ``None`` — so runners can ``getattr`` safely
+# while we add config blocks one backend at a time.
+_EMPTY_BACKEND_CONFIG = type("_EmptyBackendConfig", (), {})()
+
 
 @dataclass
 class _PRReviewReport:
@@ -329,9 +335,9 @@ class PRReviewerAgent(BaseAgent):
                     return
 
         # Hand-off path — backend chosen by ``complex_reviewer`` (Claude
-        # Code, opencode, …). Falls back to claude_code if the configured
-        # backend isn't recognized so misconfiguration doesn't silently
-        # skip review entirely.
+        # Code, opencode, pr_agent, …). Falls back to claude_code if the
+        # configured backend isn't recognized or isn't enabled so a
+        # misconfiguration doesn't silently skip review entirely.
         backend = decision.backend or cfg.complex_reviewer or "claude_code"
         if backend not in handoff_reviewer.known_backends():
             logger.warning(
@@ -341,6 +347,29 @@ class PRReviewerAgent(BaseAgent):
                 ", ".join(handoff_reviewer.known_backends()),
             )
             backend = "claude_code"
+        if cfg.enabled_backends and backend not in cfg.enabled_backends:
+            logger.warning(
+                "pr-reviewer: backend %r is registered but not in enabled_backends=%s; "
+                "falling back to claude_code",
+                backend,
+                cfg.enabled_backends,
+            )
+            backend = "claude_code"
+
+        spec = handoff_reviewer.get_spec(backend)
+        if spec.invocation == "local_subprocess":
+            await self._run_local_subprocess_backend(
+                backend=backend,
+                spec=spec,
+                pr=pr,
+                pr_number=pr_number,
+                owner=owner,
+                repo=repo,
+                report=report,
+                routing_reason=decision.reason,
+            )
+            return
+
         success = await handoff_reviewer.dispatch(
             backend=backend,
             github=self._ctx.github,
@@ -354,6 +383,129 @@ class PRReviewerAgent(BaseAgent):
             report.dispatched.append(pr_number)
         else:
             report.errors.append(f"{backend} dispatch failed for #{pr_number}")
+
+    async def _run_local_subprocess_backend(
+        self,
+        *,
+        backend: str,
+        spec: handoff_reviewer.HandoffReviewerSpec,
+        pr: dict[str, Any],
+        pr_number: int,
+        owner: str,
+        repo: str,
+        report: _PRReviewReport,
+        routing_reason: str,
+    ) -> None:
+        """Run a local-subprocess backend (pr_agent, greptile) and post the review.
+
+        Unlike the comment-trigger path, the review is produced
+        synchronously by caretaker itself, so we post the formal Reviews
+        API entry directly rather than waiting for a cross-cycle harvest.
+        Dispatch failures fall back to a regular comment so the operator
+        sees what went wrong without losing the PR's review slot.
+        """
+        cfg = self._ctx.config.pr_reviewer
+        commit_sha = (pr.get("head") or {}).get("sha", "")
+        if not commit_sha:
+            logger.warning(
+                "pr-reviewer(%s): no head SHA on #%d; cannot post review", backend, pr_number
+            )
+            report.skipped.append(pr_number)
+            return
+
+        if spec.runner is None:
+            logger.error(
+                "pr-reviewer(%s): spec marked local_subprocess but runner is None; skipping #%d",
+                backend,
+                pr_number,
+            )
+            report.errors.append(f"{backend} runner missing for #{pr_number}")
+            return
+
+        pr_url = f"https://github.com/{owner}/{repo}/pull/{pr_number}"
+        backend_config = self._resolve_local_backend_config(backend)
+
+        try:
+            review_result = await spec.runner(pr_url=pr_url, config=backend_config)
+        except Exception as exc:  # noqa: BLE001 — we always want to log + fall back
+            logger.warning(
+                "pr-reviewer(%s): runner failed on %s/%s#%d: %s",
+                backend,
+                owner,
+                repo,
+                pr_number,
+                exc,
+            )
+            try:
+                await self._ctx.github.upsert_issue_comment(
+                    owner,
+                    repo,
+                    pr_number,
+                    marker=spec.marker,
+                    body=(
+                        f"{spec.marker}\n\n"
+                        f"caretaker tried to run the **{backend}** review backend "
+                        f"and it failed: `{exc}`. The PR is unreviewed by this backend; "
+                        "consider re-running or switching `pr_reviewer.complex_reviewer`."
+                    ),
+                )
+            except Exception as post_exc:  # noqa: BLE001 — best-effort
+                logger.warning(
+                    "pr-reviewer(%s): also failed to post failure note: %s", backend, post_exc
+                )
+            report.errors.append(f"{backend} runner failed for #{pr_number}: {exc}")
+            return
+
+        try:
+            await post_review(
+                github=self._ctx.github,
+                owner=owner,
+                repo=repo,
+                pr_number=pr_number,
+                commit_sha=commit_sha,
+                result=review_result,
+                post_inline_comments=cfg.post_inline_comments,
+                force_event=cfg.review_event if cfg.review_event != "AUTO" else None,
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.warning(
+                "pr-reviewer(%s): post_review failed on %s/%s#%d: %s",
+                backend,
+                owner,
+                repo,
+                pr_number,
+                exc,
+            )
+            report.errors.append(f"{backend} post_review failed for #{pr_number}: {exc}")
+            return
+
+        try:
+            reviewed_label = "caretaker:reviewed"
+            await self._ctx.github.ensure_label(
+                owner, repo, reviewed_label, color="0075ca", description="Reviewed by caretaker"
+            )
+            await self._ctx.github.add_labels(owner, repo, pr_number, [reviewed_label])
+        except Exception as exc:  # noqa: BLE001 — best-effort, don't drop the review
+            logger.warning(
+                "pr-reviewer(%s): posted review on #%d but failed to apply reviewed label: %s",
+                backend,
+                pr_number,
+                exc,
+            )
+        report.reviewed.append(pr_number)
+
+    def _resolve_local_backend_config(self, backend: str) -> Any:
+        """Return the per-backend config object passed to the runner.
+
+        Each local-subprocess backend has its own pydantic config block on
+        :class:`PRReviewerConfig` (e.g. ``pr_agent``). Stub backends that
+        don't yet have one get an empty namespace so their runner can
+        raise ``NotImplementedError`` cleanly without a missing-attr.
+        """
+        cfg = self._ctx.config.pr_reviewer
+        if backend == "pr_agent":
+            return cfg.pr_agent
+        return _EMPTY_BACKEND_CONFIG
 
     async def _route_via_shadow(
         self,

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -276,7 +276,7 @@ class PRReviewerAgent(BaseAgent):
                     "pr-reviewer: LLM unavailable for inline review of #%d, falling back",
                     pr_number,
                 )
-                decision = decision  # fall through to claude-code below
+                # Fall through to the hand-off path below.
             else:
                 from caretaker.llm.claude import StructuredCompleteError
 
@@ -497,15 +497,12 @@ class PRReviewerAgent(BaseAgent):
     def _resolve_local_backend_config(self, backend: str) -> Any:
         """Return the per-backend config object passed to the runner.
 
-        Each local-subprocess backend has its own pydantic config block on
-        :class:`PRReviewerConfig` (e.g. ``pr_agent``). Stub backends that
-        don't yet have one get an empty namespace so their runner can
-        raise ``NotImplementedError`` cleanly without a missing-attr.
+        Convention: a backend named ``foo_bar`` looks up
+        ``PRReviewerConfig.foo_bar``. Stub backends without a config
+        block get an empty namespace so their runner can raise
+        ``NotImplementedError`` cleanly without a missing-attribute.
         """
-        cfg = self._ctx.config.pr_reviewer
-        if backend == "pr_agent":
-            return cfg.pr_agent
-        return _EMPTY_BACKEND_CONFIG
+        return getattr(self._ctx.config.pr_reviewer, backend, _EMPTY_BACKEND_CONFIG)
 
     async def _route_via_shadow(
         self,

--- a/src/caretaker/pr_reviewer/backends/__init__.py
+++ b/src/caretaker/pr_reviewer/backends/__init__.py
@@ -1,0 +1,16 @@
+"""Pluggable third-party PR-reviewer backends.
+
+Each module in this package exposes a module-level ``SPEC`` of type
+:class:`HandoffReviewerSpec` that ``handoff_reviewer._build_specs``
+registers at import time. ``local_subprocess`` backends additionally
+expose an async ``run`` callable wired into ``SPEC.runner``.
+
+Adding a backend:
+
+1. Create ``my_tool.py`` with a ``SPEC`` and (for local_subprocess) a
+   ``run(...)`` coroutine returning a ``ReviewResult``.
+2. Append the import to ``handoff_reviewer._build_specs``.
+3. Add a config block + label/mention fields if comment-triggered.
+4. Add the backend name to ``PRReviewerConfig.enabled_backends`` (or
+   leave it out so operators must opt in).
+"""

--- a/src/caretaker/pr_reviewer/backends/coderabbit.py
+++ b/src/caretaker/pr_reviewer/backends/coderabbit.py
@@ -1,0 +1,52 @@
+"""CodeRabbit (https://coderabbit.ai) comment-trigger stub.
+
+CodeRabbit is a hosted GitHub App that reviews PRs when mentioned with
+``@coderabbitai review``. Caretaker can post the trigger comment but
+the response harvest path (parsing CodeRabbit's native comment format
+into the ``caretaker-review`` JSON schema) is intentionally unwritten —
+adding it requires a sample of CodeRabbit's current comment shape and
+should be done when an operator first opts the backend in.
+
+This stub registers the spec so the registry shape stays generic and so
+operators can see the backend in ``known_backends()``. Dispatching to
+``coderabbit`` requires both:
+
+  1. Adding ``"coderabbit"`` to ``PRReviewerConfig.enabled_backends``.
+  2. Implementing the harvest parser referenced in the docstring of
+     :func:`harvest_response`.
+"""
+
+from __future__ import annotations
+
+from caretaker.pr_reviewer.handoff_reviewer import (
+    CODERABBIT_REVIEW_MARKER,
+    HandoffReviewerSpec,
+)
+
+
+def harvest_response(comment_body: str) -> None:
+    """STUB. Convert a CodeRabbit comment body into a caretaker review payload.
+
+    Implementation note for the next contributor: CodeRabbit posts its
+    review as a single Markdown comment with ``## Walkthrough`` /
+    ``## Changes`` / ``## Sequence Diagram(s)`` sections. The harvester
+    should pull the walkthrough into ``summary`` and emit the file-level
+    callouts as inline comments anchored on the file's first changed
+    line (CodeRabbit doesn't expose precise line anchors in the comment
+    text). Until written, this returns ``None`` and the comment-trigger
+    dispatch is the only working path for this backend.
+    """
+    return None
+
+
+SPEC = HandoffReviewerSpec(
+    backend="coderabbit",
+    marker=CODERABBIT_REVIEW_MARKER,
+    upstream_action_name="CodeRabbit GitHub App",
+    label_color="ff6b35",
+    label_description="coderabbit review trigger",
+    invocation="comment_trigger",
+)
+
+
+__all__ = ["SPEC", "harvest_response"]

--- a/src/caretaker/pr_reviewer/backends/greptile.py
+++ b/src/caretaker/pr_reviewer/backends/greptile.py
@@ -1,0 +1,54 @@
+"""Greptile (https://greptile.com) local-subprocess stub.
+
+Greptile is a hosted code-review service backed by a whole-repo graph
+index. Integration would call its REST API (``POST /v2/review``) with
+the PR diff and a repo identifier, then map the response into a
+:class:`ReviewResult`. This stub documents the contract; the actual
+HTTP client is intentionally unwritten so operators have a clear signal
+to implement it when first opting in.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from caretaker.pr_reviewer.handoff_reviewer import (
+    GREPTILE_REVIEW_MARKER,
+    HandoffReviewerSpec,
+)
+
+if TYPE_CHECKING:
+    from caretaker.pr_reviewer.inline_reviewer import ReviewResult
+
+
+async def run(*, pr_url: str, **_: object) -> ReviewResult:
+    """STUB. Invoke Greptile's review API and shape the response.
+
+    Required env: ``GREPTILE_API_KEY``. Endpoint:
+    ``POST https://api.greptile.com/v2/review`` with a JSON body
+    containing ``repository``, ``pull_request_number``, and
+    ``ref`` (head SHA). The response includes ``summary`` and
+    ``comments[]`` (path/line/body) which map cleanly onto
+    :class:`ReviewResult`.
+
+    Until implemented, dispatch to this backend raises so a
+    misconfiguration is loud rather than silently dropping reviews.
+    """
+    raise NotImplementedError(
+        f"greptile backend stubbed; provide GREPTILE_API_KEY and implement "
+        f"run() in caretaker/pr_reviewer/backends/greptile.py (pr_url={pr_url!r})"
+    )
+
+
+SPEC = HandoffReviewerSpec(
+    backend="greptile",
+    marker=GREPTILE_REVIEW_MARKER,
+    upstream_action_name="Greptile API (local subprocess)",
+    label_color="9333ea",
+    label_description="greptile review (pluggable backend)",
+    invocation="local_subprocess",
+    runner=run,
+)
+
+
+__all__ = ["SPEC", "run"]

--- a/src/caretaker/pr_reviewer/backends/pr_agent.py
+++ b/src/caretaker/pr_reviewer/backends/pr_agent.py
@@ -1,0 +1,252 @@
+"""pr-agent (https://github.com/The-PR-Agent/pr-agent) CLI backend.
+
+Caretaker shells out to the pr-agent CLI as a separate subprocess and
+transforms the markdown output into a :class:`ReviewResult` that
+``post_review`` can submit through the GitHub Reviews API. Keeping the
+boundary at "subprocess invocation" — never importing pr-agent code
+into the caretaker process — preserves the AGPL-3.0 aggregation
+boundary so caretaker itself stays under its own licence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from caretaker.pr_reviewer.handoff_reviewer import (
+    PR_AGENT_REVIEW_MARKER,
+    HandoffReviewerSpec,
+)
+from caretaker.pr_reviewer.inline_reviewer import InlineReviewComment, ReviewResult
+
+if TYPE_CHECKING:
+    from caretaker.config import PRAgentBackendConfig
+
+logger = logging.getLogger(__name__)
+
+
+class PRAgentInvocationError(RuntimeError):
+    """Raised when the pr-agent CLI fails (non-zero exit, timeout, missing binary)."""
+
+
+@dataclass(frozen=True)
+class PRAgentRawResult:
+    """Captured stdout/stderr and exit code from one pr-agent invocation."""
+
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+async def run_pr_agent(
+    *,
+    pr_url: str,
+    cli_path: str = "pr-agent",
+    command: str = "review",
+    timeout_seconds: int = 180,
+    extra_env: dict[str, str] | None = None,
+) -> PRAgentRawResult:
+    """Invoke ``<cli_path> --pr_url <pr_url> <command>`` as a subprocess.
+
+    Raises :class:`PRAgentInvocationError` on missing binary, timeout, or
+    non-zero exit so the caller can log and fall back. The configured
+    ``extra_env`` is layered onto the inherited environment — caretaker
+    does not strip anything else, so a deployment that relies on a
+    process-wide ``OPENAI_KEY`` keeps working without ceremony.
+    """
+    resolved = shutil.which(cli_path) or cli_path
+    if not os.path.isabs(resolved) and not shutil.which(resolved):
+        raise PRAgentInvocationError(
+            f"pr-agent CLI not found at {cli_path!r}; install it (`pip install pr-agent`) "
+            "or configure `pr_reviewer.pr_agent.cli_path` to a pinned absolute path"
+        )
+
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+
+    logger.info("pr-agent: invoking %s %s for %s", resolved, command, pr_url)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            resolved,
+            "--pr_url",
+            pr_url,
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+    except FileNotFoundError as exc:
+        raise PRAgentInvocationError(f"pr-agent CLI not executable: {exc}") from exc
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout_seconds
+        )
+    except TimeoutError as exc:
+        proc.kill()
+        # Drain so the subprocess exits cleanly. Best-effort — if the
+        # cleanup itself fails we still want the original timeout error.
+        with contextlib.suppress(Exception):
+            await proc.communicate()
+        raise PRAgentInvocationError(
+            f"pr-agent timed out after {timeout_seconds}s on {pr_url}"
+        ) from exc
+
+    stdout = stdout_bytes.decode("utf-8", errors="replace")
+    stderr = stderr_bytes.decode("utf-8", errors="replace")
+    if proc.returncode != 0:
+        raise PRAgentInvocationError(
+            f"pr-agent exited {proc.returncode} on {pr_url}: "
+            f"{stderr.strip() or stdout.strip()[:500]}"
+        )
+    return PRAgentRawResult(stdout=stdout, stderr=stderr, returncode=proc.returncode)
+
+
+# pr-agent's `/review` output uses Markdown sections like:
+#   ## PR Reviewer Guide 🔍
+#   ⏱️ Estimated effort to review [1-5]: 3
+#   🧪 No relevant tests
+#   🔒 Security concerns: ...
+#   ⚡ Recommended focus areas for review
+#   ## PR Code Suggestions ✨
+#   relevant_file | suggestion |
+# We extract a conservative ``ReviewResult`` from these — a 1-3 sentence
+# summary, a verdict (default COMMENT, REQUEST_CHANGES on explicit
+# security/critical signals), and inline comments parsed from the
+# suggestions table when present.
+_SECURITY_RE = re.compile(r"(security concern|critical issue|🚨|severe|exploit)", re.IGNORECASE)
+_NO_BLOCKERS_RE = re.compile(
+    r"(no security concerns|no relevant tests|looks good|lgtm)", re.IGNORECASE
+)
+# Loose suggestions table parser. pr-agent emits one row per suggestion
+# with columns ``relevant file`` / ``suggestion``. We don't try to parse
+# specific line numbers because pr-agent's table format varies; without
+# a reliable line, the comment goes into the summary instead of inline.
+_TABLE_ROW_RE = re.compile(
+    r"^\|\s*(?P<file>[^|]+?)\s*\|\s*(?P<suggestion>.+?)\s*\|\s*$",
+    re.MULTILINE,
+)
+
+
+def _derive_verdict(stdout: str) -> str:
+    if _SECURITY_RE.search(stdout):
+        return "REQUEST_CHANGES"
+    return "COMMENT"
+
+
+def _derive_summary(stdout: str) -> str:
+    # First non-empty paragraph that isn't a heading or table marker.
+    for chunk in stdout.split("\n\n"):
+        text = chunk.strip()
+        if not text or text.startswith(("#", "|", "---", "```")):
+            continue
+        # Cap at ~600 chars so the GitHub Reviews body stays scannable.
+        return text[:600]
+    return "pr-agent produced no narrative summary."
+
+
+def _derive_comments(stdout: str, *, max_comments: int = 8) -> list[InlineReviewComment]:
+    comments: list[InlineReviewComment] = []
+    for match in _TABLE_ROW_RE.finditer(stdout):
+        file_path = match.group("file").strip()
+        suggestion = match.group("suggestion").strip()
+        # Skip header rows / divider rows / empty cells.
+        if not file_path or file_path.lower() in {"relevant file", "file", "---"}:
+            continue
+        if not suggestion or suggestion.lower() in {"suggestion", "---"}:
+            continue
+        # Without a reliable line number, anchor at line 1 and let the
+        # reviewer click through. The comment body cites the file so
+        # context is preserved even when the anchor isn't precise.
+        comments.append(
+            InlineReviewComment(
+                path=file_path,
+                line=1,
+                body=f"_pr-agent suggestion:_ {suggestion[:280]}",
+            )
+        )
+        if len(comments) >= max_comments:
+            break
+    return comments
+
+
+def to_caretaker_review(raw: PRAgentRawResult, *, include_full_output: bool = True) -> ReviewResult:
+    """Transform pr-agent's stdout into the shared ``ReviewResult`` shape."""
+    summary = _derive_summary(raw.stdout)
+    verdict = _derive_verdict(raw.stdout)
+    comments = _derive_comments(raw.stdout)
+
+    body_parts = [
+        "**Review by [pr-agent](https://github.com/The-PR-Agent/pr-agent) "
+        "(invoked by caretaker as a third-party reviewer)**",
+        "",
+        summary,
+    ]
+    if include_full_output:
+        body_parts.extend(
+            [
+                "",
+                "<details><summary>Full pr-agent output</summary>",
+                "",
+                raw.stdout.strip()[:8000],
+                "",
+                "</details>",
+            ]
+        )
+    if _NO_BLOCKERS_RE.search(raw.stdout) and verdict == "COMMENT":
+        body_parts.extend(["", "_pr-agent did not flag blocking issues._"])
+
+    return ReviewResult(
+        summary="\n".join(body_parts),
+        verdict=verdict,
+        comments=comments,
+    )
+
+
+async def run(
+    *,
+    pr_url: str,
+    config: PRAgentBackendConfig,
+) -> ReviewResult:
+    """High-level entry point used by the spec runner.
+
+    Wraps :func:`run_pr_agent` and :func:`to_caretaker_review` into one
+    coroutine so callers don't need to know about the intermediate
+    ``PRAgentRawResult`` shape.
+    """
+    raw = await run_pr_agent(
+        pr_url=pr_url,
+        cli_path=config.cli_path,
+        command=config.command,
+        timeout_seconds=config.timeout_seconds,
+        extra_env=dict(config.extra_env) if config.extra_env else None,
+    )
+    return to_caretaker_review(raw, include_full_output=True)
+
+
+SPEC = HandoffReviewerSpec(
+    backend="pr_agent",
+    marker=PR_AGENT_REVIEW_MARKER,
+    upstream_action_name="pr-agent CLI (local subprocess)",
+    label_color="2ea44f",
+    label_description="pr-agent review (pluggable backend)",
+    invocation="local_subprocess",
+    runner=run,
+)
+
+
+__all__ = [
+    "PRAgentInvocationError",
+    "PRAgentRawResult",
+    "SPEC",
+    "run",
+    "run_pr_agent",
+    "to_caretaker_review",
+]

--- a/src/caretaker/pr_reviewer/backends/pr_agent.py
+++ b/src/caretaker/pr_reviewer/backends/pr_agent.py
@@ -166,7 +166,13 @@ async def run_pr_agent(
 # summary, a verdict (default COMMENT, REQUEST_CHANGES on explicit
 # security/critical signals), and inline comments parsed from the
 # suggestions table when present.
-_SECURITY_RE = re.compile(r"(security concern|critical issue|🚨|severe|exploit)", re.IGNORECASE)
+# Negative lookbehind on ``no `` / ``no_`` so phrasing like "no security
+# concerns found" doesn't trip the security check (caught by Claude Code's
+# review of the PR that introduced this file).
+_SECURITY_RE = re.compile(
+    r"(?<!\bno\s)(security concern|critical issue|🚨|severe|exploit)",
+    re.IGNORECASE,
+)
 _NO_BLOCKERS_RE = re.compile(
     r"(no security concerns|no relevant tests|looks good|lgtm)", re.IGNORECASE
 )

--- a/src/caretaker/pr_reviewer/backends/pr_agent.py
+++ b/src/caretaker/pr_reviewer/backends/pr_agent.py
@@ -26,6 +26,8 @@ from caretaker.pr_reviewer.handoff_reviewer import (
 from caretaker.pr_reviewer.inline_reviewer import InlineReviewComment, ReviewResult
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from caretaker.config import PRAgentBackendConfig
 
 logger = logging.getLogger(__name__)
@@ -44,6 +46,32 @@ class PRAgentRawResult:
     returncode: int
 
 
+async def _stream_lines(
+    stream: asyncio.StreamReader | None,
+    *,
+    log: Callable[[str], None],
+) -> str:
+    """Drain ``stream`` line-by-line, log each line, return the full text.
+
+    Streaming (vs ``proc.communicate()``) lets pr-agent's progress
+    markers — "fetching diff", "calling LLM", "writing review" — show
+    up live in caretaker's GH Actions job log instead of appearing in
+    one batch after the subprocess exits. The accumulated text is still
+    returned so the caller can parse the full review.
+    """
+    if stream is None:
+        return ""
+    chunks: list[str] = []
+    while True:
+        line_bytes = await stream.readline()
+        if not line_bytes:
+            break
+        line = line_bytes.decode("utf-8", errors="replace")
+        chunks.append(line)
+        log(line.rstrip("\n"))
+    return "".join(chunks)
+
+
 async def run_pr_agent(
     *,
     pr_url: str,
@@ -53,6 +81,11 @@ async def run_pr_agent(
     extra_env: dict[str, str] | None = None,
 ) -> PRAgentRawResult:
     """Invoke ``<cli_path> --pr_url <pr_url> <command>`` as a subprocess.
+
+    Streams the subprocess's stdout/stderr line-by-line through the
+    module logger so live progress is visible in caretaker's job log
+    (e.g. GitHub Actions runner output) while the review is in flight,
+    then returns the accumulated output for downstream parsing.
 
     Raises :class:`PRAgentInvocationError` on missing binary, timeout, or
     non-zero exit so the caller can log and fall back. The configured
@@ -85,22 +118,34 @@ async def run_pr_agent(
     except FileNotFoundError as exc:
         raise PRAgentInvocationError(f"pr-agent CLI not executable: {exc}") from exc
 
+    stdout_task = asyncio.create_task(
+        _stream_lines(proc.stdout, log=lambda line: logger.info("pr-agent | %s", line))
+    )
+    stderr_task = asyncio.create_task(
+        _stream_lines(proc.stderr, log=lambda line: logger.warning("pr-agent! %s", line))
+    )
+
     try:
-        stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=timeout_seconds
+        stdout, stderr = await asyncio.wait_for(
+            asyncio.gather(stdout_task, stderr_task),
+            timeout=timeout_seconds,
         )
+        await proc.wait()
     except TimeoutError as exc:
         proc.kill()
-        # Drain so the subprocess exits cleanly. Best-effort — if the
-        # cleanup itself fails we still want the original timeout error.
+        # Drain so the subprocess exits cleanly and our reader tasks
+        # don't leak. Best-effort — if cleanup fails we still want the
+        # original timeout error to propagate.
+        for task in (stdout_task, stderr_task):
+            task.cancel()
         with contextlib.suppress(Exception):
-            await proc.communicate()
+            await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+        with contextlib.suppress(Exception):
+            await proc.wait()
         raise PRAgentInvocationError(
             f"pr-agent timed out after {timeout_seconds}s on {pr_url}"
         ) from exc
 
-    stdout = stdout_bytes.decode("utf-8", errors="replace")
-    stderr = stderr_bytes.decode("utf-8", errors="replace")
     if proc.returncode != 0:
         raise PRAgentInvocationError(
             f"pr-agent exited {proc.returncode} on {pr_url}: "

--- a/src/caretaker/pr_reviewer/handoff_reviewer.py
+++ b/src/caretaker/pr_reviewer/handoff_reviewer.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 # different agent without confusion.
 CLAUDE_CODE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-handoff -->"
 OPENCODE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-opencode-handoff -->"
-PR_AGENT_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-pragent-handoff -->"
+PR_AGENT_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-pr-agent-handoff -->"
 CODERABBIT_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-coderabbit-handoff -->"
 GREPTILE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-greptile-handoff -->"
 
@@ -105,11 +105,12 @@ _OPENCODE = HandoffReviewerSpec(
 
 
 def _build_specs() -> dict[str, HandoffReviewerSpec]:
-    """Assemble the registry, importing local-subprocess runners lazily.
+    """Assemble the registry once, at module import.
 
-    Imports happen inside the function so a missing optional backend
-    (e.g. an unwritten greptile API client) never breaks startup of the
-    rest of the agent.
+    Imports happen inside the function so the ``backends`` package can
+    depend on this module's marker constants without a circular import,
+    and so a future optional backend can be skipped on ImportError
+    without breaking the rest of the agent.
     """
     specs: dict[str, HandoffReviewerSpec] = {
         _CLAUDE_CODE.backend: _CLAUDE_CODE,

--- a/src/caretaker/pr_reviewer/handoff_reviewer.py
+++ b/src/caretaker/pr_reviewer/handoff_reviewer.py
@@ -13,12 +13,14 @@ own trigger).
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from caretaker.config import PRReviewerConfig
     from caretaker.github_client.api import GitHubClient
+    from caretaker.pr_reviewer.inline_reviewer import ReviewResult
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +30,18 @@ logger = logging.getLogger(__name__)
 # different agent without confusion.
 CLAUDE_CODE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-handoff -->"
 OPENCODE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-opencode-handoff -->"
+PR_AGENT_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-pragent-handoff -->"
+CODERABBIT_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-coderabbit-handoff -->"
+GREPTILE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-greptile-handoff -->"
+
+# Invocation models a backend can use:
+#   - ``comment_trigger``: caretaker labels the PR + posts a mention
+#     comment. An external action/agent picks it up and replies. The
+#     response is harvested next cycle by ``handoff_review_consumer``.
+#   - ``local_subprocess``: caretaker runs the backend itself (CLI or
+#     library call) and posts the formal review directly via
+#     ``post_review`` — no cross-cycle harvest, no external trigger.
+InvocationMode = Literal["comment_trigger", "local_subprocess"]
 
 # Marker the agent's reply must include for caretaker to harvest the
 # review payload and re-post it as a formal PR review (Reviews tab) via
@@ -38,15 +52,38 @@ OPENCODE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-opencode-handoff -->"
 REVIEW_RESULT_MARKER = "<!-- caretaker:review-result -->"
 
 
+# Runner signature for ``local_subprocess`` backends. Receives the PR
+# coordinates plus backend-specific config; returns a ``ReviewResult``
+# ready for ``post_review``. The runner is responsible for invoking the
+# external tool, capturing its output, and shaping the response — any
+# subprocess errors should be raised so the agent can log + fall back.
+LocalRunner = Callable[..., Awaitable["ReviewResult"]]
+
+
 @dataclass(frozen=True)
 class HandoffReviewerSpec:
-    """Per-backend strings used to compose the hand-off comment."""
+    """Per-backend metadata for the PR-reviewer hand-off layer.
 
-    backend: str  # "claude_code" | "opencode" | …
+    Two invocation modes are supported (see :data:`InvocationMode`):
+
+    * ``comment_trigger`` (default): caretaker posts a labelled comment
+      and waits for an upstream agent (Claude Code, opencode) to reply.
+      The reply is harvested by ``handoff_review_consumer`` next cycle.
+      Only ``marker``, ``label_color``, ``label_description``, and the
+      ``upstream_action_name`` are required.
+
+    * ``local_subprocess``: caretaker runs the tool itself (e.g. the
+      pr-agent CLI). ``runner`` is the async callable that produces a
+      ``ReviewResult`` to be posted directly via ``post_review``.
+    """
+
+    backend: str  # "claude_code" | "opencode" | "pr_agent" | …
     marker: str
     upstream_action_name: str  # human-readable name for the closing note
     label_color: str
     label_description: str
+    invocation: InvocationMode = "comment_trigger"
+    runner: LocalRunner | None = None
 
 
 _CLAUDE_CODE = HandoffReviewerSpec(
@@ -55,6 +92,7 @@ _CLAUDE_CODE = HandoffReviewerSpec(
     upstream_action_name="anthropics/claude-code-action",
     label_color="7057ff",
     label_description="claude-code-action trigger",
+    invocation="comment_trigger",
 )
 _OPENCODE = HandoffReviewerSpec(
     backend="opencode",
@@ -62,12 +100,31 @@ _OPENCODE = HandoffReviewerSpec(
     upstream_action_name="sst/opencode/github",
     label_color="d04a02",
     label_description="opencode review trigger",
+    invocation="comment_trigger",
 )
 
-_SPECS: dict[str, HandoffReviewerSpec] = {
-    _CLAUDE_CODE.backend: _CLAUDE_CODE,
-    _OPENCODE.backend: _OPENCODE,
-}
+
+def _build_specs() -> dict[str, HandoffReviewerSpec]:
+    """Assemble the registry, importing local-subprocess runners lazily.
+
+    Imports happen inside the function so a missing optional backend
+    (e.g. an unwritten greptile API client) never breaks startup of the
+    rest of the agent.
+    """
+    specs: dict[str, HandoffReviewerSpec] = {
+        _CLAUDE_CODE.backend: _CLAUDE_CODE,
+        _OPENCODE.backend: _OPENCODE,
+    }
+    # ``backends`` package depends on this module's marker constants, so
+    # importing it at module top-level would create a circular import.
+    from caretaker.pr_reviewer.backends import coderabbit, greptile, pr_agent
+
+    for spec in (pr_agent.SPEC, coderabbit.SPEC, greptile.SPEC):
+        specs[spec.backend] = spec
+    return specs
+
+
+_SPECS: dict[str, HandoffReviewerSpec] = _build_specs()
 
 
 def _build_handoff_comment(
@@ -122,26 +179,49 @@ def _build_handoff_comment(
     return "\n".join(lines)
 
 
-def _resolve(backend: str, config: PRReviewerConfig) -> tuple[HandoffReviewerSpec, str, str]:
-    """Return the (spec, label, mention) tuple for a given backend.
-
-    Reads the per-backend label/mention from :class:`PRReviewerConfig`
-    (``claude_code_label`` / ``opencode_label`` / etc.), falling back to
-    the agent's spec defaults when the operator hasn't customised them.
-    """
+def get_spec(backend: str) -> HandoffReviewerSpec:
+    """Return the registered spec for ``backend`` or raise ``ValueError``."""
     spec = _SPECS.get(backend)
     if spec is None:
         raise ValueError(
             f"Unsupported PR reviewer backend {backend!r}. Known backends: {', '.join(_SPECS)}"
         )
-    if backend == "claude_code":
-        return spec, config.claude_code_label, config.claude_code_mention
-    if backend == "opencode":
-        return spec, config.opencode_label, config.opencode_mention
-    # Future backends would extend PRReviewerConfig with their own
-    # label/mention pair; until then ``_resolve`` only knows about
-    # claude_code and opencode.
-    raise AssertionError(f"backend {backend!r} listed in _SPECS but no config mapping")
+    return spec
+
+
+# Per-backend (label, mention) pairs for ``comment_trigger`` backends.
+# ``local_subprocess`` backends don't post a mention comment so they
+# aren't keyed here. Adding a new comment_trigger backend means adding
+# both a spec entry and a row here (plus the matching ``*_label`` /
+# ``*_mention`` fields on PRReviewerConfig).
+_COMMENT_TRIGGER_LABEL_FIELDS: dict[str, tuple[str, str]] = {
+    "claude_code": ("claude_code_label", "claude_code_mention"),
+    "opencode": ("opencode_label", "opencode_mention"),
+    "coderabbit": ("coderabbit_label", "coderabbit_mention"),
+}
+
+
+def _resolve(backend: str, config: PRReviewerConfig) -> tuple[HandoffReviewerSpec, str, str]:
+    """Return the (spec, label, mention) tuple for a comment_trigger backend.
+
+    Raises ``ValueError`` for unknown backends and ``AssertionError`` if
+    a ``comment_trigger`` backend has been registered without a config
+    mapping (programming error — the spec table and field map must stay
+    in sync).
+    """
+    spec = get_spec(backend)
+    if spec.invocation != "comment_trigger":
+        raise ValueError(
+            f"backend {backend!r} uses invocation={spec.invocation!r}; "
+            "comment-trigger _resolve() does not apply"
+        )
+    label_field, mention_field = _COMMENT_TRIGGER_LABEL_FIELDS.get(backend, ("", ""))
+    if not label_field or not hasattr(config, label_field):
+        raise AssertionError(
+            f"backend {backend!r} listed in _SPECS as comment_trigger "
+            "but no PRReviewerConfig label/mention mapping"
+        )
+    return spec, getattr(config, label_field), getattr(config, mention_field)
 
 
 async def dispatch(
@@ -154,7 +234,12 @@ async def dispatch(
     config: PRReviewerConfig,
     routing_reason: str,
 ) -> bool:
-    """Apply trigger label + post hand-off comment. Returns True on success."""
+    """Apply trigger label + post hand-off comment. Returns True on success.
+
+    For comment-trigger backends only. ``local_subprocess`` backends
+    (e.g. pr_agent) are handled directly in ``PRReviewerAgent`` because
+    they post a formal review rather than a mention comment.
+    """
     try:
         spec, label, mention = _resolve(backend, config)
     except ValueError as exc:
@@ -223,9 +308,14 @@ def known_backends() -> list[str]:
 
 __all__ = [
     "CLAUDE_CODE_REVIEW_MARKER",
-    "OPENCODE_REVIEW_MARKER",
-    "REVIEW_RESULT_MARKER",
+    "CODERABBIT_REVIEW_MARKER",
+    "GREPTILE_REVIEW_MARKER",
     "HandoffReviewerSpec",
+    "InvocationMode",
+    "OPENCODE_REVIEW_MARKER",
+    "PR_AGENT_REVIEW_MARKER",
+    "REVIEW_RESULT_MARKER",
     "dispatch",
+    "get_spec",
     "known_backends",
 ]

--- a/tests/test_pr_reviewer_pr_agent_backend.py
+++ b/tests/test_pr_reviewer_pr_agent_backend.py
@@ -102,16 +102,52 @@ async def test_run_pr_agent_raises_on_missing_binary(monkeypatch: pytest.MonkeyP
         )
 
 
+class _FakeStream:
+    """Minimal asyncio.StreamReader stand-in for line-streaming tests.
+
+    ``readline()`` returns each queued line in turn, then empty bytes
+    forever (EOF). ``slow_after`` makes the Nth readline block forever
+    so we can exercise the timeout path without sleeping the test.
+    """
+
+    def __init__(self, lines: list[bytes], *, slow_after: int | None = None) -> None:
+        self._lines = list(lines)
+        self._slow_after = slow_after
+        self._calls = 0
+
+    async def readline(self) -> bytes:
+        self._calls += 1
+        if self._slow_after is not None and self._calls > self._slow_after:
+            await asyncio.sleep(3600)  # never returns within test
+            return b""
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+
+def _fake_proc(
+    *,
+    returncode: int,
+    stdout_lines: list[bytes],
+    stderr_lines: list[bytes] | None = None,
+    slow_after: int | None = None,
+) -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = _FakeStream(stdout_lines, slow_after=slow_after)
+    proc.stderr = _FakeStream(stderr_lines or [])
+    proc.wait = AsyncMock(return_value=returncode)
+    proc.kill = MagicMock()
+    return proc
+
+
 @pytest.mark.asyncio
 async def test_run_pr_agent_raises_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pr_agent_backend.shutil, "which", lambda x: f"/usr/bin/{x}")
-
-    fake_proc = MagicMock()
-    fake_proc.returncode = 2
-    fake_proc.communicate = AsyncMock(return_value=(b"", b"boom: bad config"))
+    proc = _fake_proc(returncode=2, stdout_lines=[], stderr_lines=[b"boom: bad config\n"])
 
     async def _fake_create(*args, **kwargs):
-        return fake_proc
+        return proc
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create)
     with pytest.raises(PRAgentInvocationError, match="exited 2"):
@@ -124,13 +160,10 @@ async def test_run_pr_agent_raises_on_nonzero_exit(monkeypatch: pytest.MonkeyPat
 @pytest.mark.asyncio
 async def test_run_pr_agent_returns_stdout_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pr_agent_backend.shutil, "which", lambda x: f"/usr/bin/{x}")
-
-    fake_proc = MagicMock()
-    fake_proc.returncode = 0
-    fake_proc.communicate = AsyncMock(return_value=(b"## Review\n\nLooks good.\n", b""))
+    proc = _fake_proc(returncode=0, stdout_lines=[b"## Review\n", b"\n", b"Looks good.\n"])
 
     async def _fake_create(*args, **kwargs):
-        return fake_proc
+        return proc
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create)
     raw = await pr_agent_backend.run_pr_agent(
@@ -141,21 +174,45 @@ async def test_run_pr_agent_returns_stdout_on_success(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
-async def test_run_pr_agent_raises_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_run_pr_agent_streams_lines_to_logger(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Each subprocess line should be logged immediately, not after exit."""
     monkeypatch.setattr(pr_agent_backend.shutil, "which", lambda x: f"/usr/bin/{x}")
-
-    fake_proc = MagicMock()
-    fake_proc.returncode = None
-
-    async def _slow_communicate():
-        await asyncio.sleep(10)
-        return (b"", b"")
-
-    fake_proc.communicate = AsyncMock(side_effect=_slow_communicate)
-    fake_proc.kill = MagicMock()
+    proc = _fake_proc(
+        returncode=0,
+        stdout_lines=[b"fetching PR diff...\n", b"calling LLM...\n", b"writing review\n"],
+        stderr_lines=[b"warning: cache miss\n"],
+    )
 
     async def _fake_create(*args, **kwargs):
-        return fake_proc
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create)
+    with caplog.at_level("INFO", logger=pr_agent_backend.logger.name):
+        raw = await pr_agent_backend.run_pr_agent(
+            pr_url="https://github.com/o/r/pull/1", cli_path="pr-agent"
+        )
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("pr-agent | fetching PR diff..." in m for m in messages)
+    assert any("pr-agent | calling LLM..." in m for m in messages)
+    assert any("pr-agent | writing review" in m for m in messages)
+    # stderr should land at WARNING with the bang prefix.
+    assert any("pr-agent! warning: cache miss" in m for m in messages)
+    # And the accumulated stdout/stderr is still returned in full.
+    assert "fetching PR diff" in raw.stdout
+    assert "cache miss" in raw.stderr
+
+
+@pytest.mark.asyncio
+async def test_run_pr_agent_raises_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr_agent_backend.shutil, "which", lambda x: f"/usr/bin/{x}")
+    # First readline returns instantly; the second blocks forever, so the
+    # gather() of stream tasks never completes within the timeout.
+    proc = _fake_proc(returncode=None, stdout_lines=[b"starting...\n"], slow_after=1)
+
+    async def _fake_create(*args, **kwargs):
+        return proc
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create)
     with pytest.raises(PRAgentInvocationError, match="timed out"):
@@ -164,7 +221,7 @@ async def test_run_pr_agent_raises_on_timeout(monkeypatch: pytest.MonkeyPatch) -
             cli_path="pr-agent",
             timeout_seconds=0,
         )
-    fake_proc.kill.assert_called_once()
+    proc.kill.assert_called_once()
 
 
 # ── high-level run() coroutine wires wrapper + transformer ────────────────

--- a/tests/test_pr_reviewer_pr_agent_backend.py
+++ b/tests/test_pr_reviewer_pr_agent_backend.py
@@ -1,0 +1,225 @@
+"""Tests for the pr-agent CLI backend (subprocess wrapper + transformer)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from caretaker.config import PRAgentBackendConfig, PRReviewerConfig
+from caretaker.pr_reviewer import handoff_reviewer
+from caretaker.pr_reviewer.backends import pr_agent as pr_agent_backend
+from caretaker.pr_reviewer.backends.pr_agent import (
+    PRAgentInvocationError,
+    PRAgentRawResult,
+    to_caretaker_review,
+)
+
+# ── transformer (pure functions, no I/O) ───────────────────────────────────
+
+
+def test_transformer_uses_first_paragraph_for_summary() -> None:
+    raw = PRAgentRawResult(
+        stdout=(
+            "## PR Reviewer Guide\n\n"
+            "This PR refactors the auth middleware to use the new session store. "
+            "The change is contained and well-tested.\n\n"
+            "## PR Code Suggestions\n"
+        ),
+        stderr="",
+        returncode=0,
+    )
+    result = to_caretaker_review(raw, include_full_output=False)
+    assert "refactors the auth middleware" in result.summary
+    # Default verdict for non-security output is COMMENT.
+    assert result.verdict == "COMMENT"
+    assert result.comments == []
+
+
+def test_transformer_marks_security_findings_as_request_changes() -> None:
+    raw = PRAgentRawResult(
+        stdout=(
+            "## PR Reviewer Guide\n\n"
+            "🔒 Security concern: the new endpoint accepts user input without validation, "
+            "creating an XSS surface in the rendered template.\n"
+        ),
+        stderr="",
+        returncode=0,
+    )
+    result = to_caretaker_review(raw, include_full_output=False)
+    assert result.verdict == "REQUEST_CHANGES"
+
+
+def test_transformer_extracts_inline_comments_from_suggestions_table() -> None:
+    raw = PRAgentRawResult(
+        stdout=(
+            "## PR Code Suggestions\n"
+            "| relevant file | suggestion |\n"
+            "|---|---|\n"
+            "| src/auth/login.py | Use constant-time comparison for the token check |\n"
+            "| src/api/handlers.py | Validate request body before logging |\n"
+        ),
+        stderr="",
+        returncode=0,
+    )
+    result = to_caretaker_review(raw, include_full_output=False)
+    assert len(result.comments) == 2
+    assert result.comments[0].path == "src/auth/login.py"
+    assert "constant-time" in result.comments[0].body
+    assert result.comments[1].path == "src/api/handlers.py"
+
+
+def test_transformer_caps_inline_comments_at_eight() -> None:
+    rows = "\n".join(f"| src/f{i}.py | suggestion {i} |" for i in range(20))
+    raw = PRAgentRawResult(
+        stdout=f"## PR Code Suggestions\n| relevant file | suggestion |\n|---|---|\n{rows}\n",
+        stderr="",
+        returncode=0,
+    )
+    result = to_caretaker_review(raw, include_full_output=False)
+    assert len(result.comments) == 8
+
+
+def test_transformer_includes_full_output_when_requested() -> None:
+    raw = PRAgentRawResult(stdout="A short body.\n", stderr="", returncode=0)
+    expanded = to_caretaker_review(raw, include_full_output=True)
+    bare = to_caretaker_review(raw, include_full_output=False)
+    assert "<details>" in expanded.summary
+    assert "<details>" not in bare.summary
+
+
+# ── subprocess wrapper (mocked) ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_pr_agent_raises_on_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr_agent_backend.shutil, "which", lambda _: None)
+    with pytest.raises(PRAgentInvocationError, match="not found"):
+        await pr_agent_backend.run_pr_agent(
+            pr_url="https://github.com/o/r/pull/1",
+            cli_path="definitely-not-a-binary-xyz",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_pr_agent_raises_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr_agent_backend.shutil, "which", lambda x: f"/usr/bin/{x}")
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 2
+    fake_proc.communicate = AsyncMock(return_value=(b"", b"boom: bad config"))
+
+    async def _fake_create(*args, **kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create)
+    with pytest.raises(PRAgentInvocationError, match="exited 2"):
+        await pr_agent_backend.run_pr_agent(
+            pr_url="https://github.com/o/r/pull/1",
+            cli_path="pr-agent",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_pr_agent_returns_stdout_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr_agent_backend.shutil, "which", lambda x: f"/usr/bin/{x}")
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.communicate = AsyncMock(return_value=(b"## Review\n\nLooks good.\n", b""))
+
+    async def _fake_create(*args, **kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create)
+    raw = await pr_agent_backend.run_pr_agent(
+        pr_url="https://github.com/o/r/pull/1", cli_path="pr-agent"
+    )
+    assert raw.returncode == 0
+    assert "Looks good" in raw.stdout
+
+
+@pytest.mark.asyncio
+async def test_run_pr_agent_raises_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr_agent_backend.shutil, "which", lambda x: f"/usr/bin/{x}")
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = None
+
+    async def _slow_communicate():
+        await asyncio.sleep(10)
+        return (b"", b"")
+
+    fake_proc.communicate = AsyncMock(side_effect=_slow_communicate)
+    fake_proc.kill = MagicMock()
+
+    async def _fake_create(*args, **kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create)
+    with pytest.raises(PRAgentInvocationError, match="timed out"):
+        await pr_agent_backend.run_pr_agent(
+            pr_url="https://github.com/o/r/pull/1",
+            cli_path="pr-agent",
+            timeout_seconds=0,
+        )
+    fake_proc.kill.assert_called_once()
+
+
+# ── high-level run() coroutine wires wrapper + transformer ────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_returns_review_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_run_pr_agent(**_: object) -> PRAgentRawResult:
+        return PRAgentRawResult(
+            stdout="## Review\n\nLooks good overall.\n", stderr="", returncode=0
+        )
+
+    monkeypatch.setattr(pr_agent_backend, "run_pr_agent", _fake_run_pr_agent)
+    cfg = PRAgentBackendConfig()
+    result = await pr_agent_backend.run(pr_url="https://github.com/o/r/pull/1", config=cfg)
+    assert result.verdict == "COMMENT"
+    assert "Looks good overall" in result.summary
+
+
+# ── registry/spec wiring ──────────────────────────────────────────────────
+
+
+def test_spec_is_registered_and_marked_local_subprocess() -> None:
+    spec = handoff_reviewer.get_spec("pr_agent")
+    assert spec.invocation == "local_subprocess"
+    assert spec.runner is pr_agent_backend.run
+    assert "pr_agent" in handoff_reviewer.known_backends()
+
+
+def test_pr_agent_in_default_enabled_backends() -> None:
+    cfg = PRReviewerConfig()
+    assert "pr_agent" in cfg.enabled_backends
+    # Stubs must NOT be on by default.
+    assert "coderabbit" not in cfg.enabled_backends
+    assert "greptile" not in cfg.enabled_backends
+
+
+def test_dispatch_rejects_local_subprocess_backends() -> None:
+    """``dispatch`` is comment-trigger only; pr_agent should be rejected here."""
+    # The agent layer routes local_subprocess backends through a separate
+    # path, so calling dispatch() with one is a programming error and
+    # should raise via _resolve.
+    from caretaker.pr_reviewer.handoff_reviewer import _resolve
+
+    cfg = PRReviewerConfig()
+    with pytest.raises(ValueError, match="comment-trigger"):
+        _resolve("pr_agent", cfg)
+
+
+def test_greptile_runner_raises_not_implemented() -> None:
+    """Stub backend must fail loudly so misconfiguration isn't silent."""
+    from caretaker.pr_reviewer.backends import greptile
+
+    async def _call() -> None:
+        await greptile.run(pr_url="https://github.com/o/r/pull/1")
+
+    with pytest.raises(NotImplementedError, match="greptile"):
+        asyncio.run(_call())

--- a/tests/test_pr_reviewer_pr_agent_backend.py
+++ b/tests/test_pr_reviewer_pr_agent_backend.py
@@ -51,6 +51,25 @@ def test_transformer_marks_security_findings_as_request_changes() -> None:
     assert result.verdict == "REQUEST_CHANGES"
 
 
+def test_transformer_does_not_request_changes_on_no_security_concerns() -> None:
+    """Regression: ``no security concerns`` must not match ``security concern``.
+
+    Caught by Claude Code's review of PR #650 — the prior regex used a
+    bare substring match so phrasings like "🔒 No security concerns
+    found" were mis-classified as REQUEST_CHANGES, producing a
+    contradictory review on a clean PR.
+    """
+    raw = PRAgentRawResult(
+        stdout=(
+            "## PR Reviewer Guide\n\n🔒 No security concerns found. The change is well scoped.\n"
+        ),
+        stderr="",
+        returncode=0,
+    )
+    result = to_caretaker_review(raw, include_full_output=False)
+    assert result.verdict == "COMMENT"
+
+
 def test_transformer_extracts_inline_comments_from_suggestions_table() -> None:
     raw = PRAgentRawResult(
         stdout=(


### PR DESCRIPTION
## Summary

- Generalize the PR-reviewer hand-off layer to support both `comment_trigger` (Claude Code, opencode) and new `local_subprocess` (caretaker runs the tool) invocation modes
- Add the open-source [pr-agent](https://github.com/The-PR-Agent/pr-agent) CLI as the first concrete `local_subprocess` backend; AGPL-safe boundary (subprocess only, no in-process import)
- Stub specs for **CodeRabbit** (comment-trigger) and **Greptile** (local-subprocess) so future backends are small spec additions, not refactors
- New `enabled_backends` config gate; stubs are registered but opt-in only

## Architecture

`HandoffReviewerSpec` gains `invocation` + `runner` fields. The agent layer branches on `spec.invocation`:

- **comment_trigger** (existing): post labelled mention comment, harvest reply next cycle via `handoff_review_consumer`
- **local_subprocess** (new): caretaker runs the tool itself, transforms output into a `ReviewResult`, posts the formal review directly via the existing `post_review` path — no cross-cycle delay

Failure handling: subprocess errors (missing binary, timeout, non-zero exit) post a clear failure note on the PR and report the error rather than silently dropping the review.

## Files

- `src/caretaker/pr_reviewer/handoff_reviewer.py` — extended spec, lazy `_build_specs()`
- `src/caretaker/pr_reviewer/backends/` — new package: `pr_agent.py`, `coderabbit.py` (stub), `greptile.py` (stub)
- `src/caretaker/pr_reviewer/agent.py` — new `_run_local_subprocess_backend` branch
- `src/caretaker/config.py` — `PRAgentBackendConfig`, `enabled_backends`, coderabbit label/mention
- `tests/test_pr_reviewer_pr_agent_backend.py` — 12 new tests

## Test plan

- [x] 2399 unit tests pass (no regressions)
- [x] ruff + mypy clean
- [ ] Caretaker auto-merge picks up the `caretaker:merge` label and merges this PR (validates the merge-opt-in flow end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)