### PR TITLE
feat(pr-reviewer): claude_code_local backend — claude CLI in caretaker pod

### DIFF
--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -624,6 +624,52 @@ class ReviewAgentConfig(StrictBaseModel):
     use_llm_for_retro: bool = True
 
 
+class ClaudeCodeLocalBackendConfig(StrictBaseModel):
+    """Configuration for the ``claude_code_local`` complex-reviewer backend.
+
+    Caretaker invokes the ``claude`` (Claude Code) CLI as a subprocess
+    in its own pod, against a freshly-cloned working copy of the PR's
+    head. This is an alternative to the ``claude_code`` backend (which
+    triggers ``anthropics/claude-code-action`` in the target repo via a
+    mention comment) — ``claude_code_local`` keeps execution centralised
+    in caretaker, producing live streamed logs and removing the need to
+    install a per-repo workflow.
+
+    Designed for k8s-style deployments where caretaker runs as a
+    long-lived pod with credentials in-process. For high-PR-rate or
+    multi-tenant deployments, prefer the (future) k8s Job invocation
+    mode so each review runs in its own pod with bounded resources.
+    """
+
+    cli_path: str = "claude"
+    # Subset of tools claude is allowed to call. Defaults are read-only
+    # (Read/Glob/Grep) plus Bash for ``git diff``/``git log``. Add
+    # ``Edit``/``Write`` only if you intend to allow the reviewer to
+    # propose patches — not the typical PR-review flow.
+    allowed_tools: list[str] = Field(default_factory=lambda: ["Read", "Glob", "Grep", "Bash"])
+    # ``plan`` keeps everything read-only (safest for review).
+    # ``acceptEdits`` lets claude write files in the workdir, which we
+    # throw away anyway, so it's safe but uses more tokens.
+    permission_mode: Literal["plan", "acceptEdits", "bypassPermissions"] = "plan"
+    # Hard cap on subprocess wall time. Claude Code can run many tool
+    # turns; bound at 10 minutes by default so a runaway session doesn't
+    # pin the pod.
+    timeout_seconds: int = 600
+    # Where the temp clone lives. Empty string defers to the OS temp
+    # dir; pin to a fast-disk volume in production.
+    clone_workdir_root: str = ""
+    # Clone depth; shallow is faster but loses history-aware analyses
+    # (git blame, log). 50 is a reasonable balance for most reviews.
+    clone_depth: int = 50
+    # Extra env passed to the subprocess. ``ANTHROPIC_API_KEY`` and
+    # ``GITHUB_TOKEN`` are typical entries; caretaker will inherit any
+    # already-set values from its own env unless overridden here.
+    extra_env: dict[str, str] = Field(default_factory=dict)
+    # When True, leave the temp clone on disk after a failed run for
+    # post-mortem inspection (useful in dev; off in prod to save disk).
+    keep_workdir_on_failure: bool = False
+
+
 class PRAgentBackendConfig(StrictBaseModel):
     """Configuration for the ``pr_agent`` complex-reviewer backend.
 
@@ -713,11 +759,19 @@ class PRReviewerConfig(StrictBaseModel):
     coderabbit_mention: str = "@coderabbitai review"
     # Settings for the pr-agent CLI backend (``complex_reviewer = "pr_agent"``).
     pr_agent: PRAgentBackendConfig = Field(default_factory=PRAgentBackendConfig)
+    # Settings for the local Claude Code CLI backend
+    # (``complex_reviewer = "claude_code_local"``). Distinct from
+    # ``claude_code`` (comment-trigger via GitHub Action).
+    claude_code_local: ClaudeCodeLocalBackendConfig = Field(
+        default_factory=ClaudeCodeLocalBackendConfig
+    )
     # Backends caretaker is allowed to dispatch to. Only specs in this
     # list can be selected via ``complex_reviewer``; misconfiguration
     # surfaces at startup rather than at PR-review time. Stub backends
     # (``coderabbit``, ``greptile``) are registered in the spec registry
     # but absent here by default — opt them in explicitly.
+    # ``claude_code_local`` is also opt-in: it requires the ``claude``
+    # CLI installed in caretaker's pod and an ANTHROPIC_API_KEY.
     enabled_backends: list[str] = Field(
         default_factory=lambda: ["claude_code", "opencode", "pr_agent"]
     )

--- a/src/caretaker/pr_reviewer/backends/_subprocess_streaming.py
+++ b/src/caretaker/pr_reviewer/backends/_subprocess_streaming.py
@@ -1,0 +1,72 @@
+"""Shared async subprocess streaming helper for local-subprocess backends.
+
+Backends that shell out to long-running CLIs (pr-agent,
+claude_code_local, greptile-when-implemented) use this to pipe each
+subprocess line through the module logger as it arrives, so progress is
+visible in caretaker's job log (e.g. GitHub Actions runner) while the
+subprocess is still running instead of appearing in one batch after exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+async def stream_lines(
+    stream: asyncio.StreamReader | None,
+    *,
+    log: Callable[[str], None],
+) -> str:
+    """Drain ``stream`` line-by-line, log each line, return the full text."""
+    if stream is None:
+        return ""
+    chunks: list[str] = []
+    while True:
+        line_bytes = await stream.readline()
+        if not line_bytes:
+            break
+        line = line_bytes.decode("utf-8", errors="replace")
+        chunks.append(line)
+        log(line.rstrip("\n"))
+    return "".join(chunks)
+
+
+async def stream_subprocess_output(
+    proc: asyncio.subprocess.Process,
+    *,
+    timeout_seconds: int,
+    stdout_log: Callable[[str], None],
+    stderr_log: Callable[[str], None],
+) -> tuple[str, str]:
+    """Stream a subprocess's stdout + stderr concurrently, with timeout.
+
+    On timeout the process is killed, the stream tasks are cancelled,
+    and ``TimeoutError`` is re-raised so the caller can wrap it in a
+    backend-specific exception type. Returns ``(stdout, stderr)`` text
+    on clean exit; the caller still needs to inspect ``proc.returncode``.
+    """
+    stdout_task = asyncio.create_task(stream_lines(proc.stdout, log=stdout_log))
+    stderr_task = asyncio.create_task(stream_lines(proc.stderr, log=stderr_log))
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            asyncio.gather(stdout_task, stderr_task), timeout=timeout_seconds
+        )
+        await proc.wait()
+        return stdout, stderr
+    except TimeoutError:
+        proc.kill()
+        for task in (stdout_task, stderr_task):
+            task.cancel()
+        with contextlib.suppress(Exception):
+            await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        raise
+
+
+__all__ = ["stream_lines", "stream_subprocess_output"]

