### PR TITLE
feat(observability): env-driven log level + DEBUG default in QA

### DIFF
--- a/infra/k8s/caretaker-mcp-deployment.yaml
+++ b/infra/k8s/caretaker-mcp-deployment.yaml
@@ -61,6 +61,14 @@ spec:
             # silence-postmortem.md.
             - name: PYTHONUNBUFFERED
               value: "1"
+            # Application log level. v0.28.3+ honours this via
+            # logging.basicConfig in mcp_backend/main.py. Lower to DEBUG
+            # when diagnosing webhook / pr-reviewer behaviour; bump back
+            # to INFO once the issue is identified to keep log volume
+            # manageable. Noisy libs (httpx, openai, urllib3) are pinned
+            # to INFO regardless so the signal stays readable.
+            - name: CARETAKER_LOG_LEVEL
+              value: "DEBUG"
             # ── OpenTelemetry — point at the in-cluster collector ────
             # The collector is at otel-collector.default.svc:4317 (gRPC),
             # which fans out to Tempo with tail-sampling. ``caretaker-mcp``

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -55,7 +55,30 @@ from caretaker.observability.metrics import record_error, record_webhook_event
 from caretaker.state.token_broker import build_token_broker
 from caretaker.state.webhook_dedup import LocalDedup, RedisDedup, build_dedup
 
+# Configure root logging before any module-level loggers fire so a
+# ``CARETAKER_LOG_LEVEL=DEBUG`` env var actually surfaces application
+# logs to stdout. Without this, uvicorn's defaults leave the root logger
+# at WARNING and every ``logger.info`` / ``logger.debug`` call from
+# caretaker code silently drops, making PR-review behaviour invisible
+# in ``kubectl logs``. Levels are case-insensitive; invalid values
+# fall back to INFO so a typo doesn't silence the backend entirely.
+_LOG_LEVEL_NAME = os.environ.get("CARETAKER_LOG_LEVEL", "INFO").upper()
+_LOG_LEVEL = getattr(logging, _LOG_LEVEL_NAME, logging.INFO)
+logging.basicConfig(
+    level=_LOG_LEVEL,
+    format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+    force=True,  # uvicorn may have called basicConfig already
+)
+# Quiet down a few noisy libraries even at DEBUG so the signal stays
+# readable. Operators can re-enable individually via per-module env.
+for _noisy in ("httpx", "httpcore", "openai", "urllib3"):
+    logging.getLogger(_noisy).setLevel(max(logging.INFO, _LOG_LEVEL))
+
 logger = logging.getLogger(__name__)
+logger.info(
+    "caretaker MCP backend starting (log level=%s)",
+    logging.getLevelName(_LOG_LEVEL),
+)
 
 try:
     _PKG_VERSION = importlib.metadata.version("caretaker-github")


### PR DESCRIPTION
Adds CARETAKER_LOG_LEVEL env var honoured by mcp_backend, defaulted to DEBUG in the deployment manifest. Without this, every `logger.info`/`logger.debug` call from caretaker silently drops because uvicorn leaves the root logger at WARNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)