### PR TITLE
feat(consensus): LLM consensus engine for tiered/multi-model decisions

### DIFF
--- a/setup-templates/templates/config-default.yml
+++ b/setup-templates/templates/config-default.yml
@@ -156,6 +156,41 @@ llm:
     - architectural_review
     - issue_decomposition
 
+  # Capability-tag → concrete-model registry consumed by the consensus engine.
+  # When a decision site opts into consensus (under `agentic.<site>.consensus`),
+  # tag values like `fast` / `reasoning_anthropic` resolve here. Empty by default.
+  model_pool:
+    pool: {}
+    # Example (commented out) — uncomment + edit for your provider mix:
+    # pool:
+    #   fast: claude-haiku-4-5
+    #   reasoning_anthropic: claude-sonnet-4-6
+    #   reasoning_alt: openai/gpt-4o
+    #   cheap: claude-haiku-4-5
+
+# Per-site consensus engine opt-in. Defaults are mode=off / consensus=null
+# so adding the `llm.model_pool` above does NOT change behaviour until a
+# site opts in. Uncomment + customize the examples below to enable.
+#
+# agentic:
+#   # Cross-provider two-model agreement on PR readiness verdicts.
+#   readiness:
+#     mode: enforce
+#     consensus:
+#       strategy: always_two_models
+#       primary: reasoning_anthropic
+#       escalation: [reasoning_alt]
+#       agreement_fields: [verdict]
+#
+#   # Cheap-fast tier with reasoning escalation on low-confidence calls.
+#   size_classifier:
+#     mode: enforce
+#     consensus:
+#       strategy: tiered_confidence
+#       primary: fast
+#       escalation: [reasoning_anthropic]
+#       confidence_threshold: 0.7
+
 # Optional: foundry-backed in-process coding executor.
 # When foundry.enabled is false (default), every coding task continues to be
 # routed to @copilot via the existing comment protocol — zero behavior change.

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -1515,6 +1515,10 @@ class AgenticDomainConfig(StrictBaseModel):
     model_override: str | None = None
     # Optional per-site max-tokens override; only consumed when model_override is set.
     max_tokens_override: int | None = None
+    # Optional consensus engine config. When set, the site routes its LLM
+    # path through the engine; when None, the existing single-model path
+    # (claude.structured_complete) runs unchanged.
+    consensus: ConsensusDomainConfig | None = None
 
 
 class IssueTriageAgenticConfig(AgenticDomainConfig):
@@ -1559,6 +1563,12 @@ class AgenticConfig(StrictBaseModel):
     dispatch_guard: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
     executor_routing: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
     crystallizer_category: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
+    # Foundry's pre/post-flight sizing gate. Today the gate is a pure
+    # heuristic (file count + line count). With a non-None ``consensus``
+    # field, borderline cases consult the engine to judge whether a diff
+    # in the gray zone is mechanical (route to Foundry) or genuinely
+    # complex (escalate to Copilot).
+    size_classifier: AgenticDomainConfig = Field(default_factory=AgenticDomainConfig)
 
 
 class MaintainerConfig(StrictBaseModel):

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -6,7 +6,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from caretaker.guardrails.policy import GuardrailsConfig, MergeRollbackConfig
 
@@ -1428,6 +1428,62 @@ class AgenticEnforceGateConfig(StrictBaseModel):
             "against the most recent :mod:`caretaker.eval.store` report."
         ),
     )
+
+
+class ConsensusDomainConfig(StrictBaseModel):
+    """Per-decision-site consensus engine configuration.
+
+    Attached as an optional field to :class:`AgenticDomainConfig`. When
+    ``None``, the existing single-model path runs (no engine involved).
+    Sites opt in by setting this in YAML.
+
+    Tag values resolve through :class:`LLMConfig.model_pool`. Literal model
+    strings (anything not a known tag) pass through unchanged to the LLM
+    router.
+    """
+
+    strategy: Literal["tiered_confidence", "always_two_models"] = "tiered_confidence"
+    primary: str = Field(
+        default="fast",
+        description="Capability tag or literal model string for the primary call.",
+    )
+    escalation: list[str] = Field(
+        default_factory=lambda: ["reasoning_anthropic"],
+        description=(
+            "Ordered tags/literals for escalation. TieredConfidence consults "
+            "every entry on low-confidence; AlwaysTwoModels uses [0] as the "
+            "second voter and [1:] as tiebreakers."
+        ),
+    )
+    confidence_threshold: float = Field(
+        default=0.7,
+        ge=0.0,
+        le=1.0,
+        description="TieredConfidence escalates when verdict.confidence < this.",
+    )
+    agreement_fields: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Field names compared for AlwaysTwoModels agreement. Empty list "
+            "means compare full verdicts via ==. For readiness, set to "
+            "['verdict'] so only the closed-enum field has to match."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_strategy_specific(self) -> ConsensusDomainConfig:
+        if self.strategy == "always_two_models":
+            if not self.escalation:
+                raise ValueError(
+                    "always_two_models requires escalation[0] (no second model configured)"
+                )
+            if self.escalation[0] == self.primary:
+                raise ValueError(
+                    f"always_two_models requires escalation[0] ({self.escalation[0]!r}) "
+                    f"to be distinct from primary ({self.primary!r}); use a different "
+                    "tag or literal model so the two-model gate consults distinct models"
+                )
+        return self
 
 
 class AgenticDomainConfig(StrictBaseModel):

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -6,7 +6,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 from caretaker.guardrails.policy import GuardrailsConfig, MergeRollbackConfig
 
@@ -335,6 +335,39 @@ class AgenticBotIdentityConfig(StrictBaseModel):
     llm_cache_max_size: int = 1_000
 
 
+class ModelPoolConfig(StrictBaseModel):
+    """Capability-tag → concrete-model registry consumed by the consensus engine.
+
+    Tags are operator-defined; common values: ``fast``, ``reasoning_anthropic``,
+    ``reasoning_alt``, ``cheap``. Per-site
+    :class:`ConsensusDomainConfig.primary` / ``escalation`` accept either a
+    tag or a literal model string accepted by the LLM router.
+
+    The pool stays empty by default — sites that don't opt into consensus
+    never look at it.
+    """
+
+    pool: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Mapping of capability tag → concrete model string. Every value "
+            "must be a non-empty string accepted by the LLM router (e.g. "
+            "'claude-sonnet-4-6', 'openai/gpt-4o', 'azure_ai/gpt-4o')."
+        ),
+    )
+
+    @field_validator("pool")
+    @classmethod
+    def _no_empty_values(cls, value: dict[str, str]) -> dict[str, str]:
+        for tag, model in value.items():
+            if not isinstance(model, str) or not model:
+                raise ValueError(
+                    f"pool tag {tag!r} maps to invalid value {model!r}; "
+                    "every tag must resolve to a non-empty model string"
+                )
+        return value
+
+
 class LLMConfig(StrictBaseModel):
     # Allow population by either the new canonical name ``llm_enabled`` or the
     # legacy name ``claude_enabled`` so existing configs keep working. We
@@ -387,6 +420,9 @@ class LLMConfig(StrictBaseModel):
     # Fallback model chain — only used when provider="litellm".  Each entry is
     # a LiteLLM-format model string tried in order if the primary call fails.
     fallback_models: list[str] = Field(default_factory=list)
+    # Capability-tag → model registry consumed by the consensus engine.
+    # Empty by default; populated when a site opts into consensus.
+    model_pool: ModelPoolConfig = Field(default_factory=ModelPoolConfig)
     # Number of retries for ``ClaudeClient.structured_complete`` when the model
     # returns malformed JSON or a payload that fails pydantic validation.
     # Set to 0 to disable the self-correcting retry loop.

--- a/src/caretaker/consensus/__init__.py
+++ b/src/caretaker/consensus/__init__.py
@@ -1,0 +1,11 @@
+"""Caretaker LLM consensus engine.
+
+See ``docs/plans/2026-04-30-llm-consensus-engine-design.md`` for the design.
+"""
+
+from caretaker.consensus.trace import ConsensusTrace, ModelAttempt
+
+__all__ = [
+    "ConsensusTrace",
+    "ModelAttempt",
+]

--- a/src/caretaker/consensus/__init__.py
+++ b/src/caretaker/consensus/__init__.py
@@ -3,12 +3,16 @@
 See ``docs/plans/2026-04-30-llm-consensus-engine-design.md`` for the design.
 """
 
+from caretaker.consensus.engine import ConsensusEngine, EngineConfig, SiteConfig
 from caretaker.consensus.result import ConsensusResult, ConsensusUnavailable
 from caretaker.consensus.trace import ConsensusTrace, ModelAttempt
 
 __all__ = [
+    "ConsensusEngine",
     "ConsensusResult",
     "ConsensusTrace",
     "ConsensusUnavailable",
+    "EngineConfig",
     "ModelAttempt",
+    "SiteConfig",
 ]

--- a/src/caretaker/consensus/__init__.py
+++ b/src/caretaker/consensus/__init__.py
@@ -3,9 +3,12 @@
 See ``docs/plans/2026-04-30-llm-consensus-engine-design.md`` for the design.
 """
 
+from caretaker.consensus.result import ConsensusResult, ConsensusUnavailable
 from caretaker.consensus.trace import ConsensusTrace, ModelAttempt
 
 __all__ = [
+    "ConsensusResult",
     "ConsensusTrace",
+    "ConsensusUnavailable",
     "ModelAttempt",
 ]

--- a/src/caretaker/consensus/active.py
+++ b/src/caretaker/consensus/active.py
@@ -1,0 +1,42 @@
+"""Process-wide :class:`ConsensusEngine` holder.
+
+Mirrors :mod:`caretaker.evolution.shadow_config` — orchestrator startup and
+the FastAPI lifespan hook call :func:`configure` once with the constructed
+engine; call sites read it via :func:`get_active_engine`.
+
+Tests use :func:`reset_for_tests` between cases.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from caretaker.consensus.engine import ConsensusEngine
+
+_lock = threading.Lock()
+_active: ConsensusEngine | None = None
+
+
+def configure(engine: ConsensusEngine) -> None:
+    """Install the active engine. Idempotent."""
+    global _active  # noqa: PLW0603 — process singleton.
+    with _lock:
+        _active = engine
+
+
+def get_active_engine() -> ConsensusEngine | None:
+    """Return the installed engine, or ``None`` when unconfigured."""
+    with _lock:
+        return _active
+
+
+def reset_for_tests() -> None:
+    """Clear the active engine. Used by test fixtures."""
+    global _active  # noqa: PLW0603 — process singleton.
+    with _lock:
+        _active = None
+
+
+__all__ = ["configure", "get_active_engine", "reset_for_tests"]

--- a/src/caretaker/consensus/active.py
+++ b/src/caretaker/consensus/active.py
@@ -32,11 +32,21 @@ def get_active_engine() -> ConsensusEngine | None:
         return _active
 
 
-def reset_for_tests() -> None:
-    """Clear the active engine. Used by test fixtures."""
+def clear() -> None:
+    """Clear the active engine — production-safe equivalent of reset_for_tests.
+
+    Used by the orchestrator when re-instantiating without a configured
+    consensus engine, so stale singleton state doesn't leak across
+    construction cycles. ``reset_for_tests`` is kept as a backward-compat
+    alias for test fixtures.
+    """
     global _active  # noqa: PLW0603 — process singleton.
     with _lock:
         _active = None
 
 
-__all__ = ["configure", "get_active_engine", "reset_for_tests"]
+# Keep the original name as an alias for test code that already imports it.
+reset_for_tests = clear
+
+
+__all__ = ["clear", "configure", "get_active_engine", "reset_for_tests"]

--- a/src/caretaker/consensus/engine.py
+++ b/src/caretaker/consensus/engine.py
@@ -75,6 +75,14 @@ class ConsensusEngine:
         """
         return name in self._config.sites
 
+    def site_names(self) -> frozenset[str]:
+        """Return the names of all configured decision sites.
+
+        Public accessor used by the orchestrator's startup log line so
+        callers don't need to read the private ``_config`` attribute.
+        """
+        return frozenset(self._config.sites)
+
     async def decide(
         self,
         *,

--- a/src/caretaker/consensus/engine.py
+++ b/src/caretaker/consensus/engine.py
@@ -1,0 +1,123 @@
+"""ConsensusEngine — public API for tiered-consensus decisions."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, TypeVar
+
+from caretaker.consensus.strategies import (
+    AlwaysTwoModels,
+    Strategy,
+    StrategyContext,
+    TieredConfidence,
+)
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+    from caretaker.consensus.provider_pool import ProviderPool
+    from caretaker.consensus.result import ConsensusResult
+    from caretaker.llm.claude import ClaudeClient
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound="BaseModel")
+
+StrategyName = Literal["tiered_confidence", "always_two_models"]
+
+
+@dataclass(frozen=True, slots=True)
+class SiteConfig:
+    """Per-decision-site engine configuration.
+
+    Built once per orchestrator startup from
+    :class:`~caretaker.config.ConsensusDomainConfig` and stored on
+    :class:`EngineConfig.sites` keyed by site name.
+    """
+
+    strategy: StrategyName
+    primary: str
+    escalation: list[str]
+    confidence_threshold: float
+    agreement_fields: list[str]
+
+
+@dataclass
+class EngineConfig:
+    """Top-level engine configuration."""
+
+    pool: ProviderPool
+    sites: dict[str, SiteConfig] = field(default_factory=dict)
+
+
+# Registry — maps strategy name → constructor. Adding a new strategy is
+# (a) implement it in strategies.py, (b) add an entry here.
+_STRATEGY_REGISTRY: dict[str, type[Strategy]] = {
+    "tiered_confidence": TieredConfidence,
+    "always_two_models": AlwaysTwoModels,
+}
+
+
+class ConsensusEngine:
+    """Routes a decision to the configured strategy and returns the verdict."""
+
+    def __init__(self, *, config: EngineConfig, claude: ClaudeClient) -> None:
+        self._config = config
+        self._claude = claude
+
+    async def decide(
+        self,
+        *,
+        site_name: str,
+        schema: type[T],
+        system_prompt: str,
+        user_prompt: str,
+        feature: str,
+        max_tokens: int = 2000,
+    ) -> ConsensusResult[T]:
+        """Run the configured strategy for ``site_name`` and return the result.
+
+        Raises:
+            KeyError: ``site_name`` is not configured in :attr:`EngineConfig.sites`.
+            ValueError: configured strategy name is unknown.
+            ConsensusUnavailable: every model attempt errored.
+        """
+        try:
+            site = self._config.sites[site_name]
+        except KeyError as exc:
+            raise KeyError(
+                f"consensus engine has no configuration for site {site_name!r}; "
+                f"known sites: {sorted(self._config.sites)}"
+            ) from exc
+
+        strategy_cls = _STRATEGY_REGISTRY.get(site.strategy)
+        if strategy_cls is None:
+            raise ValueError(
+                f"unknown consensus strategy {site.strategy!r} for site {site_name!r}; "
+                f"known strategies: {sorted(_STRATEGY_REGISTRY)}"
+            )
+
+        ctx = StrategyContext(
+            site_name=site_name,
+            schema=schema,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            feature=feature,
+            primary=site.primary,
+            escalation=site.escalation,
+            confidence_threshold=site.confidence_threshold,
+            agreement_fields=site.agreement_fields,
+            pool=self._config.pool,
+            claude=self._claude,
+            max_tokens=max_tokens,
+        )
+        return await strategy_cls().run(ctx)
+
+
+__all__ = [
+    "ConsensusEngine",
+    "EngineConfig",
+    "SiteConfig",
+    "StrategyName",
+]

--- a/src/caretaker/consensus/engine.py
+++ b/src/caretaker/consensus/engine.py
@@ -66,6 +66,15 @@ class ConsensusEngine:
         self._config = config
         self._claude = claude
 
+    def has_site(self, name: str) -> bool:
+        """Return True when ``name`` is a configured decision site.
+
+        Call sites that wire the engine into existing single-model paths
+        check this before delegating, so they stay on the legacy direct
+        path when the engine is configured but not for their site.
+        """
+        return name in self._config.sites
+
     async def decide(
         self,
         *,

--- a/src/caretaker/consensus/engine.py
+++ b/src/caretaker/consensus/engine.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, TypeVar
 
+from caretaker.consensus.metrics import CONSENSUS_DECISION_SECONDS
 from caretaker.consensus.strategies import (
     AlwaysTwoModels,
     Strategy,
@@ -129,7 +130,8 @@ class ConsensusEngine:
             claude=self._claude,
             max_tokens=max_tokens,
         )
-        return await strategy_cls().run(ctx)
+        with CONSENSUS_DECISION_SECONDS.labels(site=site_name, strategy=site.strategy).time():
+            return await strategy_cls().run(ctx)
 
 
 __all__ = [

--- a/src/caretaker/consensus/engine.py
+++ b/src/caretaker/consensus/engine.py
@@ -44,7 +44,7 @@ class SiteConfig:
     agreement_fields: list[str]
 
 
-@dataclass
+@dataclass(frozen=True)
 class EngineConfig:
     """Top-level engine configuration."""
 

--- a/src/caretaker/consensus/metrics.py
+++ b/src/caretaker/consensus/metrics.py
@@ -1,0 +1,43 @@
+"""Prometheus counters/histograms for the consensus engine."""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Histogram
+
+from caretaker.observability.metrics import REGISTRY
+
+CONSENSUS_DECISIONS_TOTAL = Counter(
+    "caretaker_consensus_decisions_total",
+    "Total consensus decisions per (site, strategy, outcome).",
+    ["site", "strategy", "outcome"],
+    registry=REGISTRY,
+)
+
+CONSENSUS_DISAGREEMENT_TOTAL = Counter(
+    "caretaker_consensus_disagreement_total",
+    "AlwaysTwoModels disagreements that triggered a tiebreaker, per site.",
+    ["site"],
+    registry=REGISTRY,
+)
+
+CONSENSUS_UNAVAILABLE_TOTAL = Counter(
+    "caretaker_consensus_unavailable_total",
+    "Decisions where every model attempt errored, per site.",
+    ["site"],
+    registry=REGISTRY,
+)
+
+CONSENSUS_DECISION_SECONDS = Histogram(
+    "caretaker_consensus_decision_seconds",
+    "End-to-end engine latency including all model calls, per (site, strategy).",
+    ["site", "strategy"],
+    registry=REGISTRY,
+)
+
+
+__all__ = [
+    "CONSENSUS_DECISIONS_TOTAL",
+    "CONSENSUS_DECISION_SECONDS",
+    "CONSENSUS_DISAGREEMENT_TOTAL",
+    "CONSENSUS_UNAVAILABLE_TOTAL",
+]

--- a/src/caretaker/consensus/provider_pool.py
+++ b/src/caretaker/consensus/provider_pool.py
@@ -1,0 +1,64 @@
+"""Capability-tag → concrete model resolver.
+
+Pool entries are operator-defined: tags like ``fast``, ``reasoning_anthropic``,
+``reasoning_alt``, ``cheap`` map to concrete model strings the LLM router
+understands. Per-site consensus config (``ConsensusDomainConfig.primary`` /
+``escalation``) accepts either a tag or a literal model string. The pool
+treats any value not present as a key as a literal and passes it through.
+"""
+
+from __future__ import annotations
+
+
+class ProviderPoolError(ValueError):
+    """Raised on invalid pool construction or impossible resolution."""
+
+
+class ProviderPool:
+    """Resolves capability tags to concrete model strings.
+
+    The pool is a thin tag dictionary. Resolution is total: any value that
+    isn't a known tag is returned unchanged on the assumption it's a literal
+    model string — the LLM router validates literals at call time.
+    """
+
+    def __init__(self, pool: dict[str, str]) -> None:
+        for tag, model in pool.items():
+            if not isinstance(model, str) or not model:
+                raise ProviderPoolError(
+                    f"pool tag {tag!r} maps to invalid value {model!r}; "
+                    "every tag must resolve to a non-empty model string"
+                )
+        # Defensive copy so downstream mutations don't bleed back.
+        self._pool: dict[str, str] = dict(pool)
+
+    def resolve(self, value: str) -> tuple[str, str]:
+        """Return ``(concrete_model, tag_or_literal)``.
+
+        ``tag_or_literal`` is the original input — used by ``ModelAttempt``
+        to record what the operator typed, even when it was a literal.
+        """
+        if not value:
+            raise ProviderPoolError("cannot resolve empty model reference")
+        if value in self._pool:
+            return self._pool[value], value
+        # Treat as literal; LLM router validates at call time.
+        return value, value
+
+    def resolve_distinct(self, value: str, *, different_from: str) -> tuple[str, str]:
+        """Resolve ``value``; raise when the result equals ``different_from``.
+
+        Used by AlwaysTwoModels strategy to enforce that two voting models
+        are concretely different. The caller has already resolved the first
+        model (``different_from``); this guards the second slot.
+        """
+        model, tag = self.resolve(value)
+        if model == different_from:
+            raise ProviderPoolError(
+                f"{value!r} resolves to {model!r} which equals different_from "
+                f"({different_from!r}); two-model agreement requires distinct concrete models"
+            )
+        return model, tag
+
+
+__all__ = ["ProviderPool", "ProviderPoolError"]

--- a/src/caretaker/consensus/result.py
+++ b/src/caretaker/consensus/result.py
@@ -1,0 +1,48 @@
+"""ConsensusResult and ConsensusUnavailable — the engine's return contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from caretaker.consensus.trace import ConsensusTrace, ModelAttempt
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class ConsensusResult(Generic[T]):  # noqa: UP046 — PEP 695 syntax not yet supported by project mypy config
+    """Successful engine output.
+
+    ``verdict`` is the verdict the strategy chose to ship. ``trace`` is the
+    full per-model audit record — always populated, even on the happy path
+    where no escalation happened.
+    """
+
+    verdict: T
+    trace: ConsensusTrace
+
+
+class ConsensusUnavailable(RuntimeError):  # noqa: N818 — intentional public name, matches design doc
+    """Raised when every model attempt failed.
+
+    Carries the per-model :class:`ModelAttempt` records so the caller (and
+    the wrapping ``@shadow_decision``) can persist a useful failure trail
+    instead of just the exception message.
+    """
+
+    def __init__(
+        self,
+        *,
+        strategy: str,
+        attempts: list[ModelAttempt],
+        reason: str,
+    ) -> None:
+        self.strategy = strategy
+        self.attempts = attempts
+        self.reason = reason
+        super().__init__(f"consensus unavailable [{strategy}]: {reason}")
+
+
+__all__ = ["ConsensusResult", "ConsensusUnavailable"]

--- a/src/caretaker/consensus/result.py
+++ b/src/caretaker/consensus/result.py
@@ -40,7 +40,8 @@ class ConsensusUnavailable(RuntimeError):  # noqa: N818 — intentional public n
         reason: str,
     ) -> None:
         self.strategy = strategy
