### PR TITLE
fix(rate_limit): self-heal stale GitHub cooldown when bucket is healthy

### DIFF
--- a/src/caretaker/github_client/rate_limit.py
+++ b/src/caretaker/github_client/rate_limit.py
@@ -29,6 +29,13 @@ logger = logging.getLogger(__name__)
 _LOW_REMAINING_THRESHOLD = int(os.environ.get("CARETAKER_RL_LOW_THRESHOLD", "15"))
 _SOFT_BACKOFF_SECONDS = float(os.environ.get("CARETAKER_RL_SOFT_BACKOFF_SECONDS", "2.0"))
 _MAX_COOLDOWN_SECONDS = float(os.environ.get("CARETAKER_RL_MAX_COOLDOWN_SECONDS", "3600"))
+# Threshold at which an active cooldown is considered stale and self-healed.
+# When ``X-RateLimit-Remaining`` exceeds this on a fresh response while we're
+# still in a cooldown window, the prior block came from a 403/429 whose reset
+# has effectively elapsed (GitHub refilled the bucket) — keep blocking
+# wastes time. Tuned well above the soft-throttle threshold so a single
+# successful call doesn't repeatedly toggle the cooldown.
+_HEALTHY_REMAINING_THRESHOLD = int(os.environ.get("CARETAKER_RL_HEALTHY_THRESHOLD", "100"))
 
 
 class RateLimitCooldown:
@@ -93,6 +100,54 @@ class RateLimitCooldown:
     def update_remaining(self, remaining: int) -> None:
         with self._lock:
             self._last_remaining = remaining
+
+    def maybe_clear_if_healthy(
+        self,
+        current_remaining: int,
+        *,
+        healthy_threshold: int = _HEALTHY_REMAINING_THRESHOLD,
+        now: float | None = None,
+    ) -> bool:
+        """Clear an active cooldown when the live rate-limit budget is healthy.
+
+        Called from :func:`record_response_headers` after every successful
+        response that carries ``X-RateLimit-Remaining``. Without this, a
+        cooldown set by a single 403/429 with a far-future reset header
+        would stick for up to :data:`_MAX_COOLDOWN_SECONDS` (1 hour by
+        default) even after GitHub's bucket refilled — silently deferring
+        every agent dispatch in that window.
+
+        We only clear when:
+        * we are currently blocked (``_blocked_until`` in the future), and
+        * the freshly-observed ``current_remaining`` is well above the
+          soft-throttle floor (``healthy_threshold``, default 100).
+
+        Any subsequent rate-limit hit will re-engage the cooldown
+        immediately via :func:`record_rate_limit_response`, so the worst
+        case for a false-positive clear is one extra request before we
+        re-block.
+
+        Returns ``True`` when the cooldown was cleared.
+        """
+        now = now if now is not None else time.time()
+        with self._lock:
+            if self._blocked_until <= now:
+                return False  # already expired naturally
+            if current_remaining < healthy_threshold:
+                return False
+            previous_until = self._blocked_until
+            previous_reason = self._reason
+            self._blocked_until = 0.0
+            self._reason = ""
+        logger.info(
+            "GitHub rate-limit cooldown self-healed: remaining=%d ≥ threshold=%d "
+            "(would have blocked for another %.0fs, prior reason=%r)",
+            current_remaining,
+            healthy_threshold,
+            previous_until - now,
+            previous_reason,
+        )
+        return True
 
     def reset(self) -> None:
         """Test helper — clear all state."""
@@ -170,10 +225,19 @@ def record_response_headers(response: httpx.Response) -> None:
 
     Called on the success path so we notice budget exhaustion *before*
     the next request rather than after.
