### PR TITLE
chore(config): switch dogfood LLM routing to provider=openrouter

### DIFF
--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -162,29 +162,48 @@ escalation:
   labels: ["maintainer:escalated"]
 
 llm:
-  # Route through LiteLLM so any Azure AI Foundry / Azure OpenAI key works.
-  # provider: anthropic would require ANTHROPIC_API_KEY which is not used in
-  # this fleet — Claude is accessed via Azure AI Foundry (AZURE_AI_API_KEY).
-  provider: litellm
+  # Route through OpenRouter — single key (OPENROUTER_API_KEY) fronts 300+
+  # models from one credential. Strict prefix validation rejects any
+  # bare/non-openrouter model strings under provider=openrouter at config
+  # load (catches the common copy-paste misconfig where an Anthropic
+  # config gets pasted into an openrouter setup).
+  provider: openrouter
   claude_enabled: "true"
-  default_model: azure_ai/gpt-4.1-mini
+  default_model: openrouter/openai/gpt-4o-mini
   fallback_models:
-    - azure/gpt-4o
+    - openrouter/openai/gpt-4o-mini
+  # Most feature → model routing is supplied by the shipped
+  # DEFAULT_FEATURE_MODELS_BY_PROVIDER["openrouter"] map (see
+  # src/caretaker/config.py): ci_log_analysis → DeepSeek R1,
+  # principal_architecture_review → Claude Opus 4.6,
+  # upgrade_impact_analysis / migration_analysis / migration_plan →
+  # Claude Sonnet 4.6 with the :online suffix (web-grounded — release
+  # notes & breaking-change advisories come from current sources).
+  # Operator overrides below win over those shipped defaults.
   feature_models:
-    # Reasoning-heavy features — route to Claude via Azure AI Foundry for
-    # prompt-cache benefits (_supports_prompt_cache keys on "claude" substring).
+    # Reasoning-heavy on-PR review — top-tier Claude. Sonnet rather than
+    # Opus to keep the per-comment cost reasonable; principal_architecture_review
+    # (full-PR reviewer's reviewer) is the spot to spend Opus tokens.
     architectural_review:
-      model: azure_ai/claude-sonnet-4-5
-      max_tokens: 8000
-    principal_architecture_review:
-      model: azure_ai/claude-sonnet-4-5
+      model: openrouter/anthropic/claude-sonnet-4.6
       max_tokens: 8000
     issue_decomposition:
-      model: azure_ai/gpt-4.1
+      model: openrouter/openai/gpt-4o
       max_tokens: 4000
-    # Log grinding — fast + cheap
-    ci_log_analysis:
-      model: azure_ai/gpt-4.1-mini
+    # Features below have entries in the LEGACY DEFAULT_FEATURE_MODELS
+    # (bare claude-*-5 strings) but no per-provider override in
+    # DEFAULT_FEATURE_MODELS_BY_PROVIDER["openrouter"]. Without explicit
+    # entries here the resolver falls through to bare Claude strings,
+    # which under provider=openrouter would route Anthropic-direct
+    # (no key in this fleet) and fail. Pinning openrouter equivalents.
+    refactor_analysis:
+      model: openrouter/anthropic/claude-opus-4.6
+      max_tokens: 4000
+    analyze_review_comment:
+      model: openrouter/anthropic/claude-haiku-4.5
+      max_tokens: 1000
+    generate_reflection:
+      model: openrouter/anthropic/claude-sonnet-4.6
       max_tokens: 1500
   claude_features:
     - ci_log_analysis


### PR DESCRIPTION
## Summary

Flips this repo's `.github/maintainer/config.yml` from `provider: litellm` (Azure AI Foundry routing) to `provider: openrouter` end-to-end. One key (`OPENROUTER_API_KEY`) fronts the whole feature map, and the strict `openrouter/` prefix validator (added in #665) catches misconfigs at config load.

