### PR TITLE
feat: OpenRouter integration with per-feature routing + :online web grounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **OpenRouter integration with per-feature model routing and `:online`
+  web-grounded analysis.** New `provider: openrouter` value for
+  `LLMConfig` constructs a `LiteLLMProvider` configured for OpenRouter
+  credentials. Caretaker ships per-feature defaults via
+  `DEFAULT_FEATURE_MODELS_BY_PROVIDER["openrouter"]`: `ci_log_analysis`
+  → DeepSeek R1, `principal_architecture_review` → Claude Opus 4.6,
+  and `upgrade_impact_analysis` / `migration_analysis` /
+  `migration_plan` → Claude Sonnet 4.6 with the `:online` suffix so
+  release-note and breaking-change context comes from current web
+  sources rather than stale model knowledge. Operator's
+  `feature_models[*]` overrides still win over shipped defaults.
+
+  Strict prefix validation under `provider: openrouter` rejects bare
+  Anthropic-style model strings at config load (the most common
+  misconfig — copy-pasting an Anthropic config). The `caretaker
+  doctor` preflight recognises the `openrouter/` prefix and renders
+  appropriate severity (FAIL for primary models, WARN for
+  fallback-only). Spans on `:online` requests carry
+  `caretaker.llm.online=true` so cost dashboards can break out
+  web-grounded spend.
+
+  Both `OPENROUTER_API_KEY` (canonical) and `OPEN_ROUTER_API_KEY`
+  (operator variant) are accepted; whichever is set is mirrored onto
+  the canonical name LiteLLM reads. Live AKS deployment wires the key
+  from Azure Key Vault (`openclaw-kv-301919`) into
+  `caretaker-secrets:openrouter-api-key` and onto the
+  `OPENROUTER_API_KEY` env var on the MCP and agent-worker pods with
+  `optional: true`.
+
 - **Pre-dispatch comment gate for the GitHub App webhook receiver.**
   New module `caretaker.github_app.comment_gate` runs in front of
   `WebhookDispatcher.dispatch` for `issue_comment`,

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ llm:
   feature_models:
     ci_log_analysis:
       model: openrouter/deepseek/deepseek-r1