+
+    Also self-heals a stale cooldown: if we're currently blocked but the
+    response's ``X-RateLimit-Remaining`` shows the bucket has refilled,
+    clear the cooldown so subsequent agent dispatches aren't gated by a
+    timer that has effectively elapsed. See
+    :meth:`RateLimitCooldown.maybe_clear_if_healthy`.
     """
     _blocked_until, remaining = parse_rate_limit_headers(response)
     if remaining is not None:
         _COOLDOWN.update_remaining(remaining)
+        # Self-heal BEFORE the soft-throttle check so a healthy reading
+        # clears a stale block before we'd consider re-engaging one.
+        _COOLDOWN.maybe_clear_if_healthy(remaining)
         _publish_rate_limit_metrics()
         if remaining <= _LOW_REMAINING_THRESHOLD:
             # Soft throttle: add a small blocking window so bursts don't

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -117,6 +117,107 @@ def test_record_response_headers_no_throttle_on_healthy_remaining() -> None:
     assert get_cooldown().is_blocked() is False
 
 
+# ── Cooldown self-heal ─────────────────────────────────────────────────
+
+
+def test_self_heal_clears_stale_cooldown_when_remaining_is_healthy() -> None:
+    """A 403/429 sets a long cooldown; a later 200 with healthy remaining
+    must clear it. Reproduces the production incident where a stale
+    cooldown blocked agent dispatch despite ``X-RateLimit-Remaining``
+    showing the bucket had refilled (PR #657 deferred ~1h)."""
+    cd = get_cooldown()
+    # Engage a long cooldown (the kind a sticky 403 would create).
+    cd.mark_blocked(time.time() + 3500, reason="HTTP 403 rate-limited")
+    assert cd.is_blocked() is True
+
+    # A fresh successful response shows the bucket is healthy.
+    resp = _resp({"X-RateLimit-Remaining": "11491"}, status=200)
+    record_response_headers(resp)
+
+    assert cd.is_blocked() is False
+    assert cd.snapshot()["last_remaining"] == 11491
+    assert cd.snapshot()["reason"] == ""
+
+
+def test_self_heal_does_not_clear_when_remaining_is_low() -> None:
+    """A genuinely-throttled cooldown must stay engaged when remaining
+    is still below the healthy threshold — clearing here would let the
+    agent burn the rest of the budget."""
+    cd = get_cooldown()
+    cd.mark_blocked(time.time() + 60, reason="HTTP 429 rate-limited")
+
+    # Remaining=20 is above the soft-throttle floor (15) but below the
+    # healthy floor (100) — cooldown must persist.
+    resp = _resp({"X-RateLimit-Remaining": "20"}, status=200)
+    record_response_headers(resp)
+
+    assert cd.is_blocked() is True
+    assert cd.snapshot()["last_remaining"] == 20
+
+
+def test_self_heal_clears_then_soft_throttle_does_not_re_engage_at_healthy() -> None:
+    """The self-heal clears, the soft-throttle does NOT re-engage at the
+    healthy reading. Net result: cooldown is fully off."""
+    cd = get_cooldown()
+    cd.mark_blocked(time.time() + 600, reason="HTTP 429 rate-limited")
+
+    resp = _resp({"X-RateLimit-Remaining": "5000"}, status=200)
+    record_response_headers(resp)
+
+    assert cd.is_blocked() is False
+    # Soft-throttle floor is 15, so 5000 is comfortably above it.
+
+
+def test_self_heal_no_op_when_already_unblocked() -> None:
+    """maybe_clear_if_healthy on an unblocked cooldown is a no-op."""
+    cd = get_cooldown()
+    assert cd.is_blocked() is False
+
+    cleared = cd.maybe_clear_if_healthy(5000)
+
+    assert cleared is False
+    assert cd.is_blocked() is False
+
+
+def test_self_heal_no_op_when_naturally_expired() -> None:
+    """An already-expired cooldown is not considered self-healed."""
+    cd = get_cooldown()
+    # Set a block in the past — already expired by the time we observe.
+    cd.mark_blocked(time.time() - 1, reason="stale")
+    cleared = cd.maybe_clear_if_healthy(5000)
+    assert cleared is False
+
+
+def test_self_heal_returns_true_only_on_actual_clear() -> None:
+    cd = get_cooldown()
+    cd.mark_blocked(time.time() + 100, reason="active")
+
+    # Below threshold → False, no clear.
+    assert cd.maybe_clear_if_healthy(50) is False
+    assert cd.is_blocked() is True
+
+    # Above threshold → True, cleared.
+    assert cd.maybe_clear_if_healthy(500) is True
+    assert cd.is_blocked() is False
+
+    # Subsequent call on already-cleared cooldown → False.
+    assert cd.maybe_clear_if_healthy(500) is False
+
+
+def test_self_heal_threshold_is_configurable_per_call() -> None:
+    """The healthy_threshold kwarg lets ops override the env-derived default."""
+    cd = get_cooldown()
+    cd.mark_blocked(time.time() + 100, reason="active")
+
+    # Caller demands a much higher bar — 50 is below it, no clear.
+    assert cd.maybe_clear_if_healthy(50, healthy_threshold=1000) is False
+    assert cd.is_blocked() is True
+
+    # Below the default threshold (100) but above an explicit lower bar.
+    assert cd.maybe_clear_if_healthy(50, healthy_threshold=10) is True
+    assert cd.is_blocked() is False
+
+
 # ── Client integration ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Caretaker was holding a 58-minute rate-limit cooldown (`caretaker_rate_limit_cooldown_seconds=3502`) while the live GitHub bucket showed plenty of headroom (`caretaker_rate_limit_remaining=11491`). Effect: every webhook arriving during the window got `"dispatched": false` from the receiver — agents skipped, no readiness check, no review. **PRs #657 and #658 both landed during the window and got skipped entirely.**

This was the operational gap surfaced during validation of PR #657 (the orchestrator-self-chaining work). The state-machine work in #657 was unaffected; this is a separate fix to the rate-limit kill-switch.

## Root cause

`RateLimitCooldown._blocked_until` is monotonically forward-only. A 403/429 with a far-future `X-RateLimit-Reset` pinned it for up to `_MAX_COOLDOWN_SECONDS` (1 hour cap). When GitHub's bucket refilled and subsequent calls observed healthy `X-RateLimit-Remaining` headers, the cooldown stayed stuck — `update_remaining` only mutated `_last_remaining`, never `_blocked_until`.

## The fix

Adds `RateLimitCooldown.maybe_clear_if_healthy(remaining)`. It clears the cooldown when:

1. We're currently blocked, AND
2. The freshly-observed `X-RateLimit-Remaining` is well above the soft-throttle floor (default 100, env-configurable via `CARETAKER_RL_HEALTHY_THRESHOLD`)

Wired into `record_response_headers` **before** the soft-throttle re-check so a healthy reading clears stale state without immediately re-engaging from the same response. Any subsequent rate-limit hit re-engages the cooldown via `record_rate_limit_response` as before; worst-case false-positive is one extra request before re-block.

## Tests

7 new tests in `tests/test_rate_limit.py`:

| Test | Asserts |
|---|---|
| `test_self_heal_clears_stale_cooldown_when_remaining_is_healthy` | The production case — long cooldown + healthy reading → cleared |
| `test_self_heal_does_not_clear_when_remaining_is_low` | Genuine throttle stays engaged when below threshold |
| `test_self_heal_clears_then_soft_throttle_does_not_re_engage_at_healthy` | Net result is fully off |
| `test_self_heal_no_op_when_already_unblocked` | Idempotent on unblocked state |
| `test_self_heal_no_op_when_naturally_expired` | Doesn't claim credit for natural expiry |
| `test_self_heal_returns_true_only_on_actual_clear` | Return value is the clear signal |
| `test_self_heal_threshold_is_configurable_per_call` | Operational override via kwarg works |

All 22 `test_rate_limit.py` tests pass. Full ruff + mypy strict clean.

## Operational impact when this lands

The next successful GitHub call from any code path (installation token refresh, periodic reconcile, the receiver's own GitHub calls) will observe a fresh `X-RateLimit-Remaining` header. If it's healthy, the stale cooldown clears and webhook dispatching resumes immediately — no pod restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)