The runtime side is already in place: `openclaw-kv-301919/OPENROUTER-API-KEY` → `caretaker-secrets:openrouter-api-key` → pod env `OPENROUTER_API_KEY` (verified live).

## Per-feature routing

| Feature | Model | Rationale |
| --- | --- | --- |
| `ci_log_analysis` | `openrouter/deepseek/deepseek-r1` | Shipped default — cheap & fast for log triage |
| `architectural_review` | `openrouter/anthropic/claude-sonnet-4.6` | Per-comment cost-tuned (vs Opus on full-PR review) |
| `principal_architecture_review` | `openrouter/anthropic/claude-opus-4.6` | Shipped default — full-PR reviewer's reviewer |
| `issue_decomposition` | `openrouter/openai/gpt-4o` | Strong instruction-following |
| `upgrade_impact_analysis` | `openrouter/anthropic/claude-sonnet-4.6:online` | Web-grounded release notes |
| `migration_analysis` | `openrouter/anthropic/claude-sonnet-4.6:online` | Web-grounded breaking-change advisories |
| `migration_plan` | `openrouter/anthropic/claude-sonnet-4.6:online` | Web-grounded |
| `refactor_analysis` | `openrouter/anthropic/claude-opus-4.6` | Pinned (see Resolver gap below) |
| `analyze_review_comment` | `openrouter/anthropic/claude-haiku-4.5` | Pinned, fast triage tier |
| `generate_reflection` | `openrouter/anthropic/claude-sonnet-4.6` | Pinned |
| `default_model` / fallthrough | `openrouter/openai/gpt-4o-mini` | Cheapest sensible default |

Where the table says "shipped default", that comes from `DEFAULT_FEATURE_MODELS_BY_PROVIDER[\"openrouter\"]` in [src/caretaker/config.py](src/caretaker/config.py) — the operator config doesn't need to repeat them.

## :online cost note

Three features (`upgrade_impact_analysis`, `migration_analysis`, `migration_plan`) carry the `:online` suffix, which adds OpenRouter's web search step (~\$4 / 1k searches) on top of the model call. Spans on these requests carry `caretaker.llm.online=true` so cost dashboards can break out web-grounded spend (added in #665).

## Resolver gap (follow-up worth filing)

`refactor_analysis`, `analyze_review_comment`, and `generate_reflection` have entries in the **legacy** `DEFAULT_FEATURE_MODELS` table (bare `claude-*-5` strings) but no per-provider override in `DEFAULT_FEATURE_MODELS_BY_PROVIDER[\"openrouter\"]`. Today's `_resolve_feature` precedence is:

1. operator override
2. per-provider default
3. **legacy DEFAULT_FEATURE_MODELS**
4. operator's `default_model`

Step 3 catches these three features and returns bare Claude strings, which under `provider: openrouter` would route Anthropic-direct (no key in this fleet) and fail at runtime. I've pinned them explicitly here as a workaround. The proper fix is a follow-up patch: `_resolve_feature` should skip step 3 when `provider != \"anthropic\"`.

## Verification

```
$ python -c "from caretaker.config import MaintainerConfig; ..."
ALL ROUTING THROUGH OPENROUTER: True
```

All 11 feature checks (10 known + unknown fallthrough) resolve to `openrouter/...` strings; strict prefix validator passes.

## Rollback

If something misbehaves, revert this single commit. The orchestrator will re-read `.github/maintainer/config.yml` on next pod cycle (or restart the deployment to force).

## Test plan

- [x] `python -c "MaintainerConfig.model_validate(...)"` — strict prefix validator passes
- [x] `_resolve_feature` preview — every feature resolves to an `openrouter/`-prefixed string
- [x] OpenRouter catalogue check — all referenced model IDs exist as of today
- [ ] CI passes on the PR
- [ ] Post-merge: orchestrator hourly run completes; no LLM-route errors in pod logs; `caretaker.llm.online=true` span samples appear in OTEL collector for upgrade/migration features

🤖 Generated with [Claude Code](https://claude.com/claude-code)