-        self.attempts = attempts
+        # Defensive copy so caller-side mutations don't corrupt the trace.
+        self.attempts = list(attempts)
         self.reason = reason
         super().__init__(f"consensus unavailable [{strategy}]: {reason}")
 

--- a/src/caretaker/consensus/strategies.py
+++ b/src/caretaker/consensus/strategies.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound="BaseModel")
 
 
-@dataclass
+@dataclass(frozen=True)
 class StrategyContext:
     """Inputs shared across every strategy invocation.
 
@@ -64,7 +64,7 @@ class Strategy(Protocol):
 
 def _verdict_summary(verdict: Any) -> str:
     """Short, JSON-safe summary of a verdict for the audit trail."""
-    for field_name in ("verdict", "label", "decision", "category"):
+    for field_name in ("verdict", "label", "decision", "category", "stuck_reason"):
         value = getattr(verdict, field_name, None)
         if isinstance(value, str):
             return value[:100]
@@ -181,9 +181,13 @@ class TieredConfidence:
             )
 
         # If escalation produced anything, take the highest-confidence.
-        candidate_pool: list[tuple[Any, ModelAttempt]] = list(escalation_verdicts)
+        # Primary appears first so it wins ties — Python's ``max`` returns
+        # the first maximum, which matches operator intuition (ship the
+        # cheaper default unless escalation is strictly stronger).
+        candidate_pool: list[tuple[Any, ModelAttempt]] = []
         if primary_verdict is not None:
             candidate_pool.append((primary_verdict, primary_attempt))
+        candidate_pool.extend(escalation_verdicts)
 
         def _conf(item: tuple[Any, ModelAttempt]) -> float:
             return item[1].confidence if item[1].confidence is not None else 0.0

--- a/src/caretaker/consensus/strategies.py
+++ b/src/caretaker/consensus/strategies.py
@@ -1,0 +1,207 @@
+"""Pluggable consensus strategies.
+
+Each strategy implements the same async ``run(ctx) -> ConsensusResult``
+contract, raising :class:`ConsensusUnavailable` when every model attempt
+errored out. The engine selects a strategy by name from
+``ConsensusDomainConfig.strategy``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
+
+from caretaker.consensus.result import ConsensusResult, ConsensusUnavailable
+from caretaker.consensus.trace import ConsensusTrace, ModelAttempt
+from caretaker.llm.claude import StructuredCompleteError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pydantic import BaseModel
+
+    from caretaker.consensus.provider_pool import ProviderPool
+    from caretaker.llm.claude import ClaudeClient
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound="BaseModel")
+
+
+@dataclass
+class StrategyContext:
+    """Inputs shared across every strategy invocation.
+
+    Built once per ``engine.decide(...)`` call. Strategies do not mutate it.
+    """
+
+    site_name: str
+    schema: type[Any]
+    system_prompt: str
+    user_prompt: str
+    feature: str
+    primary: str
+    escalation: Sequence[str]
+    confidence_threshold: float
+    agreement_fields: Sequence[str]
+    pool: ProviderPool
+    claude: ClaudeClient
+    max_tokens: int = 2000
+
+
+class Strategy(Protocol):
+    """Strategy protocol — every concrete strategy implements ``run``."""
+
+    name: str
+
+    async def run(self, ctx: StrategyContext) -> ConsensusResult[Any]: ...
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _verdict_summary(verdict: Any) -> str:
+    """Short, JSON-safe summary of a verdict for the audit trail."""
+    for field_name in ("verdict", "label", "decision", "category"):
+        value = getattr(verdict, field_name, None)
+        if isinstance(value, str):
+            return value[:100]
+    return type(verdict).__name__
+
+
+def _verdict_confidence(verdict: Any) -> float | None:
+    """Read ``confidence`` off a verdict if it has one."""
+    confidence = getattr(verdict, "confidence", None)
+    if isinstance(confidence, (int, float)):
+        return float(confidence)
+    return None
+
+
+async def _call_one(
+    ctx: StrategyContext,
+    *,
+    tag_or_literal: str,
+) -> tuple[Any | None, ModelAttempt]:
+    """Resolve one tag/literal, call the model, build a ModelAttempt.
+
+    Returns ``(verdict_or_None, attempt)``. ``verdict_or_None`` is ``None``
+    when the call errored — the attempt's ``error`` field carries the
+    stringified exception.
+    """
+    model, tag = ctx.pool.resolve(tag_or_literal)
+    started = time.monotonic()
+    try:
+        verdict = await ctx.claude.structured_complete(
+            ctx.user_prompt,
+            schema=ctx.schema,
+            feature=ctx.feature,
+            system=ctx.system_prompt,
+            model=model,
+            max_tokens=ctx.max_tokens,
+        )
+    except StructuredCompleteError as exc:
+        latency_ms = int((time.monotonic() - started) * 1000)
+        return None, ModelAttempt(
+            model=model,
+            tag=tag,
+            latency_ms=latency_ms,
+            confidence=None,
+            verdict_summary=None,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+    return verdict, ModelAttempt(
+        model=model,
+        tag=tag,
+        latency_ms=latency_ms,
+        confidence=_verdict_confidence(verdict),
+        verdict_summary=_verdict_summary(verdict),
+        error=None,
+    )
+
+
+# ── TieredConfidence ──────────────────────────────────────────────────────
+
+
+@dataclass
+class TieredConfidence:
+    """Primary model first; escalate if its self-reported confidence is low.
+
+    Order of operations:
+
+    1. Call ``primary``. If the verdict's ``confidence`` is ≥ threshold,
+       ship it.
+    2. Else call every entry in ``escalation`` in order, collecting verdicts
+       and errors. If any verdict comes back, ship the **highest-confidence**
+       one (treating ``None`` confidence as 0.0 — degraded model).
+    3. If every model errored, raise :class:`ConsensusUnavailable`.
+
+    Primary error → escalation runs (the tier failure isn't fatal until both
+    tiers exhaust). This matches the spec's "single model error" handling.
+    """
+
+    name: str = "tiered_confidence"
+
+    async def run(self, ctx: StrategyContext) -> ConsensusResult[Any]:
+        attempts: list[ModelAttempt] = []
+        primary_verdict, primary_attempt = await _call_one(ctx, tag_or_literal=ctx.primary)
+        attempts.append(primary_attempt)
+
+        if (
+            primary_verdict is not None
+            and primary_attempt.confidence is not None
+            and primary_attempt.confidence >= ctx.confidence_threshold
+        ):
+            return ConsensusResult(
+                verdict=primary_verdict,
+                trace=ConsensusTrace(
+                    strategy=self.name,
+                    attempts=attempts,
+                    escalated=False,
+                    final_model=primary_attempt.model,
+                ),
+            )
+
+        # Escalate.
+        escalation_verdicts: list[tuple[Any, ModelAttempt]] = []
+        for entry in ctx.escalation:
+            verdict, attempt = await _call_one(ctx, tag_or_literal=entry)
+            attempts.append(attempt)
+            if verdict is not None:
+                escalation_verdicts.append((verdict, attempt))
+
+        if not escalation_verdicts and primary_verdict is None:
+            raise ConsensusUnavailable(
+                strategy=self.name,
+                attempts=attempts,
+                reason="primary errored and every escalation tier errored",
+            )
+
+        # If escalation produced anything, take the highest-confidence.
+        candidate_pool: list[tuple[Any, ModelAttempt]] = list(escalation_verdicts)
+        if primary_verdict is not None:
+            candidate_pool.append((primary_verdict, primary_attempt))
+
+        def _conf(item: tuple[Any, ModelAttempt]) -> float:
+            return item[1].confidence if item[1].confidence is not None else 0.0
+
+        winner_verdict, winner_attempt = max(candidate_pool, key=_conf)
+        return ConsensusResult(
+            verdict=winner_verdict,
+            trace=ConsensusTrace(
+                strategy=self.name,
+                attempts=attempts,
+                escalated=True,
+                final_model=winner_attempt.model,
+            ),
+        )
+
+
+__all__ = [
+    "Strategy",
+    "StrategyContext",
+    "TieredConfidence",
+]

--- a/src/caretaker/consensus/strategies.py
+++ b/src/caretaker/consensus/strategies.py
@@ -14,6 +14,11 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
+from caretaker.consensus.metrics import (
+    CONSENSUS_DECISIONS_TOTAL,
+    CONSENSUS_DISAGREEMENT_TOTAL,
+    CONSENSUS_UNAVAILABLE_TOTAL,
+)
 from caretaker.consensus.result import ConsensusResult, ConsensusUnavailable
 from caretaker.consensus.trace import ConsensusTrace, ModelAttempt
 from caretaker.llm.claude import StructuredCompleteError
@@ -156,6 +161,9 @@ class TieredConfidence:
             and primary_attempt.confidence is not None
             and primary_attempt.confidence >= ctx.confidence_threshold
         ):