--- a/src/caretaker/pr_reviewer/backends/claude_code_local.py
+++ b/src/caretaker/pr_reviewer/backends/claude_code_local.py
@@ -1,0 +1,443 @@
+"""``claude_code_local`` backend — runs the Claude Code CLI in caretaker's pod.
+
+An alternative to the ``claude_code`` backend (which triggers
+``anthropics/claude-code-action`` in the target repo via a mention
+comment). This backend instead:
+
+  1. Clones the PR's head into a temp workdir inside caretaker's pod
+  2. Spawns ``claude -p "<review prompt>" --output-format=stream-json``
+  3. Streams every event to caretaker's logger (visible live in GH
+     Actions / kubectl logs)
+  4. Parses the final ``result`` event's text for a ``caretaker-review``
+     JSON block, transforms it into a :class:`ReviewResult`
+  5. Cleans up the workdir (kept on disk only when the run failed AND
+     the operator opted into ``keep_workdir_on_failure``)
+
+Compared to the action-based path it: removes the per-target-repo
+workflow install requirement, centralises credentials and observability
+in caretaker, and gives synchronous logs. Compared to ``inline_reviewer``
+(direct LLM API call) it: gives Claude tool access (Read/Glob/Grep/Bash)
+so the review can navigate the tree, not just consume the diff.
+
+For multi-tenant or high-PR-rate fleets, swap the in-pod subprocess for
+a Kubernetes Job per review so each session has its own resource
+budget. The runner shape (:func:`run`) is the same; only
+:func:`_invoke_claude` would change. See the TODO at the bottom of this
+file for the path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import shutil
+import tempfile
+import urllib.parse
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
+from caretaker.pr_reviewer.handoff_reviewer import (
+    CLAUDE_CODE_LOCAL_REVIEW_MARKER,
+    HandoffReviewerSpec,
+)
+from caretaker.pr_reviewer.inline_reviewer import InlineReviewComment, ReviewResult
+
+if TYPE_CHECKING:
+    from caretaker.config import ClaudeCodeLocalBackendConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeCodeLocalError(RuntimeError):
+    """Raised when the local claude CLI run fails (clone, invocation, parse)."""
+
+
+@dataclass(frozen=True)
+class _ParsedPRURL:
+    owner: str
+    repo: str
+    number: int
+
+
+def _parse_pr_url(pr_url: str) -> _ParsedPRURL:
+    """Extract owner/repo/PR number from a github PR URL.
+
+    Accepts both ``https://github.com/owner/repo/pull/N`` (browser URL)
+    and ``https://api.github.com/repos/owner/repo/pulls/N`` (API URL)
+    so the caller doesn't need to normalise.
+    """
+    parsed = urllib.parse.urlparse(pr_url)
+    parts = [p for p in parsed.path.split("/") if p]
+    # Browser form: owner/repo/pull/N
+    if len(parts) >= 4 and parts[-2] in {"pull", "pulls"}:
+        return _ParsedPRURL(owner=parts[-4], repo=parts[-3], number=int(parts[-1]))
+    # API form: repos/owner/repo/pulls/N
+    if len(parts) >= 5 and parts[0] == "repos" and parts[-2] in {"pull", "pulls"}:
+        return _ParsedPRURL(owner=parts[1], repo=parts[2], number=int(parts[-1]))
+    raise ClaudeCodeLocalError(f"cannot parse PR URL: {pr_url!r}")
+
+
+def _clone_url(parsed: _ParsedPRURL, *, github_token: str | None) -> str:
+    """Build the HTTPS clone URL, embedding the token when present.
+
+    Token-embedded clone is the standard pattern for GitHub Actions
+    runners; the token never lands on disk because git only uses it for
+    the HTTP exchange. If no token is configured, fall back to the
+    public URL — works for public repos, fails clearly for private.
+    """
+    if github_token:
+        return f"https://x-access-token:{github_token}@github.com/{parsed.owner}/{parsed.repo}.git"
+    return f"https://github.com/{parsed.owner}/{parsed.repo}.git"
+
+
+async def _run_git(
+    *args: str, cwd: str | None = None, timeout: int = 120, env: dict[str, str] | None = None
+) -> str:
+    """Run ``git <args>``, stream output, raise ``ClaudeCodeLocalError`` on failure."""
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        *args,
+        cwd=cwd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    try:
+        stdout, stderr = await stream_subprocess_output(
+            proc,
+            timeout_seconds=timeout,
+            stdout_log=lambda line: logger.info("git | %s", line),
+            stderr_log=lambda line: logger.info("git! %s", line),  # git uses stderr for progress
+        )
+    except TimeoutError as exc:
+        raise ClaudeCodeLocalError(f"git {args[0]} timed out after {timeout}s") from exc
+    if proc.returncode != 0:
+        raise ClaudeCodeLocalError(
+            f"git {' '.join(args)} exited {proc.returncode}: "
+            f"{stderr.strip() or stdout.strip()[:500]}"
+        )
+    return stdout
+
+
+async def _prepare_workdir(
+    pr_url: str,
+    *,
+    config: ClaudeCodeLocalBackendConfig,
+) -> tuple[str, _ParsedPRURL]:
+    """Clone the repo + check out the PR head into a fresh temp dir.
+
+    Returns ``(workdir_path, parsed_url)``. Caller is responsible for
+    cleanup via :func:`_cleanup_workdir`.
+    """
+    parsed = _parse_pr_url(pr_url)
+    root = config.clone_workdir_root or None
+    workdir = tempfile.mkdtemp(prefix=f"caretaker-claude-{parsed.repo}-{parsed.number}-", dir=root)
+    logger.info(
+        "claude_code_local: workdir=%s for %s/%s#%d",
+        workdir,
+        parsed.owner,
+        parsed.repo,
+        parsed.number,
+    )
+
+    token = (config.extra_env.get("GITHUB_TOKEN") or os.environ.get("GITHUB_TOKEN") or "").strip()
+    clone_url = _clone_url(parsed, github_token=token)
+    # Clone shallow into an inner ``repo/`` so claude's cwd is the repo
+    # itself, not a wrapper dir. Use ``--quiet`` so we don't double-log
+    # progress (we already stream stderr).
+    repo_dir = os.path.join(workdir, "repo")
+    await _run_git(
+        "clone",
+        "--depth",
+        str(config.clone_depth),
+        "--quiet",
+        clone_url,
+        repo_dir,
+    )
+    # Fetch the PR head ref into a local branch and check it out.
+    pr_ref = f"refs/pull/{parsed.number}/head"
+    await _run_git("fetch", "origin", f"{pr_ref}:caretaker/pr-head", cwd=repo_dir)
+    await _run_git("checkout", "caretaker/pr-head", cwd=repo_dir)
+    return repo_dir, parsed
+
+
+def _cleanup_workdir(workdir: str, *, keep: bool) -> None:
+    """Remove the workdir unless the operator asked to keep it for debugging."""
+    if keep:
+        logger.warning("claude_code_local: keeping workdir %s for inspection", workdir)
+        return
+    parent = os.path.dirname(workdir.rstrip("/"))
+    shutil.rmtree(parent, ignore_errors=True)
+
+
+# TODO(reviewer-prompt): The prompt below is the highest-leverage knob
+# in this whole backend — it shapes what claude looks at, what verdict
+# thresholds it applies, and how strict the JSON output is. Tune it to
+# your repo's review priorities (security weight, test coverage gates,
+# style preferences, anything domain-specific) before turning this
+# backend on in production. The output schema MUST stay stable so the
+# parser keeps working — keep the ``caretaker-review`` fence + JSON
+# field names exactly as documented.
+_REVIEW_PROMPT = """\
+You are reviewing a pull request that has been freshly cloned into the
+current working directory. The PR head is checked out as the current
+branch (``caretaker/pr-head``). The default base branch is the remote
+default (run ``git remote show origin`` to confirm).
+
+Steps:
+  1. Identify the changed files via ``git diff --name-only origin/HEAD``.
+  2. Read each changed file (use the Read tool, not just diff context).
+  3. Walk neighbouring code with Glob/Grep to understand call sites.
+  4. Evaluate: correctness, security, API/back-compat, test coverage.
+
+Output ONE message with ONLY the following two parts, in order:
+
+  1. A short prose summary of your findings (2–6 sentences).
+
+  2. The exact marker ``<!-- caretaker:review-result -->`` on its own
+     line, followed by a fenced JSON block tagged ``caretaker-review``
+     with this schema (no comments, strict JSON):
+
+     ```caretaker-review
+     {
+       "verdict": "APPROVE" | "COMMENT" | "REQUEST_CHANGES",
+       "summary": "1–3 sentence overall assessment",
+       "comments": [
+         {"path": "src/foo.py", "line": 42, "body": "..."}
+       ]
+     }
+     ```
+
+Pick ``REQUEST_CHANGES`` only for blocking issues (security,
+correctness, broken tests). ``COMMENT`` for non-blocking observations.
+``APPROVE`` only when you have no concerns at all. Cap inline
+``comments`` at 8 entries; line numbers refer to the new file
+(right-hand side of the diff).
+"""
+
+
+async def _invoke_claude(
+    *,
+    workdir: str,
+    config: ClaudeCodeLocalBackendConfig,
+) -> str:
+    """Spawn the claude CLI in ``workdir`` and return its stdout text.
+
+    Uses ``--output-format stream-json`` so we get one JSON event per
+    line and can stream them through the logger as they arrive. The
+    final ``result`` event contains the assistant's full message text,
+    which the parser then walks.
+    """
+    resolved = shutil.which(config.cli_path) or config.cli_path
+    if not os.path.isabs(resolved) and not shutil.which(resolved):
+        raise ClaudeCodeLocalError(
+            f"claude CLI not found at {config.cli_path!r}; install it "
+            "(`npm install -g @anthropic-ai/claude-code` or pin a path)"
+        )
+    env = os.environ.copy()
+    if config.extra_env:
+        env.update(config.extra_env)
+
+    args = [
+        resolved,
+        "-p",
+        _REVIEW_PROMPT,
+        "--output-format",
+        "stream-json",
+        "--verbose",  # required when using stream-json output
+        "--permission-mode",
+        config.permission_mode,
+    ]
+    if config.allowed_tools:
+        args += ["--allowed-tools", " ".join(config.allowed_tools)]
+
+    logger.info("claude_code_local: invoking %s in %s", resolved, workdir)
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        cwd=workdir,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    try:
+        stdout, stderr = await stream_subprocess_output(
+            proc,
+            timeout_seconds=config.timeout_seconds,
+            stdout_log=lambda line: logger.info("claude | %s", _truncate(line, 400)),
+            stderr_log=lambda line: logger.warning("claude! %s", line),
+        )
+    except TimeoutError as exc:
+        raise ClaudeCodeLocalError(f"claude timed out after {config.timeout_seconds}s") from exc
+    if proc.returncode != 0:
+        raise ClaudeCodeLocalError(
+            f"claude exited {proc.returncode}: {stderr.strip() or stdout.strip()[:500]}"
+        )
+    return stdout
+
+
+def _truncate(line: str, max_len: int) -> str:
+    """Cap a log line so a streamed JSON event doesn't fill the runner buffer."""
+    if len(line) <= max_len:
+        return line
+    return line[:max_len] + f"… ({len(line) - max_len} more chars)"
+
+
+_RESULT_TEXT_RE = re.compile(r"```caretaker-review\s*\n(?P<json>.+?)\n\s*```", re.DOTALL)
+
+
+def _extract_assistant_text(stream_json_stdout: str) -> str:
+    """Pull the final assistant text from claude's stream-json output.
+
+    Each non-empty line in ``stream-json`` mode is a JSON event. The
+    last event with ``type == "result"`` contains a ``result`` field
+    holding the assistant's full final message (or, when the session
+    ends without a result, we concatenate ``assistant`` events as a
+    fallback so a partial response is still parseable).
+    """
+    final_result: str | None = None
+    assistant_chunks: list[str] = []
+    for raw_line in stream_json_stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        etype = event.get("type")
+        if etype == "result":
+            text = event.get("result")
+            if isinstance(text, str):
+                final_result = text
+        elif etype == "assistant":
+            # ``assistant`` events carry an ``message.content`` array of
+            # blocks; the text-bearing ones have ``type=text``.
+            message = event.get("message") or {}
+            for block in message.get("content") or []:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        assistant_chunks.append(text)
+    return final_result if final_result is not None else "\n".join(assistant_chunks)
+
+
+def _parse_review_payload(assistant_text: str) -> ReviewResult:
+    """Find the ``caretaker-review`` JSON block; fall back to a generic COMMENT review.
+
+    The fallback ensures a noisy or non-conforming claude reply still
+    produces *some* review on the PR rather than dropping the work.
+    """
+    match = _RESULT_TEXT_RE.search(assistant_text)
+    if not match:
+        logger.warning(
+            "claude_code_local: no caretaker-review JSON block in claude reply; "
+            "wrapping the prose as a COMMENT review (length=%d)",
+            len(assistant_text),
+        )
+        return ReviewResult(
+            summary=(
+                "**Review by claude_code_local (fallback parse)**\n\n"
+                "Claude did not emit a structured `caretaker-review` JSON block; "
+                "its prose response is included below.\n\n"
+                f"{assistant_text.strip()[:4000]}"
+            ),
+            verdict="COMMENT",
+            comments=[],
+        )
+    raw = match.group("json").strip()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ClaudeCodeLocalError(f"caretaker-review block is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ClaudeCodeLocalError("caretaker-review payload is not a JSON object")
+
+    summary = payload.get("summary", "").strip() if isinstance(payload.get("summary"), str) else ""
+    verdict = payload.get("verdict", "COMMENT")
+    if verdict not in {"APPROVE", "COMMENT", "REQUEST_CHANGES"}:
+        verdict = "COMMENT"
+    raw_comments = payload.get("comments") or []
+    comments: list[InlineReviewComment] = []
+    if isinstance(raw_comments, list):
+        for entry in raw_comments[:8]:
+            if not isinstance(entry, dict):
+                continue
+            path = entry.get("path")
+            line = entry.get("line")
+            body = entry.get("body")
+            if (
+                isinstance(path, str)
+                and path
+                and isinstance(line, int)
+                and line > 0
+                and isinstance(body, str)
+                and body.strip()
+            ):
+                comments.append(InlineReviewComment(path=path, line=line, body=body.strip()))
+
+    body = (
+        "**Review by claude_code_local "
+        "(Claude Code CLI in caretaker's pod)**\n\n"
+        f"{summary or 'Claude returned no summary text.'}"
+    )
+    return ReviewResult(summary=body, verdict=verdict, comments=comments)
+
+
+async def run(
+    *,
+    pr_url: str,
+    config: ClaudeCodeLocalBackendConfig,
+) -> ReviewResult:
+    """Backend runner — clone, invoke claude, parse, return ``ReviewResult``.
+
+    Workdir cleanup is in a finally so a partial run still tidies up
+    unless ``keep_workdir_on_failure`` is set.
+    """
+    workdir: str | None = None
+    success = False
+    try:
+        workdir, _parsed = await _prepare_workdir(pr_url, config=config)
+        stream_stdout = await _invoke_claude(workdir=workdir, config=config)
+        text = _extract_assistant_text(stream_stdout)
+        result = _parse_review_payload(text)
+        success = True
+        return result
+    finally:
+        if workdir is not None:
+            _cleanup_workdir(workdir, keep=(not success and config.keep_workdir_on_failure))
+
+
+# TODO(k8s-job-mode): When deploying to a fleet that runs many concurrent
+# reviews, swap the in-pod subprocess for a Kubernetes Job. Suggested
+# shape: add ``invocation_mode: Literal["subprocess", "k8s_job"]`` to
+# ClaudeCodeLocalBackendConfig and route through a separate
+# ``_invoke_claude_via_k8s_job`` helper that templates a Job manifest
+# (image, resource limits, secrets, the same prompt + git steps as an
+# init container) and tails ``kubectl logs -f`` for the streaming view.
+# The :func:`run` body stays the same; only the invocation indirection
+# changes. The dispatcher in agent.py already calls ``spec.runner``
+# blindly, so no plumbing change above this layer.
+
+
+SPEC = HandoffReviewerSpec(
+    backend="claude_code_local",
+    marker=CLAUDE_CODE_LOCAL_REVIEW_MARKER,
+    upstream_action_name="Claude Code CLI (in caretaker pod)",
+    label_color="6f42c1",
+    label_description="claude_code_local review (pluggable backend)",
+    invocation="local_subprocess",
+    runner=run,
+)
+
+
+__all__ = [
+    "SPEC",
+    "ClaudeCodeLocalError",
+    "run",
+]

--- a/src/caretaker/pr_reviewer/backends/pr_agent.py
+++ b/src/caretaker/pr_reviewer/backends/pr_agent.py
@@ -11,7 +11,6 @@ boundary so caretaker itself stays under its own licence.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import os
 import re
@@ -19,6 +18,7 @@ import shutil
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
 from caretaker.pr_reviewer.handoff_reviewer import (
     PR_AGENT_REVIEW_MARKER,
     HandoffReviewerSpec,
@@ -26,8 +26,6 @@ from caretaker.pr_reviewer.handoff_reviewer import (
 from caretaker.pr_reviewer.inline_reviewer import InlineReviewComment, ReviewResult
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from caretaker.config import PRAgentBackendConfig
 
 logger = logging.getLogger(__name__)
@@ -44,32 +42,6 @@ class PRAgentRawResult:
     stdout: str
     stderr: str
     returncode: int
-
-
-async def _stream_lines(
-    stream: asyncio.StreamReader | None,
-    *,
-    log: Callable[[str], None],
-) -> str:
-    """Drain ``stream`` line-by-line, log each line, return the full text.
-
-    Streaming (vs ``proc.communicate()``) lets pr-agent's progress
-    markers — "fetching diff", "calling LLM", "writing review" — show
-    up live in caretaker's GH Actions job log instead of appearing in
-    one batch after the subprocess exits. The accumulated text is still
-    returned so the caller can parse the full review.
-    """
-    if stream is None:
-        return ""
-    chunks: list[str] = []
-    while True:
-        line_bytes = await stream.readline()
-        if not line_bytes:
-            break
-        line = line_bytes.decode("utf-8", errors="replace")
-        chunks.append(line)
-        log(line.rstrip("\n"))
-    return "".join(chunks)
 
 
 async def run_pr_agent(
@@ -118,30 +90,14 @@ async def run_pr_agent(
     except FileNotFoundError as exc:
         raise PRAgentInvocationError(f"pr-agent CLI not executable: {exc}") from exc
 
-    stdout_task = asyncio.create_task(
-        _stream_lines(proc.stdout, log=lambda line: logger.info("pr-agent | %s", line))
-    )
-    stderr_task = asyncio.create_task(
-        _stream_lines(proc.stderr, log=lambda line: logger.warning("pr-agent! %s", line))
-    )
-
     try:
-        stdout, stderr = await asyncio.wait_for(
-            asyncio.gather(stdout_task, stderr_task),
-            timeout=timeout_seconds,
+        stdout, stderr = await stream_subprocess_output(
+            proc,
+            timeout_seconds=timeout_seconds,
+            stdout_log=lambda line: logger.info("pr-agent | %s", line),
+            stderr_log=lambda line: logger.warning("pr-agent! %s", line),
         )
-        await proc.wait()
     except TimeoutError as exc:
-        proc.kill()
-        # Drain so the subprocess exits cleanly and our reader tasks
-        # don't leak. Best-effort — if cleanup fails we still want the
-        # original timeout error to propagate.
-        for task in (stdout_task, stderr_task):
-            task.cancel()
-        with contextlib.suppress(Exception):
-            await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
-        with contextlib.suppress(Exception):
-            await proc.wait()
         raise PRAgentInvocationError(
             f"pr-agent timed out after {timeout_seconds}s on {pr_url}"
         ) from exc

--- a/src/caretaker/pr_reviewer/handoff_reviewer.py
+++ b/src/caretaker/pr_reviewer/handoff_reviewer.py
@@ -33,6 +33,7 @@ OPENCODE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-opencode-handoff -->"
 PR_AGENT_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-pr-agent-handoff -->"
 CODERABBIT_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-coderabbit-handoff -->"
 GREPTILE_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-greptile-handoff -->"
+CLAUDE_CODE_LOCAL_REVIEW_MARKER = "<!-- caretaker:pr-reviewer-claude-code-local-handoff -->"
 
 # Invocation models a backend can use:
 #   - ``comment_trigger``: caretaker labels the PR + posts a mention
@@ -118,9 +119,14 @@ def _build_specs() -> dict[str, HandoffReviewerSpec]:
     }
     # ``backends`` package depends on this module's marker constants, so
     # importing it at module top-level would create a circular import.
-    from caretaker.pr_reviewer.backends import coderabbit, greptile, pr_agent
+    from caretaker.pr_reviewer.backends import (
+        claude_code_local,
+        coderabbit,
+        greptile,
+        pr_agent,
+    )
 
-    for spec in (pr_agent.SPEC, coderabbit.SPEC, greptile.SPEC):
+    for spec in (pr_agent.SPEC, coderabbit.SPEC, greptile.SPEC, claude_code_local.SPEC):
         specs[spec.backend] = spec
     return specs
 
@@ -308,6 +314,7 @@ def known_backends() -> list[str]:
 
 
 __all__ = [
+    "CLAUDE_CODE_LOCAL_REVIEW_MARKER",
     "CLAUDE_CODE_REVIEW_MARKER",
     "CODERABBIT_REVIEW_MARKER",
     "GREPTILE_REVIEW_MARKER",

--- a/tests/test_pr_reviewer_claude_code_local_backend.py
+++ b/tests/test_pr_reviewer_claude_code_local_backend.py
@@ -1,0 +1,193 @@
+"""Tests for the claude_code_local backend.
+
+The clone + claude-CLI invocation paths require real binaries and are
+out of scope for unit tests; they're exercised in integration runs. The
+parts under test here are the pure-Python ones: PR-URL parsing, the
+stream-json event extractor, the JSON-block parser, and the spec/config
+wiring.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from caretaker.config import ClaudeCodeLocalBackendConfig, PRReviewerConfig
+from caretaker.pr_reviewer import handoff_reviewer
+from caretaker.pr_reviewer.backends import claude_code_local
+from caretaker.pr_reviewer.backends.claude_code_local import (
+    ClaudeCodeLocalError,
+    _extract_assistant_text,
+    _parse_pr_url,
+    _parse_review_payload,
+)
+
+# ── PR-URL parsing ────────────────────────────────────────────────────────
+
+
+def test_parse_pr_url_browser_form() -> None:
+    parsed = _parse_pr_url("https://github.com/owner/repo/pull/42")
+    assert (parsed.owner, parsed.repo, parsed.number) == ("owner", "repo", 42)
+
+
+def test_parse_pr_url_api_form() -> None:
+    parsed = _parse_pr_url("https://api.github.com/repos/o/r/pulls/7")
+    assert (parsed.owner, parsed.repo, parsed.number) == ("o", "r", 7)
+
+
+def test_parse_pr_url_invalid_raises() -> None:
+    with pytest.raises(ClaudeCodeLocalError, match="cannot parse"):
+        _parse_pr_url("https://github.com/owner/repo/issues/42")
+
+
+# ── stream-json event extractor ───────────────────────────────────────────
+
+
+def _make_stream_json(events: list[dict]) -> str:
+    return "\n".join(json.dumps(e) for e in events) + "\n"
+
+
+def test_extract_assistant_text_prefers_result_event() -> None:
+    stream = _make_stream_json(
+        [
+            {"type": "system", "subtype": "init"},
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "thinking..."}]},
+            },
+            {"type": "result", "result": "FINAL_TEXT", "subtype": "success"},
+        ]
+    )
+    assert _extract_assistant_text(stream) == "FINAL_TEXT"
+
+
+def test_extract_assistant_text_falls_back_to_assistant_chunks() -> None:
+    """When no `result` event arrives, concatenate assistant text blocks."""
+    stream = _make_stream_json(
+        [
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "part A"}]},
+            },
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "part B"}]},
+            },
+        ]
+    )
+    assert _extract_assistant_text(stream) == "part A\npart B"
+
+
+def test_extract_assistant_text_skips_malformed_lines() -> None:
+    stream = "not json\n" + json.dumps({"type": "result", "result": "OK"}) + "\nalso not json\n"
+    assert _extract_assistant_text(stream) == "OK"
+
+
+# ── JSON-block parser ────────────────────────────────────────────────────
+
+
+def test_parse_review_payload_extracts_json_block() -> None:
+    text = (
+        "Some prose summary first.\n\n"
+        "<!-- caretaker:review-result -->\n"
+        "```caretaker-review\n"
+        '{"verdict": "REQUEST_CHANGES", "summary": "auth bug", '
+        '"comments": [{"path": "src/x.py", "line": 5, "body": "fix"}]}\n'
+        "```\n"
+    )
+    result = _parse_review_payload(text)
+    assert result.verdict == "REQUEST_CHANGES"
+    assert "auth bug" in result.summary
+    assert len(result.comments) == 1
+    assert result.comments[0].path == "src/x.py"
+    assert result.comments[0].line == 5
+
+
+def test_parse_review_payload_missing_block_falls_back_to_comment() -> None:
+    """A claude reply without the fence still produces some review."""
+    text = "Just prose, no JSON. Looks good to me."
+    result = _parse_review_payload(text)
+    assert result.verdict == "COMMENT"
+    assert "Just prose" in result.summary
+    assert result.comments == []
+
+
+def test_parse_review_payload_invalid_verdict_defaults_to_comment() -> None:
+    text = (
+        "```caretaker-review\n"
+        '{"verdict": "WAFFLE", "summary": "weird verdict", "comments": []}\n'
+        "```\n"
+    )
+    result = _parse_review_payload(text)
+    assert result.verdict == "COMMENT"
+
+
+def test_parse_review_payload_filters_invalid_comments() -> None:
+    """Comments missing path/line/body are dropped, not crashed on."""
+    text = (
+        "```caretaker-review\n"
+        + json.dumps(
+            {
+                "verdict": "COMMENT",
+                "summary": "ok",
+                "comments": [
+                    {"path": "src/a.py", "line": 1, "body": "good"},
+                    {"path": "", "line": 2, "body": "bad-empty-path"},
+                    {"path": "src/b.py", "line": 0, "body": "bad-line"},
+                    {"path": "src/c.py", "line": 3, "body": ""},
+                    "not-a-dict",
+                ],
+            }
+        )
+        + "\n```\n"
+    )
+    result = _parse_review_payload(text)
+    assert len(result.comments) == 1
+    assert result.comments[0].path == "src/a.py"
+
+
+def test_parse_review_payload_caps_comments_at_eight() -> None:
+    comments = [{"path": f"src/f{i}.py", "line": 1, "body": f"c{i}"} for i in range(20)]
+    text = (
+        "```caretaker-review\n"
+        + json.dumps({"verdict": "COMMENT", "summary": "ok", "comments": comments})
+        + "\n```\n"
+    )
+    result = _parse_review_payload(text)
+    assert len(result.comments) == 8
+
+
+def test_parse_review_payload_invalid_json_raises() -> None:
+    text = "```caretaker-review\n{not-json}\n```\n"
+    with pytest.raises(ClaudeCodeLocalError, match="not valid JSON"):
+        _parse_review_payload(text)
+
+
+# ── registry / spec wiring ───────────────────────────────────────────────
+
+
+def test_spec_is_registered_as_local_subprocess() -> None:
+    spec = handoff_reviewer.get_spec("claude_code_local")
+    assert spec.invocation == "local_subprocess"
+    assert spec.runner is claude_code_local.run
+    assert spec.marker == handoff_reviewer.CLAUDE_CODE_LOCAL_REVIEW_MARKER
+    assert "claude_code_local" in handoff_reviewer.known_backends()
+
+
+def test_marker_is_distinct_from_claude_code_action_marker() -> None:
+    """The two claude-flavoured backends must not share a marker (prevents harvest mix-up)."""
+    assert (
+        handoff_reviewer.CLAUDE_CODE_LOCAL_REVIEW_MARKER
+        != handoff_reviewer.CLAUDE_CODE_REVIEW_MARKER
+    )
+
+
+def test_claude_code_local_opt_in_only_by_default() -> None:
+    """Backend ships registered but not enabled — needs explicit opt-in."""
+    cfg = PRReviewerConfig()
+    assert "claude_code_local" not in cfg.enabled_backends
+    # The config block exists with safe defaults, though.
+    assert isinstance(cfg.claude_code_local, ClaudeCodeLocalBackendConfig)
+    assert cfg.claude_code_local.permission_mode == "plan"
+    assert "Read" in cfg.claude_code_local.allowed_tools


### PR DESCRIPTION
> ⚠️ **Stacked on [#650](https://github.com/ianlintner/caretaker/pull/650).** Base set to that branch — change to ``main`` after #650 merges. Drafted until then.

## Summary

- New ``claude_code_local`` backend: clones the PR head into a temp workdir in caretaker's pod, runs ``claude -p ... --output-format=stream-json`` with read-only tools, streams every event through caretaker's logger, and parses the resulting ``caretaker-review`` JSON block into a ``ReviewResult`` posted via the existing ``post_review`` path
- Shared ``_subprocess_streaming`` helper extracted from pr_agent — both backends now pipe their subprocess output through caretaker's logger consistently
- Backend ships **registered but opt-in only** (not in default ``enabled_backends``); requires the ``claude`` CLI installed in the pod and an ``ANTHROPIC_API_KEY``
- Fallback parser: a non-conforming claude reply still produces a COMMENT review rather than dropping the work

## Why

Removes the ``anthropics/claude-code-action`` per-target-repo workflow install requirement, centralises credentials and observability in caretaker, and gives synchronous live logs in caretaker's job. Compared to ``inline_reviewer`` it gives Claude tool access (Read/Glob/Grep/Bash) to navigate the tree, not just consume the diff.

## Important TODOs left in the code

1. **``TODO(reviewer-prompt)``** in ``claude_code_local.py`` — the prompt is the highest-leverage knob. Tune to repo-specific review priorities (security weight, style preferences, anything domain-specific) before turning the backend on in production. Schema must stay stable so the parser keeps working.
2. **``TODO(k8s-job-mode)``** — for high-PR-rate / multi-tenant fleets, swap the in-pod subprocess for a Kubernetes Job per review. The runner shape is unchanged; only ``_invoke_claude`` would route through ``kubectl``-driven Job creation.

## Files

- ``src/caretaker/pr_reviewer/backends/claude_code_local.py`` — NEW
- ``src/caretaker/pr_reviewer/backends/_subprocess_streaming.py`` — NEW (shared helper)
- ``src/caretaker/pr_reviewer/backends/pr_agent.py`` — refactored to use shared helper
- ``src/caretaker/pr_reviewer/handoff_reviewer.py`` — register spec + add marker constant
- ``src/caretaker/config.py`` — ``ClaudeCodeLocalBackendConfig``
- ``tests/test_pr_reviewer_claude_code_local_backend.py`` — 14 tests covering URL parsing, stream-json extraction, JSON-block parser, registry wiring, opt-in default

## Test plan

- [x] 136 PR-reviewer tests pass (incl. existing pr_agent suite)
- [x] ruff + mypy clean
- [ ] Integration test against a real PR with the ``claude`` CLI installed (manual; out of CI scope until k8s-job mode lands)
- [ ] Tune the review prompt for caretaker's review priorities

🤖 Generated with [Claude Code](https://claude.com/claude-code)