-    architectural_review:
+    principal_architecture_review:
       model: openrouter/anthropic/claude-opus-4.6
 ```
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,45 @@ Add `ANTHROPIC_API_KEY` to unlock enhanced AI features:
 - **Issue decomposition** — breaks down multi-faceted bugs
 - **Upgrade impact analysis** — assesses breaking change risk
 
+### Optional: OpenRouter Integration
+
+Add `OPENROUTER_API_KEY` and set `provider: openrouter` in
+`.github/maintainer/config.yml` to route LLM calls through
+[OpenRouter](https://openrouter.ai), which gives you:
+
+- **300+ models behind one key** — DeepSeek R1, Gemini, Llama, Qwen,
+  GLM, plus all the proprietary frontier models.
+- **Per-feature model routing** — pin different caretaker features to
+  different best-fit models via `feature_models`.
+- **Web-grounded analysis** — append `:online` to a model string to add
+  a web search step before the completion. Caretaker ships this as the
+  default for `upgrade_impact_analysis`, `migration_analysis`, and
+  `migration_plan` so release-note and breaking-change context comes
+  from current sources rather than stale model knowledge.
+
+Sample config:
+
+```yaml
+llm:
+  provider: openrouter
+  default_model: openrouter/anthropic/claude-sonnet-4.6
+  feature_models:
+    ci_log_analysis:
+      model: openrouter/deepseek/deepseek-r1
+    architectural_review:
+      model: openrouter/anthropic/claude-opus-4.6
+```
+
+**Cost note:** `:online` adds OpenRouter's web-search step
+(~$4 per 1k searches) on top of the model call. The
+`caretaker.llm.online=true` OTel span attribute lets you break out
+web-grounded spend in cost dashboards.
+
+When `provider: openrouter` is set, every model string must begin
+with `openrouter/`. Caretaker rejects bare model names at
+config-load to prevent the silent bypass to Anthropic-direct that
+LiteLLM otherwise performs.
+
 ---
 
 ## What's new

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ Add `ANTHROPIC_API_KEY` to unlock enhanced AI features:
 
 ### Optional: OpenRouter Integration
 
-Add `OPENROUTER_API_KEY` and set `provider: openrouter` in
+Set `OPENROUTER_API_KEY` (or its accepted alias `OPEN_ROUTER_API_KEY`)
+and `provider: openrouter` in
 `.github/maintainer/config.yml` to route LLM calls through
 [OpenRouter](https://openrouter.ai), which gives you:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,7 +185,7 @@ llm:
     ci_log_analysis:
       model: openrouter/deepseek/deepseek-r1
       max_tokens: 2500
-    architectural_review:
+    principal_architecture_review:
       model: openrouter/anthropic/claude-opus-4.6
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,3 +157,74 @@ Caretaker supports optional remote capability expansion via Model Context Protoc
 - `mcp`: Configures connection to a remote MCP backend service. Must be enabled to route capabilities.
 - `azure`: Allows using Azure Managed Identity for secure access to remote backends and resources.
 - `telemetry`: Enables telemetry scaffolding for remote tool calls and latency. At present this is stub/debug instrumentation and does not export data to Azure Application Insights.
+
+## LLM provider selection
+
+The `llm` block selects which provider executes Caretaker's analysis
+features (CI log triage, architectural review, upgrade impact, etc.).
+
+### Supported providers
+
+| `provider` | Description |
+| --- | --- |
+| `anthropic` | Direct Anthropic SDK with `ANTHROPIC_API_KEY`. Default. |
+| `litellm` | Multi-provider routing (Anthropic, OpenAI, Vertex, Azure OpenAI, Azure AI Foundry, Bedrock, Ollama, Mistral, Cohere, Groq). Each provider's env vars apply. |
+| `openrouter` | LiteLLM under the hood, but pinned to OpenRouter via `OPENROUTER_API_KEY`. Strict `openrouter/`-prefix model strings. |
+
+### Per-feature model routing
+
+`feature_models` overrides the model used for a specific analysis
+feature. Caretaker ships a per-provider default map; operator entries
+win over both.
+
+```yaml
+llm:
+  provider: openrouter
+  default_model: openrouter/anthropic/claude-sonnet-4.6
+  feature_models:
+    ci_log_analysis:
+      model: openrouter/deepseek/deepseek-r1
+      max_tokens: 2500
+    architectural_review:
+      model: openrouter/anthropic/claude-opus-4.6
+```
+
+### Strict prefix rule under `provider: openrouter`
+
+When `provider` is `openrouter`, every model string in `default_model`,
+every `feature_models[*].model`, and every `fallback_models` entry must
+begin with `openrouter/`. Caretaker raises a `ValidationError` at
+config-load otherwise. The error names every offending field with a
+fix suggestion.
+
+Without this rule, LiteLLM would silently route bare names like
+`claude-sonnet-4-5` to Anthropic-direct, breaking billing dashboards,
+rate limits, and observability against the operator's intent.
+
+### `:online` web-grounded analysis
+
+Append `:online` to any model string to enable OpenRouter's web search
+step before the completion. Caretaker's shipped defaults use this for
+`upgrade_impact_analysis`, `migration_analysis`, and `migration_plan`,
+where release notes and breaking-change advisories benefit from current
+external context.
+
+**Cost note:** `:online` adds approximately $4 per 1k searches on top
+of the model call. The OTel span attribute `caretaker.llm.online=true`
+lets cost dashboards filter web-grounded spend without parsing model
+strings downstream.
+
+### Browse OpenRouter's model catalogue
+
+See [openrouter.ai/models](https://openrouter.ai/models) for the
+current model list. Model IDs occasionally rename; if Caretaker's
+shipped defaults stop resolving, override them in `feature_models`.
+
+### Deployment note (k8s)
+
+For Caretaker deployments running on Kubernetes (e.g. the Azure setup
+referenced from this project), the `OPENROUTER_API_KEY` must be
+available in the runtime environment. The recommended pattern is a
+`SealedSecret` sourced from your local environment and committed to
+your manifests repository before merging the Caretaker code change
+that depends on the key.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,7 +169,7 @@ features (CI log triage, architectural review, upgrade impact, etc.).
 | --- | --- |
 | `anthropic` | Direct Anthropic SDK with `ANTHROPIC_API_KEY`. Default. |
 | `litellm` | Multi-provider routing (Anthropic, OpenAI, Vertex, Azure OpenAI, Azure AI Foundry, Bedrock, Ollama, Mistral, Cohere, Groq). Each provider's env vars apply. |
-| `openrouter` | LiteLLM under the hood, but pinned to OpenRouter via `OPENROUTER_API_KEY`. Strict `openrouter/`-prefix model strings. |
+| `openrouter` | LiteLLM under the hood, but pinned to OpenRouter via `OPENROUTER_API_KEY` (or its alias `OPEN_ROUTER_API_KEY`). Strict `openrouter/`-prefix model strings. |
 
 ### Per-feature model routing
 
@@ -220,11 +220,25 @@ See [openrouter.ai/models](https://openrouter.ai/models) for the
 current model list. Model IDs occasionally rename; if Caretaker's
 shipped defaults stop resolving, override them in `feature_models`.
 
+### Accepted env var names
+
+Caretaker accepts either of the following for the OpenRouter credential:
+
+- `OPENROUTER_API_KEY` — canonical, what LiteLLM and OpenRouter's own
+  docs use.
+- `OPEN_ROUTER_API_KEY` — common operator-side variant.
+
+Whichever is set will be mirrored onto the canonical name at provider
+construction so downstream consumers (LiteLLM) find it. The `caretaker
+doctor` check renders one row under the canonical name and treats
+either alias as satisfying it.
+
 ### Deployment note (k8s)
 
 For Caretaker deployments running on Kubernetes (e.g. the Azure setup
-referenced from this project), the `OPENROUTER_API_KEY` must be
-available in the runtime environment. The recommended pattern is a
-`SealedSecret` sourced from your local environment and committed to
-your manifests repository before merging the Caretaker code change
-that depends on the key.
+referenced from this project), `OPENROUTER_API_KEY` must be available
+in the runtime environment. In the live AKS setup the value lives in
+the `openclaw-kv-301919` Azure Key Vault as `OPENROUTER-API-KEY` and is
+projected into the `caretaker-secrets` Kubernetes Secret under key
+`openrouter-api-key`; the deployment manifests in `infra/k8s/` mount
+that key as the `OPENROUTER_API_KEY` env var with `optional: true`.

--- a/docs/superpowers/plans/2026-05-01-openrouter-integration.md
+++ b/docs/superpowers/plans/2026-05-01-openrouter-integration.md
@@ -1,0 +1,1169 @@
+# OpenRouter Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add OpenRouter as a recognized first-class LLM provider with per-feature model routing and a `:online` web-grounded default for upgrade/migration features.
+
+**Architecture:** Additive on top of the existing `LiteLLMProvider` and `feature_models` config. No new provider class. `provider: openrouter` becomes a recognized alias in `build_provider`; a new `DEFAULT_FEATURE_MODELS_BY_PROVIDER` dict supplies provider-aware shipped defaults; strict pydantic validation ensures all OpenRouter configs use the `openrouter/` prefix. The existing doctor `_MODEL_PREFIX_ENV_MAP` infrastructure handles env-var validation with one tuple addition (simpler than the spec originally described — discovered during plan-writing, see Task 7).
+
+**Tech Stack:** Python 3.12+, pydantic v2 (`StrictBaseModel` with `model_validator`), pytest, LiteLLM, OpenTelemetry GenAI semantic conventions.
+
+**Spec:** [`docs/superpowers/specs/2026-05-01-openrouter-integration-design.md`](../specs/2026-05-01-openrouter-integration-design.md)
+
+---
+
+## File Structure
+
+| File | Role | Action |
+|------|------|--------|
+| `src/caretaker/llm/provider.py` | LLM provider implementations & factory | Modify (Tasks 1, 3, 6) |
+| `src/caretaker/config.py` | Pydantic config models including `LLMConfig` | Modify (Tasks 2, 4, 5) |
+| `src/caretaker/llm/claude.py` | Feature-keyed client with `_resolve_feature` | Modify (Task 4) |
+| `src/caretaker/doctor.py` | Preflight env-var checks via `_MODEL_PREFIX_ENV_MAP` | Modify (Task 7) |
+| `tests/test_llm.py` | Provider, router, resolver tests | Modify (Tasks 1, 3, 4, 6) |
+| `tests/test_config.py` | Config-validation tests | Modify (Tasks 2, 5) |
+| `tests/test_doctor_llm_env.py` | Doctor env-ref tests | Modify (Task 7) |
+| `README.md` | Top-level integration docs | Modify (Task 8) |
+| `docs/configuration.md` | Full config schema reference | Modify (Task 8) |
+
+---
+
+## Task 1: Recognize `OPENROUTER_API_KEY` in `LiteLLMProvider.available`
+
+**Why this task matters:** Today `LiteLLMProvider.available` returns False if the only credential set is `OPENROUTER_API_KEY`, even though LiteLLM itself routes `openrouter/*` model strings fine using that key. This is a latent bug independent of the larger integration; fixing it first unblocks every other task.
+
+**Files:**
+- Modify: `src/caretaker/llm/provider.py:317-330` (add one entry to the env-var allowlist)
+- Test: `tests/test_llm.py` (add one test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_llm.py` near the other `LiteLLMProvider` `available`-property tests (around line 198):
+
+```python
+def test_litellm_provider_available_with_only_openrouter_key(monkeypatch):
+    """LiteLLMProvider.available must return True when only OPENROUTER_API_KEY is set."""
+    # Clear every other credential the allowlist checks, leaving only OpenRouter.
+    for key in (
+        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "AZURE_API_KEY", "AZURE_AI_API_KEY",
+        "VERTEX_PROJECT", "GOOGLE_APPLICATION_CREDENTIALS", "AWS_ACCESS_KEY_ID",
+        "MISTRAL_API_KEY", "COHERE_API_KEY", "GROQ_API_KEY", "OLLAMA_API_BASE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+
+    p = build_provider("litellm")
+    # Skip if litellm package isn't installed in the test env — the regression
+    # we're guarding only matters when the package IS installed.
+    if not getattr(p, "package_installed", False):
+        pytest.skip("litellm package not installed")
+    assert p.available is True
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pytest tests/test_llm.py::test_litellm_provider_available_with_only_openrouter_key -v
+```
+
+Expected: FAIL — `assert False is True` because the env-var allowlist does not yet include `OPENROUTER_API_KEY`.
+
+- [ ] **Step 3: Add `OPENROUTER_API_KEY` to the allowlist**
+
+In `src/caretaker/llm/provider.py:317-330`, edit the tuple inside `LiteLLMProvider.available`:
+
+```python
+return any(
+    os.environ.get(key)
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "AZURE_API_KEY",
+        "AZURE_AI_API_KEY",
+        "VERTEX_PROJECT",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "AWS_ACCESS_KEY_ID",
+        "MISTRAL_API_KEY",
+        "COHERE_API_KEY",
+        "GROQ_API_KEY",
+        "OLLAMA_API_BASE",
+        "OPENROUTER_API_KEY",
+    )
+)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pytest tests/test_llm.py::test_litellm_provider_available_with_only_openrouter_key -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the rest of the test_llm.py file to confirm no regressions**
+
+```bash
+pytest tests/test_llm.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/caretaker/llm/provider.py tests/test_llm.py
+git commit -m "fix(llm): recognize OPENROUTER_API_KEY in LiteLLMProvider.available
+
+Previously LiteLLMProvider.available returned False when the only
+configured credential was OPENROUTER_API_KEY, even though LiteLLM
+routes openrouter/* models fine using that key. Add it to the
+env-var allowlist so OpenRouter-only configs activate the router."
+```
+
+---
+
+## Task 2: Add `"openrouter"` to the `LLMConfig.provider` Literal
+
+**Why this task matters:** `LLMConfig.provider` is currently `Literal["anthropic", "litellm"]`, so setting `provider: openrouter` in YAML raises a pydantic validation error before the factory even gets a chance to handle it. This widens the type so `provider: openrouter` becomes a valid config value.
+
+**Files:**
+- Modify: `src/caretaker/config.py:412` (change Literal)
+- Test: `tests/test_config.py` (add one test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_llm_config_accepts_openrouter_provider():
+    """LLMConfig must accept provider='openrouter' as a recognized value."""
+    from caretaker.config import LLMConfig
+
+    config = LLMConfig(provider="openrouter", default_model="openrouter/anthropic/claude-sonnet-4.6")
+    assert config.provider == "openrouter"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pytest tests/test_config.py::test_llm_config_accepts_openrouter_provider -v
+```
+
+Expected: FAIL — pydantic raises `ValidationError: Input should be 'anthropic' or 'litellm'`.
+
+- [ ] **Step 3: Widen the Literal**
+
+In `src/caretaker/config.py:412`, change:
+
+```python
+provider: Literal["anthropic", "litellm"] = "anthropic"
+```
+
+to:
+
+```python
+# "openrouter" is an alias that resolves to LiteLLM under the hood but
+# enforces openrouter/-prefixed model strings (see model_validator below).
+provider: Literal["anthropic", "litellm", "openrouter"] = "anthropic"
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pytest tests/test_config.py::test_llm_config_accepts_openrouter_provider -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the rest of test_config.py for regressions**
+
+```bash
+pytest tests/test_config.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/caretaker/config.py tests/test_config.py
+git commit -m "feat(config): accept provider='openrouter' on LLMConfig
+
+Widens the provider Literal to include openrouter as a recognized
+value. Routing behavior added in subsequent commit."
+```
+
+---
+
+## Task 3: Add `"openrouter"` branch in `build_provider`
+
+**Why this task matters:** The factory function constructs the right provider class per name. We add a branch that returns a `LiteLLMProvider` (no new class) but logs a clear, OpenRouter-specific warning when `OPENROUTER_API_KEY` is unset — operators see "OPENROUTER_API_KEY is not set" instead of the generic LiteLLM "no credentials" message.
+
+**Files:**
+- Modify: `src/caretaker/llm/provider.py:701-724` (`build_provider`)
+- Test: `tests/test_llm.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_llm.py` near the other `build_provider` tests (around line 184):
+
+```python
+def test_build_provider_openrouter_returns_litellm(monkeypatch):
+    """build_provider('openrouter') returns a LiteLLMProvider instance."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+    p = build_provider("openrouter")
+    if not getattr(p, "package_installed", False):
+        pytest.skip("litellm package not installed")
+    assert p.name == "litellm"
+    assert isinstance(p, LiteLLMProvider)
+
+
+def test_build_provider_openrouter_warns_when_key_missing(monkeypatch, caplog):
+    """build_provider('openrouter') warns specifically about OPENROUTER_API_KEY."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    with caplog.at_level("WARNING"):
+        build_provider("openrouter")
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "OPENROUTER_API_KEY" in messages
+
+
+def test_build_provider_openrouter_no_warning_when_key_present(monkeypatch, caplog):
+    """No 'OPENROUTER_API_KEY' warning when the env var is set."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+    with caplog.at_level("WARNING"):
+        build_provider("openrouter")
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "OPENROUTER_API_KEY is not set" not in messages
+```
+
+Make sure `LiteLLMProvider` is in the import block at the top of `tests/test_llm.py` (alongside `build_provider`).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pytest tests/test_llm.py::test_build_provider_openrouter_returns_litellm tests/test_llm.py::test_build_provider_openrouter_warns_when_key_missing tests/test_llm.py::test_build_provider_openrouter_no_warning_when_key_present -v
+```
+
+Expected: all three FAIL — `build_provider("openrouter")` falls through the unknown-provider branch and returns a `NullProvider` with a generic warning.
+
+- [ ] **Step 3: Add the openrouter branch**
+
+In `src/caretaker/llm/provider.py:701-724`, modify `build_provider`:
+
+```python
+def build_provider(
+    provider_name: str,
+    *,
+    timeout: float = 60.0,
+    fallback_models: list[str] | None = None,
+) -> LLMProvider:
+    """Factory: construct a provider from its name.
+
+    Unknown or explicitly disabled providers return a ``NullProvider``.
+    """
+    name = provider_name.lower().strip()
+    if name == "anthropic":
+        return AnthropicProvider(timeout=timeout)
+    if name == "openrouter":
+        # Alias: LiteLLM with explicit OpenRouter credential check. We log
+        # a targeted warning rather than the generic "no credentials" one
+        # so operators see the exact env var to set.
+        if not os.environ.get("OPENROUTER_API_KEY"):
+            logger.warning(
+                "provider='openrouter' but OPENROUTER_API_KEY is not set; "
+                "LLM features will fall back to their non-LLM paths"
+            )
+        provider = LiteLLMProvider(fallback_models=fallback_models, timeout=timeout)
+        if not provider.package_installed:
+            logger.warning(
+                "Configured provider 'openrouter' but litellm package is not installed; "
+                "install with `pip install litellm`"
+            )
+            return NullProvider()
+        return provider
+    if name == "litellm":
+        provider = LiteLLMProvider(fallback_models=fallback_models, timeout=timeout)
+        if not provider.package_installed:
+            logger.warning(
+                "Configured provider 'litellm' but package not installed; "
+                "falling back to AnthropicProvider"
+            )
+            return AnthropicProvider(timeout=timeout)
+        return provider
+    logger.warning("Unknown LLM provider '%s'; using NullProvider", provider_name)
+    return NullProvider()
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pytest tests/test_llm.py -k "openrouter" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full test_llm.py for regressions**
+
+```bash
+pytest tests/test_llm.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/caretaker/llm/provider.py tests/test_llm.py
+git commit -m "feat(llm): add openrouter provider alias to build_provider
+
+provider='openrouter' constructs a LiteLLMProvider (no new class) and
+logs a targeted warning when OPENROUTER_API_KEY is unset, so operators
+see the exact env var to set rather than a generic credentials warning."
+```
+
+---
+
+## Task 4: Provider-aware default feature models
+
+**Why this task matters:** OpenRouter operators need shipped defaults that route specific features to specific best-fit OpenRouter models — including the `:online` suffix on three features. This is the heart of the "per-feature model diversity" goal. Anthropic operators must see no behavior change.
+
+**Files:**
+- Modify: `src/caretaker/config.py:293-315` (add `DEFAULT_FEATURE_MODELS_BY_PROVIDER`)
+- Modify: `src/caretaker/llm/claude.py:138-155` (`_resolve_feature`)
+- Test: `tests/test_llm.py`
+
+- [ ] **Step 1: Verify the OpenRouter model strings against the live catalog**
+
+The spec uses `openrouter/anthropic/claude-opus-4.6`, `openrouter/anthropic/claude-sonnet-4.6:online`, and `openrouter/deepseek/deepseek-r1`. Visit `https://openrouter.ai/models?q=anthropic` and `https://openrouter.ai/models?q=deepseek` and confirm the exact model IDs. **If any string in the spec is wrong, update the spec doc first** — see [`docs/superpowers/specs/2026-05-01-openrouter-integration-design.md`](../specs/2026-05-01-openrouter-integration-design.md) — then proceed with the verified strings here.
+
+Record what you found. The strings that ship in `DEFAULT_FEATURE_MODELS_BY_PROVIDER` must match the catalog exactly; LiteLLM forwards the model string verbatim and OpenRouter returns 404 on a typo.
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `tests/test_llm.py`:
+
+```python
+def test_resolve_feature_uses_openrouter_default_for_migration_analysis():
+    """When provider='openrouter', migration_analysis resolves to the :online model."""
+    from caretaker.llm.claude import ClaudeClient
+
+    config = LLMConfig(
+        provider="openrouter",
+        default_model="openrouter/anthropic/claude-sonnet-4.6",
+    )
+    client = ClaudeClient(config=config)
+    model, max_tokens = client._resolve_feature("migration_analysis", default_max_tokens=1)
+    assert model == "openrouter/anthropic/claude-sonnet-4.6:online"
+    assert max_tokens == 4000
+
+
+def test_resolve_feature_uses_legacy_default_for_anthropic_provider():
+    """When provider='anthropic', migration_analysis resolves to the legacy Claude default."""
+    from caretaker.llm.claude import ClaudeClient
+    from caretaker.config import DEFAULT_REASONING_MODEL
+
+    config = LLMConfig(provider="anthropic")
+    client = ClaudeClient(config=config)
+    model, max_tokens = client._resolve_feature("migration_analysis", default_max_tokens=1)
+    assert model == DEFAULT_REASONING_MODEL
+    assert max_tokens == 4000
+
+
+def test_resolve_feature_operator_override_beats_openrouter_default():
+    """Operator's feature_models override is authoritative; :online is NOT re-appended."""
+    from caretaker.llm.claude import ClaudeClient
+
+    config = LLMConfig(
+        provider="openrouter",
+        default_model="openrouter/anthropic/claude-sonnet-4.6",
+        feature_models={
+            "migration_analysis": FeatureModelConfig(
+                model="openrouter/google/gemini-2.0-flash",
+                max_tokens=2000,
+            ),
+        },
+    )
+    client = ClaudeClient(config=config)
+    model, max_tokens = client._resolve_feature("migration_analysis", default_max_tokens=1)
+    assert model == "openrouter/google/gemini-2.0-flash"
+    assert max_tokens == 2000
+
+
+def test_resolve_feature_unknown_feature_falls_through_to_default_model():
+    """A feature with no entry in either default map falls back to default_model."""
+    from caretaker.llm.claude import ClaudeClient
+
+    config = LLMConfig(
+        provider="openrouter",
+        default_model="openrouter/anthropic/claude-sonnet-4.6",
+    )
+    client = ClaudeClient(config=config)
+    model, _ = client._resolve_feature("not_a_real_feature", default_max_tokens=1500)
+    assert model == "openrouter/anthropic/claude-sonnet-4.6"
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+```bash
+pytest tests/test_llm.py -k "resolve_feature" -v
+```
+
+Expected: at least three FAIL — `DEFAULT_FEATURE_MODELS_BY_PROVIDER` doesn't exist; the OpenRouter-provider path resolves to the legacy Claude model.
+
+- [ ] **Step 4: Add `DEFAULT_FEATURE_MODELS_BY_PROVIDER` in `config.py`**
+
+In `src/caretaker/config.py` immediately below the existing `DEFAULT_FEATURE_MODELS` (around line 315), add:
+
+```python
+# Provider-aware default feature models. Consulted by ClaudeClient._resolve_feature
+# BEFORE the legacy DEFAULT_FEATURE_MODELS table when the provider matches.
+# Operator's feature_models config still wins over both.
+#
+# Why per-provider rather than a single map: Anthropic operators don't want
+# openrouter/-prefixed strings injected, and OpenRouter operators don't want
+# bare 'claude-sonnet-4-5' strings (LiteLLM would route those Anthropic-direct,
+# silently bypassing OpenRouter and breaking cost/billing/rate-limits).
+DEFAULT_FEATURE_MODELS_BY_PROVIDER: dict[str, dict[str, dict[str, int | str]]] = {
+    "openrouter": {
+        "ci_log_analysis": {
+            "model": "openrouter/deepseek/deepseek-r1",
+            "max_tokens": 2000,
+        },
+        "principal_architecture_review": {
+            "model": "openrouter/anthropic/claude-opus-4.6",
+            "max_tokens": 4000,
+        },
+        "upgrade_impact_analysis": {
+            "model": "openrouter/anthropic/claude-sonnet-4.6:online",
+            "max_tokens": 3000,
+        },
+        "migration_analysis": {
+            "model": "openrouter/anthropic/claude-sonnet-4.6:online",
+            "max_tokens": 4000,
+        },
+        "migration_plan": {
+            "model": "openrouter/anthropic/claude-sonnet-4.6:online",
+            "max_tokens": 5000,
+        },
+        # Other features fall through to default_model.
+    },
+}
+```
+
+- [ ] **Step 5: Update `_resolve_feature` to consult the per-provider map first**
+
+In `src/caretaker/llm/claude.py:138-155`, replace `_resolve_feature` with:
+
+```python
+def _resolve_feature(self, feature: str, default_max_tokens: int) -> tuple[str, int]:
+    """Return the (model, max_tokens) pair for a feature.
+
+    Resolution order:
+      1. Operator's feature_models[feature] override.
+      2. Caretaker's DEFAULT_FEATURE_MODELS_BY_PROVIDER[provider][feature].
+      3. Legacy DEFAULT_FEATURE_MODELS[feature] (Anthropic-flavored defaults).
+      4. config.default_model + the caller-supplied default_max_tokens.
+    """
+    if self._config is None:
+        return _LEGACY_FEATURE_DEFAULTS.get(feature, (_FALLBACK_MODEL, default_max_tokens))
+
+    from caretaker.config import (
+        DEFAULT_FEATURE_MODELS,
+        DEFAULT_FEATURE_MODELS_BY_PROVIDER,
+    )
+
+    # Provider-aware default first; fall back to legacy Anthropic-flavored map.
+    by_provider = DEFAULT_FEATURE_MODELS_BY_PROVIDER.get(self._config.provider, {})
+    base = by_provider.get(feature) or DEFAULT_FEATURE_MODELS.get(feature, {})
+    override = self._config.feature_models.get(feature)
+
+    model: str = str(base.get("model") or self._config.default_model)
+    max_tokens = int(base.get("max_tokens") or default_max_tokens)
+    if override is not None:
+        if override.model:
+            model = override.model
+        if override.max_tokens:
+            max_tokens = override.max_tokens
+    return model, max_tokens
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+pytest tests/test_llm.py -k "resolve_feature" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run full test_llm.py for regressions**
+
+```bash
+pytest tests/test_llm.py -v
+```
+
+Expected: all tests pass — Anthropic operators see no behavior change because their `provider="anthropic"` does not appear in `DEFAULT_FEATURE_MODELS_BY_PROVIDER`, so they fall through to `DEFAULT_FEATURE_MODELS` (unchanged path).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/caretaker/config.py src/caretaker/llm/claude.py tests/test_llm.py
+git commit -m "feat(llm): per-provider default feature models with OpenRouter map
+
+Adds DEFAULT_FEATURE_MODELS_BY_PROVIDER consulted by _resolve_feature
+before the legacy DEFAULT_FEATURE_MODELS table. Operator feature_models
+overrides still win. Ships OpenRouter defaults: deepseek-r1 for CI logs,
+claude-opus-4.6 for architectural review, claude-sonnet-4.6:online for
+upgrade/migration analysis. Anthropic operators see no behavior change."
+```
+
+---
+
+## Task 5: Strict prefix validation for OpenRouter configs
+
+**Why this task matters:** Without this, an operator who sets `provider: openrouter` but forgets the `openrouter/` prefix on a model string gets routed Anthropic-direct via LiteLLM's bare-name fallback, silently bypassing OpenRouter. Their billing dashboard, rate limits, and observability all break in confusing ways. Failing fast at config-load with a clear message is the right trade.
+
+**Files:**
+- Modify: `src/caretaker/config.py` (add `model_validator` on `LLMConfig`)
+- Test: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_config.py`:
+
+```python
+import pytest
+from pydantic import ValidationError
+
+
+def test_openrouter_provider_rejects_bare_default_model():
+    """provider='openrouter' must reject default_model lacking the openrouter/ prefix."""
+    from caretaker.config import LLMConfig
+
+    with pytest.raises(ValidationError, match="openrouter/"):
+        LLMConfig(provider="openrouter", default_model="claude-sonnet-4-5")
+
+
+def test_openrouter_provider_rejects_bare_feature_model():
+    """provider='openrouter' must reject feature_models entries lacking the prefix."""
+    from caretaker.config import FeatureModelConfig, LLMConfig
+
+    with pytest.raises(ValidationError, match="openrouter/"):
+        LLMConfig(
+            provider="openrouter",
+            default_model="openrouter/anthropic/claude-sonnet-4.6",
+            feature_models={
+                "ci_log_analysis": FeatureModelConfig(model="claude-haiku-4-5"),
+            },
+        )
+
+
+def test_openrouter_provider_rejects_bare_fallback_model():
+    """provider='openrouter' must reject fallback_models entries lacking the prefix."""
+    from caretaker.config import LLMConfig
+
+    with pytest.raises(ValidationError, match="openrouter/"):
+        LLMConfig(
+            provider="openrouter",
+            default_model="openrouter/anthropic/claude-sonnet-4.6",
+            fallback_models=["claude-haiku-4-5"],
+        )
+
+
+def test_openrouter_provider_accepts_all_prefixed_models():
+    """A fully-prefixed OpenRouter config validates cleanly."""
+    from caretaker.config import FeatureModelConfig, LLMConfig
+
+    config = LLMConfig(
+        provider="openrouter",
+        default_model="openrouter/anthropic/claude-sonnet-4.6",
+        feature_models={
+            "ci_log_analysis": FeatureModelConfig(model="openrouter/deepseek/deepseek-r1"),
+        },
+        fallback_models=["openrouter/google/gemini-2.0-flash"],
+    )
+    assert config.provider == "openrouter"
+
+
+def test_anthropic_provider_still_accepts_bare_models():
+    """Strict prefix check must NOT apply when provider != openrouter."""
+    from caretaker.config import LLMConfig
+
+    config = LLMConfig(provider="anthropic", default_model="claude-sonnet-4-5")
+    assert config.default_model == "claude-sonnet-4-5"
+
+
+def test_litellm_provider_still_accepts_mixed_prefixes():
+    """provider='litellm' must accept any prefix shape; only openrouter is strict."""
+    from caretaker.config import LLMConfig
+
+    config = LLMConfig(
+        provider="litellm",
+        default_model="azure_ai/gpt-4o",
+        fallback_models=["claude-sonnet-4-5", "openai/gpt-4o-mini"],
+    )
+    assert config.provider == "litellm"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pytest tests/test_config.py -k "openrouter or litellm_provider_still" -v
+```
+
+Expected: the four "rejects" tests FAIL (no validation happens yet); the two "accepts" tests PASS.
+
+- [ ] **Step 3: Add the model validator**
+
+In `src/caretaker/config.py`, find the existing imports and ensure `model_validator` is imported from pydantic alongside `field_validator`:
+
+```python
+from pydantic import AliasChoices, ConfigDict, Field, field_validator, model_validator
+```
+
+Then in `LLMConfig` (the class beginning at line 371), add an `@model_validator(mode="after")` method directly below the field declarations (i.e. after `bot_identity` at line 434):
+
+```python
+@model_validator(mode="after")
+def _validate_openrouter_prefix(self) -> "LLMConfig":
+    """When provider='openrouter', every model string must use the openrouter/ prefix.
+
+    Prevents the silent bypass to Anthropic-direct that LiteLLM performs
+    when given a bare 'claude-*' string — that bypass breaks billing,
+    rate limits, and observability against the operator's intent.
+    """
+    if self.provider != "openrouter":
+        return self
+
+    bad: list[tuple[str, str]] = []
+    if not self.default_model.startswith("openrouter/"):
+        bad.append(("default_model", self.default_model))
+    for feature, override in self.feature_models.items():
+        if override.model and not override.model.startswith("openrouter/"):
+            bad.append((f"feature_models.{feature}.model", override.model))
+    for i, m in enumerate(self.fallback_models):
+        if m and not m.startswith("openrouter/"):
+            bad.append((f"fallback_models[{i}]", m))
+
+    if bad:
+        details = "; ".join(f"{path}={value!r}" for path, value in bad)
+        raise ValueError(
+            f"provider='openrouter' requires every model string to start with 'openrouter/'. "
+            f"Offending entries: {details}. "
+            f"Either prefix them (e.g. 'openrouter/anthropic/claude-sonnet-4.6') "
+            f"or change provider to 'litellm' / 'anthropic'."
+        )
+    return self
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pytest tests/test_config.py -k "openrouter or litellm_provider_still" -v
+```
+
+Expected: all six PASS.
+
+- [ ] **Step 5: Run the full config test file for regressions**
+
+```bash
+pytest tests/test_config.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/caretaker/config.py tests/test_config.py
+git commit -m "feat(config): strict openrouter/ prefix validation under provider=openrouter
+
+Catches silent-bypass misconfigs at config-load time. When provider is
+'openrouter', default_model, every feature_models[*].model, and every
+fallback_models entry must start with 'openrouter/'. The error message
+points at the offending entries with a fix suggestion."
+```
+
+---
+
+## Task 6: `caretaker.llm.online=true` span attribute
+
+**Why this task matters:** `:online` web search adds ~$4/1k searches on top of the model call. Operators need to see what fraction of LLM spend is web-grounded directly from the existing OTel telemetry without parsing model strings downstream. One attribute on the span lets cost dashboards filter on it.
+
+**Files:**
+- Modify: `src/caretaker/llm/provider.py` (in `LiteLLMProvider.complete` and `complete_with_tools`)
+- Test: `tests/test_llm.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_llm.py`. Use the existing `_acompletion` mock pattern; if you're unsure of the exact shape, search the file for `mock_acompletion` or similar:
+
+```python
+@pytest.mark.asyncio
+async def test_litellm_complete_sets_online_attribute_on_online_model(monkeypatch):
+    """LiteLLMProvider tags the span with caretaker.llm.online=True for :online models."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+    captured_attrs: dict[str, object] = {}
+
+    class FakeSpan:
+        def set_attribute(self, key: str, value: object) -> None:
+            captured_attrs[key] = value
+        def record_response(self, **kwargs):
+            pass
+
+    from contextlib import contextmanager
+    @contextmanager
+    def fake_span(**kwargs):
+        # Capture extra_attrs which the wrapper splats onto the span.
+        for k, v in (kwargs.get("extra_attrs") or {}).items():
+            captured_attrs[k] = v
+        yield FakeSpan()
+
+    monkeypatch.setattr("caretaker.llm.provider.llm_chat_span", fake_span)
+
+    async def fake_acompletion(**kwargs):
+        class _Choice:
+            def __init__(self):
+                class _Msg: content = "ok"
+                self.message = _Msg()
+                self.finish_reason = "stop"
+        class _Resp:
+            choices = [_Choice()]
+            usage = type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})()
+            id = "x"
+            model = "openrouter/anthropic/claude-sonnet-4.6:online"
+        return _Resp()
+
+    p = LiteLLMProvider()
+    if not p.package_installed:
+        pytest.skip("litellm package not installed")
+    p._acompletion = fake_acompletion  # type: ignore[assignment]
+
+    await p.complete(LLMRequest(
+        feature="upgrade_impact_analysis",
+        prompt="hi",
+        model="openrouter/anthropic/claude-sonnet-4.6:online",
+        max_tokens=10,
+    ))
+
+    assert captured_attrs.get("caretaker.llm.online") is True
+
+
+@pytest.mark.asyncio
+async def test_litellm_complete_omits_online_attribute_on_non_online_model(monkeypatch):
+    """No caretaker.llm.online attribute when the model lacks the :online suffix."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+    captured_attrs: dict[str, object] = {}
+
+    class FakeSpan:
+        def set_attribute(self, key: str, value: object) -> None:
+            captured_attrs[key] = value
+        def record_response(self, **kwargs):
+            pass
+
+    from contextlib import contextmanager
+    @contextmanager
+    def fake_span(**kwargs):
+        for k, v in (kwargs.get("extra_attrs") or {}).items():
+            captured_attrs[k] = v
+        yield FakeSpan()
+
+    monkeypatch.setattr("caretaker.llm.provider.llm_chat_span", fake_span)
+
+    async def fake_acompletion(**kwargs):
+        class _Choice:
+            def __init__(self):
+                class _Msg: content = "ok"
+                self.message = _Msg()
+                self.finish_reason = "stop"
+        class _Resp:
+            choices = [_Choice()]
+            usage = type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})()
+            id = "x"
+            model = "openrouter/anthropic/claude-sonnet-4.6"
+        return _Resp()
+
+    p = LiteLLMProvider()
+    if not p.package_installed:
+        pytest.skip("litellm package not installed")
+    p._acompletion = fake_acompletion  # type: ignore[assignment]
+
+    await p.complete(LLMRequest(
+        feature="ci_log_analysis",
+        prompt="hi",
+        model="openrouter/anthropic/claude-sonnet-4.6",
+        max_tokens=10,
+    ))
+
+    assert "caretaker.llm.online" not in captured_attrs
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pytest tests/test_llm.py -k "online_attribute" -v
+```
+
+Expected: the first test FAILs (`caretaker.llm.online` is not yet set anywhere); the second PASSes (vacuous — attribute is absent).
+
+- [ ] **Step 3: Set the span attribute in `LiteLLMProvider.complete`**
+
+In `src/caretaker/llm/provider.py` inside `LiteLLMProvider.complete` (around line 356), modify the `extra_attrs` dict passed to `llm_chat_span`:
+
+```python
+with llm_chat_span(
+    system=_genai_system_for_model(request.model),
+    model=request.model,
+    max_tokens=request.max_tokens,
+    temperature=request.temperature,
+    extra_attrs={
+        "caretaker.llm.feature": request.feature,
+        "caretaker.llm.router": "litellm",
+        **({"caretaker.llm.online": True} if request.model.endswith(":online") else {}),
+    },
+) as span:
+```
+
+And do the same in `complete_with_tools` (around line 447):
+
+```python
+with llm_chat_span(
+    system=_genai_system_for_model(request.model),
+    model=request.model,
+    operation="chat.tool_use",
+    max_tokens=request.max_tokens,
+    temperature=request.temperature,
+    extra_attrs={
+        "caretaker.llm.feature": request.feature,
+        "caretaker.llm.router": "litellm",
+        "caretaker.llm.tool_count": len(tools),
+        **({"caretaker.llm.online": True} if request.model.endswith(":online") else {}),
+    },
+) as _tool_span:
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pytest tests/test_llm.py -k "online_attribute" -v
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Run full test_llm.py for regressions**
+
+```bash
+pytest tests/test_llm.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/caretaker/llm/provider.py tests/test_llm.py
+git commit -m "feat(observability): tag :online model spans with caretaker.llm.online
+
+Sets caretaker.llm.online=True on the GenAI span when the resolved
+model string ends with :online. Cost dashboards can now filter on it
+to break out web-grounded LLM spend without parsing model strings."
+```
+
+---
+
+## Task 7: Doctor recognizes `openrouter/` prefix
+
+**Why this task matters:** During plan-writing we discovered that `caretaker.doctor` already has a sophisticated `_MODEL_PREFIX_ENV_MAP` that walks every distinct model string in the config and reports missing env vars. This is much cleaner than the spec's originally proposed standalone "doctor check" — adding one tuple entry covers `default_model`, `feature_models`, and `fallback_models` simultaneously, with proper FAIL/WARN severity (FAIL when it's a primary model, WARN when only in the fallback chain).
+
+**Files:**
+- Modify: `src/caretaker/doctor.py:381-395` (`_MODEL_PREFIX_ENV_MAP`)
+- Test: `tests/test_doctor_llm_env.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_doctor_llm_env.py` (follow the existing test patterns in that file — look at how other prefix→env tests are structured):
+
+```python
+def test_doctor_reports_missing_openrouter_key_for_primary_model(monkeypatch):
+    """When default_model is openrouter/* and OPENROUTER_API_KEY is missing → FAIL row."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    from caretaker.config import LLMConfig, MaintainerConfig
+    from caretaker.doctor import _collect_llm_env_references, check_env_secrets
+
+    # Use whatever existing fixture or factory the file uses to build a MaintainerConfig.
+    # Adjust this construction to match the patterns already used in this test file.
+    config = _make_minimal_maintainer_config(
+        llm=LLMConfig(
+            provider="openrouter",
+            default_model="openrouter/anthropic/claude-sonnet-4.6",
+        )
+    )
+
+    refs = _collect_llm_env_references(config)
+    env_names = {ref.env_name for ref in refs}
+    assert "OPENROUTER_API_KEY" in env_names
+
+    # Severity check: primary model with missing env → FAIL.
+    results = check_env_secrets(config)
+    openrouter_results = [r for r in results if "OPENROUTER_API_KEY" in (r.detail or "") or "OPENROUTER_API_KEY" in r.name]
+    assert openrouter_results, "expected a row referencing OPENROUTER_API_KEY"
+    assert any(r.severity.name == "FAIL" for r in openrouter_results)
+
+
+def test_doctor_recognizes_openrouter_prefix_in_fallback_only(monkeypatch):
+    """An openrouter/* model that appears only in fallback_models → WARN, not FAIL."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    from caretaker.config import LLMConfig, MaintainerConfig
+    from caretaker.doctor import check_env_secrets
+
+    config = _make_minimal_maintainer_config(
+        llm=LLMConfig(
+            provider="litellm",  # litellm allows mixed prefixes
+            default_model="anthropic/claude-sonnet-4.6",
+            fallback_models=["openrouter/anthropic/claude-sonnet-4.6"],
+        )
+    )
+
+    results = check_env_secrets(config)
+    openrouter_rows = [r for r in results if "OPENROUTER_API_KEY" in (r.detail or "") or "OPENROUTER_API_KEY" in r.name]
+    assert openrouter_rows, "expected a row referencing OPENROUTER_API_KEY"
+    # Fallback-only → owner_enabled=False → WARN, not FAIL.
+    assert all(r.severity.name == "WARN" for r in openrouter_rows)
+```
+
+If `tests/test_doctor_llm_env.py` does not have a `_make_minimal_maintainer_config` helper, look for the existing patterns it uses to build `MaintainerConfig` objects (likely a fixture or inline constructor) and copy that idiom verbatim.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pytest tests/test_doctor_llm_env.py -k "openrouter" -v
+```
+
+Expected: both FAIL — `_env_vars_for_model("openrouter/...")` returns `((), None)` because no prefix matches, so the doctor never emits a row referencing `OPENROUTER_API_KEY`.
+
+- [ ] **Step 3: Add the openrouter prefix to the env map**
+
+In `src/caretaker/doctor.py:381-395`, add a new tuple entry to `_MODEL_PREFIX_ENV_MAP`. Place it at the top (longest/most specific first, per the existing comment):
+
+```python
+_MODEL_PREFIX_ENV_MAP: tuple[tuple[str, tuple[str, ...]], ...] = (
+    # Longest / most specific first.
+    ("openrouter/", ("OPENROUTER_API_KEY",)),
+    ("ollama_chat/", ("OLLAMA_API_BASE",)),
+    ("vertex_ai/", ("GOOGLE_APPLICATION_CREDENTIALS", "VERTEX_PROJECT")),
+    ("azure_ai/", ("AZURE_AI_API_KEY", "AZURE_AI_API_BASE")),
+    ("anthropic/", ("ANTHROPIC_API_KEY",)),
+    ("bedrock/", ("AWS_ACCESS_KEY_ID",)),
+    ("openai/", ("OPENAI_API_KEY",)),
+    ("ollama/", ("OLLAMA_API_BASE",)),
+    ("mistral/", ("MISTRAL_API_KEY",)),
+    ("cohere/", ("COHERE_API_KEY",)),
+    ("gemini/", ("GEMINI_API_KEY",)),
+    ("groq/", ("GROQ_API_KEY",)),
+    ("azure/", ("AZURE_API_KEY", "AZURE_API_BASE")),
+)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pytest tests/test_doctor_llm_env.py -k "openrouter" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full doctor test files for regressions**
+
+```bash
+pytest tests/test_doctor.py tests/test_doctor_llm_env.py tests/test_doctor_llm_probe.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/caretaker/doctor.py tests/test_doctor_llm_env.py
+git commit -m "feat(doctor): recognize openrouter/ prefix in env-var preflight check
+
+Adds OPENROUTER_API_KEY to the model-prefix → env-vars map so caretaker
+doctor reports missing OpenRouter credentials with the same FAIL/WARN
+severity rules as every other provider. No new check function needed."
+```
+
+---
+
+## Task 8: Documentation
+
+**Why this task matters:** Without docs the integration is undiscoverable. This task adds a top-level README section pointing operators at OpenRouter and a configuration.md section with the full schema, including the explicit `:online` cost call-out the spec requires.
+
+**Files:**
+- Modify: `README.md` (add a section sibling to "Optional: Claude Integration")
+- Modify: `docs/configuration.md` (extend the LLM config reference)
+
+This task has no automated tests — it's documentation. The verification step is reading the rendered docs.
+
+- [ ] **Step 1: Add the OpenRouter section to README.md**
+
+Find the existing "Optional: Claude Integration" section in `README.md` (around line 185-193). Add a sibling section directly below it:
+
+```markdown
+### Optional: OpenRouter Integration
+
+Add `OPENROUTER_API_KEY` and set `provider: openrouter` in
+`.github/maintainer/config.yml` to route LLM calls through
+[OpenRouter](https://openrouter.ai), which gives you:
+
+- **300+ models behind one key** — DeepSeek R1, Gemini, Llama, Qwen,
+  GLM, plus all the proprietary frontier models.
+- **Per-feature model routing** — pin different caretaker features to
+  different best-fit models via `feature_models`.
+- **Web-grounded analysis** — append `:online` to a model string to add
+  a web search step before the completion. Caretaker ships this as the
+  default for `upgrade_impact_analysis`, `migration_analysis`, and
+  `migration_plan` so release-note and breaking-change context comes
+  from current sources rather than stale model knowledge.
+
+Sample config:
+
+\`\`\`yaml
+llm:
+  provider: openrouter
+  default_model: openrouter/anthropic/claude-sonnet-4.6
+  feature_models:
+    ci_log_analysis:
+      model: openrouter/deepseek/deepseek-r1
+    architectural_review:
+      model: openrouter/anthropic/claude-opus-4.6
+\`\`\`
+
+**Cost note:** `:online` adds OpenRouter's web-search step
+(~$4 per 1k searches) on top of the model call. The
+`caretaker.llm.online=true` OTel span attribute lets you break out
+web-grounded spend in cost dashboards.
+
+When `provider: openrouter` is set, every model string must begin
+with `openrouter/`. Caretaker rejects bare model names at
+config-load to prevent the silent bypass to Anthropic-direct that
+LiteLLM otherwise performs.
+```
+
+(Replace the escaped backticks `\`\`\`` with literal triple backticks when writing the file.)
+
+- [ ] **Step 2: Extend `docs/configuration.md`**
+
+Open `docs/configuration.md` and find the existing LLM configuration section. Add a subsection covering:
+
+1. The full set of valid `provider` values: `anthropic`, `litellm`, `openrouter`.
+2. The `feature_models` schema with an OpenRouter example.
+3. The strict-prefix rule for `provider: openrouter` and the error operators see when they violate it.
+4. A pointer to the model catalog at https://openrouter.ai/models.
+5. The `:online` cost note (mirrored from README).
+6. Pre-deployment note: the `OPENROUTER_API_KEY` must be available in the runtime environment (e.g. as a SealedSecret in the bigboy k8s manifests for Azure deployments).
+
+Match the style of the surrounding sections in `docs/configuration.md` — likely yaml fenced blocks with prose between.
+
+- [ ] **Step 3: Render and inspect the docs**
+
+```bash
+mkdocs serve
+```
+
+Open the local site, navigate to the configuration page, and confirm:
+
+- The new section renders cleanly (no broken yaml fences, no missing headings).
+- Cross-link to README OpenRouter section works.
+- Code blocks have correct language tags (`yaml`, not `yml`, to match site convention).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/configuration.md
+git commit -m "docs: add OpenRouter integration section to README and config reference
+
+Documents provider=openrouter, per-feature model routing via
+feature_models, the strict openrouter/ prefix rule, the :online
+suffix and its web-search cost surcharge, and the OTel attribute
+for breaking out web-grounded spend."
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+pytest tests/ -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run the type checker**
+
+```bash
+mypy src/
+```
+
+Expected: no new errors. (Pre-existing baseline errors recorded in `mypy.log` are acceptable; the diff vs. that baseline must be empty.)
+
+- [ ] **Step 3: Run the linter**
+
+```bash
+ruff check src/ tests/
+ruff format --check src/ tests/
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke test (operator perspective)**
+
+In a scratch directory, create a minimal `config.yml`:
+
+```yaml
+llm:
+  provider: openrouter
+  default_model: openrouter/anthropic/claude-sonnet-4.6
+  feature_models:
+    ci_log_analysis:
+      model: openrouter/deepseek/deepseek-r1
+```
+
+Set `OPENROUTER_API_KEY` in your shell from the value in `~/.zshrc`. Run:
+
+```bash
+caretaker doctor --config /path/to/config.yml
+```
+
+Expected output: an OpenRouter row reporting `OPENROUTER_API_KEY` as `OK`. The two distinct models (`openrouter/anthropic/claude-sonnet-4.6` and `openrouter/deepseek/deepseek-r1`) should each appear in the `--llm-probe` output if you pass that flag, both routed to the `OPENROUTER_API_KEY` env requirement.
+
+- [ ] **Step 5: Pre-merge deployment checklist (operational, not code)**
+
+Per the spec: caretaker's runtime k8s manifests live in the **bigboy** project, not this repo. Do these steps **before** merging the caretaker PR, otherwise the deployed pods will crash on missing env on the next rollout:
+
+1. In `~/Projects/bigboy`, take the `OPENROUTER_API_KEY` value from `~/.zshrc` and `kubeseal` it into a `SealedSecret` against the Azure cluster's controller cert.
+2. Wire the new secret into the caretaker `Deployment` env block and any agent-task `Job` template that reads it.
+3. Open and merge the bigboy PR FIRST.
+4. Then merge the caretaker PR.
+
+---
+
+## Plan self-review
+
+Before handing off to execution:
+
+- **Spec coverage:** Spec Change 1 → Task 1. Change 2 → Tasks 2 + 3. Change 3 → Task 4. Change 4 → Task 5. Change 5 → Task 6. Change 6 → Task 7 (simpler than spec described — one tuple entry to the existing `_MODEL_PREFIX_ENV_MAP`, not a new check function. Worth noting in the spec post-merge). Change 7 → Task 8. ✓
+- **No placeholders:** Every step has either an exact command, exact file/line reference, or full code body. The Task 8 README block uses escaped backticks because the plan itself is a markdown file — explicit instruction to unescape on write. ✓
+- **Type consistency:** `_resolve_feature` signature and return shape (`tuple[str, int]`) is preserved across Tasks 4 and the existing call sites. `DEFAULT_FEATURE_MODELS_BY_PROVIDER` annotation matches the existing `DEFAULT_FEATURE_MODELS` shape. The `model_validator` in Task 5 uses pydantic v2 syntax matching the existing `field_validator` usage in `ModelPoolConfig`. ✓
+- **TDD discipline:** Every code-bearing task starts with a failing test. ✓
+
+---
+
+## Execution handoff
+
+Plan complete and saved to [`docs/superpowers/plans/2026-05-01-openrouter-integration.md`](2026-05-01-openrouter-integration.md). Two execution options:
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using `executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-01-openrouter-integration-design.md
+++ b/docs/superpowers/specs/2026-05-01-openrouter-integration-design.md
@@ -1,0 +1,318 @@
+# OpenRouter Integration — Design
+
+**Date:** 2026-05-01
+**Status:** Approved (brainstorm), pending implementation plan
+**Scope:** Per-feature model routing (A) + web-grounded analysis via `:online` (C)
+
+---
+
+## Motivation
+
+Caretaker today routes all LLM analysis features (CI log triage, architectural
+review, upgrade impact, migration planning, etc.) through a single configured
+provider — typically Anthropic-direct or LiteLLM with one model. Two limitations
+follow:
+
+1. **One model fits all features.** A cheap Gemini Flash call would suffice for
+   label triage; an architectural review wants Claude Opus or DeepSeek R1.
+   Today everything pays the same per-token rate as the highest-capability
+   feature.
+2. **No web-grounded context.** Features that benefit from current external
+   information — `upgrade_impact_analysis` (release notes), `migration_analysis`
+   / `migration_plan` (breaking-change advisories) — answer from stale model
+   knowledge.
+
+OpenRouter solves both behind a single API key: 300+ models from one credential,
+plus the `:online` model-string suffix that adds a web search step before the
+completion.
+
+The codebase already has the structural hooks needed: `LLMConfig.feature_models`
+and `_resolve_feature()` (`src/caretaker/llm/claude.py:138`) implement
+per-feature model resolution today. `LiteLLMProvider`
+(`src/caretaker/llm/provider.py:275`) already accepts `openrouter/...` model
+strings. The integration is therefore additive and small.
+
+---
+
+## Scope
+
+### In scope
+
+- New recognized provider name `openrouter` that constructs a `LiteLLMProvider`
+  configured for OpenRouter credentials.
+- Caretaker-shipped per-feature model defaults specifically for the OpenRouter
+  provider, including `:online` suffix on three features: `upgrade_impact_analysis`,
+  `migration_analysis`, `migration_plan`.
+- Operator-overridable per-feature model map via existing `feature_models`
+  config — unchanged, just exercised through the new defaults.
+- Strict config validation: when `provider: openrouter`, model strings must be
+  prefixed with `openrouter/` to prevent silent bypass to Anthropic-direct.
+- Telemetry tagging: spans flag `caretaker.llm.online=true` when the resolved
+  model carries the `:online` suffix, so cost dashboards can break out web-
+  grounded spend.
+- Doctor (`caretaker.doctor`) warning when `provider: openrouter` is set but
+  `OPENROUTER_API_KEY` is missing.
+- Documentation: README sibling section to "Optional: Claude Integration" with
+  explicit `:online` cost call-out.
+
+### Out of scope (future iterations)
+
+- Cost guardrails / hard spend caps.
+- Cross-provider fallback chains via OpenRouter's `models` array.
+- `:floor` (cheapest underlying provider) and `:nitro` (fastest) variants.
+- BYOK passthrough (caretaker uses direct keys).
+- A/B shadow comparison of two models for the same prompt.
+- `openrouter/auto` autorouter (gives up the per-feature control this design
+  is built around).
+
+---
+
+## Architecture
+
+Three surgical changes; no new files, no new abstractions.
+
+### Change 1 — `LiteLLMProvider.available` recognizes OpenRouter
+
+**File:** `src/caretaker/llm/provider.py:317-330`
+
+Add `"OPENROUTER_API_KEY"` to the env-var allowlist that
+`LiteLLMProvider.available` consults. Without this, an operator who configures
+only `OPENROUTER_API_KEY` gets a `NullProvider` even though LiteLLM itself
+would route the request fine. This is also a latent bug for any user wanting
+LiteLLM+OpenRouter today; the fix is independent of the rest of the design.
+
+### Change 2 — `provider: openrouter` alias in the factory
+
+**File:** `src/caretaker/llm/provider.py:701-724` (`build_provider`)
+
+Recognize `"openrouter"` as a provider name. Constructs a `LiteLLMProvider`
+with one extra behavior: log a clear warning when `OPENROUTER_API_KEY` is
+missing, rather than the generic "no credentials" message. No new class.
+
+```python
+if name == "openrouter":
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        logger.warning(
+            "provider='openrouter' but OPENROUTER_API_KEY is not set"
+        )
+    return LiteLLMProvider(
+        fallback_models=fallback_models,
+        timeout=timeout,
+    )
+```
+
+### Change 3 — Provider-aware default feature models
+
+**File:** `src/caretaker/config.py` (alongside `DEFAULT_FEATURE_MODELS`)
+
+Today `DEFAULT_FEATURE_MODELS` is a single dict of Claude model strings.
+Extend with a per-provider lookup that the resolver consults first:
+
+```python
+DEFAULT_FEATURE_MODELS_BY_PROVIDER: dict[str, dict[str, dict[str, Any]]] = {
+    "openrouter": {
+        "ci_log_analysis": {
+            "model": "openrouter/deepseek/deepseek-r1",
+            "max_tokens": 2000,
+        },
+        "principal_architecture_review": {
+            "model": "openrouter/anthropic/claude-opus-4.6",
+            "max_tokens": 4000,
+        },
+        "upgrade_impact_analysis": {
+            "model": "openrouter/anthropic/claude-sonnet-4.6:online",
+            "max_tokens": 3000,
+        },
+        "migration_analysis": {
+            "model": "openrouter/anthropic/claude-sonnet-4.6:online",
+            "max_tokens": 4000,
+        },
+        "migration_plan": {
+            "model": "openrouter/anthropic/claude-sonnet-4.6:online",
+            "max_tokens": 5000,
+        },
+        # other features fall through to default_model
+    },
+}
+```
+
+`_resolve_feature` in `src/caretaker/llm/claude.py:138` consults
+`DEFAULT_FEATURE_MODELS_BY_PROVIDER[config.provider]` first, falling back to
+the existing `DEFAULT_FEATURE_MODELS` (which becomes the implicit Anthropic-
+default table). Operator's `feature_models` override still wins — that
+precedence rule is unchanged.
+
+**Why per-provider rather than a single map:** Anthropic operators don't want
+`openrouter/...` model strings injected, and OpenRouter operators don't want
+bare `claude-sonnet-4-5` strings (which LiteLLM would route Anthropic-direct,
+silently bypassing OpenRouter and breaking cost/billing/rate-limits in
+confusing ways).
+
+### Change 4 — Strict config validation
+
+**File:** `src/caretaker/config.py` (`LLMConfig` post-init or load-time check)
+
+When `provider == "openrouter"`, every model string in scope must start with
+`openrouter/`. Validate:
+
+- `default_model`
+- Every `feature_models[*].model` value
+- Every entry in `fallback_models`
+
+Raise a config error at startup with a message that suggests the prefix. This
+catches the most common misconfig — copy-pasting an Anthropic config into a
+caretaker setup that intends to use OpenRouter — at config-load time rather
+than as a confusing routing bug at run time.
+
+### Change 5 — Online-suffix telemetry
+
+**File:** `src/caretaker/observability/llm_span.py` (or where spans are built)
+
+When the resolved model string ends with `:online`, set
+`caretaker.llm.online=true` on the span. Implementation is one line at request
+build time. This makes "what fraction of our LLM spend is web-grounded"
+answerable directly from telemetry without parsing model strings downstream.
+
+### Change 6 — Doctor check
+
+**File:** `src/caretaker/doctor.py`
+
+Add a check: if `LLMConfig.provider == "openrouter"` and `OPENROUTER_API_KEY`
+is unset, emit a warning (not an error). Mirrors the existing Anthropic check.
+
+### Change 7 — Documentation
+
+**File:** `README.md` (sibling section to "Optional: Claude Integration")
+**File:** `docs/configuration.md` (full config schema reference)
+
+Add:
+
+- Sample config block showing `provider: openrouter` with `feature_models`.
+- Explicit note that `:online` carries an additional ~$4 / 1k searches cost
+  on top of the model call.
+- Pointer to OpenRouter model catalogue and how to choose models.
+
+---
+
+## Configuration surface
+
+Operator-facing config in `.github/maintainer/config.yml`:
+
+```yaml
+llm:
+  provider: openrouter
+  default_model: openrouter/anthropic/claude-sonnet-4
+  feature_models:
+    ci_log_analysis:
+      model: openrouter/deepseek/deepseek-r1
+      max_tokens: 2500
+    architectural_review:
+      model: openrouter/anthropic/claude-opus-4
+    upgrade_impact_analysis:
+      model: openrouter/anthropic/claude-sonnet-4:online
+```
+
+Feature → model resolution order (already implemented; just extended):
+
+1. Operator's `feature_models[feature]` — wins if present.
+2. Caretaker's `DEFAULT_FEATURE_MODELS_BY_PROVIDER[provider][feature]` —
+   provider-aware shipped default.
+3. Operator's `default_model` — fallback for any feature without a specific
+   mapping.
+
+The shipped `:online` defaults (Section: Architecture / Change 3) are config
+defaults, not enforced in code. An operator who sets
+`feature_models.migration_analysis.model: openrouter/anthropic/claude-sonnet-4`
+(no `:online`) gets exactly that — caretaker does not re-append the suffix.
+
+---
+
+## Backwards compatibility
+
+This is purely additive:
+
+- Operators on `provider: anthropic` see no behavior change. Their resolution
+  falls through to the unchanged `DEFAULT_FEATURE_MODELS` table.
+- Operators on `provider: litellm` with non-OpenRouter models see no behavior
+  change.
+- Operators on `provider: litellm` with `OPENROUTER_API_KEY` and bare
+  `openrouter/...` model strings now work where they didn't before (Change 1
+  is a bug fix).
+
+No migration guide required. No config schema breakage.
+
+---
+
+## Testing
+
+All tests are unit-level; no live OpenRouter calls. LiteLLM's `acompletion`
+is already mocked in the existing test fixtures.
+
+- `build_provider("openrouter")` returns a `LiteLLMProvider`.
+- `build_provider("openrouter")` logs the warning when `OPENROUTER_API_KEY`
+  is unset; logs nothing extra when it is set.
+- `LiteLLMProvider.available` returns `True` when only `OPENROUTER_API_KEY`
+  is set (regression for Change 1).
+- `_resolve_feature("migration_analysis")` with `provider="openrouter"` and no
+  operator override returns
+  `("openrouter/anthropic/claude-sonnet-4:online", 4000)`.
+- `_resolve_feature("migration_analysis")` with `provider="anthropic"` returns
+  the legacy Claude default (unchanged behavior).
+- `_resolve_feature("migration_analysis")` with operator override
+  `feature_models.migration_analysis.model = openrouter/google/gemini-2.0-flash`
+  returns the override; the `:online` default does not get re-applied.
+- `LLMConfig` raises a config error when `provider="openrouter"` and
+  `default_model="claude-sonnet-4-5"` (no prefix).
+- `LLMConfig` raises a config error when `provider="openrouter"` and any
+  `feature_models[*].model` lacks the `openrouter/` prefix.
+- `LLMConfig` raises a config error when `provider="openrouter"` and any
+  `fallback_models` entry lacks the `openrouter/` prefix.
+- Span attribute `caretaker.llm.online=true` is set when resolved model ends
+  with `:online`; absent or `false` otherwise.
+- Doctor warns (does not error) when `provider="openrouter"` and
+  `OPENROUTER_API_KEY` is unset.
+
+---
+
+## Deployment / rollout (operational, not code)
+
+Caretaker's runtime k8s manifests live in the **bigboy** project, not this
+repository. The `OPENROUTER_API_KEY` must reach Azure pods via a SealedSecret
+before any merge of code that consumes it.
+
+Pre-merge checklist:
+
+1. Open caretaker PR with the seven changes + tests + docs.
+2. In `bigboy`, create a `SealedSecret` for `OPENROUTER_API_KEY` (`kubeseal`
+   the value from `$OPENROUTER_API_KEY` in `~/.zshrc` against the Azure
+   cluster controller cert).
+3. Wire the secret into the caretaker `Deployment` env and any agent-task
+   `Job` template that reads it.
+4. **Merge bigboy first, then caretaker.** Reverse order causes pods to crash
+   on missing env on the next deployment.
+
+---
+
+## Open questions
+
+None at design time. All decisions resolved during brainstorming:
+
+- Per-feature model routing approach: **direct feature → model map** (not
+  tiered).
+- `:online` features: `upgrade_impact_analysis`, `migration_analysis`,
+  `migration_plan`.
+- `:online` enforcement: **shipped as config default, not enforced in code.**
+- Bare-model-string handling under `provider: openrouter`: **strict validation,
+  raise at config load.**
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `:online` web search costs surprise operators | Explicit cost note in README; `caretaker.llm.online=true` span attribute for cost-dashboard breakdown. |
+| OpenRouter outage takes down all caretaker LLM calls | Out of scope for this iteration; future work covers fallback chains. Today's behavior matches current single-provider risk. |
+| LiteLLM `completion_cost` may underreport OpenRouter costs | Existing telemetry path; same risk that exists for any LiteLLM-routed model. Not regressed. |
+| Operator copies an Anthropic config and sets `provider: openrouter` | Strict validation (Change 4) catches bare model strings at config load, with a message suggesting the prefix. |
+| bigboy SealedSecret step forgotten before merge | Pre-merge checklist in this spec; project memory entry pinned for future sessions. |

--- a/infra/k8s/caretaker-agent-worker.yaml
+++ b/infra/k8s/caretaker-agent-worker.yaml
@@ -141,6 +141,12 @@ spec:
                   name: caretaker-secrets
                   key: anthropic-api-key
                   optional: true
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: caretaker-secrets
+                  key: openrouter-api-key
+                  optional: true
             - name: AZURE_AI_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/infra/k8s/caretaker-mcp-deployment.yaml
+++ b/infra/k8s/caretaker-mcp-deployment.yaml
@@ -276,6 +276,12 @@ spec:
                   name: caretaker-secrets
                   key: anthropic-api-key
                   optional: true
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: caretaker-secrets
+                  key: openrouter-api-key
+                  optional: true
           resources:
             requests:
               cpu: "10m"

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -332,6 +332,9 @@ DEFAULT_FEATURE_MODELS_BY_PROVIDER: dict[str, dict[str, dict[str, int | str]]] =
             "model": "openrouter/anthropic/claude-opus-4.6",
             "max_tokens": 4000,
         },
+        # upgrade_impact_analysis has no DEFAULT_FEATURE_MODELS entry; Anthropic
+        # operators resolve it to LLMConfig.default_model. The :online suffix is
+        # OpenRouter-specific (web-grounded search before completion).
         "upgrade_impact_analysis": {
             "model": "openrouter/anthropic/claude-sonnet-4.6:online",
             "max_tokens": 3000,
@@ -344,7 +347,8 @@ DEFAULT_FEATURE_MODELS_BY_PROVIDER: dict[str, dict[str, dict[str, int | str]]] =
             "model": "openrouter/anthropic/claude-sonnet-4.6:online",
             "max_tokens": 5000,
         },
-        # Other features fall through to default_model.
+        # Other features fall through to DEFAULT_FEATURE_MODELS (legacy) or
+        # default_model — see ClaudeClient._resolve_feature for precedence.
     },
 }
 

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -314,6 +314,40 @@ DEFAULT_FEATURE_MODELS: dict[str, dict[str, int | str]] = {
     "migration_plan": {"model": DEFAULT_REASONING_MODEL, "max_tokens": 5000},
 }
 
+# Provider-aware default feature models. Consulted by ClaudeClient._resolve_feature
+# BEFORE the legacy DEFAULT_FEATURE_MODELS table when the provider matches.
+# Operator's feature_models config still wins over both.
+#
+# Why per-provider rather than a single map: Anthropic operators don't want
+# openrouter/-prefixed strings injected, and OpenRouter operators don't want
+# bare 'claude-sonnet-4-5' strings (LiteLLM would route those Anthropic-direct,
+# silently bypassing OpenRouter and breaking cost/billing/rate-limits).
+DEFAULT_FEATURE_MODELS_BY_PROVIDER: dict[str, dict[str, dict[str, int | str]]] = {
+    "openrouter": {
+        "ci_log_analysis": {
+            "model": "openrouter/deepseek/deepseek-r1",
+            "max_tokens": 2000,
+        },
+        "principal_architecture_review": {
+            "model": "openrouter/anthropic/claude-opus-4.6",
+            "max_tokens": 4000,
+        },
+        "upgrade_impact_analysis": {
+            "model": "openrouter/anthropic/claude-sonnet-4.6:online",
+            "max_tokens": 3000,
+        },
+        "migration_analysis": {
+            "model": "openrouter/anthropic/claude-sonnet-4.6:online",
+            "max_tokens": 4000,
+        },
+        "migration_plan": {
+            "model": "openrouter/anthropic/claude-sonnet-4.6:online",
+            "max_tokens": 5000,
+        },
+        # Other features fall through to default_model.
+    },
+}
+
 
 class FeatureModelConfig(StrictBaseModel):
     """Per-feature model override."""

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -409,7 +409,9 @@ class LLMConfig(StrictBaseModel):
     # Provider selection: "anthropic" (default, direct SDK) or "litellm"
     # (multi-provider: OpenAI, Vertex, Azure OpenAI, Azure AI Foundry,
     # Bedrock, Ollama, Mistral, Cohere, Groq, etc.)
-    provider: Literal["anthropic", "litellm"] = "anthropic"
+    # "openrouter" is an alias that resolves to LiteLLM under the hood but
+    # enforces openrouter/-prefixed model strings (see model_validator below).
+    provider: Literal["anthropic", "litellm", "openrouter"] = "anthropic"
     # Model used when a feature has no explicit override. For litellm this
     # can be prefixed (e.g. "openai/gpt-4o", "azure_ai/gpt-4o", "vertex_ai/gemini-1.5-pro").
     default_model: str = DEFAULT_MODEL

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -473,6 +473,38 @@ class LLMConfig(StrictBaseModel):
     # without a breaking change because callers read through this model.
     bot_identity: AgenticBotIdentityConfig = Field(default_factory=AgenticBotIdentityConfig)
 
+    @model_validator(mode="after")
+    def _validate_openrouter_prefix(self) -> LLMConfig:
+        """When provider='openrouter', every model string must use the openrouter/ prefix.
+
+        Prevents the silent bypass to Anthropic-direct that LiteLLM performs
+        when given a bare 'claude-*' string — that bypass breaks billing,
+        rate limits, and observability against the operator's intent.
+        """
+        if self.provider != "openrouter":
+            return self
+
+        bad: list[tuple[str, str]] = []
+        if not self.default_model.startswith("openrouter/"):
+            bad.append(("llm.default_model", self.default_model))
+        for feature, override in self.feature_models.items():
+            if override.model and not override.model.startswith("openrouter/"):
+                bad.append((f"llm.feature_models.{feature}.model", override.model))
+        for i, m in enumerate(self.fallback_models):
+            if m and not m.startswith("openrouter/"):
+                bad.append((f"llm.fallback_models[{i}]", m))
+
+        if bad:
+            offenders = "\n  ".join(f"{path} = {value!r}" for path, value in bad)
+            raise ValueError(
+                f"provider='openrouter' requires every model string to start with "
+                f"'openrouter/'. Offending fields:\n  {offenders}\n"
+                f"Fix each one (e.g. 'openrouter/anthropic/claude-sonnet-4.6') or "
+                f"change provider to 'litellm' if you intentionally want to mix "
+                f"non-openrouter prefixes."
+            )
+        return self
+
 
 class OrchestratorConfig(StrictBaseModel):
     schedule: Literal["hourly", "daily", "weekly", "manual"] = "daily"

--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -50,6 +50,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from caretaker.github_client.scope_gap import is_scope_gap_message
+from caretaker.llm.provider import OPENROUTER_API_KEY_ALIASES
 
 if TYPE_CHECKING:
     from caretaker.config import MaintainerConfig
@@ -237,6 +238,12 @@ class EnvReference:
     owner_enabled: bool
     # Free-form description surfaced in the detail column.
     purpose: str
+    # Accepted alias env names for ``env_name``. The existence check in
+    # :func:`check_env_secrets` treats the env as present when ``env_name``
+    # *or any alias* is set. Used for credentials whose canonical name
+    # has a commonly-seen variant (e.g. OPENROUTER_API_KEY vs
+    # OPEN_ROUTER_API_KEY). Empty by default.
+    aliases: tuple[str, ...] = ()
 
 
 def collect_env_references(config: MaintainerConfig) -> list[EnvReference]:
@@ -523,11 +530,17 @@ def _collect_llm_env_references(config: MaintainerConfig) -> list[EnvReference]:
         for env_name in envs:
             existing = seen.get(env_name)
             if existing is None:
+                # Honor accepted alias env names so e.g. OPEN_ROUTER_API_KEY
+                # satisfies the OPENROUTER_API_KEY row.
+                aliases: tuple[str, ...] = ()
+                if env_name == OPENROUTER_API_KEY_ALIASES[0]:
+                    aliases = OPENROUTER_API_KEY_ALIASES[1:]
                 ref = EnvReference(
                     env_name=env_name,
                     config_path="llm.default_model / feature_models / fallback_models",
                     owner_enabled=owner_enabled,
                     purpose=_purpose(env_name, model, prefix),
+                    aliases=aliases,
                 )
                 seen[env_name] = ref
                 refs.append(ref)
@@ -540,6 +553,7 @@ def _collect_llm_env_references(config: MaintainerConfig) -> list[EnvReference]:
                     config_path=existing.config_path,
                     owner_enabled=True,
                     purpose=existing.purpose,
+                    aliases=existing.aliases,
                 )
                 # Replace in the ordered list too.
                 for i, r in enumerate(refs):
@@ -596,7 +610,7 @@ def check_env_secrets(config: MaintainerConfig, env: dict[str, str]) -> list[Che
         )
 
     for ref in refs:
-        present = bool(env.get(ref.env_name))
+        present = bool(env.get(ref.env_name)) or any(bool(env.get(alias)) for alias in ref.aliases)
         if present:
             severity = Severity.OK
             detail = f"{ref.purpose} present"
@@ -640,7 +654,7 @@ def _render_model_env_row(ref: EnvReference, env: dict[str, str]) -> CheckResult
             detail=ref.purpose,
             hint=ref.config_path,
         )
-    present = bool(env.get(ref.env_name))
+    present = bool(env.get(ref.env_name)) or any(bool(env.get(alias)) for alias in ref.aliases)
     if present:
         return CheckResult(
             category="llm",

--- a/src/caretaker/doctor.py
+++ b/src/caretaker/doctor.py
@@ -380,6 +380,7 @@ def collect_env_references(config: MaintainerConfig) -> list[EnvReference]:
 # :func:`_env_vars_for_model`.
 _MODEL_PREFIX_ENV_MAP: tuple[tuple[str, tuple[str, ...]], ...] = (
     # Longest / most specific first.
+    ("openrouter/", ("OPENROUTER_API_KEY",)),
     ("ollama_chat/", ("OLLAMA_API_BASE",)),
     ("vertex_ai/", ("GOOGLE_APPLICATION_CREDENTIALS", "VERTEX_PROJECT")),
     ("azure_ai/", ("AZURE_AI_API_KEY", "AZURE_AI_API_BASE")),

--- a/src/caretaker/llm/claude.py
+++ b/src/caretaker/llm/claude.py
@@ -136,13 +136,25 @@ class ClaudeClient:
     # ── Internal routing ─────────────────────────────────────────────────────
 
     def _resolve_feature(self, feature: str, default_max_tokens: int) -> tuple[str, int]:
-        """Return the (model, max_tokens) pair for a feature."""
+        """Return the (model, max_tokens) pair for a feature.
+
+        Resolution order:
+          1. Operator's feature_models[feature] override.
+          2. Caretaker's DEFAULT_FEATURE_MODELS_BY_PROVIDER[provider][feature].
+          3. Legacy DEFAULT_FEATURE_MODELS[feature] (Anthropic-flavored defaults).
+          4. config.default_model + the caller-supplied default_max_tokens.
+        """
         if self._config is None:
             return _LEGACY_FEATURE_DEFAULTS.get(feature, (_FALLBACK_MODEL, default_max_tokens))
 
-        from caretaker.config import DEFAULT_FEATURE_MODELS
+        from caretaker.config import (
+            DEFAULT_FEATURE_MODELS,
+            DEFAULT_FEATURE_MODELS_BY_PROVIDER,
+        )
 
-        base = DEFAULT_FEATURE_MODELS.get(feature, {})
+        # Provider-aware default first; fall back to legacy Anthropic-flavored map.
+        by_provider = DEFAULT_FEATURE_MODELS_BY_PROVIDER.get(self._config.provider, {})
+        base = by_provider.get(feature) or DEFAULT_FEATURE_MODELS.get(feature, {})
         override = self._config.feature_models.get(feature)
 
         model: str = str(base.get("model") or self._config.default_model)

--- a/src/caretaker/llm/provider.py
+++ b/src/caretaker/llm/provider.py
@@ -326,6 +326,7 @@ class LiteLLMProvider:
                 "COHERE_API_KEY",
                 "GROQ_API_KEY",
                 "OLLAMA_API_BASE",
+                "OPENROUTER_API_KEY",
             )
         )
 

--- a/src/caretaker/llm/provider.py
+++ b/src/caretaker/llm/provider.py
@@ -38,6 +38,33 @@ from caretaker.observability.metrics import record_llm_cache_usage
 logger = logging.getLogger(__name__)
 
 
+# Accepted env var names for the OpenRouter API key. ``OPENROUTER_API_KEY``
+# is the canonical name LiteLLM (and OpenRouter's own docs) read; the
+# underscore-separated form is a common operator variant. Both are
+# accepted; whichever is set will be mirrored onto the canonical name
+# at provider construction so downstream consumers find it.
+OPENROUTER_API_KEY_ENV: str = "OPENROUTER_API_KEY"
+OPENROUTER_API_KEY_ALIASES: tuple[str, ...] = (
+    OPENROUTER_API_KEY_ENV,
+    "OPEN_ROUTER_API_KEY",
+)
+
+
+def resolve_openrouter_api_key() -> str | None:
+    """Return the OpenRouter API key from any accepted env var name.
+
+    Mirrors the resolved value onto :data:`OPENROUTER_API_KEY_ENV` so
+    LiteLLM (which only consults the canonical name internally) finds
+    it regardless of which alias the operator set.
+    """
+    for name in OPENROUTER_API_KEY_ALIASES:
+        value = os.environ.get(name)
+        if value:
+            os.environ.setdefault(OPENROUTER_API_KEY_ENV, value)
+            return value
+    return None
+
+
 # Models that support Anthropic prompt caching via the ``cache_control`` content-
 # block annotation.  We key off substring matches because both the Anthropic
 # native SDK (``claude-*``) and LiteLLM-routed variants (``anthropic/claude-*``,
@@ -326,7 +353,7 @@ class LiteLLMProvider:
                 "COHERE_API_KEY",
                 "GROQ_API_KEY",
                 "OLLAMA_API_BASE",
-                "OPENROUTER_API_KEY",
+                *OPENROUTER_API_KEY_ALIASES,
             )
         )
 
@@ -725,10 +752,14 @@ def build_provider(
             return NullProvider()
         # Targeted warning so operators see the exact env var to set
         # rather than LiteLLM's generic "no credentials" message.
-        if not os.environ.get("OPENROUTER_API_KEY"):
+        # ``resolve_openrouter_api_key`` also mirrors any accepted alias
+        # onto the canonical OPENROUTER_API_KEY name LiteLLM reads.
+        if resolve_openrouter_api_key() is None:
             logger.warning(
-                "provider='openrouter' but OPENROUTER_API_KEY is not set; "
-                "LLM features will fall back to their non-LLM paths"
+                "provider='openrouter' but no OpenRouter API key is set "
+                "(checked %s); LLM features will fall back to their "
+                "non-LLM paths",
+                " or ".join(OPENROUTER_API_KEY_ALIASES),
             )
         return provider
     if name == "litellm":

--- a/src/caretaker/llm/provider.py
+++ b/src/caretaker/llm/provider.py
@@ -712,6 +712,23 @@ def build_provider(
     name = provider_name.lower().strip()
     if name == "anthropic":
         return AnthropicProvider(timeout=timeout)
+    if name == "openrouter":
+        # Alias: LiteLLM with explicit OpenRouter credential check. We log
+        # a targeted warning rather than the generic "no credentials" one
+        # so operators see the exact env var to set.
+        if not os.environ.get("OPENROUTER_API_KEY"):
+            logger.warning(
+                "provider='openrouter' but OPENROUTER_API_KEY is not set; "
+                "LLM features will fall back to their non-LLM paths"
+            )
+        provider = LiteLLMProvider(fallback_models=fallback_models, timeout=timeout)
+        if not provider.package_installed:
+            logger.warning(
+                "Configured provider 'openrouter' but litellm package is not installed; "
+                "install with `pip install litellm`"
+            )
+            return NullProvider()
+        return provider
     if name == "litellm":
         provider = LiteLLMProvider(fallback_models=fallback_models, timeout=timeout)
         if not provider.package_installed:

--- a/src/caretaker/llm/provider.py
+++ b/src/caretaker/llm/provider.py
@@ -715,14 +715,7 @@ def build_provider(
     if name == "anthropic":
         return AnthropicProvider(timeout=timeout)
     if name == "openrouter":
-        # Alias: LiteLLM with explicit OpenRouter credential check. We log
-        # a targeted warning rather than the generic "no credentials" one
-        # so operators see the exact env var to set.
-        if not os.environ.get("OPENROUTER_API_KEY"):
-            logger.warning(
-                "provider='openrouter' but OPENROUTER_API_KEY is not set; "
-                "LLM features will fall back to their non-LLM paths"
-            )
+        # Alias: LiteLLM with explicit OpenRouter credential check.
         provider = LiteLLMProvider(fallback_models=fallback_models, timeout=timeout)
         if not provider.package_installed:
             logger.warning(
@@ -730,6 +723,13 @@ def build_provider(
                 "install with `pip install litellm`"
             )
             return NullProvider()
+        # Targeted warning so operators see the exact env var to set
+        # rather than LiteLLM's generic "no credentials" message.
+        if not os.environ.get("OPENROUTER_API_KEY"):
+            logger.warning(
+                "provider='openrouter' but OPENROUTER_API_KEY is not set; "
+                "LLM features will fall back to their non-LLM paths"
+            )
         return provider
     if name == "litellm":
         provider = LiteLLMProvider(fallback_models=fallback_models, timeout=timeout)

--- a/src/caretaker/llm/provider.py
+++ b/src/caretaker/llm/provider.py
@@ -362,6 +362,7 @@ class LiteLLMProvider:
             extra_attrs={
                 "caretaker.llm.feature": request.feature,
                 "caretaker.llm.router": "litellm",
+                **({"caretaker.llm.online": True} if request.model.endswith(":online") else {}),
             },
         ) as span:
             response = await self._acompletion(**kwargs)
@@ -455,6 +456,7 @@ class LiteLLMProvider:
                 "caretaker.llm.feature": request.feature,
                 "caretaker.llm.router": "litellm",
                 "caretaker.llm.tool_count": len(tools),
+                **({"caretaker.llm.online": True} if request.model.endswith(":online") else {}),
             },
         ) as _tool_span:
             response = await self._acompletion(**kwargs)

--- a/src/caretaker/llm/provider.py
+++ b/src/caretaker/llm/provider.py
@@ -743,6 +743,20 @@ def build_provider(
         return AnthropicProvider(timeout=timeout)
     if name == "openrouter":
         # Alias: LiteLLM with explicit OpenRouter credential check.
+        # Resolve the credential first — this also mirrors any accepted
+        # alias (e.g. OPEN_ROUTER_API_KEY) onto the canonical
+        # OPENROUTER_API_KEY name LiteLLM reads. Done before the
+        # package check so the warning fires regardless of whether
+        # litellm is installed; operators benefit either way.
+        if resolve_openrouter_api_key() is None:
+            # Names listed inline (not interpolated) so CodeQL doesn't
+            # flag the warning as logging sensitive data — these are
+            # env-var *names*, never values.
+            logger.warning(
+                "provider='openrouter' but no OpenRouter API key is set "
+                "(checked OPENROUTER_API_KEY or OPEN_ROUTER_API_KEY); "
+                "LLM features will fall back to their non-LLM paths"
+            )
         provider = LiteLLMProvider(fallback_models=fallback_models, timeout=timeout)
         if not provider.package_installed:
             logger.warning(
@@ -750,17 +764,6 @@ def build_provider(
                 "install with `pip install litellm`"
             )
             return NullProvider()
-        # Targeted warning so operators see the exact env var to set
-        # rather than LiteLLM's generic "no credentials" message.
-        # ``resolve_openrouter_api_key`` also mirrors any accepted alias
-        # onto the canonical OPENROUTER_API_KEY name LiteLLM reads.
-        if resolve_openrouter_api_key() is None:
-            logger.warning(
-                "provider='openrouter' but no OpenRouter API key is set "
-                "(checked %s); LLM features will fall back to their "
-                "non-LLM paths",
-                " or ".join(OPENROUTER_API_KEY_ALIASES),
-            )
         return provider
     if name == "litellm":
         provider = LiteLLMProvider(fallback_models=fallback_models, timeout=timeout)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,3 +135,13 @@ pr_agent:
         repo_root = Path(__file__).resolve().parents[1]
         schema_path = repo_root / "schema" / "config.v1.schema.json"
         assert schema_path.exists()
+
+
+def test_llm_config_accepts_openrouter_provider():
+    """LLMConfig must accept provider='openrouter' as a recognized value."""
+    from caretaker.config import LLMConfig
+
+    config = LLMConfig(
+        provider="openrouter", default_model="openrouter/anthropic/claude-sonnet-4.6"
+    )
+    assert config.provider == "openrouter"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,3 +145,99 @@ def test_llm_config_accepts_openrouter_provider():
         provider="openrouter", default_model="openrouter/anthropic/claude-sonnet-4.6"
     )
     assert config.provider == "openrouter"
+
+
+def test_openrouter_provider_rejects_bare_default_model():
+    """provider='openrouter' must reject default_model lacking the openrouter/ prefix."""
+    from pydantic import ValidationError
+
+    from caretaker.config import LLMConfig
+
+    with pytest.raises(ValidationError, match="openrouter/"):
+        LLMConfig(provider="openrouter", default_model="claude-sonnet-4-5")
+
+
+def test_openrouter_provider_rejects_bare_feature_model():
+    """provider='openrouter' must reject feature_models entries lacking the prefix."""
+    from pydantic import ValidationError
+
+    from caretaker.config import FeatureModelConfig, LLMConfig
+
+    with pytest.raises(ValidationError, match="openrouter/"):
+        LLMConfig(
+            provider="openrouter",
+            default_model="openrouter/anthropic/claude-sonnet-4.6",
+            feature_models={
+                "ci_log_analysis": FeatureModelConfig(model="claude-haiku-4-5"),
+            },
+        )
+
+
+def test_openrouter_provider_rejects_bare_fallback_model():
+    """provider='openrouter' must reject fallback_models entries lacking the prefix."""
+    from pydantic import ValidationError
+
+    from caretaker.config import LLMConfig
+
+    with pytest.raises(ValidationError, match="openrouter/"):
+        LLMConfig(
+            provider="openrouter",
+            default_model="openrouter/anthropic/claude-sonnet-4.6",
+            fallback_models=["claude-haiku-4-5"],
+        )
+
+
+def test_openrouter_provider_accepts_all_prefixed_models():
+    """A fully-prefixed OpenRouter config validates cleanly."""
+    from caretaker.config import FeatureModelConfig, LLMConfig
+
+    config = LLMConfig(
+        provider="openrouter",
+        default_model="openrouter/anthropic/claude-sonnet-4.6",
+        feature_models={
+            "ci_log_analysis": FeatureModelConfig(model="openrouter/deepseek/deepseek-r1"),
+        },
+        fallback_models=["openrouter/google/gemini-2.0-flash"],
+    )
+    assert config.provider == "openrouter"
+
+
+def test_anthropic_provider_still_accepts_bare_models():
+    """Strict prefix check must NOT apply when provider != openrouter."""
+    from caretaker.config import LLMConfig
+
+    config = LLMConfig(provider="anthropic", default_model="claude-sonnet-4-5")
+    assert config.default_model == "claude-sonnet-4-5"
+
+
+def test_litellm_provider_still_accepts_mixed_prefixes():
+    """provider='litellm' must accept any prefix shape; only openrouter is strict."""
+    from caretaker.config import LLMConfig
+
+    config = LLMConfig(
+        provider="litellm",
+        default_model="azure_ai/gpt-4o",
+        fallback_models=["claude-sonnet-4-5", "openai/gpt-4o-mini"],
+    )
+    assert config.provider == "litellm"
+
+
+def test_openrouter_validator_lists_all_offenders():
+    """The error message lists every offending field, not just the first."""
+    from pydantic import ValidationError
+
+    from caretaker.config import FeatureModelConfig, LLMConfig
+
+    with pytest.raises(ValidationError) as exc_info:
+        LLMConfig(
+            provider="openrouter",
+            default_model="claude-sonnet-4-5",  # offender 1
+            feature_models={
+                "ci_log_analysis": FeatureModelConfig(model="gpt-4o"),  # offender 2
+            },
+            fallback_models=["claude-haiku-4-5"],  # offender 3
+        )
+    msg = str(exc_info.value)
+    assert "llm.default_model" in msg
+    assert "llm.feature_models.ci_log_analysis.model" in msg
+    assert "llm.fallback_models[0]" in msg

--- a/tests/test_doctor_llm_env.py
+++ b/tests/test_doctor_llm_env.py
@@ -239,6 +239,25 @@ def test_default_model_openrouter_ok_when_key_present() -> None:
     assert _row(rows, "OPENROUTER_API_KEY").severity is Severity.OK
 
 
+def test_openrouter_alias_open_router_satisfies_canonical_row() -> None:
+    """OPEN_ROUTER_API_KEY satisfies the OPENROUTER_API_KEY check (single OK row)."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "openrouter",
+                "default_model": "openrouter/anthropic/claude-sonnet-4.6",
+            }
+        }
+    )
+    env = {"GITHUB_TOKEN": "x", "OPEN_ROUTER_API_KEY": "sk-or-v1-test-alias"}
+    rows = _llm_rows(check_env_secrets(config, env))
+    names = [r.name for r in rows]
+    # Only one row, under the canonical name.
+    assert names.count("OPENROUTER_API_KEY") == 1
+    assert "OPEN_ROUTER_API_KEY" not in names
+    assert _row(rows, "OPENROUTER_API_KEY").severity is Severity.OK
+
+
 def test_openrouter_in_fallback_only_warns_not_fails() -> None:
     """openrouter/ model only in fallback_models → WARN, not FAIL."""
     config = _load_config(

--- a/tests/test_doctor_llm_env.py
+++ b/tests/test_doctor_llm_env.py
@@ -203,3 +203,56 @@ def test_dedup_when_two_models_share_env() -> None:
     assert len(azure_ai_key_rows) == 1
     azure_ai_base_rows = [r for r in rows if r.name == "AZURE_AI_API_BASE"]
     assert len(azure_ai_base_rows) == 1
+
+
+def test_default_model_openrouter_requires_openrouter_key() -> None:
+    """openrouter/ default_model → FAIL on OPENROUTER_API_KEY when env empty."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "openrouter",
+                "default_model": "openrouter/anthropic/claude-sonnet-4.6",
+            }
+        }
+    )
+    rows = _llm_rows(check_env_secrets(config, {"GITHUB_TOKEN": "x"}))
+    names = {r.name for r in rows}
+    assert "OPENROUTER_API_KEY" in names
+    # No spurious ANTHROPIC_API_KEY row — the bare-model fallback must NOT
+    # match openrouter/anthropic/* because the openrouter/ prefix wins.
+    assert "ANTHROPIC_API_KEY" not in names
+    assert _row(rows, "OPENROUTER_API_KEY").severity is Severity.FAIL
+
+
+def test_default_model_openrouter_ok_when_key_present() -> None:
+    """openrouter/ default_model with OPENROUTER_API_KEY set → OK."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "openrouter",
+                "default_model": "openrouter/anthropic/claude-sonnet-4.6",
+            }
+        }
+    )
+    env = {"GITHUB_TOKEN": "x", "OPENROUTER_API_KEY": "sk-or-v1-test"}
+    rows = _llm_rows(check_env_secrets(config, env))
+    assert _row(rows, "OPENROUTER_API_KEY").severity is Severity.OK
+
+
+def test_openrouter_in_fallback_only_warns_not_fails() -> None:
+    """openrouter/ model only in fallback_models → WARN, not FAIL."""
+    config = _load_config(
+        {
+            "llm": {
+                "provider": "litellm",
+                "default_model": "anthropic/claude-sonnet-4.6",
+                "fallback_models": ["openrouter/anthropic/claude-sonnet-4.6"],
+            }
+        }
+    )
+    env = {"GITHUB_TOKEN": "x", "ANTHROPIC_API_KEY": "sk-ant-test"}
+    rows = _llm_rows(check_env_secrets(config, env))
+    names = {r.name for r in rows}
+    assert "OPENROUTER_API_KEY" in names
+    # Fallback-only owner_enabled=False → WARN.
+    assert _row(rows, "OPENROUTER_API_KEY").severity is Severity.WARN

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -901,3 +901,126 @@ class TestPromptCacheFailOpen:
         # open behaviour is the absence of the call at the provider level.
         annotated = _annotate_system_cache_control(messages)
         assert isinstance(annotated[0]["content"], list)
+
+
+# ── LiteLLMProvider :online span attributes ──────────────────────────────────
+
+
+class TestLiteLLMOnlineSpanAttribute:
+    """LiteLLMProvider tags spans with caretaker.llm.online for :online models."""
+
+    @pytest.mark.asyncio
+    async def test_litellm_complete_sets_online_attribute_on_online_model(
+        self, monkeypatch
+    ) -> None:
+        """LiteLLMProvider tags the span with caretaker.llm.online=True for :online models."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+        captured_attrs: dict[str, object] = {}
+
+        class FakeSpan:
+            def set_attribute(self, key: str, value: object) -> None:
+                captured_attrs[key] = value
+
+            def record_response(self, **kwargs: Any) -> None:
+                pass
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_span(**kwargs: Any) -> Any:  # type: ignore[no-untyped-def]
+            for k, v in (kwargs.get("extra_attrs") or {}).items():
+                captured_attrs[k] = v
+            yield FakeSpan()
+
+        monkeypatch.setattr("caretaker.llm.provider.llm_chat_span", fake_span)
+
+        async def fake_acompletion(**kwargs: Any) -> Any:  # type: ignore[no-untyped-def]
+            class _Choice:
+                def __init__(self) -> None:
+                    class _Msg:
+                        content = "ok"
+
+                    self.message = _Msg()
+                    self.finish_reason = "stop"
+
+            class _Resp:
+                choices = [_Choice()]
+                usage = type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})()
+                id = "x"
+                model = "openrouter/anthropic/claude-sonnet-4.6:online"
+
+            return _Resp()
+
+        p = LiteLLMProvider()
+        if not p.package_installed:
+            pytest.skip("litellm package not installed")
+        p._acompletion = fake_acompletion  # type: ignore[assignment]
+
+        await p.complete(
+            LLMRequest(
+                feature="upgrade_impact_analysis",
+                prompt="hi",
+                model="openrouter/anthropic/claude-sonnet-4.6:online",
+                max_tokens=10,
+            )
+        )
+
+        assert captured_attrs.get("caretaker.llm.online") is True
+
+    @pytest.mark.asyncio
+    async def test_litellm_complete_omits_online_attribute_on_non_online_model(
+        self, monkeypatch
+    ) -> None:
+        """No caretaker.llm.online attribute when the model lacks the :online suffix."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+        captured_attrs: dict[str, object] = {}
+
+        class FakeSpan:
+            def set_attribute(self, key: str, value: object) -> None:
+                captured_attrs[key] = value
+
+            def record_response(self, **kwargs: Any) -> None:
+                pass
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_span(**kwargs: Any) -> Any:  # type: ignore[no-untyped-def]
+            for k, v in (kwargs.get("extra_attrs") or {}).items():
+                captured_attrs[k] = v
+            yield FakeSpan()
+
+        monkeypatch.setattr("caretaker.llm.provider.llm_chat_span", fake_span)
+
+        async def fake_acompletion(**kwargs: Any) -> Any:  # type: ignore[no-untyped-def]
+            class _Choice:
+                def __init__(self) -> None:
+                    class _Msg:
+                        content = "ok"
+
+                    self.message = _Msg()
+                    self.finish_reason = "stop"
+
+            class _Resp:
+                choices = [_Choice()]
+                usage = type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})()
+                id = "x"
+                model = "openrouter/anthropic/claude-sonnet-4.6"
+
+            return _Resp()
+
+        p = LiteLLMProvider()
+        if not p.package_installed:
+            pytest.skip("litellm package not installed")
+        p._acompletion = fake_acompletion  # type: ignore[assignment]
+
+        await p.complete(
+            LLMRequest(
+                feature="ci_log_analysis",
+                prompt="hi",
+                model="openrouter/anthropic/claude-sonnet-4.6",
+                max_tokens=10,
+            )
+        )
+
+        assert "caretaker.llm.online" not in captured_attrs

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -198,6 +198,35 @@ class TestProviderFactory:
             p = build_provider("litellm")
         assert isinstance(p, AnthropicProvider)
 
+    def test_build_provider_openrouter_returns_litellm(self, monkeypatch) -> None:
+        """build_provider('openrouter') returns a LiteLLMProvider instance."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+        with patch(
+            "caretaker.llm.provider.LiteLLMProvider.package_installed",
+            new=True,
+        ):
+            p = build_provider("openrouter")
+        assert p.name == "litellm"
+        assert isinstance(p, LiteLLMProvider)
+
+    def test_build_provider_openrouter_warns_when_key_missing(self, monkeypatch, caplog) -> None:
+        """build_provider('openrouter') warns specifically about OPENROUTER_API_KEY."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with caplog.at_level("WARNING"):
+            build_provider("openrouter")
+        messages = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "OPENROUTER_API_KEY" in messages
+
+    def test_build_provider_openrouter_no_warning_when_key_present(
+        self, monkeypatch, caplog
+    ) -> None:
+        """No 'OPENROUTER_API_KEY' warning when the env var is set."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+        with caplog.at_level("WARNING"):
+            build_provider("openrouter")
+        messages = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "OPENROUTER_API_KEY is not set" not in messages
+
 
 # ── AnthropicProvider availability ───────────────────────────────────────────
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -280,8 +280,9 @@ class TestProviderFactory:
         assert isinstance(p, LiteLLMProvider)
 
     def test_build_provider_openrouter_warns_when_key_missing(self, monkeypatch, caplog) -> None:
-        """build_provider('openrouter') warns specifically about OPENROUTER_API_KEY."""
+        """build_provider('openrouter') warns when no accepted env var is set."""
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPEN_ROUTER_API_KEY", raising=False)
         with caplog.at_level("WARNING"):
             build_provider("openrouter")
         messages = " ".join(rec.getMessage() for rec in caplog.records)
@@ -290,12 +291,33 @@ class TestProviderFactory:
     def test_build_provider_openrouter_no_warning_when_key_present(
         self, monkeypatch, caplog
     ) -> None:
-        """No 'OPENROUTER_API_KEY' warning when the env var is set."""
+        """No warning when the canonical env var is set."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
         with caplog.at_level("WARNING"):
             build_provider("openrouter")
         messages = " ".join(rec.getMessage() for rec in caplog.records)
-        assert "OPENROUTER_API_KEY is not set" not in messages
+        assert "no OpenRouter API key" not in messages
+
+    def test_build_provider_openrouter_accepts_open_router_alias(self, monkeypatch, caplog) -> None:
+        """OPEN_ROUTER_API_KEY alias satisfies the openrouter provider check."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("OPEN_ROUTER_API_KEY", "sk-or-v1-test-alias")
+        with caplog.at_level("WARNING"):
+            build_provider("openrouter")
+        messages = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "no OpenRouter API key" not in messages
+        # And the alias is mirrored onto the canonical name LiteLLM reads.
+        assert os.environ.get("OPENROUTER_API_KEY") == "sk-or-v1-test-alias"
+
+    def test_build_provider_openrouter_warns_when_no_alias_set(self, monkeypatch, caplog) -> None:
+        """Warning lists both accepted env var names so operators see the choice."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPEN_ROUTER_API_KEY", raising=False)
+        with caplog.at_level("WARNING"):
+            build_provider("openrouter")
+        messages = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "OPENROUTER_API_KEY" in messages
+        assert "OPEN_ROUTER_API_KEY" in messages
 
     def test_build_provider_openrouter_without_litellm_returns_null(self, monkeypatch) -> None:
         """build_provider('openrouter') returns NullProvider when litellm missing."""
@@ -364,6 +386,19 @@ class TestLiteLLMProvider:
         ):
             p = LiteLLMProvider()
             # Mock the internal _acompletion so it appears the package is installed
+            p._acompletion = MagicMock()
+            assert p.available is True
+
+    def test_litellm_provider_available_with_only_open_router_alias(self) -> None:
+        """LiteLLMProvider.available accepts the OPEN_ROUTER_API_KEY alias too."""
+        with patch.dict(
+            os.environ,
+            {
+                "OPEN_ROUTER_API_KEY": "sk-or-v1-test",
+            },
+            clear=True,
+        ):
+            p = LiteLLMProvider()
             p._acompletion = MagicMock()
             assert p.available is True
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -297,6 +297,13 @@ class TestProviderFactory:
         messages = " ".join(rec.getMessage() for rec in caplog.records)
         assert "OPENROUTER_API_KEY is not set" not in messages
 
+    def test_build_provider_openrouter_without_litellm_returns_null(self, monkeypatch) -> None:
+        """build_provider('openrouter') returns NullProvider when litellm missing."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+        with patch("caretaker.llm.provider.LiteLLMProvider.package_installed", new=False):
+            p = build_provider("openrouter")
+        assert isinstance(p, NullProvider)
+
 
 # ── AnthropicProvider availability ───────────────────────────────────────────
 
@@ -1024,3 +1031,67 @@ class TestLiteLLMOnlineSpanAttribute:
         )
 
         assert "caretaker.llm.online" not in captured_attrs
+
+    @pytest.mark.asyncio
+    async def test_litellm_complete_with_tools_sets_online_attribute_on_online_model(
+        self, monkeypatch
+    ) -> None:
+        """complete_with_tools tags the span with caretaker.llm.online=True for :online models."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+        captured_attrs: dict[str, object] = {}
+
+        class FakeSpan:
+            def set_attribute(self, key: str, value: object) -> None:
+                captured_attrs[key] = value
+
+            def record_response(self, **kwargs: Any) -> None:
+                pass
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_span(**kwargs: Any) -> Any:  # type: ignore[no-untyped-def]
+            for k, v in (kwargs.get("extra_attrs") or {}).items():
+                captured_attrs[k] = v
+            yield FakeSpan()
+
+        monkeypatch.setattr("caretaker.llm.provider.llm_chat_span", fake_span)
+
+        async def fake_acompletion(**kwargs: Any) -> Any:  # type: ignore[no-untyped-def]
+            class _Choice:
+                def __init__(self) -> None:
+                    class _Msg:
+                        content = "ok"
+                        tool_calls = None
+                        role = "assistant"
+
+                        def model_dump(self) -> dict[str, Any]:
+                            return {"role": "assistant", "content": "ok"}
+
+                    self.message = _Msg()
+                    self.finish_reason = "stop"
+
+            class _Resp:
+                choices = [_Choice()]
+                usage = type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})()
+                id = "x"
+                model = "openrouter/anthropic/claude-sonnet-4.6:online"
+
+            return _Resp()
+
+        p = LiteLLMProvider()
+        if not p.package_installed:
+            pytest.skip("litellm package not installed")
+        p._acompletion = fake_acompletion  # type: ignore[assignment]
+
+        await p.complete_with_tools(
+            LLMRequest(
+                feature="upgrade_impact_analysis",
+                prompt="hi",
+                model="openrouter/anthropic/claude-sonnet-4.6:online",
+                max_tokens=10,
+            ),
+            tools=[],
+        )
+
+        assert captured_attrs.get("caretaker.llm.online") is True

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -176,6 +176,59 @@ class TestFeatureModelResolution:
         assert provider.calls[0].model == "claude-sonnet-4-5"
 
 
+# ── _resolve_feature per-provider routing ────────────────────────────────────
+
+
+class TestResolveFeature:
+    def test_resolve_feature_uses_openrouter_default_for_migration_analysis(self) -> None:
+        """When provider='openrouter', migration_analysis resolves to the :online model."""
+        config = LLMConfig(
+            provider="openrouter",
+            default_model="openrouter/anthropic/claude-sonnet-4.6",
+        )
+        client = ClaudeClient(config=config)
+        model, max_tokens = client._resolve_feature("migration_analysis", default_max_tokens=1)
+        assert model == "openrouter/anthropic/claude-sonnet-4.6:online"
+        assert max_tokens == 4000
+
+    def test_resolve_feature_uses_legacy_default_for_anthropic_provider(self) -> None:
+        """When provider='anthropic', migration_analysis resolves to the legacy Claude default."""
+        from caretaker.config import DEFAULT_REASONING_MODEL
+
+        config = LLMConfig(provider="anthropic")
+        client = ClaudeClient(config=config)
+        model, max_tokens = client._resolve_feature("migration_analysis", default_max_tokens=1)
+        assert model == DEFAULT_REASONING_MODEL
+        assert max_tokens == 4000
+
+    def test_resolve_feature_operator_override_beats_openrouter_default(self) -> None:
+        """Operator's feature_models override is authoritative; :online is NOT re-appended."""
+        config = LLMConfig(
+            provider="openrouter",
+            default_model="openrouter/anthropic/claude-sonnet-4.6",
+            feature_models={
+                "migration_analysis": FeatureModelConfig(
+                    model="openrouter/google/gemini-2.0-flash",
+                    max_tokens=2000,
+                ),
+            },
+        )
+        client = ClaudeClient(config=config)
+        model, max_tokens = client._resolve_feature("migration_analysis", default_max_tokens=1)
+        assert model == "openrouter/google/gemini-2.0-flash"
+        assert max_tokens == 2000
+
+    def test_resolve_feature_unknown_feature_falls_through_to_default_model(self) -> None:
+        """A feature with no entry in either default map falls back to default_model."""
+        config = LLMConfig(
+            provider="openrouter",
+            default_model="openrouter/anthropic/claude-sonnet-4.6",
+        )
+        client = ClaudeClient(config=config)
+        model, _ = client._resolve_feature("not_a_real_feature", default_max_tokens=1500)
+        assert model == "openrouter/anthropic/claude-sonnet-4.6"
+
+
 # ── Provider factory ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -228,6 +228,23 @@ class TestResolveFeature:
         model, _ = client._resolve_feature("not_a_real_feature", default_max_tokens=1500)
         assert model == "openrouter/anthropic/claude-sonnet-4.6"
 
+    def test_resolve_feature_openrouter_falls_through_to_legacy_for_unmapped_features(
+        self,
+    ) -> None:
+        """Under openrouter, unmapped features fall back to DEFAULT_FEATURE_MODELS."""
+        from caretaker.config import DEFAULT_FEATURE_MODELS
+
+        config = LLMConfig(
+            provider="openrouter",
+            default_model="openrouter/anthropic/claude-sonnet-4.6",
+        )
+        client = ClaudeClient(config=config)
+        # ci_triage is in DEFAULT_FEATURE_MODELS but NOT in
+        # DEFAULT_FEATURE_MODELS_BY_PROVIDER["openrouter"].
+        model, max_tokens = client._resolve_feature("ci_triage", default_max_tokens=1)
+        assert model == DEFAULT_FEATURE_MODELS["ci_triage"]["model"]
+        assert max_tokens == DEFAULT_FEATURE_MODELS["ci_triage"]["max_tokens"]
+
 
 # ── Provider factory ─────────────────────────────────────────────────────────
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -246,6 +246,21 @@ class TestLiteLLMProvider:
             else:
                 assert p.available is False
 
+    def test_litellm_provider_available_with_only_openrouter_key(self) -> None:
+        """LiteLLMProvider.available must return True when only OPENROUTER_API_KEY is set."""
+        # Clear every other credential the allowlist checks, leaving only OpenRouter.
+        with patch.dict(
+            os.environ,
+            {
+                "OPENROUTER_API_KEY": "sk-or-v1-test",
+            },
+            clear=True,
+        ):
+            p = LiteLLMProvider()
+            # Mock the internal _acompletion so it appears the package is installed
+            p._acompletion = MagicMock()
+            assert p.available is True
+
     def test_fallback_models_passed_through(self) -> None:
         p = LiteLLMProvider(fallback_models=["openai/gpt-4o", "vertex_ai/gemini-1.5-pro"])
         assert p._fallback_models == ["openai/gpt-4o", "vertex_ai/gemini-1.5-pro"]


### PR DESCRIPTION
## Summary

Adds `provider: openrouter` to caretaker's LLM config, with caretaker-shipped per-feature defaults and `:online` web-grounded analysis on three features. Two surgical, additive changes; no new abstractions, no migration required for existing operators.

### What you get
- **300+ models behind one key** — DeepSeek R1 for cheap triage, Claude Opus 4.6 for architectural review, Sonnet 4.6 with `:online` web search for `upgrade_impact_analysis` / `migration_analysis` / `migration_plan` (so release-note context comes from current sources, not stale model knowledge).
- **Per-feature model routing** preserved end-to-end — operator's `feature_models[*]` still wins over the shipped per-provider defaults.
- **Strict prefix validation** — bare Anthropic-style model strings under `provider: openrouter` raise at config load with a YAML-style path, catching the most common copy-paste misconfig.
- **`:online` cost telemetry** — spans on web-grounded calls carry `caretaker.llm.online=true` so cost dashboards can break out web-grounded spend.
- **Doctor preflight** recognises the `openrouter/` prefix and emits FAIL/WARN appropriately.
- **Env var alias** — both `OPENROUTER_API_KEY` (canonical) and `OPEN_ROUTER_API_KEY` (operator variant) are accepted; whichever is set is mirrored onto the canonical name LiteLLM reads.

### Backwards compat
Purely additive. Operators on `provider: anthropic` see no change. Operators on `provider: litellm` with non-OpenRouter models see no change. The single bug fix — `LiteLLMProvider.available` now returns True when only `OPENROUTER_API_KEY` is set — only widens the cases where LLM features run.

### Infra
The runtime k8s manifests in `infra/k8s/` mount `OPENROUTER_API_KEY` from the existing `caretaker-secrets` Secret with `optional: true`. The Azure Key Vault `openclaw-kv-301919` and the live `caretaker-secrets` have already been populated with the key value (out of band) so no merge-ordering urgency.

### Touched files
- `src/caretaker/llm/provider.py` — alias resolver + `openrouter` factory branch.
- `src/caretaker/llm/claude.py` — `_resolve_feature` consults `DEFAULT_FEATURE_MODELS_BY_PROVIDER` first.
- `src/caretaker/config.py` — `Literal["anthropic","litellm","openrouter"]`, per-provider feature map, `model_validator` for the prefix rule.
- `src/caretaker/doctor.py` — `openrouter/` prefix in the env map; `EnvReference.aliases` field for the OpenRouter env-var alias.
- `src/caretaker/observability/llm_span.py` — `caretaker.llm.online=true` span attribute.
- `infra/k8s/caretaker-mcp-deployment.yaml`, `infra/k8s/caretaker-agent-worker.yaml` — env wiring.
- `tests/test_llm.py`, `tests/test_config.py`, `tests/test_doctor_llm_env.py` — unit tests.
- `README.md`, `docs/configuration.md`, `CHANGELOG.md`, `docs/superpowers/specs/2026-05-01-openrouter-integration-design.md`, `docs/superpowers/plans/2026-05-01-openrouter-integration.md`.

## Test plan

- [x] Full unit suite: `pytest -q` → 2550 passed
- [x] `ruff check src tests` clean
- [x] `ruff format --check src tests` clean
- [x] `mypy src/caretaker` — only pre-existing `redundant-cast` noise in `shadow.py` (not from this branch; `git stash && mypy` confirms baseline)
- [ ] CI passes on the PR
- [ ] Live verification post-merge: a deploy reconciles the manifest update; new `caretaker-mcp` pod env contains `OPENROUTER_API_KEY`; existing features (anthropic-default config) still work
- [ ] Optional smoke test: switch a non-prod config to `provider: openrouter` and exercise `migration_analysis`; confirm `caretaker.llm.online=true` span attribute lands in the OTEL collector

🤖 Generated with [Claude Code](https://claude.com/claude-code)