+            CONSENSUS_DECISIONS_TOTAL.labels(
+                site=ctx.site_name, strategy=self.name, outcome="primary_shipped"
+            ).inc()
             return ConsensusResult(
                 verdict=primary_verdict,
                 trace=ConsensusTrace(
@@ -175,6 +183,7 @@ class TieredConfidence:
                 escalation_verdicts.append((verdict, attempt))
 
         if not escalation_verdicts and primary_verdict is None:
+            CONSENSUS_UNAVAILABLE_TOTAL.labels(site=ctx.site_name).inc()
             raise ConsensusUnavailable(
                 strategy=self.name,
                 attempts=attempts,
@@ -194,6 +203,9 @@ class TieredConfidence:
             return item[1].confidence if item[1].confidence is not None else 0.0
 
         winner_verdict, winner_attempt = max(candidate_pool, key=_conf)
+        CONSENSUS_DECISIONS_TOTAL.labels(
+            site=ctx.site_name, strategy=self.name, outcome="escalated"
+        ).inc()
         return ConsensusResult(
             verdict=winner_verdict,
             trace=ConsensusTrace(
@@ -245,6 +257,7 @@ class AlwaysTwoModels:
 
     async def run(self, ctx: StrategyContext) -> ConsensusResult[Any]:
         if not ctx.escalation:
+            CONSENSUS_UNAVAILABLE_TOTAL.labels(site=ctx.site_name).inc()
             raise ConsensusUnavailable(
                 strategy=self.name,
                 attempts=[],
@@ -270,6 +283,9 @@ class AlwaysTwoModels:
             and second_verdict is not None
             and _agree(primary_verdict, second_verdict, ctx.agreement_fields)
         ):
+            CONSENSUS_DECISIONS_TOTAL.labels(
+                site=ctx.site_name, strategy=self.name, outcome="primary_shipped"
+            ).inc()
             return ConsensusResult(
                 verdict=primary_verdict,
                 trace=ConsensusTrace(
@@ -281,6 +297,15 @@ class AlwaysTwoModels:
             )
 
         # Disagreement OR a leg errored → run tiebreaker tier.
+        # Only count "true disagreement" (both succeeded, disagreed) — not
+        # degradations where one leg errored. That's what the counter is for.
+        if (
+            primary_verdict is not None
+            and second_verdict is not None
+            and not _agree(primary_verdict, second_verdict, ctx.agreement_fields)
+        ):
+            CONSENSUS_DISAGREEMENT_TOTAL.labels(site=ctx.site_name).inc()
+
         tiebreaker_verdict: Any | None = None
         tiebreaker_attempt: ModelAttempt | None = None
         for entry in ctx.escalation[1:]:
@@ -301,6 +326,7 @@ class AlwaysTwoModels:
             candidates.append((tiebreaker_verdict, tiebreaker_attempt))
 
         if not candidates:
+            CONSENSUS_UNAVAILABLE_TOTAL.labels(site=ctx.site_name).inc()
             raise ConsensusUnavailable(
                 strategy=self.name,
                 attempts=attempts,
@@ -313,6 +339,9 @@ class AlwaysTwoModels:
         # shipped verdict so cost/latency/bug triage stays unambiguous.
         # Agreement information remains reconstructable from ``attempts``.
         if tiebreaker_verdict is not None and tiebreaker_attempt is not None:
+            CONSENSUS_DECISIONS_TOTAL.labels(
+                site=ctx.site_name, strategy=self.name, outcome="tiebreaker_shipped"
+            ).inc()
             return ConsensusResult(
                 verdict=tiebreaker_verdict,
                 trace=ConsensusTrace(
@@ -329,6 +358,7 @@ class AlwaysTwoModels:
         # would contradict that. Raise ConsensusUnavailable so the wrapping
         # @shadow_decision falls through to the legacy heuristic, which on
         # readiness returns "block-merge" (the safe default).
+        CONSENSUS_UNAVAILABLE_TOTAL.labels(site=ctx.site_name).inc()
         raise ConsensusUnavailable(
             strategy=self.name,
             attempts=attempts,

--- a/src/caretaker/consensus/strategies.py
+++ b/src/caretaker/consensus/strategies.py
@@ -307,23 +307,12 @@ class AlwaysTwoModels:
                 reason="primary, secondary, and every tiebreaker errored",
             )
 
-        # If tiebreaker exists, prefer it. When it agrees with a surviving
-        # prior verdict on the agreement fields, surface the agreement-winner
-        # as the final_model (so traces show "two models agreed on X");
-        # otherwise the tiebreaker itself is the deciding vote.
+        # Tiebreaker exists — it's the verdict we ship, regardless of
+        # whether it agreed with a prior or cast a fresh deciding vote.
+        # ``final_model`` always points at the model that produced the
+        # shipped verdict so cost/latency/bug triage stays unambiguous.
+        # Agreement information remains reconstructable from ``attempts``.
         if tiebreaker_verdict is not None and tiebreaker_attempt is not None:
-            for verdict, attempt in candidates[:-1]:  # exclude tiebreaker self
-                if _agree(tiebreaker_verdict, verdict, ctx.agreement_fields):
-                    return ConsensusResult(
-                        verdict=tiebreaker_verdict,
-                        trace=ConsensusTrace(
-                            strategy=self.name,
-                            attempts=attempts,
-                            escalated=True,
-                            final_model=attempt.model,
-                        ),
-                    )
-            # No prior agreement — tiebreaker casts the deciding vote.
             return ConsensusResult(
                 verdict=tiebreaker_verdict,
                 trace=ConsensusTrace(
@@ -334,18 +323,18 @@ class AlwaysTwoModels:
                 ),
             )
 
-        # Fall back to highest-confidence among all candidates.
-        def _conf(item: tuple[Any, ModelAttempt]) -> float:
-            return item[1].confidence if item[1].confidence is not None else 0.0
-
-        winner_verdict, winner_attempt = max(candidates, key=_conf)
-        return ConsensusResult(
-            verdict=winner_verdict,
-            trace=ConsensusTrace(
-                strategy=self.name,
-                attempts=attempts,
-                escalated=True,
-                final_model=winner_attempt.model,
+        # Tiebreaker tier exhausted (or absent) AND we lack two-model agreement.
+        # The strategy's contract is "two models must agree (or a tiebreaker
+        # breaks the tie)" — silently shipping the higher-confidence verdict
+        # would contradict that. Raise ConsensusUnavailable so the wrapping
+        # @shadow_decision falls through to the legacy heuristic, which on
+        # readiness returns "block-merge" (the safe default).
+        raise ConsensusUnavailable(
+            strategy=self.name,
+            attempts=attempts,
+            reason=(
+                "two-model disagreement and tiebreaker tier exhausted; "
+                "consensus contract requires agreement or a casting vote"
             ),
         )
 

--- a/src/caretaker/consensus/strategies.py
+++ b/src/caretaker/consensus/strategies.py
@@ -19,6 +19,7 @@ from caretaker.consensus.metrics import (
     CONSENSUS_DISAGREEMENT_TOTAL,
     CONSENSUS_UNAVAILABLE_TOTAL,
 )
+from caretaker.consensus.provider_pool import ProviderPoolError
 from caretaker.consensus.result import ConsensusResult, ConsensusUnavailable
 from caretaker.consensus.trace import ConsensusTrace, ModelAttempt
 from caretaker.llm.claude import StructuredCompleteError
@@ -34,6 +35,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound="BaseModel")
+
+# Sentinel for missing-field detection in ``_agree``. Module-level so the
+# two ``getattr`` calls share the same instance — using ``object()`` inline
+# would create two distinct sentinels that never compare equal, causing
+# spurious tiebreaker escalations on any verdict schema that lacks an
+# ``agreement_fields`` entry.
+_MISSING_FIELD = object()
 
 
 @dataclass(frozen=True)
@@ -108,6 +116,25 @@ async def _call_one(
             max_tokens=ctx.max_tokens,
         )
     except StructuredCompleteError as exc:
+        latency_ms = int((time.monotonic() - started) * 1000)
+        return None, ModelAttempt(
+            model=model,
+            tag=tag,
+            latency_ms=latency_ms,
+            confidence=None,
+            verdict_summary=None,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    except Exception as exc:  # noqa: BLE001 — capture unexpected errors in audit trail
+        # Network errors, auth failures, asyncio cancellations, etc.
+        # Without this, AlwaysTwoModels' asyncio.gather would lose the
+        # other leg's result when one leg errored unexpectedly.
+        logger.warning(
+            "Unexpected error in _call_one for site=%s model=%s: %s",
+            ctx.site_name,
+            model,
+            exc,
+        )
         latency_ms = int((time.monotonic() - started) * 1000)
         return None, ModelAttempt(
             model=model,
@@ -228,7 +255,7 @@ def _agree(a: Any, b: Any, fields: Sequence[str]) -> bool:
         except Exception:  # noqa: BLE001 — exotic __eq__ that raises
             return False
     for field_name in fields:
-        if getattr(a, field_name, object()) != getattr(b, field_name, object()):
+        if getattr(a, field_name, _MISSING_FIELD) != getattr(b, field_name, _MISSING_FIELD):
             return False
     return True
 
@@ -247,10 +274,14 @@ class AlwaysTwoModels:
     3. Else (disagreement, or one errored) call ``escalation[1:]`` in
        order until the next available model produces a verdict — that's
        the tiebreaker.
-    4. Tiebreaker's verdict ships if it agrees with at least one of the
-       prior verdicts on the agreement fields; otherwise the highest-
-       confidence verdict among all attempts wins.
-    5. If every model errored, raise :class:`ConsensusUnavailable`.
+    4. Tiebreaker's verdict ships unconditionally when present — the
+       tiebreaker IS the casting vote, regardless of whether it happens
+       to agree with a prior. ``final_model`` always points at the model
+       that produced the shipped verdict so cost/latency/bug-triage stays
+       unambiguous; agreement information remains reconstructable from
+       the ``attempts`` list.
+    5. If every model errored (or primary+secondary disagreed AND every
+       tiebreaker errored), raise :class:`ConsensusUnavailable`.
     """
 
     name: str = "always_two_models"
@@ -266,8 +297,20 @@ class AlwaysTwoModels:
 
         # Resolve primary first; resolve escalation[0] distinctly.
         primary_model, _ = ctx.pool.resolve(ctx.primary)
-        # Validate distinctness (raises if same concrete model).
-        ctx.pool.resolve_distinct(ctx.escalation[0], different_from=primary_model)
+        # Validate distinctness — primary and escalation[0] must resolve to
+        # different concrete models for two-model agreement to be meaningful.
+        # On misconfiguration (two tags pointing at the same model), surface
+        # ConsensusUnavailable so the wrapping @shadow_decision falls through
+        # to the legacy heuristic instead of crashing.
+        try:
+            ctx.pool.resolve_distinct(ctx.escalation[0], different_from=primary_model)
+        except ProviderPoolError as exc:
+            CONSENSUS_UNAVAILABLE_TOTAL.labels(site=ctx.site_name).inc()
+            raise ConsensusUnavailable(
+                strategy=self.name,
+                attempts=[],
+                reason=f"pool misconfiguration: {exc}",
+            ) from exc
 
         # Run primary + secondary in parallel.
         first_call = _call_one(ctx, tag_or_literal=ctx.primary)

--- a/src/caretaker/consensus/strategies.py
+++ b/src/caretaker/consensus/strategies.py
@@ -8,6 +8,7 @@ errored out. The engine selects a strategy by name from
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from dataclasses import dataclass
@@ -204,7 +205,153 @@ class TieredConfidence:
         )
 
 
+# ── AlwaysTwoModels ───────────────────────────────────────────────────────
+
+
+def _agree(a: Any, b: Any, fields: Sequence[str]) -> bool:
+    """Decide whether two verdicts agree on the configured fields."""
+    if not fields:
+        try:
+            return bool(a == b)
+        except Exception:  # noqa: BLE001 — exotic __eq__ that raises
+            return False
+    for field_name in fields:
+        if getattr(a, field_name, object()) != getattr(b, field_name, object()):
+            return False
+    return True
+
+
+@dataclass
+class AlwaysTwoModels:
+    """Two-model agreement strategy with tiebreaker escalation.
+
+    Order of operations:
+
+    1. Call ``primary`` and ``escalation[0]`` in parallel. The escalation
+       tag must resolve to a different concrete model than ``primary``;
+       :func:`ProviderPool.resolve_distinct` enforces this.
+    2. If both succeed and agree on ``agreement_fields`` (or full verdict
+       if the list is empty), ship primary's verdict.
+    3. Else (disagreement, or one errored) call ``escalation[1:]`` in
+       order until the next available model produces a verdict — that's
+       the tiebreaker.
+    4. Tiebreaker's verdict ships if it agrees with at least one of the
+       prior verdicts on the agreement fields; otherwise the highest-
+       confidence verdict among all attempts wins.
+    5. If every model errored, raise :class:`ConsensusUnavailable`.
+    """
+
+    name: str = "always_two_models"
+
+    async def run(self, ctx: StrategyContext) -> ConsensusResult[Any]:
+        if not ctx.escalation:
+            raise ConsensusUnavailable(
+                strategy=self.name,
+                attempts=[],
+                reason="always_two_models requires escalation[0] (no second model configured)",
+            )
+
+        # Resolve primary first; resolve escalation[0] distinctly.
+        primary_model, _ = ctx.pool.resolve(ctx.primary)
+        # Validate distinctness (raises if same concrete model).
+        ctx.pool.resolve_distinct(ctx.escalation[0], different_from=primary_model)
+
+        # Run primary + secondary in parallel.
+        first_call = _call_one(ctx, tag_or_literal=ctx.primary)
+        second_call = _call_one(ctx, tag_or_literal=ctx.escalation[0])
+        (primary_verdict, primary_attempt), (second_verdict, second_attempt) = await asyncio.gather(
+            first_call, second_call
+        )
+        attempts: list[ModelAttempt] = [primary_attempt, second_attempt]
+
+        # Both succeed and agree → ship primary.
+        if (
+            primary_verdict is not None
+            and second_verdict is not None
+            and _agree(primary_verdict, second_verdict, ctx.agreement_fields)
+        ):
+            return ConsensusResult(
+                verdict=primary_verdict,
+                trace=ConsensusTrace(
+                    strategy=self.name,
+                    attempts=attempts,
+                    escalated=False,
+                    final_model=primary_attempt.model,
+                ),
+            )
+
+        # Disagreement OR a leg errored → run tiebreaker tier.
+        tiebreaker_verdict: Any | None = None
+        tiebreaker_attempt: ModelAttempt | None = None
+        for entry in ctx.escalation[1:]:
+            verdict, attempt = await _call_one(ctx, tag_or_literal=entry)
+            attempts.append(attempt)
+            if verdict is not None:
+                tiebreaker_verdict = verdict
+                tiebreaker_attempt = attempt
+                break
+
+        # Promote whatever's available to a winner.
+        candidates: list[tuple[Any, ModelAttempt]] = []
+        if primary_verdict is not None:
+            candidates.append((primary_verdict, primary_attempt))
+        if second_verdict is not None:
+            candidates.append((second_verdict, second_attempt))
+        if tiebreaker_verdict is not None and tiebreaker_attempt is not None:
+            candidates.append((tiebreaker_verdict, tiebreaker_attempt))
+
+        if not candidates:
+            raise ConsensusUnavailable(
+                strategy=self.name,
+                attempts=attempts,
+                reason="primary, secondary, and every tiebreaker errored",
+            )
+
+        # If tiebreaker exists, prefer it. When it agrees with a surviving
+        # prior verdict on the agreement fields, surface the agreement-winner
+        # as the final_model (so traces show "two models agreed on X");
+        # otherwise the tiebreaker itself is the deciding vote.
+        if tiebreaker_verdict is not None and tiebreaker_attempt is not None:
+            for verdict, attempt in candidates[:-1]:  # exclude tiebreaker self
+                if _agree(tiebreaker_verdict, verdict, ctx.agreement_fields):
+                    return ConsensusResult(
+                        verdict=tiebreaker_verdict,
+                        trace=ConsensusTrace(
+                            strategy=self.name,
+                            attempts=attempts,
+                            escalated=True,
+                            final_model=attempt.model,
+                        ),
+                    )
+            # No prior agreement — tiebreaker casts the deciding vote.
+            return ConsensusResult(
+                verdict=tiebreaker_verdict,
+                trace=ConsensusTrace(
+                    strategy=self.name,
+                    attempts=attempts,
+                    escalated=True,
+                    final_model=tiebreaker_attempt.model,
+                ),
+            )
+
+        # Fall back to highest-confidence among all candidates.
+        def _conf(item: tuple[Any, ModelAttempt]) -> float:
+            return item[1].confidence if item[1].confidence is not None else 0.0
+
+        winner_verdict, winner_attempt = max(candidates, key=_conf)
+        return ConsensusResult(
+            verdict=winner_verdict,
+            trace=ConsensusTrace(
+                strategy=self.name,
+                attempts=attempts,
+                escalated=True,
+                final_model=winner_attempt.model,
+            ),
+        )
+
+
 __all__ = [
+    "AlwaysTwoModels",
     "Strategy",
     "StrategyContext",
     "TieredConfidence",

--- a/src/caretaker/consensus/trace.py
+++ b/src/caretaker/consensus/trace.py
@@ -3,8 +3,15 @@
 A :class:`ConsensusTrace` is the authoritative serialised audit for one
 ``engine.decide(...)`` call. It records every model attempt — including
 errors — in attempt order, plus the final model whose verdict was shipped.
-The record is JSON-serialised onto :attr:`ShadowDecisionRecord.consensus_trace_json`
-for persistence and surfacing through the existing admin API.
+
+The schema is **designed** to be JSON-serialised onto
+:attr:`ShadowDecisionRecord.consensus_trace_json` for persistence and
+surfaced through the existing admin API. End-to-end wire-up — capturing
+the trace from ``engine.decide`` and flowing it through the
+``@shadow_decision`` decorator — is a follow-up; today the field exists
+on :class:`ShadowDecisionRecord` but is left ``None`` by the call sites
+(readiness, size_classifier). Tracked as a follow-up after this PR
+merges.
 
 Both types are :class:`pydantic.BaseModel` for cheap roundtrip; values
 are scalar so the persisted JSON is grep-friendly.

--- a/src/caretaker/consensus/trace.py
+++ b/src/caretaker/consensus/trace.py
@@ -1,0 +1,78 @@
+"""Per-decision consensus audit records.
+
+A :class:`ConsensusTrace` is the authoritative serialised audit for one
+``engine.decide(...)`` call. It records every model attempt — including
+errors — in attempt order, plus the final model whose verdict was shipped.
+The record is JSON-serialised onto :attr:`ShadowDecisionRecord.consensus_trace_json`
+for persistence and surfacing through the existing admin API.
+
+Both types are :class:`pydantic.BaseModel` for cheap roundtrip; values
+are scalar so the persisted JSON is grep-friendly.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelAttempt(BaseModel):
+    """One model invocation inside a consensus decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str = Field(description="Concrete model string (e.g. 'claude-sonnet-4-6').")
+    tag: str = Field(
+        description=(
+            "Capability tag the model was resolved from "
+            "('fast', 'reasoning_anthropic', etc.). Equals the literal model "
+            "string when the caller passed a literal instead of a tag."
+        ),
+    )
+    latency_ms: int = Field(ge=0, description="Wall-clock duration of the model call.")
+    confidence: float | None = Field(
+        default=None,
+        description=(
+            "Self-reported confidence from the model's verdict. ``None`` "
+            "when the call errored or the verdict had no confidence field."
+        ),
+    )
+    verdict_summary: str | None = Field(
+        default=None,
+        max_length=200,
+        description=(
+            "Short summary of the model's verdict for log readability. ``None`` on error."
+        ),
+    )
+    error: str | None = Field(
+        default=None,
+        description="Stringified exception when the call failed; otherwise ``None``.",
+    )
+
+
+class ConsensusTrace(BaseModel):
+    """Audit record for one consensus decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    strategy: str = Field(description="Strategy name: 'tiered_confidence' or 'always_two_models'.")
+    attempts: list[ModelAttempt] = Field(
+        default_factory=list,
+        description="Model invocations in the order they happened.",
+    )
+    escalated: bool = Field(
+        default=False,
+        description=(
+            "True when the strategy had to escalate beyond the primary model "
+            "(low confidence in tiered, disagreement in always-two)."
+        ),
+    )
+    final_model: str = Field(
+        default="",
+        description=(
+            "The model whose verdict was returned to the caller. Empty string "
+            "when the engine raised ConsensusUnavailable."
+        ),
+    )
+
+
+__all__ = ["ConsensusTrace", "ModelAttempt"]

--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -129,6 +129,71 @@ class DoctorReport:
         }
 
 
+# ── Consensus engine config validation ─────────────────────────────────
+
+
+def diagnose_consensus_config(config: MaintainerConfig) -> list[str]:
+    """Return human-readable issues with the consensus engine configuration.
+
+    Each entry is a single-sentence issue. Empty list means the consensus
+    configuration is internally consistent. Caller decides whether to log
+    warnings or fail-fast.
+
+    Heuristic for "literal vs tag": a string containing ``/`` or any digit
+    (model versioning, e.g. ``claude-sonnet-4-6``, ``haiku-4-5``) is
+    treated as a literal model identifier and its absence from
+    ``llm.model_pool.pool`` is not an error. Everything else looks like a
+    capability tag — if it isn't in the pool, surface the issue so a typo
+    like ``reasoning_antropic`` fails fast at startup rather than at
+    decision time.
+    """
+    issues: list[str] = []
+    pool = config.llm.model_pool.pool
+
+    site_names = (
+        "readiness",
+        "ci_triage",
+        "review_classification",
+        "issue_triage",
+        "cascade",
+        "stuck_pr",
+        "bot_identity",
+        "dispatch_guard",
+        "executor_routing",
+        "crystallizer_category",
+        "size_classifier",
+    )
+
+    def _is_literal(value: str) -> bool:
+        if "/" in value:
+            return True
+        # Treat anything containing a digit (model versioning, e.g.
+        # "claude-sonnet-4-6", "haiku-4-5") as a likely literal; pure
+        # tags don't contain version digits.
+        return bool(value) and any(c.isdigit() for c in value)
+
+    for site_name in site_names:
+        domain = getattr(config.agentic, site_name, None)
+        if domain is None:
+            continue
+        consensus_cfg = getattr(domain, "consensus", None)
+        if consensus_cfg is None:
+            continue
+        labelled: list[tuple[str, str]] = [("primary", consensus_cfg.primary)]
+        labelled.extend((f"escalation[{i}]", v) for i, v in enumerate(consensus_cfg.escalation))
+        for label, value in labelled:
+            if value in pool:
+                continue
+            if _is_literal(value):
+                continue
+            issues.append(
+                f"site {site_name!r} {label} references tag {value!r} "
+                f"which is not present in llm.model_pool.pool"
+            )
+
+    return issues
+
+
 # ── Config → env-var references ────────────────────────────────────────
 
 

--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -191,6 +191,32 @@ def diagnose_consensus_config(config: MaintainerConfig) -> list[str]:
                 f"which is not present in llm.model_pool.pool"
             )
 
+    # Validate AlwaysTwoModels distinctness: when strategy is always_two_models,
+    # primary and escalation[0] must resolve to DIFFERENT concrete models. A
+    # pool with two tags pointing at the same model would silently consult
+    # one model twice rather than achieving two-model agreement.
+    for site_name in site_names:
+        domain = getattr(config.agentic, site_name, None)
+        if domain is None:
+            continue
+        consensus_cfg = getattr(domain, "consensus", None)
+        if consensus_cfg is None:
+            continue
+        if consensus_cfg.strategy != "always_two_models":
+            continue
+        if not consensus_cfg.escalation:
+            continue
+        primary_resolved = pool.get(consensus_cfg.primary, consensus_cfg.primary)
+        secondary_resolved = pool.get(consensus_cfg.escalation[0], consensus_cfg.escalation[0])
+        if primary_resolved == secondary_resolved:
+            issues.append(
+                f"site {site_name!r} uses always_two_models but primary "
+                f"({consensus_cfg.primary!r}) and escalation[0] "
+                f"({consensus_cfg.escalation[0]!r}) both resolve to "
+                f"{primary_resolved!r} — two-model agreement requires distinct "
+                f"concrete models"
+            )
+
     return issues
 
 

--- a/src/caretaker/evolution/shadow.py
+++ b/src/caretaker/evolution/shadow.py
@@ -207,6 +207,15 @@ class ShadowDecisionRecord(BaseModel):
             "(e.g. candidate errored before issuing an LLM request)."
         ),
     )
+    consensus_trace_json: str | None = Field(
+        default=None,
+        description=(
+            "JSON-serialised :class:`caretaker.consensus.ConsensusTrace` for "
+            "decisions that ran through the consensus engine. ``None`` for "
+            "legacy-only decisions and for sites where ``AgenticDomainConfig."
+            "consensus`` is None."
+        ),
+    )
     # Diagnostic field, tri-state:
     #
     # * ``True``  — strict equality check ran and disagreed (LLM drift in
@@ -271,6 +280,9 @@ def write_shadow_decision(record: ShadowDecisionRecord) -> None:
         # normalises the empty-string back to ``None`` on read.
         "legacy_model": record.legacy_model or "",
         "candidate_model": record.candidate_model or "",
+        # Empty string when None so Neo4j storage doesn't have to special-case
+        # NULLs; admin API normalises empty string back to None on read.
+        "consensus_trace_json": record.consensus_trace_json or "",
     }
     stats = writer.stats()
     if stats.get("enabled"):

--- a/src/caretaker/foundry/executor.py
+++ b/src/caretaker/foundry/executor.py
@@ -34,8 +34,8 @@ from caretaker.foundry.prompts import build_prompt
 from caretaker.foundry.size_classifier import (
     ClassifierResult,
     Decision,
-    post_flight,
-    pre_flight,
+    decide_post,
+    decide_pre,
 )
 from caretaker.foundry.tool_loop import ToolLoopError, run_tool_loop
 from caretaker.foundry.tools import ToolContext, build_tool_registry
@@ -262,7 +262,7 @@ class FoundryExecutor:
         head_repo = pr.head_repo_full_name or f"{self._owner}/{self._repo}"
         base_repo = pr.base_repo_full_name or f"{self._owner}/{self._repo}"
 
-        pre = pre_flight(
+        pre = await decide_pre(
             task_type=task.task_type.value,
             allowed_task_types=self._config.allowed_task_types,
             head_repo_full_name=head_repo,
@@ -351,7 +351,7 @@ class FoundryExecutor:
 
                 # Post-flight sizing gate
                 diff_stats = await workspace.diff_stat()
-                post = post_flight(
+                post = await decide_post(
                     files_changed=diff_stats["files_changed"],
                     insertions=diff_stats["insertions"],
                     deletions=diff_stats["deletions"],

--- a/src/caretaker/foundry/size_classifier.py
+++ b/src/caretaker/foundry/size_classifier.py
@@ -232,8 +232,6 @@ async def decide_post(
         return legacy
 
     total_lines = insertions + deletions
-    files_borderline = borderline_low_files <= files_changed <= borderline_high_files
-    lines_borderline = borderline_low_lines <= total_lines <= borderline_high_lines
 
     if files_changed < borderline_low_files and total_lines < borderline_low_lines:
         # Well under both floors — fast path.
@@ -247,9 +245,6 @@ async def decide_post(
                 f"lines={total_lines}; escalating without engine consult"
             ),
         )
-
-    if not (files_borderline or lines_borderline):
-        return legacy  # in mixed gray-zones we trust the legacy gate
 
     return await _engine_consult_or_fallback(
         site="size_classifier",

--- a/src/caretaker/foundry/size_classifier.py
+++ b/src/caretaker/foundry/size_classifier.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
+from pydantic import BaseModel, Field
+
 
 class Decision(StrEnum):
     """What the classifier says to do with a task."""
@@ -103,3 +105,191 @@ def post_flight(
             reason=(f"diff is {total_lines} lines (> max_diff_lines={max_diff_lines})"),
         )
     return ClassifierResult(decision=Decision.ROUTE_FOUNDRY, reason="within_budget")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Hybrid floor/ceiling decision API
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class SizeVerdict(BaseModel):
+    """LLM-emitted verdict in the borderline zone.
+
+    Schema kept tight: closed enum + confidence + free-text reason. The
+    consensus engine compares verdicts on ``decision`` for AlwaysTwoModels
+    if a site ever swaps strategies.
+    """
+
+    decision: Decision
+    confidence: float = Field(ge=0.0, le=1.0)
+    reason: str = Field(max_length=300)
+
+
+_SIZE_SYSTEM_PROMPT = """\
+You are caretaker's size_classifier. Given a Foundry task summary,
+decide whether the diff/error is small enough to route to the
+Foundry executor (ROUTE_FOUNDRY) or should escalate to Copilot
+(ESCALATE_COPILOT).
+
+Rules:
+- Mechanical refactors (rename, lint fix, type tightening) — ROUTE_FOUNDRY
+  even at higher line counts.
+- Genuinely complex logic changes, multi-package refactors, or anything
+  touching auth/migrations/public APIs — ESCALATE_COPILOT.
+- ``confidence`` is your self-assessed probability the verdict is correct.
+- ``reason`` must be a single line no longer than 300 characters.
+"""
+
+
+async def decide_pre(
+    *,
+    task_type: str,
+    allowed_task_types: list[str],
+    head_repo_full_name: str | None,
+    base_repo_full_name: str | None,
+    route_same_repo_only: bool,
+    error_output: str,
+    max_error_output_chars: int = 16_000,
+    borderline_low_error_chars: int = 4_000,
+    borderline_high_error_chars: int = 12_000,
+) -> ClassifierResult:
+    """Async pre-flight gate with deterministic floor/ceiling.
+
+    Below ``borderline_low_error_chars`` → always ROUTE_FOUNDRY.
+    Above ``borderline_high_error_chars`` (or any other deterministic
+    rejection like task-type mismatch / fork PR) → ESCALATE_COPILOT.
+    Between → consult the consensus engine (when active).
+    """
+    # Hard rejections — task type, fork PR — short-circuit.
+    legacy = pre_flight(
+        task_type=task_type,
+        allowed_task_types=allowed_task_types,
+        head_repo_full_name=head_repo_full_name,
+        base_repo_full_name=base_repo_full_name,
+        route_same_repo_only=route_same_repo_only,
+        error_output=error_output,
+        max_error_output_chars=max_error_output_chars,
+    )
+    if legacy.decision != Decision.ROUTE_FOUNDRY:
+        # Above ceiling or hard reject — return as-is.
+        return legacy
+
+    error_chars = len(error_output or "")
+    if error_chars < borderline_low_error_chars:
+        return legacy  # well under low band — fast path stays
+
+    if error_chars > borderline_high_error_chars:
+        return ClassifierResult(
+            decision=Decision.ESCALATE_COPILOT,
+            reason=(
+                f"error_output is {error_chars} chars (> borderline high "
+                f"{borderline_high_error_chars}); escalating without engine consult"
+            ),
+        )
+
+    # Borderline — consult engine if active.
+    return await _engine_consult_or_fallback(
+        site="size_classifier",
+        prompt=(
+            f"Foundry pre-flight summary:\n"
+            f"- task_type: {task_type}\n"
+            f"- error_output_chars: {error_chars}\n"
+            f"- error_output_excerpt:\n{(error_output or '')[:1000]}\n"
+        ),
+        fallback=legacy,
+    )
+
+
+async def decide_post(
+    *,
+    files_changed: int,
+    insertions: int,
+    deletions: int,
+    max_files_touched: int,
+    max_diff_lines: int,
+    borderline_low_files: int = 3,
+    borderline_high_files: int = 10,
+    borderline_low_lines: int = 100,
+    borderline_high_lines: int = 300,
+) -> ClassifierResult:
+    """Async post-flight gate with deterministic floor/ceiling.
+
+    Both files-changed and total-lines have their own borderline bands.
+    A diff is "borderline" if **either** dimension is in its band — gives
+    the engine a chance to weigh "lots of small files" vs "few large
+    files" cases.
+    """
+    legacy = post_flight(
+        files_changed=files_changed,
+        insertions=insertions,
+        deletions=deletions,
+        max_files_touched=max_files_touched,
+        max_diff_lines=max_diff_lines,
+    )
+    if legacy.decision == Decision.ESCALATE_COPILOT:
+        # Above the hard ceiling — never consult the engine; it can't
+        # rescue a 25-file diff.
+        return legacy
+
+    total_lines = insertions + deletions
+    files_borderline = borderline_low_files <= files_changed <= borderline_high_files
+    lines_borderline = borderline_low_lines <= total_lines <= borderline_high_lines
+
+    if files_changed < borderline_low_files and total_lines < borderline_low_lines:
+        # Well under both floors — fast path.
+        return legacy
+
+    if files_changed > borderline_high_files or total_lines > borderline_high_lines:
+        return ClassifierResult(
+            decision=Decision.ESCALATE_COPILOT,
+            reason=(
+                f"borderline ceiling exceeded: files={files_changed} "
+                f"lines={total_lines}; escalating without engine consult"
+            ),
+        )
+
+    if not (files_borderline or lines_borderline):
+        return legacy  # in mixed gray-zones we trust the legacy gate
+
+    return await _engine_consult_or_fallback(
+        site="size_classifier",
+        prompt=(
+            f"Foundry post-flight diff summary:\n"
+            f"- files_changed: {files_changed}\n"
+            f"- insertions: {insertions}\n"
+            f"- deletions: {deletions}\n"
+            f"- total_lines: {total_lines}\n"
+        ),
+        fallback=legacy,
+    )
+
+
+async def _engine_consult_or_fallback(
+    *,
+    site: str,
+    prompt: str,
+    fallback: ClassifierResult,
+) -> ClassifierResult:
+    """Call the consensus engine when active; on failure return ``fallback``."""
+    from caretaker.consensus import active as consensus_active
+    from caretaker.consensus.result import ConsensusUnavailable
+
+    engine = consensus_active.get_active_engine()
+    if engine is None or not engine.has_site(site):
+        return fallback
+
+    try:
+        result = await engine.decide(
+            site_name=site,
+            schema=SizeVerdict,
+            system_prompt=_SIZE_SYSTEM_PROMPT,
+            user_prompt=prompt,
+            feature="size_classifier",
+        )
+    except ConsensusUnavailable:
+        return fallback
+
+    return ClassifierResult(
+        decision=result.verdict.decision,
+        reason=f"engine: {result.verdict.reason}",
+    )

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -43,6 +43,7 @@ from caretaker.state.tracker import StateTracker
 
 if TYPE_CHECKING:
     from caretaker.coding_agents.registry import CodingAgentRegistry
+    from caretaker.consensus.engine import ConsensusEngine
     from caretaker.evolution.insight_store import InsightStore
     from caretaker.goals.models import GoalEvaluation
     from caretaker.llm.claude import ClaudeClient
@@ -259,6 +260,56 @@ def _build_credentials_provider(
         return app_provider
 
 
+_CONSENSUS_SITE_NAMES: tuple[str, ...] = (
+    "readiness",
+    "ci_triage",
+    "review_classification",
+    "issue_triage",
+    "cascade",
+    "stuck_pr",
+    "bot_identity",
+    "dispatch_guard",
+    "executor_routing",
+    "crystallizer_category",
+    "size_classifier",
+)
+
+
+def _build_consensus_engine(config: MaintainerConfig) -> ConsensusEngine | None:
+    """Build a ConsensusEngine from the configured sites, or return None.
+
+    Walks every :class:`AgenticDomainConfig` on :class:`AgenticConfig` and
+    collects the ones with a non-None ``consensus`` field. If none opt in,
+    no engine is built and the existing single-model paths run unchanged.
+    """
+    from caretaker.consensus.engine import ConsensusEngine, EngineConfig, SiteConfig
+    from caretaker.consensus.provider_pool import ProviderPool
+    from caretaker.llm.claude import ClaudeClient
+
+    sites: dict[str, SiteConfig] = {}
+    for site_name in _CONSENSUS_SITE_NAMES:
+        domain = getattr(config.agentic, site_name, None)
+        if domain is None:
+            continue
+        consensus_cfg = getattr(domain, "consensus", None)
+        if consensus_cfg is None:
+            continue
+        sites[site_name] = SiteConfig(
+            strategy=consensus_cfg.strategy,
+            primary=consensus_cfg.primary,
+            escalation=list(consensus_cfg.escalation),
+            confidence_threshold=consensus_cfg.confidence_threshold,
+            agreement_fields=list(consensus_cfg.agreement_fields),
+        )
+
+    if not sites:
+        return None
+
+    pool = ProviderPool(dict(config.llm.model_pool.pool))
+    claude = ClaudeClient(config=config.llm)
+    return ConsensusEngine(config=EngineConfig(pool=pool, sites=sites), claude=claude)
+
+
 class Orchestrator:
     """Central orchestrator that coordinates all agents."""
 
@@ -274,6 +325,25 @@ class Orchestrator:
         self._owner = owner
         self._repo = repo
         self._llm = LLMRouter(config.llm)
+
+        # ── Consensus engine (Phase 3 of agentic migration) ────────────
+        from caretaker.consensus import active as consensus_active
+        from caretaker.evolution import shadow_config
+
+        # Install the agentic config so @shadow_decision can resolve modes.
+        # This was previously only set in tests; production runs need it too.
+        shadow_config.configure_maintainer(config)
+
+        self._consensus_engine = _build_consensus_engine(config)
+        if self._consensus_engine is not None:
+            consensus_active.configure(self._consensus_engine)
+            logger.info(
+                "Consensus engine active for sites: %s",
+                sorted(self._consensus_engine.site_names()),
+            )
+        else:
+            consensus_active.reset_for_tests()
+
         self._state_tracker = StateTracker(github, owner, repo)
 
         # Memory backend — configured persistence backend (MongoDB when enabled)

--- a/src/caretaker/orchestrator.py
+++ b/src/caretaker/orchestrator.py
@@ -342,7 +342,7 @@ class Orchestrator:
                 sorted(self._consensus_engine.site_names()),
             )
         else:
-            consensus_active.reset_for_tests()
+            consensus_active.clear()
 
         self._state_tracker = StateTracker(github, owner, repo)
 

--- a/src/caretaker/pr_agent/readiness_llm.py
+++ b/src/caretaker/pr_agent/readiness_llm.py
@@ -378,6 +378,11 @@ async def evaluate_pr_readiness_llm(
     harness A/B pattern (see docs/plans/2026-Q2-agentic-migration.md).
     ``max_tokens`` is the matching per-site override; ``None`` means
     "use the feature's resolved default".
+
+    When the consensus engine is configured for the "readiness" site, the
+    ``model`` parameter is ignored — strategies own per-tier model selection
+    through their capability-tag config. The ``max_tokens`` parameter is still
+    honoured (passed through to every per-tier model call).
     """
     memory_block: str | None = None
     if retriever is not None:
@@ -394,6 +399,12 @@ async def evaluate_pr_readiness_llm(
 
     engine = consensus_active.get_active_engine()
     if engine is not None and engine.has_site("readiness"):
+        # Thread ``max_tokens`` through to the engine when the call site
+        # set a per-site cap; otherwise let ``engine.decide`` use its own
+        # default (mirrors the direct-path treatment a few lines below).
+        engine_kwargs: dict[str, Any] = {}
+        if max_tokens is not None:
+            engine_kwargs["max_tokens"] = max_tokens
         try:
             result = await engine.decide(
                 site_name="readiness",
@@ -401,6 +412,7 @@ async def evaluate_pr_readiness_llm(
                 system_prompt=_READINESS_SYSTEM_PROMPT,
                 user_prompt=prompt,
                 feature="pr_readiness",
+                **engine_kwargs,
             )
         except ConsensusUnavailable as exc:
             logger.info(

--- a/src/caretaker/pr_agent/readiness_llm.py
+++ b/src/caretaker/pr_agent/readiness_llm.py
@@ -384,6 +384,35 @@ async def evaluate_pr_readiness_llm(
         memory_block = await _build_memory_block_for_readiness(context, retriever)
 
     prompt = build_readiness_prompt(context, memory_block=memory_block)
+
+    # Consensus engine routing — when a process-wide engine is configured for
+    # the "readiness" site, route through the engine. Otherwise fall back to
+    # the existing single-model direct path. Imported lazily so module import
+    # stays cheap and circular-import-safe.
+    from caretaker.consensus import active as consensus_active
+    from caretaker.consensus.result import ConsensusUnavailable
+
+    engine = consensus_active.get_active_engine()
+    if engine is not None and engine.has_site("readiness"):
+        try:
+            result = await engine.decide(
+                site_name="readiness",
+                schema=Readiness,
+                system_prompt=_READINESS_SYSTEM_PROMPT,
+                user_prompt=prompt,
+                feature="pr_readiness",
+            )
+        except ConsensusUnavailable as exc:
+            logger.info(
+                "evaluate_pr_readiness_llm: consensus unavailable for PR #%s: %s",
+                context.pr.number,
+                exc,
+            )
+            return None
+        return result.verdict
+
+    # No engine configured for this site — direct single-model path
+    # (existing behaviour).
     try:
         # Pass ``model`` through only when the override is set so the
         # default feature-resolution path stays unchanged for operators

--- a/tests/test_consensus_active.py
+++ b/tests/test_consensus_active.py
@@ -1,0 +1,33 @@
+"""Tests for the process-wide ConsensusEngine holder."""
+
+from __future__ import annotations
+
+from caretaker.consensus import active
+from caretaker.consensus.engine import ConsensusEngine, EngineConfig
+from caretaker.consensus.provider_pool import ProviderPool
+
+
+def _engine() -> ConsensusEngine:
+    pool = ProviderPool({"fast": "fake-fast"})
+    return ConsensusEngine(
+        config=EngineConfig(pool=pool, sites={}),
+        claude=object(),  # type: ignore[arg-type]
+    )
+
+
+def test_get_returns_none_when_unconfigured() -> None:
+    active.reset_for_tests()
+    assert active.get_active_engine() is None
+
+
+def test_configure_installs_engine() -> None:
+    active.reset_for_tests()
+    engine = _engine()
+    active.configure(engine)
+    assert active.get_active_engine() is engine
+
+
+def test_reset_clears_engine() -> None:
+    active.configure(_engine())
+    active.reset_for_tests()
+    assert active.get_active_engine() is None

--- a/tests/test_consensus_config.py
+++ b/tests/test_consensus_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from caretaker.config import LLMConfig, ModelPoolConfig
+from caretaker.config import ConsensusDomainConfig, LLMConfig, ModelPoolConfig
 
 
 def test_model_pool_config_defaults_empty() -> None:
@@ -31,3 +31,47 @@ def test_llm_config_accepts_pool() -> None:
 def test_model_pool_rejects_empty_value() -> None:
     with pytest.raises(ValidationError):
         ModelPoolConfig(pool={"fast": ""})
+
+
+def test_consensus_domain_defaults() -> None:
+    cfg = ConsensusDomainConfig()
+    assert cfg.strategy == "tiered_confidence"
+    assert cfg.primary == "fast"
+    assert cfg.escalation == ["reasoning_anthropic"]
+    assert cfg.confidence_threshold == 0.7
+    assert cfg.agreement_fields == []
+
+
+def test_consensus_domain_accepts_always_two_with_distinct_escalation() -> None:
+    cfg = ConsensusDomainConfig(
+        strategy="always_two_models",
+        primary="reasoning_anthropic",
+        escalation=["reasoning_alt"],
+        agreement_fields=["verdict"],
+    )
+    assert cfg.strategy == "always_two_models"
+
+
+def test_consensus_domain_rejects_always_two_without_escalation() -> None:
+    with pytest.raises(ValidationError, match="escalation"):
+        ConsensusDomainConfig(
+            strategy="always_two_models",
+            primary="reasoning_anthropic",
+            escalation=[],
+        )
+
+
+def test_consensus_domain_rejects_always_two_with_same_primary_in_escalation() -> None:
+    with pytest.raises(ValidationError, match="distinct"):
+        ConsensusDomainConfig(
+            strategy="always_two_models",
+            primary="reasoning_anthropic",
+            escalation=["reasoning_anthropic"],
+        )
+
+
+def test_confidence_threshold_bounded() -> None:
+    with pytest.raises(ValidationError):
+        ConsensusDomainConfig(confidence_threshold=1.5)
+    with pytest.raises(ValidationError):
+        ConsensusDomainConfig(confidence_threshold=-0.1)

--- a/tests/test_consensus_config.py
+++ b/tests/test_consensus_config.py
@@ -1,0 +1,33 @@
+"""Tests for new consensus-related config models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from caretaker.config import LLMConfig, ModelPoolConfig
+
+
+def test_model_pool_config_defaults_empty() -> None:
+    cfg = ModelPoolConfig()
+    assert cfg.pool == {}
+
+
+def test_model_pool_config_accepts_tags() -> None:
+    cfg = ModelPoolConfig(pool={"fast": "haiku-4-5", "reasoning_anthropic": "claude-sonnet-4-6"})
+    assert cfg.pool["fast"] == "haiku-4-5"
+
+
+def test_llm_config_has_model_pool_default() -> None:
+    cfg = LLMConfig()
+    assert cfg.model_pool.pool == {}
+
+
+def test_llm_config_accepts_pool() -> None:
+    cfg = LLMConfig(model_pool=ModelPoolConfig(pool={"fast": "haiku-4-5"}))
+    assert cfg.model_pool.pool["fast"] == "haiku-4-5"
+
+
+def test_model_pool_rejects_empty_value() -> None:
+    with pytest.raises(ValidationError):
+        ModelPoolConfig(pool={"fast": ""})

--- a/tests/test_consensus_config.py
+++ b/tests/test_consensus_config.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from caretaker.config import ConsensusDomainConfig, LLMConfig, ModelPoolConfig
+from caretaker.config import (
+    AgenticConfig,
+    AgenticDomainConfig,
+    ConsensusDomainConfig,
+    LLMConfig,
+    ModelPoolConfig,
+)
 
 
 def test_model_pool_config_defaults_empty() -> None:
@@ -75,3 +81,21 @@ def test_confidence_threshold_bounded() -> None:
         ConsensusDomainConfig(confidence_threshold=1.5)
     with pytest.raises(ValidationError):
         ConsensusDomainConfig(confidence_threshold=-0.1)
+
+
+def test_agentic_domain_consensus_default_none() -> None:
+    cfg = AgenticDomainConfig()
+    assert cfg.consensus is None
+
+
+def test_agentic_domain_accepts_consensus() -> None:
+    consensus = ConsensusDomainConfig(strategy="tiered_confidence")
+    cfg = AgenticDomainConfig(consensus=consensus)
+    assert cfg.consensus is consensus
+
+
+def test_agentic_config_has_size_classifier_slot() -> None:
+    cfg = AgenticConfig()
+    assert isinstance(cfg.size_classifier, AgenticDomainConfig)
+    assert cfg.size_classifier.mode == "off"
+    assert cfg.size_classifier.consensus is None

--- a/tests/test_consensus_e2e.py
+++ b/tests/test_consensus_e2e.py
@@ -1,0 +1,121 @@
+"""End-to-end smoke: orchestrator-built engine running a readiness decision."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from caretaker.config import (
+    AgenticConfig,
+    AgenticDomainConfig,
+    ConsensusDomainConfig,
+    LLMConfig,
+    MaintainerConfig,
+    ModelPoolConfig,
+)
+from caretaker.consensus import active as consensus_active
+from caretaker.orchestrator import _build_consensus_engine
+
+
+@dataclass
+class _FakeClaude:
+    responses: dict[str, list[Any]] = field(default_factory=dict)
+    calls: list[str] = field(default_factory=list)
+
+    async def structured_complete(
+        self,
+        prompt: str,
+        *,
+        schema: type[Any],
+        feature: str,
+        system: str | None = None,
+        model: str | None = None,
+        max_retries: int | None = None,
+        max_tokens: int = 2000,
+    ) -> Any:
+        self.calls.append(model or "<default>")
+        queue = self.responses.get(model or "<default>", [])
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+@pytest.fixture(autouse=True)
+def _reset_active() -> None:
+    consensus_active.reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_e2e_orchestrator_engine_runs_two_provider_readiness_decision() -> None:
+    """End-to-end: build engine via orchestrator helper, swap claude, run readiness."""
+    from caretaker.pr_agent.readiness_llm import Readiness
+
+    # Real config types — only the ClaudeClient gets faked.
+    config = MaintainerConfig(
+        llm=LLMConfig(
+            model_pool=ModelPoolConfig(
+                pool={
+                    "reasoning_anthropic": "fake-anthropic",
+                    "reasoning_alt": "fake-alt",
+                },
+            ),
+        ),
+        agentic=AgenticConfig(
+            readiness=AgenticDomainConfig(
+                mode="enforce",
+                consensus=ConsensusDomainConfig(
+                    strategy="always_two_models",
+                    primary="reasoning_anthropic",
+                    escalation=["reasoning_alt"],
+                    agreement_fields=["verdict"],
+                ),
+            ),
+        ),
+    )
+
+    engine = _build_consensus_engine(config)
+    assert engine is not None
+    assert engine.has_site("readiness")
+
+    # Inject a fake claude — the helper built a real ClaudeClient that would
+    # try to hit a real provider; swap it for the test.
+    fake_claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [
+                Readiness(
+                    verdict="ready",  # type: ignore[arg-type]
+                    summary="ok",
+                    confidence=0.9,
+                    blockers=[],
+                ),
+            ],
+            "fake-alt": [
+                Readiness(
+                    verdict="ready",  # type: ignore[arg-type]
+                    summary="ok",
+                    confidence=0.85,
+                    blockers=[],
+                ),
+            ],
+        },
+    )
+    engine._claude = fake_claude  # type: ignore[attr-defined]
+    consensus_active.configure(engine)
+
+    result = await engine.decide(
+        site_name="readiness",
+        schema=Readiness,
+        system_prompt="sys",
+        user_prompt="user",
+        feature="readiness",
+    )
+
+    # Both providers consulted in parallel via AlwaysTwoModels.
+    assert sorted(fake_claude.calls) == ["fake-alt", "fake-anthropic"]
+    # Both returned "ready" → primary's verdict ships, no escalation.
+    assert result.verdict.verdict == "ready"
+    assert result.trace.escalated is False
+    assert result.trace.final_model == "fake-anthropic"

--- a/tests/test_consensus_engine.py
+++ b/tests/test_consensus_engine.py
@@ -119,7 +119,7 @@ async def test_engine_routes_to_always_two_models() -> None:
 @pytest.mark.asyncio
 async def test_engine_raises_for_unknown_site() -> None:
     engine = _engine(_FakeClaude(), sites={})
-    with pytest.raises(KeyError, match="unknown_site"):
+    with pytest.raises(KeyError, match=r"site 'unknown_site'"):
         await engine.decide(
             site_name="unknown_site",
             schema=_Verdict,
@@ -171,7 +171,7 @@ async def test_engine_raises_for_unknown_strategy() -> None:
             ),
         },
     )
-    with pytest.raises(ValueError, match="unknown_strategy"):
+    with pytest.raises(ValueError, match=r"unknown consensus strategy 'unknown_strategy'"):
         await engine.decide(
             site_name="readiness",
             schema=_Verdict,
@@ -179,3 +179,21 @@ async def test_engine_raises_for_unknown_strategy() -> None:
             user_prompt="user",
             feature="readiness",
         )
+
+
+@pytest.mark.asyncio
+async def test_engine_has_site_returns_true_for_configured_site() -> None:
+    engine = _engine(
+        _FakeClaude(),
+        sites={
+            "readiness": SiteConfig(
+                strategy="tiered_confidence",
+                primary="fast",
+                escalation=["reasoning_anthropic"],
+                confidence_threshold=0.7,
+                agreement_fields=[],
+            ),
+        },
+    )
+    assert engine.has_site("readiness") is True
+    assert engine.has_site("size_classifier") is False

--- a/tests/test_consensus_engine.py
+++ b/tests/test_consensus_engine.py
@@ -197,3 +197,27 @@ async def test_engine_has_site_returns_true_for_configured_site() -> None:
     )
     assert engine.has_site("readiness") is True
     assert engine.has_site("size_classifier") is False
+
+
+def test_engine_site_names_returns_all_configured_sites() -> None:
+    """``site_names()`` returns every configured site as a frozenset."""
+    engine = _engine(
+        _FakeClaude(),
+        sites={
+            "readiness": SiteConfig(
+                strategy="tiered_confidence",
+                primary="fast",
+                escalation=["reasoning_anthropic"],
+                confidence_threshold=0.7,
+                agreement_fields=[],
+            ),
+            "size_classifier": SiteConfig(
+                strategy="tiered_confidence",
+                primary="fast",
+                escalation=["reasoning_anthropic"],
+                confidence_threshold=0.7,
+                agreement_fields=[],
+            ),
+        },
+    )
+    assert engine.site_names() == frozenset({"readiness", "size_classifier"})

--- a/tests/test_consensus_engine.py
+++ b/tests/test_consensus_engine.py
@@ -1,0 +1,181 @@
+"""Tests for ConsensusEngine.decide orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from caretaker.consensus.engine import ConsensusEngine, EngineConfig, SiteConfig
+from caretaker.consensus.provider_pool import ProviderPool
+from caretaker.consensus.result import ConsensusUnavailable
+
+
+class _Verdict(BaseModel):
+    label: str
+    confidence: float
+
+
+@dataclass
+class _FakeClaude:
+    responses: dict[str, list[Any]] = field(default_factory=dict)
+    calls: list[str] = field(default_factory=list)
+
+    async def structured_complete(
+        self,
+        prompt: str,
+        *,
+        schema: type[Any],
+        feature: str,
+        system: str | None = None,
+        model: str | None = None,
+        max_retries: int | None = None,
+        max_tokens: int = 2000,
+    ) -> Any:
+        assert model is not None
+        self.calls.append(model)
+        queue = self.responses.get(model, [])
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+def _engine(claude: _FakeClaude, *, sites: dict[str, SiteConfig]) -> ConsensusEngine:
+    return ConsensusEngine(
+        config=EngineConfig(
+            pool=ProviderPool(
+                {
+                    "fast": "fake-fast",
+                    "reasoning_anthropic": "fake-strong",
+                    "reasoning_alt": "fake-alt",
+                }
+            ),
+            sites=sites,
+        ),
+        claude=claude,
+    )
+
+
+@pytest.mark.asyncio
+async def test_engine_routes_to_tiered_strategy() -> None:
+    claude = _FakeClaude(responses={"fake-fast": [_Verdict(label="ready", confidence=0.95)]})
+    engine = _engine(
+        claude,
+        sites={
+            "readiness": SiteConfig(
+                strategy="tiered_confidence",
+                primary="fast",
+                escalation=["reasoning_anthropic"],
+                confidence_threshold=0.7,
+                agreement_fields=[],
+            ),
+        },
+    )
+    result = await engine.decide(
+        site_name="readiness",
+        schema=_Verdict,
+        system_prompt="sys",
+        user_prompt="user",
+        feature="readiness",
+    )
+    assert result.verdict.label == "ready"
+    assert result.trace.strategy == "tiered_confidence"
+
+
+@pytest.mark.asyncio
+async def test_engine_routes_to_always_two_models() -> None:
+    claude = _FakeClaude(
+        responses={
+            "fake-strong": [_Verdict(label="ready", confidence=0.9)],
+            "fake-alt": [_Verdict(label="ready", confidence=0.85)],
+        },
+    )
+    engine = _engine(
+        claude,
+        sites={
+            "readiness": SiteConfig(
+                strategy="always_two_models",
+                primary="reasoning_anthropic",
+                escalation=["reasoning_alt"],
+                confidence_threshold=0.7,
+                agreement_fields=["label"],
+            ),
+        },
+    )
+    result = await engine.decide(
+        site_name="readiness",
+        schema=_Verdict,
+        system_prompt="sys",
+        user_prompt="user",
+        feature="readiness",
+    )
+    assert result.verdict.label == "ready"
+    assert result.trace.strategy == "always_two_models"
+
+
+@pytest.mark.asyncio
+async def test_engine_raises_for_unknown_site() -> None:
+    engine = _engine(_FakeClaude(), sites={})
+    with pytest.raises(KeyError, match="unknown_site"):
+        await engine.decide(
+            site_name="unknown_site",
+            schema=_Verdict,
+            system_prompt="sys",
+            user_prompt="user",
+            feature="readiness",
+        )
+
+
+@pytest.mark.asyncio
+async def test_engine_propagates_consensus_unavailable() -> None:
+    from caretaker.llm.claude import StructuredCompleteError
+
+    err = StructuredCompleteError(raw_text="", validation_error=RuntimeError("nope"))
+    claude = _FakeClaude(responses={"fake-fast": [err], "fake-strong": [err]})
+    engine = _engine(
+        claude,
+        sites={
+            "readiness": SiteConfig(
+                strategy="tiered_confidence",
+                primary="fast",
+                escalation=["reasoning_anthropic"],
+                confidence_threshold=0.7,
+                agreement_fields=[],
+            ),
+        },
+    )
+    with pytest.raises(ConsensusUnavailable):
+        await engine.decide(
+            site_name="readiness",
+            schema=_Verdict,
+            system_prompt="sys",
+            user_prompt="user",
+            feature="readiness",
+        )
+
+
+@pytest.mark.asyncio
+async def test_engine_raises_for_unknown_strategy() -> None:
+    engine = _engine(
+        _FakeClaude(),
+        sites={
+            "readiness": SiteConfig(
+                strategy="unknown_strategy",  # type: ignore[arg-type]
+                primary="fast",
+                escalation=[],
+                confidence_threshold=0.7,
+                agreement_fields=[],
+            ),
+        },
+    )
+    with pytest.raises(ValueError, match="unknown_strategy"):
+        await engine.decide(
+            site_name="readiness",
+            schema=_Verdict,
+            system_prompt="sys",
+            user_prompt="user",
+            feature="readiness",
+        )

--- a/tests/test_consensus_metrics.py
+++ b/tests/test_consensus_metrics.py
@@ -1,0 +1,128 @@
+"""Tests that consensus strategies increment Prometheus counters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, Field
+
+from caretaker.consensus.metrics import (
+    CONSENSUS_DECISIONS_TOTAL,
+    CONSENSUS_DISAGREEMENT_TOTAL,
+    CONSENSUS_UNAVAILABLE_TOTAL,
+)
+from caretaker.consensus.provider_pool import ProviderPool
+from caretaker.consensus.result import ConsensusUnavailable
+from caretaker.consensus.strategies import (
+    AlwaysTwoModels,
+    StrategyContext,
+    TieredConfidence,
+)
+from caretaker.llm.claude import StructuredCompleteError
+
+
+class _Verdict(BaseModel):
+    label: str
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+@dataclass
+class _FakeClaude:
+    responses: dict[str, list[Any]] = field(default_factory=dict)
+
+    async def structured_complete(
+        self,
+        prompt: str,
+        *,
+        schema: type[Any],
+        feature: str,
+        system: str | None = None,
+        model: str | None = None,
+        max_retries: int | None = None,
+        max_tokens: int = 2000,
+    ) -> Any:
+        queue = self.responses.get(model or "<default>", [])
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+@pytest.mark.asyncio
+async def test_tiered_increments_primary_shipped_counter() -> None:
+    before = CONSENSUS_DECISIONS_TOTAL.labels(
+        site="readiness", strategy="tiered_confidence", outcome="primary_shipped"
+    )._value.get()
+    claude = _FakeClaude(responses={"fake-fast": [_Verdict(label="ready", confidence=0.95)]})
+    ctx = StrategyContext(
+        site_name="readiness",
+        schema=_Verdict,
+        system_prompt="sys",
+        user_prompt="user",
+        feature="readiness",
+        primary="fast",
+        escalation=["reasoning_anthropic"],
+        confidence_threshold=0.7,
+        agreement_fields=[],
+        pool=ProviderPool({"fast": "fake-fast", "reasoning_anthropic": "fake-strong"}),
+        claude=claude,
+    )
+    await TieredConfidence().run(ctx)
+    after = CONSENSUS_DECISIONS_TOTAL.labels(
+        site="readiness", strategy="tiered_confidence", outcome="primary_shipped"
+    )._value.get()
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
+async def test_atm_increments_disagreement_counter() -> None:
+    before = CONSENSUS_DISAGREEMENT_TOTAL.labels(site="readiness")._value.get()
+    claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [_Verdict(label="ready", confidence=0.9)],
+            "fake-alt": [_Verdict(label="not_ready", confidence=0.85)],
+            "literal-tiebreaker": [_Verdict(label="ready", confidence=0.7)],
+        },
+    )
+    ctx = StrategyContext(
+        site_name="readiness",
+        schema=_Verdict,
+        system_prompt="sys",
+        user_prompt="user",
+        feature="readiness",
+        primary="reasoning_anthropic",
+        escalation=["reasoning_alt", "literal-tiebreaker"],
+        confidence_threshold=0.7,
+        agreement_fields=["label"],
+        pool=ProviderPool({"reasoning_anthropic": "fake-anthropic", "reasoning_alt": "fake-alt"}),
+        claude=claude,
+    )
+    await AlwaysTwoModels().run(ctx)
+    after = CONSENSUS_DISAGREEMENT_TOTAL.labels(site="readiness")._value.get()
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
+async def test_unavailable_counter_increments_on_total_failure() -> None:
+    before = CONSENSUS_UNAVAILABLE_TOTAL.labels(site="readiness")._value.get()
+    err = StructuredCompleteError(raw_text="", validation_error=RuntimeError("nope"))
+    claude = _FakeClaude(responses={"fake-fast": [err], "fake-strong": [err]})
+    ctx = StrategyContext(
+        site_name="readiness",
+        schema=_Verdict,
+        system_prompt="sys",
+        user_prompt="user",
+        feature="readiness",
+        primary="fast",
+        escalation=["reasoning_anthropic"],
+        confidence_threshold=0.7,
+        agreement_fields=[],
+        pool=ProviderPool({"fast": "fake-fast", "reasoning_anthropic": "fake-strong"}),
+        claude=claude,
+    )
+    with pytest.raises(ConsensusUnavailable):
+        await TieredConfidence().run(ctx)
+    after = CONSENSUS_UNAVAILABLE_TOTAL.labels(site="readiness")._value.get()
+    assert after == before + 1

--- a/tests/test_consensus_provider_pool.py
+++ b/tests/test_consensus_provider_pool.py
@@ -1,0 +1,57 @@
+"""Tests for ProviderPool."""
+
+from __future__ import annotations
+
+import pytest
+
+from caretaker.consensus.provider_pool import ProviderPool, ProviderPoolError
+
+
+def test_resolves_known_tag_to_concrete_model() -> None:
+    pool = ProviderPool({"fast": "haiku-4-5", "reasoning_anthropic": "claude-sonnet-4-6"})
+    assert pool.resolve("fast") == ("haiku-4-5", "fast")
+    assert pool.resolve("reasoning_anthropic") == ("claude-sonnet-4-6", "reasoning_anthropic")
+
+
+def test_literal_model_string_passes_through() -> None:
+    """When the caller provides a literal model string, it's returned unchanged.
+
+    Heuristic for "literal vs tag": literal contains a slash, dot, or hyphen
+    that's not in any pool key. We treat any value that's not a pool key as
+    a literal and pass it through to the LLM router.
+    """
+    pool = ProviderPool({"fast": "haiku-4-5"})
+    assert pool.resolve("openai/gpt-4o") == ("openai/gpt-4o", "openai/gpt-4o")
+    assert pool.resolve("claude-sonnet-4-6") == ("claude-sonnet-4-6", "claude-sonnet-4-6")
+
+
+def test_unknown_empty_value_raises() -> None:
+    pool = ProviderPool({"fast": "haiku-4-5"})
+    with pytest.raises(ProviderPoolError):
+        pool.resolve("")
+
+
+def test_resolve_distinct_returns_two_distinct_models() -> None:
+    pool = ProviderPool({"fast": "haiku-4-5", "reasoning_anthropic": "claude-sonnet-4-6"})
+    primary_model, _ = pool.resolve("fast")
+    second_model, _ = pool.resolve_distinct("reasoning_anthropic", different_from=primary_model)
+    assert second_model == "claude-sonnet-4-6"
+    assert second_model != primary_model
+
+
+def test_resolve_distinct_raises_when_same_concrete_model() -> None:
+    """resolve_distinct raises when two tags resolve to the same model.
+
+    This is the validation hook for AlwaysTwoModels — if 'reasoning_anthropic'
+    and 'reasoning_alt' both happen to point at the same concrete model,
+    the strategy must fail-fast at config time, not silently consult the
+    same model twice.
+    """
+    pool = ProviderPool({"r1": "claude-sonnet-4-6", "r2": "claude-sonnet-4-6"})
+    with pytest.raises(ProviderPoolError):
+        pool.resolve_distinct("r2", different_from="claude-sonnet-4-6")
+
+
+def test_pool_construction_rejects_empty_value() -> None:
+    with pytest.raises(ProviderPoolError):
+        ProviderPool({"fast": ""})

--- a/tests/test_consensus_result.py
+++ b/tests/test_consensus_result.py
@@ -1,0 +1,63 @@
+"""Tests for ConsensusResult and ConsensusUnavailable."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from caretaker.consensus.result import ConsensusResult, ConsensusUnavailable
+from caretaker.consensus.trace import ConsensusTrace, ModelAttempt
+
+
+class _Verdict(BaseModel):
+    label: str
+    confidence: float
+
+
+def test_consensus_result_carries_verdict_and_trace() -> None:
+    verdict = _Verdict(label="ready", confidence=0.91)
+    trace = ConsensusTrace(
+        strategy="tiered_confidence",
+        attempts=[
+            ModelAttempt(
+                model="claude-sonnet-4-6",
+                tag="reasoning_anthropic",
+                latency_ms=412,
+                confidence=0.91,
+                verdict_summary="ready",
+            ),
+        ],
+        final_model="claude-sonnet-4-6",
+    )
+    result = ConsensusResult(verdict=verdict, trace=trace)
+    assert result.verdict is verdict
+    assert result.trace is trace
+
+
+def test_consensus_unavailable_carries_attempts() -> None:
+    attempts = [
+        ModelAttempt(
+            model="haiku-4-5",
+            tag="fast",
+            latency_ms=2000,
+            error="timeout",
+        ),
+    ]
+    exc = ConsensusUnavailable(
+        strategy="tiered_confidence",
+        attempts=attempts,
+        reason="all tiers exhausted",
+    )
+    assert exc.strategy == "tiered_confidence"
+    assert exc.attempts == attempts
+    assert exc.reason == "all tiers exhausted"
+    assert "tiered_confidence" in str(exc)
+
+
+def test_consensus_unavailable_is_exception() -> None:
+    with pytest.raises(ConsensusUnavailable):
+        raise ConsensusUnavailable(
+            strategy="tiered_confidence",
+            attempts=[],
+            reason="nothing tried",
+        )

--- a/tests/test_consensus_strategies.py
+++ b/tests/test_consensus_strategies.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from caretaker.consensus.provider_pool import ProviderPool
 from caretaker.consensus.result import ConsensusUnavailable
 from caretaker.consensus.strategies import (
+    AlwaysTwoModels,
     StrategyContext,
     TieredConfidence,
 )
@@ -176,3 +177,133 @@ async def test_tiered_primary_wins_ties() -> None:
     assert result.trace.final_model == "fake-fast"
     # escalation still ran (primary was below threshold), so escalated=True
     assert result.trace.escalated is True
+
+
+# ── AlwaysTwoModels ───────────────────────────────────────────────────────
+
+
+def _atm_ctx(
+    claude: _FakeClaude, *, primary: str, escalation: list[str], agreement: list[str]
+) -> StrategyContext:
+    return StrategyContext(
+        site_name="readiness",
+        schema=_Verdict,
+        system_prompt="sys",
+        user_prompt="user",
+        feature="readiness",
+        primary=primary,
+        escalation=escalation,
+        confidence_threshold=0.7,
+        agreement_fields=agreement,
+        pool=ProviderPool({"reasoning_anthropic": "fake-anthropic", "reasoning_alt": "fake-alt"}),
+        claude=claude,
+    )
+
+
+@pytest.mark.asyncio
+async def test_atm_ships_primary_when_models_agree() -> None:
+    claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [_Verdict(label="ready", confidence=0.9)],
+            "fake-alt": [_Verdict(label="ready", confidence=0.85)],
+        },
+    )
+    strategy = AlwaysTwoModels()
+    ctx = _atm_ctx(
+        claude,
+        primary="reasoning_anthropic",
+        escalation=["reasoning_alt"],
+        agreement=["label"],
+    )
+    result = await strategy.run(ctx)
+    assert result.verdict.label == "ready"
+    assert result.trace.escalated is False
+    assert result.trace.final_model == "fake-anthropic"
+    # Both must have been called (in parallel).
+    assert sorted(claude.calls) == ["fake-alt", "fake-anthropic"]
+
+
+@pytest.mark.asyncio
+async def test_atm_escalates_to_tiebreaker_on_disagreement() -> None:
+    claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [_Verdict(label="ready", confidence=0.9)],
+            "fake-alt": [_Verdict(label="not_ready", confidence=0.85)],
+            "literal-tiebreaker": [_Verdict(label="needs_human", confidence=0.7)],
+        },
+    )
+    strategy = AlwaysTwoModels()
+    ctx = _atm_ctx(
+        claude,
+        primary="reasoning_anthropic",
+        escalation=["reasoning_alt", "literal-tiebreaker"],
+        agreement=["label"],
+    )
+    result = await strategy.run(ctx)
+    assert result.verdict.label == "needs_human"
+    assert result.trace.escalated is True
+    assert result.trace.final_model == "literal-tiebreaker"
+
+
+@pytest.mark.asyncio
+async def test_atm_promotes_tiebreaker_when_one_model_errors() -> None:
+    err = StructuredCompleteError(raw_text="", validation_error=RuntimeError("nope"))
+    claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [_Verdict(label="ready", confidence=0.9)],
+            "fake-alt": [err],
+            "literal-tiebreaker": [_Verdict(label="ready", confidence=0.85)],
+        },
+    )
+    strategy = AlwaysTwoModels()
+    ctx = _atm_ctx(
+        claude,
+        primary="reasoning_anthropic",
+        escalation=["reasoning_alt", "literal-tiebreaker"],
+        agreement=["label"],
+    )
+    result = await strategy.run(ctx)
+    # Two votes ('fake-anthropic' + 'literal-tiebreaker') agree on 'ready'.
+    assert result.verdict.label == "ready"
+    # Final model is the surviving primary (it was the agreement winner).
+    assert result.trace.final_model in ("fake-anthropic", "literal-tiebreaker")
+
+
+@pytest.mark.asyncio
+async def test_atm_raises_when_both_initial_models_error() -> None:
+    err = StructuredCompleteError(raw_text="", validation_error=RuntimeError("nope"))
+    claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [err],
+            "fake-alt": [err],
+        },
+    )
+    strategy = AlwaysTwoModels()
+    ctx = _atm_ctx(
+        claude,
+        primary="reasoning_anthropic",
+        escalation=["reasoning_alt"],
+        agreement=["label"],
+    )
+    with pytest.raises(ConsensusUnavailable):
+        await strategy.run(ctx)
+
+
+@pytest.mark.asyncio
+async def test_atm_compares_full_verdict_when_agreement_fields_empty() -> None:
+    """With agreement_fields=[], the strategy compares full verdicts via __eq__."""
+    claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [_Verdict(label="ready", confidence=0.9)],
+            "fake-alt": [_Verdict(label="ready", confidence=0.9)],
+        },
+    )
+    strategy = AlwaysTwoModels()
+    ctx = _atm_ctx(
+        claude,
+        primary="reasoning_anthropic",
+        escalation=["reasoning_alt"],
+        agreement=[],
+    )
+    result = await strategy.run(ctx)
+    assert result.trace.escalated is False

--- a/tests/test_consensus_strategies.py
+++ b/tests/test_consensus_strategies.py
@@ -158,3 +158,21 @@ async def test_tiered_recovers_when_only_primary_errors() -> None:
     assert result.verdict.label == "ready"
     assert result.trace.escalated is True
     assert claude.calls == ["fake-fast", "fake-strong"]
+
+
+@pytest.mark.asyncio
+async def test_tiered_primary_wins_ties() -> None:
+    """When primary and escalation tie on confidence, primary wins (cheaper default)."""
+    claude = _FakeClaude(
+        responses={
+            "fake-fast": [_Verdict(label="ready", confidence=0.85)],
+            "fake-strong": [_Verdict(label="not_ready", confidence=0.85)],
+        },
+    )
+    strategy = TieredConfidence()
+    ctx = _ctx(claude, primary="fast", escalation=["reasoning_anthropic"], threshold=0.9)
+    result = await strategy.run(ctx)
+    assert result.verdict.label == "ready"
+    assert result.trace.final_model == "fake-fast"
+    # escalation still ran (primary was below threshold), so escalated=True
+    assert result.trace.escalated is True

--- a/tests/test_consensus_strategies.py
+++ b/tests/test_consensus_strategies.py
@@ -357,3 +357,44 @@ async def test_atm_raises_when_disagreement_and_tiebreaker_tier_exhausted() -> N
     )
     with pytest.raises(ConsensusUnavailable):
         await strategy.run(ctx)
+
+
+def test_agree_treats_missing_fields_as_match() -> None:
+    """When both verdicts lack a configured agreement field, _agree returns True."""
+    from caretaker.consensus.strategies import _agree
+
+    class _Bare(BaseModel):
+        label: str
+
+    a = _Bare(label="x")
+    b = _Bare(label="x")
+    # Neither has 'verdict' — _agree should not report disagreement.
+    assert _agree(a, b, ["verdict"]) is True
+
+
+@pytest.mark.asyncio
+async def test_atm_raises_consensus_unavailable_on_pool_misconfiguration() -> None:
+    """When pool maps two distinct tags to the same model, raise ConsensusUnavailable.
+
+    Without this guard, ProviderPoolError (a ValueError) would propagate uncaught
+    past the @shadow_decision wrapper's safe-default fallback.
+    """
+    claude = _FakeClaude(responses={})
+    # Two tags both resolve to "fake-same".
+    pool = ProviderPool({"primary_tag": "fake-same", "secondary_tag": "fake-same"})
+    ctx = StrategyContext(
+        site_name="readiness",
+        schema=_Verdict,
+        system_prompt="sys",
+        user_prompt="user",
+        feature="readiness",
+        primary="primary_tag",
+        escalation=["secondary_tag"],
+        confidence_threshold=0.7,
+        agreement_fields=["label"],
+        pool=pool,
+        claude=claude,
+    )
+    with pytest.raises(ConsensusUnavailable) as excinfo:
+        await AlwaysTwoModels().run(ctx)
+    assert "pool misconfiguration" in str(excinfo.value)

--- a/tests/test_consensus_strategies.py
+++ b/tests/test_consensus_strategies.py
@@ -1,0 +1,160 @@
+"""Tests for consensus strategies.
+
+Uses a fake ClaudeClient that returns canned verdicts to exercise the
+strategy logic without hitting real LLMs. Each fake call records
+which model was requested so the test can assert call shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, Field
+
+from caretaker.consensus.provider_pool import ProviderPool
+from caretaker.consensus.result import ConsensusUnavailable
+from caretaker.consensus.strategies import (
+    StrategyContext,
+    TieredConfidence,
+)
+from caretaker.llm.claude import StructuredCompleteError
+
+
+class _Verdict(BaseModel):
+    label: str
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+@dataclass
+class _FakeClaude:
+    """Fake ClaudeClient used by strategy tests.
+
+    ``responses`` maps concrete model string → list of (verdict | exception)
+    consumed in call order. ``calls`` records the model passed on each call.
+    """
+
+    responses: dict[str, list[Any]] = field(default_factory=dict)
+    calls: list[str] = field(default_factory=list)
+
+    async def structured_complete(
+        self,
+        prompt: str,
+        *,
+        schema: type[Any],
+        feature: str,
+        system: str | None = None,
+        model: str | None = None,
+        max_retries: int | None = None,
+        max_tokens: int = 2000,
+    ) -> Any:
+        assert model is not None, "strategy must pass an explicit model"
+        self.calls.append(model)
+        queue = self.responses.get(model, [])
+        if not queue:
+            raise StructuredCompleteError(
+                raw_text="", validation_error=RuntimeError(f"no canned response for {model}")
+            )
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+def _ctx(
+    claude: _FakeClaude, *, primary: str, escalation: list[str], threshold: float = 0.7
+) -> StrategyContext:
+    return StrategyContext(
+        site_name="readiness",
+        schema=_Verdict,
+        system_prompt="sys",
+        user_prompt="user",
+        feature="readiness",
+        primary=primary,
+        escalation=escalation,
+        confidence_threshold=threshold,
+        agreement_fields=[],
+        pool=ProviderPool({"fast": "fake-fast", "reasoning_anthropic": "fake-strong"}),
+        claude=claude,
+    )
+
+
+# ── TieredConfidence ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tiered_ships_primary_when_above_threshold() -> None:
+    claude = _FakeClaude(
+        responses={"fake-fast": [_Verdict(label="ready", confidence=0.9)]},
+    )
+    strategy = TieredConfidence()
+    ctx = _ctx(claude, primary="fast", escalation=["reasoning_anthropic"])
+    result = await strategy.run(ctx)
+    assert result.verdict.label == "ready"
+    assert result.trace.escalated is False
+    assert result.trace.final_model == "fake-fast"
+    assert claude.calls == ["fake-fast"]
+
+
+@pytest.mark.asyncio
+async def test_tiered_escalates_when_below_threshold() -> None:
+    claude = _FakeClaude(
+        responses={
+            "fake-fast": [_Verdict(label="not_ready", confidence=0.4)],
+            "fake-strong": [_Verdict(label="ready", confidence=0.95)],
+        },
+    )
+    strategy = TieredConfidence()
+    ctx = _ctx(claude, primary="fast", escalation=["reasoning_anthropic"])
+    result = await strategy.run(ctx)
+    assert result.verdict.label == "ready"
+    assert result.trace.escalated is True
+    assert result.trace.final_model == "fake-strong"
+    assert claude.calls == ["fake-fast", "fake-strong"]
+
+
+@pytest.mark.asyncio
+async def test_tiered_picks_highest_confidence_in_escalation_tier() -> None:
+    claude = _FakeClaude(
+        responses={
+            "fake-fast": [_Verdict(label="not_ready", confidence=0.3)],
+            "fake-strong": [_Verdict(label="ready", confidence=0.65)],
+            "literal-strongest": [_Verdict(label="needs_human", confidence=0.92)],
+        },
+    )
+    strategy = TieredConfidence()
+    ctx = _ctx(claude, primary="fast", escalation=["reasoning_anthropic", "literal-strongest"])
+    result = await strategy.run(ctx)
+    # Highest confidence among escalation tier wins.
+    assert result.verdict.label == "needs_human"
+    assert result.trace.final_model == "literal-strongest"
+
+
+@pytest.mark.asyncio
+async def test_tiered_raises_when_all_models_error() -> None:
+    err = StructuredCompleteError(raw_text="", validation_error=RuntimeError("nope"))
+    claude = _FakeClaude(responses={"fake-fast": [err], "fake-strong": [err]})
+    strategy = TieredConfidence()
+    ctx = _ctx(claude, primary="fast", escalation=["reasoning_anthropic"])
+    with pytest.raises(ConsensusUnavailable) as excinfo:
+        await strategy.run(ctx)
+    assert excinfo.value.strategy == "tiered_confidence"
+    assert len(excinfo.value.attempts) == 2
+
+
+@pytest.mark.asyncio
+async def test_tiered_recovers_when_only_primary_errors() -> None:
+    err = StructuredCompleteError(raw_text="", validation_error=RuntimeError("nope"))
+    claude = _FakeClaude(
+        responses={
+            "fake-fast": [err],
+            "fake-strong": [_Verdict(label="ready", confidence=0.85)],
+        },
+    )
+    strategy = TieredConfidence()
+    ctx = _ctx(claude, primary="fast", escalation=["reasoning_anthropic"])
+    result = await strategy.run(ctx)
+    assert result.verdict.label == "ready"
+    assert result.trace.escalated is True
+    assert claude.calls == ["fake-fast", "fake-strong"]

--- a/tests/test_consensus_strategies.py
+++ b/tests/test_consensus_strategies.py
@@ -265,8 +265,10 @@ async def test_atm_promotes_tiebreaker_when_one_model_errors() -> None:
     result = await strategy.run(ctx)
     # Two votes ('fake-anthropic' + 'literal-tiebreaker') agree on 'ready'.
     assert result.verdict.label == "ready"
-    # Final model is the surviving primary (it was the agreement winner).
-    assert result.trace.final_model in ("fake-anthropic", "literal-tiebreaker")
+    # final_model is always the model that produced the shipped verdict.
+    # Here the tiebreaker agreed with the surviving primary, so the
+    # tiebreaker's verdict shipped → final_model is the tiebreaker.
+    assert result.trace.final_model == "literal-tiebreaker"
 
 
 @pytest.mark.asyncio
@@ -307,3 +309,51 @@ async def test_atm_compares_full_verdict_when_agreement_fields_empty() -> None:
     )
     result = await strategy.run(ctx)
     assert result.trace.escalated is False
+
+
+@pytest.mark.asyncio
+async def test_atm_raises_when_disagreement_and_no_tiebreaker_tier() -> None:
+    """When primary and secondary disagree and there's no tiebreaker tier, raise.
+
+    The AlwaysTwoModels contract is "two models must agree (or a tiebreaker
+    breaks the tie)." With only escalation[0] configured and the two voters
+    disagreeing, we lack both. Raise ConsensusUnavailable so the caller
+    falls back to the safe default (e.g. block-merge for readiness).
+    """
+    claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [_Verdict(label="ready", confidence=0.9)],
+            "fake-alt": [_Verdict(label="not_ready", confidence=0.85)],
+        },
+    )
+    strategy = AlwaysTwoModels()
+    ctx = _atm_ctx(
+        claude,
+        primary="reasoning_anthropic",
+        escalation=["reasoning_alt"],  # no tiebreaker tier
+        agreement=["label"],
+    )
+    with pytest.raises(ConsensusUnavailable):
+        await strategy.run(ctx)
+
+
+@pytest.mark.asyncio
+async def test_atm_raises_when_disagreement_and_tiebreaker_tier_exhausted() -> None:
+    """Same as above but with a tiebreaker tier where every entry errors."""
+    err = StructuredCompleteError(raw_text="", validation_error=RuntimeError("nope"))
+    claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [_Verdict(label="ready", confidence=0.9)],
+            "fake-alt": [_Verdict(label="not_ready", confidence=0.85)],
+            "literal-tiebreaker": [err],
+        },
+    )
+    strategy = AlwaysTwoModels()
+    ctx = _atm_ctx(
+        claude,
+        primary="reasoning_anthropic",
+        escalation=["reasoning_alt", "literal-tiebreaker"],
+        agreement=["label"],
+    )
+    with pytest.raises(ConsensusUnavailable):
+        await strategy.run(ctx)

--- a/tests/test_consensus_trace.py
+++ b/tests/test_consensus_trace.py
@@ -1,0 +1,63 @@
+"""Tests for ConsensusTrace and ModelAttempt audit records."""
+
+from __future__ import annotations
+
+from caretaker.consensus.trace import ConsensusTrace, ModelAttempt
+
+
+def test_model_attempt_roundtrip() -> None:
+    attempt = ModelAttempt(
+        model="claude-sonnet-4-6",
+        tag="reasoning_anthropic",
+        latency_ms=412,
+        confidence=0.82,
+        verdict_summary="ready",
+        error=None,
+    )
+    payload = attempt.model_dump_json()
+    decoded = ModelAttempt.model_validate_json(payload)
+    assert decoded == attempt
+
+
+def test_consensus_trace_records_strategy_and_attempts() -> None:
+    trace = ConsensusTrace(
+        strategy="tiered_confidence",
+        attempts=[
+            ModelAttempt(
+                model="haiku-4-5",
+                tag="fast",
+                latency_ms=120,
+                confidence=0.55,
+                verdict_summary="not_ready",
+            ),
+            ModelAttempt(
+                model="claude-sonnet-4-6",
+                tag="reasoning_anthropic",
+                latency_ms=412,
+                confidence=0.91,
+                verdict_summary="ready",
+            ),
+        ],
+        escalated=True,
+        final_model="claude-sonnet-4-6",
+    )
+    assert trace.escalated is True
+    assert len(trace.attempts) == 2
+    assert trace.final_model == "claude-sonnet-4-6"
+
+    payload = trace.model_dump_json()
+    decoded = ConsensusTrace.model_validate_json(payload)
+    assert decoded == trace
+
+
+def test_model_attempt_with_error_records_failure() -> None:
+    attempt = ModelAttempt(
+        model="claude-sonnet-4-6",
+        tag="reasoning_anthropic",
+        latency_ms=4200,
+        confidence=None,
+        verdict_summary=None,
+        error="StructuredCompleteError: timeout",
+    )
+    assert attempt.error == "StructuredCompleteError: timeout"
+    assert attempt.confidence is None

--- a/tests/test_doctor_consensus.py
+++ b/tests/test_doctor_consensus.py
@@ -70,3 +70,27 @@ def test_diagnose_does_not_flag_literal_model_strings() -> None:
     )
     issues = diagnose_consensus_config(config)
     assert issues == []
+
+
+def test_diagnose_flags_always_two_models_with_same_concrete_model() -> None:
+    """When primary and escalation[0] resolve to the same model, surface it."""
+    config = MaintainerConfig(
+        llm=LLMConfig(
+            model_pool=ModelPoolConfig(
+                pool={"a": "claude-sonnet-4-6", "b": "claude-sonnet-4-6"},
+            ),
+        ),
+        agentic=AgenticConfig(
+            readiness=AgenticDomainConfig(
+                mode="enforce",
+                consensus=ConsensusDomainConfig(
+                    strategy="always_two_models",
+                    primary="a",
+                    escalation=["b"],
+                    agreement_fields=["verdict"],
+                ),
+            ),
+        ),
+    )
+    issues = diagnose_consensus_config(config)
+    assert any("two-model agreement requires distinct concrete models" in issue for issue in issues)

--- a/tests/test_doctor_consensus.py
+++ b/tests/test_doctor_consensus.py
@@ -1,0 +1,72 @@
+"""Tests that doctor.py flags consensus config issues."""
+
+from __future__ import annotations
+
+from caretaker.config import (
+    AgenticConfig,
+    AgenticDomainConfig,
+    ConsensusDomainConfig,
+    LLMConfig,
+    MaintainerConfig,
+    ModelPoolConfig,
+)
+from caretaker.doctor import diagnose_consensus_config
+
+
+def test_diagnose_passes_when_tags_present_in_pool() -> None:
+    config = MaintainerConfig(
+        llm=LLMConfig(
+            model_pool=ModelPoolConfig(
+                pool={"fast": "claude-haiku-4-5", "reasoning_anthropic": "claude-sonnet-4-6"},
+            ),
+        ),
+        agentic=AgenticConfig(
+            readiness=AgenticDomainConfig(
+                mode="enforce",
+                consensus=ConsensusDomainConfig(
+                    strategy="tiered_confidence",
+                    primary="fast",
+                    escalation=["reasoning_anthropic"],
+                ),
+            ),
+        ),
+    )
+    issues = diagnose_consensus_config(config)
+    assert issues == []
+
+
+def test_diagnose_flags_missing_tag_and_keeps_literal_pass_through() -> None:
+    config = MaintainerConfig(
+        llm=LLMConfig(model_pool=ModelPoolConfig(pool={"fast": "claude-haiku-4-5"})),
+        agentic=AgenticConfig(
+            readiness=AgenticDomainConfig(
+                mode="enforce",
+                consensus=ConsensusDomainConfig(
+                    strategy="tiered_confidence",
+                    primary="fast",
+                    escalation=["reasoning_anthropic_TYPO"],  # tag-shaped, not in pool
+                ),
+            ),
+        ),
+    )
+    issues = diagnose_consensus_config(config)
+    assert any("reasoning_anthropic_TYPO" in issue for issue in issues)
+
+
+def test_diagnose_does_not_flag_literal_model_strings() -> None:
+    """Literals (strings with '/' or starting with a known prefix) pass through."""
+    config = MaintainerConfig(
+        llm=LLMConfig(model_pool=ModelPoolConfig(pool={"fast": "claude-haiku-4-5"})),
+        agentic=AgenticConfig(
+            readiness=AgenticDomainConfig(
+                mode="enforce",
+                consensus=ConsensusDomainConfig(
+                    strategy="tiered_confidence",
+                    primary="fast",
+                    escalation=["openai/gpt-4o"],  # literal — pool miss is OK
+                ),
+            ),
+        ),
+    )
+    issues = diagnose_consensus_config(config)
+    assert issues == []

--- a/tests/test_orchestrator_consensus.py
+++ b/tests/test_orchestrator_consensus.py
@@ -1,0 +1,86 @@
+"""Test that Orchestrator constructs and installs a ConsensusEngine when sites opt in."""
+
+from __future__ import annotations
+
+from caretaker.config import (
+    AgenticConfig,
+    AgenticDomainConfig,
+    ConsensusDomainConfig,
+    LLMConfig,
+    MaintainerConfig,
+    ModelPoolConfig,
+)
+from caretaker.consensus import active as consensus_active
+
+
+def test_orchestrator_init_installs_consensus_when_any_site_opts_in() -> None:
+    """When at least one AgenticDomainConfig has consensus set, install the engine."""
+    consensus_active.reset_for_tests()
+
+    config = MaintainerConfig(
+        llm=LLMConfig(
+            model_pool=ModelPoolConfig(
+                pool={
+                    "fast": "claude-haiku-4-5",
+                    "reasoning_anthropic": "claude-sonnet-4-6",
+                    "reasoning_alt": "openai/gpt-4o",
+                },
+            ),
+        ),
+        agentic=AgenticConfig(
+            readiness=AgenticDomainConfig(
+                mode="enforce",
+                consensus=ConsensusDomainConfig(
+                    strategy="always_two_models",
+                    primary="reasoning_anthropic",
+                    escalation=["reasoning_alt"],
+                    agreement_fields=["verdict"],
+                ),
+            ),
+        ),
+    )
+
+    from caretaker.orchestrator import _build_consensus_engine
+
+    engine = _build_consensus_engine(config)
+    assert engine is not None
+    assert engine.has_site("readiness") is True
+
+
+def test_orchestrator_init_skips_consensus_when_no_site_opts_in() -> None:
+    consensus_active.reset_for_tests()
+
+    config = MaintainerConfig()  # all defaults — no consensus anywhere
+
+    from caretaker.orchestrator import _build_consensus_engine
+
+    engine = _build_consensus_engine(config)
+    assert engine is None
+
+
+def test_orchestrator_init_size_classifier_consensus() -> None:
+    consensus_active.reset_for_tests()
+
+    config = MaintainerConfig(
+        llm=LLMConfig(
+            model_pool=ModelPoolConfig(
+                pool={"fast": "claude-haiku-4-5", "reasoning_anthropic": "claude-sonnet-4-6"},
+            ),
+        ),
+        agentic=AgenticConfig(
+            size_classifier=AgenticDomainConfig(
+                mode="enforce",
+                consensus=ConsensusDomainConfig(
+                    strategy="tiered_confidence",
+                    primary="fast",
+                    escalation=["reasoning_anthropic"],
+                ),
+            ),
+        ),
+    )
+
+    from caretaker.orchestrator import _build_consensus_engine
+
+    engine = _build_consensus_engine(config)
+    assert engine is not None
+    assert engine.has_site("size_classifier") is True

--- a/tests/test_pr_readiness_consensus.py
+++ b/tests/test_pr_readiness_consensus.py
@@ -66,17 +66,23 @@ class _FakePR:
 
 
 def _build_ctx() -> Any:
-    """Build a PRReadinessContext sufficient for build_readiness_prompt to render."""
+    """Build a PRReadinessContext sufficient for build_readiness_prompt to render.
+
+    Constructed via the real dataclass constructor (rather than ``__new__``)
+    so future required fields surface as a constructor TypeError instead of
+    silently leaving the test stub partially populated. ``pr`` is duck-typed
+    — ``PullRequest`` is a TYPE_CHECKING-only annotation on the dataclass.
+    """
     from caretaker.pr_agent.readiness_llm import PRReadinessContext
 
-    ctx = PRReadinessContext.__new__(PRReadinessContext)
-    object.__setattr__(ctx, "pr", _FakePR())
-    object.__setattr__(ctx, "check_runs", [])
-    object.__setattr__(ctx, "reviews", [])
-    object.__setattr__(ctx, "linked_issues", [])
-    object.__setattr__(ctx, "repo_slug", "owner/repo")
-    object.__setattr__(ctx, "is_solo_maintainer", True)
-    return ctx
+    return PRReadinessContext(
+        pr=_FakePR(),  # type: ignore[arg-type]  # duck-typed; PullRequest is TYPE_CHECKING-only
+        check_runs=[],
+        reviews=[],
+        linked_issues=[],
+        repo_slug="owner/repo",
+        is_solo_maintainer=True,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr_readiness_consensus.py
+++ b/tests/test_pr_readiness_consensus.py
@@ -1,0 +1,167 @@
+"""Integration: evaluate_pr_readiness_llm uses the consensus engine when configured."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from caretaker.consensus import active as consensus_active
+from caretaker.consensus.engine import ConsensusEngine, EngineConfig, SiteConfig
+from caretaker.consensus.provider_pool import ProviderPool
+from caretaker.pr_agent.readiness_llm import Readiness
+
+
+@dataclass
+class _FakeClaude:
+    responses: dict[str, list[Any]] = field(default_factory=dict)
+    calls: list[str] = field(default_factory=list)
+    available: bool = True
+
+    async def structured_complete(
+        self,
+        prompt: str,
+        *,
+        schema: type[Any],
+        feature: str,
+        system: str | None = None,
+        model: str | None = None,
+        max_retries: int | None = None,
+        max_tokens: int = 2000,
+    ) -> Any:
+        self.calls.append(model or "<default>")
+        if model is not None:
+            queue = self.responses.get(model, [])
+        else:
+            queue = self.responses.get("<default>", [])
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+def _readiness(verdict: str, confidence: float = 0.9) -> Readiness:
+    return Readiness(
+        verdict=verdict,  # type: ignore[arg-type]
+        summary=f"r summary {verdict}",
+        confidence=confidence,
+        blockers=[],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_active() -> None:
+    consensus_active.reset_for_tests()
+
+
+@dataclass
+class _FakePR:
+    number: int = 1
+    title: str = "Test PR"
+    body: str | None = "Body"
+    draft: bool = False
+    mergeable: bool | None = True
+    labels: list[Any] = field(default_factory=list)
+
+
+def _build_ctx() -> Any:
+    """Build a PRReadinessContext sufficient for build_readiness_prompt to render."""
+    from caretaker.pr_agent.readiness_llm import PRReadinessContext
+
+    ctx = PRReadinessContext.__new__(PRReadinessContext)
+    object.__setattr__(ctx, "pr", _FakePR())
+    object.__setattr__(ctx, "check_runs", [])
+    object.__setattr__(ctx, "reviews", [])
+    object.__setattr__(ctx, "linked_issues", [])
+    object.__setattr__(ctx, "repo_slug", "owner/repo")
+    object.__setattr__(ctx, "is_solo_maintainer", True)
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_readiness_uses_engine_when_active() -> None:
+    """When consensus engine is active, evaluate_pr_readiness_llm calls engine."""
+    from caretaker.pr_agent.readiness_llm import evaluate_pr_readiness_llm
+
+    claude = _FakeClaude(
+        responses={
+            "fake-anthropic": [_readiness("ready", confidence=0.92)],
+            "fake-alt": [_readiness("ready", confidence=0.88)],
+        },
+    )
+    engine = ConsensusEngine(
+        config=EngineConfig(
+            pool=ProviderPool(
+                {"reasoning_anthropic": "fake-anthropic", "reasoning_alt": "fake-alt"}
+            ),
+            sites={
+                "readiness": SiteConfig(
+                    strategy="always_two_models",
+                    primary="reasoning_anthropic",
+                    escalation=["reasoning_alt"],
+                    confidence_threshold=0.7,
+                    agreement_fields=["verdict"],
+                ),
+            },
+        ),
+        claude=claude,
+    )
+    consensus_active.configure(engine)
+
+    ctx = _build_ctx()
+
+    verdict = await evaluate_pr_readiness_llm(ctx, claude=claude)
+    assert verdict is not None
+    assert verdict.verdict == "ready"
+    assert "fake-anthropic" in claude.calls
+    assert "fake-alt" in claude.calls
+
+
+@pytest.mark.asyncio
+async def test_readiness_falls_back_when_engine_unavailable() -> None:
+    """Engine raising ConsensusUnavailable returns None so shadow falls through."""
+    from caretaker.llm.claude import StructuredCompleteError
+    from caretaker.pr_agent.readiness_llm import evaluate_pr_readiness_llm
+
+    err = StructuredCompleteError(raw_text="", validation_error=RuntimeError("nope"))
+    claude = _FakeClaude(responses={"fake-anthropic": [err], "fake-alt": [err]})
+    engine = ConsensusEngine(
+        config=EngineConfig(
+            pool=ProviderPool(
+                {"reasoning_anthropic": "fake-anthropic", "reasoning_alt": "fake-alt"}
+            ),
+            sites={
+                "readiness": SiteConfig(
+                    strategy="always_two_models",
+                    primary="reasoning_anthropic",
+                    escalation=["reasoning_alt"],
+                    confidence_threshold=0.7,
+                    agreement_fields=["verdict"],
+                ),
+            },
+        ),
+        claude=claude,
+    )
+    consensus_active.configure(engine)
+
+    ctx = _build_ctx()
+
+    verdict = await evaluate_pr_readiness_llm(ctx, claude=claude)
+    assert verdict is None  # ConsensusUnavailable -> None -> @shadow_decision falls through
+
+
+@pytest.mark.asyncio
+async def test_readiness_uses_direct_call_when_engine_inactive() -> None:
+    """When no engine is active, falls back to the direct claude.structured_complete path."""
+    from caretaker.pr_agent.readiness_llm import evaluate_pr_readiness_llm
+
+    consensus_active.reset_for_tests()
+    claude = _FakeClaude(responses={"<default>": [_readiness("blocked", confidence=0.6)]})
+
+    ctx = _build_ctx()
+
+    verdict = await evaluate_pr_readiness_llm(ctx, claude=claude)
+    assert verdict is not None
+    assert verdict.verdict == "blocked"
+    assert claude.calls == ["<default>"]  # Single direct call, model=None

--- a/tests/test_shadow_consensus_trace.py
+++ b/tests/test_shadow_consensus_trace.py
@@ -1,0 +1,33 @@
+"""Test that ShadowDecisionRecord carries an optional consensus_trace_json."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from caretaker.evolution.shadow import ShadowDecisionRecord
+
+
+def test_shadow_record_has_consensus_trace_field() -> None:
+    record = ShadowDecisionRecord(
+        id="abc",
+        name="readiness",
+        run_at=datetime.now(UTC),
+        outcome="enforced_candidate",
+        mode="enforce",
+        legacy_verdict_json="null",
+        candidate_verdict_json='{"verdict":"ready"}',
+        consensus_trace_json='{"strategy":"tiered_confidence","attempts":[],"escalated":false,"final_model":"x"}',
+    )
+    assert record.consensus_trace_json is not None
+
+
+def test_shadow_record_consensus_trace_defaults_none() -> None:
+    record = ShadowDecisionRecord(
+        id="abc",
+        name="readiness",
+        run_at=datetime.now(UTC),
+        outcome="agree",
+        mode="shadow",
+        legacy_verdict_json="null",
+    )
+    assert record.consensus_trace_json is None

--- a/tests/test_size_classifier_consensus.py
+++ b/tests/test_size_classifier_consensus.py
@@ -1,0 +1,204 @@
+"""Tests for the size_classifier hybrid floor/ceiling + LLM borderline path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from caretaker.consensus import active as consensus_active
+from caretaker.consensus.engine import ConsensusEngine, EngineConfig, SiteConfig
+from caretaker.consensus.provider_pool import ProviderPool
+from caretaker.foundry.size_classifier import (
+    Decision,
+    SizeVerdict,
+    decide_post,
+    decide_pre,
+)
+
+
+@dataclass
+class _FakeClaude:
+    responses: dict[str, list[Any]] = field(default_factory=dict)
+    calls: list[str] = field(default_factory=list)
+
+    async def structured_complete(
+        self,
+        prompt: str,
+        *,
+        schema: type[Any],
+        feature: str,
+        system: str | None = None,
+        model: str | None = None,
+        max_retries: int | None = None,
+        max_tokens: int = 2000,
+    ) -> Any:
+        self.calls.append(model or "<default>")
+        queue = self.responses.get(model or "<default>", [])
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+@pytest.fixture(autouse=True)
+def _reset_active() -> None:
+    consensus_active.reset_for_tests()
+
+
+# ── Floor: counts well under low band always route to Foundry ──────────────
+
+
+@pytest.mark.asyncio
+async def test_decide_post_floor_routes_to_foundry_without_engine() -> None:
+    result = await decide_post(
+        files_changed=1,
+        insertions=10,
+        deletions=2,
+        max_files_touched=20,
+        max_diff_lines=400,
+        borderline_low_files=5,
+        borderline_high_files=15,
+        borderline_low_lines=100,
+        borderline_high_lines=300,
+    )
+    assert result.decision == Decision.ROUTE_FOUNDRY
+
+
+# ── Ceiling: counts well over high band always escalate ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_decide_post_ceiling_escalates_without_engine() -> None:
+    result = await decide_post(
+        files_changed=25,
+        insertions=600,
+        deletions=200,
+        max_files_touched=20,
+        max_diff_lines=400,
+        borderline_low_files=5,
+        borderline_high_files=15,
+        borderline_low_lines=100,
+        borderline_high_lines=300,
+    )
+    assert result.decision == Decision.ESCALATE_COPILOT
+
+
+# ── Borderline: in the gray zone, consult the engine ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_decide_post_borderline_consults_engine() -> None:
+    claude = _FakeClaude(
+        responses={
+            "fake-fast": [
+                SizeVerdict(
+                    decision=Decision.ROUTE_FOUNDRY, confidence=0.85, reason="mechanical refactor"
+                )
+            ],
+        },
+    )
+    engine = ConsensusEngine(
+        config=EngineConfig(
+            pool=ProviderPool({"fast": "fake-fast", "reasoning_anthropic": "fake-strong"}),
+            sites={
+                "size_classifier": SiteConfig(
+                    strategy="tiered_confidence",
+                    primary="fast",
+                    escalation=["reasoning_anthropic"],
+                    confidence_threshold=0.7,
+                    agreement_fields=[],
+                ),
+            },
+        ),
+        claude=claude,
+    )
+    consensus_active.configure(engine)
+
+    result = await decide_post(
+        files_changed=10,  # in [5, 15] → borderline
+        insertions=200,
+        deletions=20,
+        max_files_touched=20,
+        max_diff_lines=400,
+        borderline_low_files=5,
+        borderline_high_files=15,
+        borderline_low_lines=100,
+        borderline_high_lines=300,
+    )
+    assert result.decision == Decision.ROUTE_FOUNDRY
+    assert claude.calls == ["fake-fast"]
+
+
+# ── Borderline + engine failure: fall back to count gate ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_decide_post_borderline_falls_back_on_engine_failure() -> None:
+    from caretaker.llm.claude import StructuredCompleteError
+
+    err = StructuredCompleteError(raw_text="", validation_error=RuntimeError("nope"))
+    claude = _FakeClaude(responses={"fake-fast": [err], "fake-strong": [err]})
+    engine = ConsensusEngine(
+        config=EngineConfig(
+            pool=ProviderPool({"fast": "fake-fast", "reasoning_anthropic": "fake-strong"}),
+            sites={
+                "size_classifier": SiteConfig(
+                    strategy="tiered_confidence",
+                    primary="fast",
+                    escalation=["reasoning_anthropic"],
+                    confidence_threshold=0.7,
+                    agreement_fields=[],
+                ),
+            },
+        ),
+        claude=claude,
+    )
+    consensus_active.configure(engine)
+
+    # Borderline counts that the legacy gate would route to Foundry
+    # (under both max thresholds).
+    result = await decide_post(
+        files_changed=10,
+        insertions=200,
+        deletions=20,
+        max_files_touched=20,
+        max_diff_lines=400,
+        borderline_low_files=5,
+        borderline_high_files=15,
+        borderline_low_lines=100,
+        borderline_high_lines=300,
+    )
+    assert result.decision == Decision.ROUTE_FOUNDRY
+
+
+# ── decide_pre: only the error_output dimension has a borderline ──────────
+
+
+@pytest.mark.asyncio
+async def test_decide_pre_floor_passes_through() -> None:
+    result = await decide_pre(
+        task_type="lint_failure",
+        allowed_task_types=["lint_failure"],
+        head_repo_full_name="owner/repo",
+        base_repo_full_name="owner/repo",
+        route_same_repo_only=True,
+        error_output="short failure",
+        max_error_output_chars=16_000,
+    )
+    assert result.decision == Decision.ROUTE_FOUNDRY
+
+
+@pytest.mark.asyncio
+async def test_decide_pre_ceiling_escalates() -> None:
+    result = await decide_pre(
+        task_type="lint_failure",
+        allowed_task_types=["lint_failure"],
+        head_repo_full_name="owner/repo",
+        base_repo_full_name="owner/repo",
+        route_same_repo_only=True,
+        error_output="x" * 20_000,
+        max_error_output_chars=16_000,
+    )
+    assert result.decision == Decision.ESCALATE_COPILOT


### PR DESCRIPTION
## Summary

Implements the LLM consensus engine designed in #656 and planned in #658. 23 commits across 3 layers (foundation, config, integration) plus 14 new test files. **69 consensus-suite tests pass; broader regression suites (orchestrator, foundry, executor, readiness, shadow_decorator) pass without regression.**

The engine lets caretaker decision sites consult one or more LLM models — selected from a capability-tagged provider pool — and ship the LLM verdict as authoritative. Two proof-point sites are wired in:

- **\`readiness\`** (PR merge gate) — uses \`always_two_models\` strategy with cross-provider distinct models. Two reasoning-class models from different providers must agree on the \`verdict\` field before caretaker proceeds.
- **\`size_classifier\`** (Foundry sizing gate) — uses \`tiered_confidence\` strategy with hybrid deterministic floor/ceiling. Fast-path counts route immediately; only borderline cases consult the LLM.

## Architecture

New \`src/caretaker/consensus/\` module (8 files):
- \`trace.py\` / \`result.py\` — \`ConsensusTrace\`, \`ModelAttempt\`, \`ConsensusResult\`, \`ConsensusUnavailable\`.
- \`provider_pool.py\` — capability-tag → concrete-model resolver. Tags pass through to literals; \`resolve_distinct\` enforces concrete-model distinctness for the two-model gate.
- \`strategies.py\` — \`Strategy\` Protocol, \`StrategyContext\` (frozen dataclass), \`TieredConfidence\` (escalate on low confidence), \`AlwaysTwoModels\` (parallel + tiebreaker as casting vote).
- \`engine.py\` — \`ConsensusEngine.decide()\` + strategy registry. Public \`has_site()\` / \`site_names()\` accessors.
- \`active.py\` — process-wide engine holder (mirrors \`evolution/shadow_config\`).
- \`metrics.py\` — Prometheus counters + histogram, all on the shared registry.

Config additions to \`src/caretaker/config.py\`:
- \`ModelPoolConfig\` on \`LLMConfig\`.
- \`ConsensusDomainConfig\` with strategy-specific validation (always_two_models requires non-empty escalation + distinct primary).
- \`AgenticDomainConfig.consensus\` (opt-in; \`None\` preserves existing single-model path byte-identically).
- New \`AgenticConfig.size_classifier\` slot (Foundry sizing gate had no per-site config surface previously).

Integration:
- \`evolution/shadow.py\` — \`ShadowDecisionRecord.consensus_trace_json\` field added.
- \`pr_agent/readiness_llm.py\` — \`evaluate_pr_readiness_llm\` routes through engine when active; falls back to direct path when not. \`max_tokens\` threaded through.
- \`foundry/size_classifier.py\` — new async \`decide_pre\` / \`decide_post\` wrap pure \`pre_flight\` / \`post_flight\`. \`SizeVerdict\` schema for the LLM borderline path. Engine failure → fallback to count-gate verdict.
- \`foundry/executor.py\` — switched two sizing-gate calls to async.
- \`orchestrator.py\` — \`_build_consensus_engine\` walks every \`AgenticDomainConfig\`, collects sites with \`consensus\` set, builds engine, installs via \`consensus.active.configure(...)\`. Also wires \`shadow_config.configure_maintainer(config)\` (was previously never called in production).
- \`doctor.py\` — \`diagnose_consensus_config\` flags pool-tag typos at startup.
- \`setup-templates/templates/config-default.yml\` — commented examples (no behavior change at default).

## Failure-mode discipline

- Engine raises \`ConsensusUnavailable\` when every model attempt errors.
- \`evaluate_pr_readiness_llm\` returns \`None\` on \`ConsensusUnavailable\` → \`@shadow_decision\` falls through to legacy heuristic → block-merge default.
- \`decide_pre\`/\`decide_post\` fall back to the synchronous count-gate verdict on engine failure.
- The orchestrator never wedges on a provider outage.

## Defaults preserve byte-identical legacy behavior

\`agentic.<site>.consensus = None\` (the default for every site) bypasses the engine entirely. Sites only opt in when operators set the field in YAML. Adding the engine code changes nothing observable until a site is configured for it.

## Known follow-ups (deferred per design + final review)

1. **Trace persistence end-to-end.** \`ShadowDecisionRecord.consensus_trace_json\` and \`ConsensusTrace\` are wired in schema; threading the trace from \`engine.decide()\` through to the \`@shadow_decision\` decorator (via contextvar or widened return contract) is a small follow-up. The docstring on \`trace.py\` is honest about this. No production risk because no site is configured-on by default.
2. **Threshold auto-learning** from shadow disagreement records (per design).
3. **Standalone \`@consensus_decision\` decorator** alongside \`@shadow_decision\` (per design's "maturity target").
4. **Migrating the other 8 \`@shadow_decision\` sites** (ci_triage, review_classification, issue_triage, cascade, stuck_pr, bot_identity, dispatch_guard, executor_routing, crystallizer_category) — they can opt in incrementally.

## Test plan

- [ ] CI passes: ruff format, ruff check, mypy strict, pytest.
- [ ] Reviewers confirm the byte-identical-legacy-default invariant by inspecting the \`consensus is None\` early-return paths in \`pr_agent/readiness_llm.py\` and \`foundry/size_classifier.py\`.
- [ ] Reviewers confirm the \`ConsensusUnavailable\` fallback paths route to safe defaults (block-merge for readiness, count-gate for size_classifier).
- [ ] Operator sanity-check: load \`setup-templates/templates/config-default.yml\` through \`MaintainerConfig.model_validate\` — should parse cleanly with empty pool.
- [ ] Smoke-test on caretaker's own repo with \`agentic.readiness.consensus\` set + a real \`model_pool\` — confirm two-model agreement on a real PR before promoting more broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)