### PR TITLE
fix(docker): install git in MCP image

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -26,7 +26,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # the frontend-build stage breaks because Docker dereferences symlinks
 # (npm wrapper requires ../lib/cli.js via relative resolution).
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg git \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean \


### PR DESCRIPTION
Live-fire QA on caretaker-qa PR #107 with v0.28.1 surfaced this: `opencode_local` fails with `[Errno 2] No such file or directory: 'git'` because python:3.14-slim doesn't include git, and `prepare_workdir` runs `git clone`. Adds git to the same apt install line that already pulls curl/ca-certificates/gnupg/nodejs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)