### PR TITLE
feat(observability): phases 1-4 — metrics, health probe, OTEL spans, cost tracking, PR timeline

### DIFF
--- a/docs/plans/2026-05-06-observability-improvements.md
+++ b/docs/plans/2026-05-06-observability-improvements.md
@@ -1,0 +1,265 @@
+# Observability Improvements — Lessons from v0.28 QA
+
+**Status:** Proposed plan
+**Author:** drafted 2026-05-06 after the v0.28.0 → v0.28.4 live-fire QA cycle
+**Owner:** TBD
+**Related work:** v0.28.x release series (PRs #674, #677, #679, #681, #683)
+
+---
+
+## 1. Why this plan exists
+
+Shipping `opencode_local` to caretaker-qa took five patch releases (v0.28.1 → v0.28.4) because the failure modes were almost all silent:
+
+| # | Bug | Failure signal we *had* | Failure signal we *needed* |
+|---|---|---|---|
+| 1 | `opencode -p` is wrong syntax | "Empty review body" on PR | An `opencode_invocations_total{outcome="cli_help_returned"}` counter |
+| 2 | Bogus model IDs | None (parser fell back to COMMENT review) | A loud log + metric when fallback parser fires |
+| 3 | `git` not in image | `[Errno 2] No such file or directory: 'git'` *eventually* surfaced as a comment | A `/health/deep` self-test that would have caught it pre-deploy |
+| 4 | Backend stdout silent | Pod logs only showed startup messages | DEBUG-level env var (added in v0.28.3) — needs default-INFO with structured fields |
+| 5 | `gemini-3-pro-preview` rejected by OpenRouter | "No endpoints found" buried in subprocess WARNING line | Pre-flight model probing in CI + alerts on first runtime failure |
+
+Every one of these would have been a 5-minute fix if the right signal existed. Most of the time on the v0.28.x cycle was spent piecing together what the backend was doing rather than fixing actual code.
+
+---
+
+## 2. What we already have (don't rebuild)
+
+- **Prometheus metrics** at `:9090` — ~30 counters/histograms for HTTP, eventbus, fix-ladder, LLM cache, etc. (`src/caretaker/observability/metrics.py`)
+- **OTEL traces → Tempo** — `caretaker-mcp` is on the always-keep sampling list; auto-instrumentors for FastAPI, httpx, Redis, Neo4j (`src/caretaker/observability/bootstrap.py`)
+- **Trace ID stamping on log records** — every `LogRecord` gets `otelTraceID` / `otelSpanID` (same module)
+- **Admin dashboard** at `caretaker.cat-herding.net` — has read-only state/runs/PR endpoints behind OIDC
+- **CARETAKER_LOG_LEVEL env var** (added v0.28.3) — controls Python root logger
+
+The plan below builds on all of this. No new observability stack.
+
+---
+
+## 3. Phase 1 — Quick wins (1 day total, high signal)
+
+These are the items that would have caught all five v0.28.x bugs. Implement first.
+
+### 3.1 Per-PR audit log line at INFO
+
+Today's logs are either silent (INFO) or a firehose (DEBUG). Add **one summary line per PR review** at INFO that captures the full decision in a single line that can be `grep`'d:
+
+```
+INFO caretaker.pr_reviewer.agent: pr_review_complete repo=ianlintner/caretaker-qa pr=108 author=ianlintner is_caretaker_owned=False routing=score=0_inline tier=None backend=opencode_local model=openrouter/google/gemini-2.5-pro verdict=REQUEST_CHANGES duration_ms=42103 issue_categories=[lint,format,correctness] auto_fix_dispatched=False auto_fix_reason="not caretaker-owned"
+```
+
+**Where:** `src/caretaker/pr_reviewer/agent.py:_handle_pr` — log this line right before `return`. Use `logger.info` with `extra={...}` so structured-log consumers (Tempo logs, Grafana Loki) get fields, not a giant string.
+
+### 3.2 Loud fallback-parser warning
+
+The `opencode_local` fallback parser silently produced a useless review on bug #2 and #5. Add:
+
+```python
+# in opencode_local._parse_review_payload, fallback branch
+logger.warning(
+    "opencode_local: fallback parse used — structured caretaker-review JSON missing. "
+    "stdout_bytes=%d sample=%r",
+    len(assistant_text), assistant_text[:200],
+)
+record_error("pr_reviewer", "opencode_local_fallback_parse")
+```
+
+Counter the fallback in Prometheus too (see 3.4).
+
+### 3.3 `/health/deep` endpoint
+
+A new readiness-style endpoint that probes external dependencies and returns a structured health verdict. Would have caught bugs #3 and #5 before deploy.
+
+```json
+GET /health/deep
+{
+  "status": "ok|degraded|fail",
+  "checks": {
+    "git_cli": {"status": "ok", "version": "2.47.3"},
+    "opencode_cli": {"status": "ok", "version": "1.14.39"},
+    "redis": {"status": "ok", "latency_ms": 3},
+    "mongo": {"status": "ok"},
+    "neo4j": {"status": "ok"},
+    "openrouter_models": {
+      "status": "degraded",
+      "configured_models": [...],
+      "probed_at": "2026-05-06T14:00:00Z",
+      "results": {
+        "openrouter/google/gemini-2.5-pro": "ok",
+        "openrouter/google/gemini-3-pro-preview": "fail: No endpoints found"
+      }
+    }
+  }
+}
+```
+
+**Where:** new endpoint in `src/caretaker/mcp_backend/main.py`. Rate-limit the OpenRouter model probe (hourly cache) so it doesn't burn tokens on every kubelet probe.
+
+### 3.4 Five new Prometheus counters
+
+Bolt-on additions to `observability/metrics.py`:
+
+```python
+PR_REVIEW_OUTCOME_TOTAL = Counter(
+    "caretaker_pr_review_outcome_total",
+    "PR review outcomes by backend, tier, verdict",
+    ["backend", "tier", "verdict"],  # tier in {trivial,simple,standard,complex,none}
+)
+PR_REVIEW_DURATION_SECONDS = Histogram(
+    "caretaker_pr_review_duration_seconds",
+    "End-to-end PR review duration",
+    ["backend", "tier"],
+    buckets=[1, 5, 10, 30, 60, 120, 300, 600],
+)
+COMPLEXITY_CLASSIFIER_TIER_TOTAL = Counter(
+    "caretaker_complexity_classifier_tier_total",
+    "Complexity classifier verdicts by tier and decision source",
+    ["tier", "source"],  # source in {fast_path, llm, heuristic_fallback}
+)
+OPENCODE_INVOCATION_TOTAL = Counter(
+    "caretaker_opencode_invocation_total",
+    "opencode CLI subprocess invocations by model and outcome",
+    ["model", "mode", "outcome"],  # mode={review,fix}, outcome={ok,parse_fallback,timeout,no_endpoints,error}
+)
+AUTO_FIX_DISPATCH_TOTAL = Counter(
+    "caretaker_auto_fix_dispatch_total",
+    "Auto-fix dispatcher decisions",
+    ["backend", "category", "outcome"],  # outcome={dispatched_success,dispatched_fail,skipped}
+)
+```
+
+Wire into the agent at the same call sites the audit log line goes (3.1).
+
+---
+
+## 4. Phase 2 — Per-PR timeline endpoint (~1 day)
+
+Today, "what did caretaker do on PR #108?" requires `kubectl logs -l app=caretaker-mcp --since=1h | grep 108` across both pods. Replace with:
+
+```
+GET /api/admin/pr/{owner}/{repo}/{number}/timeline
+```
+
+Returns a chronological list of every backend decision touching that PR, drawn from MongoDB's existing `fleet_heartbeats` + a new `pr_decisions` collection that the agent writes to as it goes:
+
+```json
+[
+  {"at": "2026-05-06T14:01:14Z", "agent": "pr_reviewer", "event": "review_started", "backend": "opencode_local", "tier": null, "model": "openrouter/google/gemini-2.5-pro"},
+  {"at": "2026-05-06T14:01:38Z", "agent": "pr_reviewer", "event": "review_posted", "verdict": "COMMENT", "fallback": true, "duration_ms": 24000},
+  {"at": "2026-05-06T14:01:45Z", "agent": "pr_agent", "event": "state_transition", "from": "discovered", "to": "review_changes_requested"},
+  {"at": "2026-05-06T14:01:45Z", "agent": "pr_agent", "event": "auto_fix_skipped", "reason": "not caretaker-owned"}
+]
+```
+
+**Where:** new collection `pr_decisions` (TTL 30d), write helper in `src/caretaker/state/pr_decisions.py`, endpoint in `src/caretaker/admin/api/pr_routes.py`. SPA can render this as a vertical timeline on the existing PR detail page.
+
+### 4.1 Trace-ID linking
+
+Each `pr_decisions` row carries `trace_id` from the active OTEL span. The admin SPA renders that as a link to Tempo (`tempo.default.svc:3200/api/traces/{trace_id}`) so a single click jumps from "we picked tier=trivial" → the full trace.
+
+---
+
+## 5. Phase 3 — Cost tracking (~1 day)
+
+We just shifted models from Opus/R1 to Gemini/DeepSeek, but we have **no measurement** of whether that's actually saving money. The opencode CLI emits token counts on the final result event in stream-json mode (we can also intercept via OpenRouter's `X-Total-Tokens` headers).
+
+```python
+LLM_TOKENS_TOTAL = Counter(
+    "caretaker_llm_tokens_total",
+    "Tokens consumed per model and direction",
+    ["model", "direction"],  # direction in {prompt, completion}
+)
+LLM_COST_USD_TOTAL = Counter(
+    "caretaker_llm_cost_usd_total",
+    "Estimated USD cost per model (using a static price table)",
+    ["model"],
+)
+```
+
+Static price table in `config.py` keyed by model ID; updated quarterly. Grafana dashboard panel "Per-repo daily LLM spend" answers "did the v0.28 model shift work?" in one chart.
+
+---
+
+## 6. Phase 4 — Tempo trace richness (~half day)
+
+We're already sending traces but they're sparse. Add custom spans for the slow / decision-heavy operations:
+
+| Operation | Span name | Useful attributes |
+|---|---|---|
+| opencode subprocess | `opencode_local.invoke` | `opencode.model`, `opencode.mode`, `opencode.workdir`, `opencode.exit_code` |
+| Complexity classifier | `complexity_classifier.classify` | `pr.repo`, `pr.number`, `tier`, `source`, `confidence` |
+| `prepare_workdir` | `pr_review.clone_workdir` | `pr.head_sha`, `clone_depth` |
+| `dispatch_auto_fix` | `auto_fix.dispatch` | `decision.backend`, `decision.categories`, `attempt`, `outcome.success` |
+| `inline_reviewer.review` | `inline_reviewer.review` | `pr.diff_lines`, `model`, `verdict` |
+
+Each PR review then becomes a single trace tree in Tempo:
+
+```
+pr_reviewer.handle_pr (root span, repo=caretaker-qa, pr=108)
+├── routing.decide
+├── complexity_classifier.classify (tier=standard, source=llm)
+├── opencode_local.run
+│   ├── pr_review.clone_workdir (200ms)
+│   └── opencode_local.invoke (model=gemini-2.5-pro, 24000ms)
+├── github.create_review (verdict=REQUEST_CHANGES)
+└── auto_fix.dispatch (outcome=skipped, reason=not_caretaker_owned)
+```
+
+A Grafana dashboard with "slowest reviews last 24h" + "highest-cost reviews" + "fallback-parser triggers" reads straight from these spans.
+
+**Where:** add `tracer = trace.get_tracer(__name__)` + `with tracer.start_as_current_span(...):` blocks in five files. Mostly mechanical, ~150 LoC total.
+
+---
+
+## 7. Phase 5 — Alerting (1 day after Phase 1 metrics land)
+
+Once Phase 1's counters exist, wire Prometheus alert rules. Sample set:
+
+| Alert | Expression | Severity |
+|---|---|---|
+| `OpencodeFallbackParseSpike` | `rate(caretaker_opencode_invocation_total{outcome="parse_fallback"}[10m]) > 0.1` | warning |
+| `OpencodeNoEndpointsSpike` | `rate(caretaker_opencode_invocation_total{outcome="no_endpoints"}[10m]) > 0.05` | critical |
+| `AutoFixFailureRate` | `rate(caretaker_auto_fix_dispatch_total{outcome="dispatched_fail"}[1h]) / rate(caretaker_auto_fix_dispatch_total[1h]) > 0.3` | warning |
+| `PRReviewLatencyHigh` | `histogram_quantile(0.95, caretaker_pr_review_duration_seconds_bucket) > 300` | info |
+| `WebhookSignatureFailures` | `rate(caretaker_errors_total{kind="webhook_signature"}[5m]) > 0` | critical |
+
+Notification target: GitHub Issue auto-creation in `ianlintner/caretaker` with the `meta:alert` label (uses caretaker's own issue agent — eat your own dog food).
+
+---
+
+## 8. Phase 6 — Local diagnostic CLI (stretch, ~half day)
+
+```bash
+caretaker debug pr-review https://github.com/ianlintner/caretaker-qa/pull/108
+```
+
+Runs the full pr_reviewer flow against the deployed backend's config but **without writing to GitHub** — prints the routing decision, complexity tier, opencode invocation, parsed review, and what auto-fix would do. Lets ops dry-run a fix-config change before pushing it.
+
+**Where:** new `caretaker debug` subcommand group in `src/caretaker/cli.py`. Reuses the existing agent classes with a `dry_run=True` flag added to `PRReviewerAgent.execute`.
+
+---
+
+## 9. Sequencing
+
+| Phase | Effort | Unblocks |
+|---|---|---|
+| 1. Audit log line, fallback warning, /health/deep, 5 metrics | 1 day | Catches the next v0.28.x-class bug at deploy time |
+| 2. Per-PR timeline endpoint | 1 day | Replaces every "what did caretaker do on this PR?" investigation |
+| 3. Cost tracking | 1 day | Answers "did the model shift save money?" |
+| 4. Tempo trace richness | 0.5 day | Slow-review root-cause diagnosis |
+| 5. Alerting | 1 day (after 1) | Pages on real failures, not just charts |
+| 6. Local debug CLI | 0.5 day | Pre-deploy validation by ops |
+
+Recommend landing **Phase 1 in a single PR this week** — that's where the cost/value ratio is best. Phases 2-6 can run in parallel afterward.
+
+---
+
+## 10. Open questions
+
+- **Cost table maintenance:** OpenRouter prices change. Should we ingest their `/models` endpoint nightly into a Mongo collection and use that, or hand-maintain a static table? Static is simpler; ingestion is more accurate.
+- **PII / secret redaction in audit log:** the per-PR timeline writes structured JSON. Need a redactor that strips `Bearer ...`, `sk-or-...` patterns, etc., before persistence.
+- **Trace sampling for cost:** caretaker-mcp is "always-keep" today. With richer spans that's fine for QA but might be too much in a busy fleet. Likely want to switch to a tail-sampler that always keeps `verdict=REQUEST_CHANGES` and `outcome=parse_fallback` and probabilistically samples the rest.
+- **Local logging vs OTEL log pipeline:** currently we stamp trace IDs on logs but don't ship them via OTEL. If we're using Loki/Grafana already, hooking `OTLPLogExporter` would unify "logs near traces" in Grafana — worth doing in Phase 4 alongside richer spans.
+
+---
+
+*End of plan.*

--- a/src/caretaker/admin/pr_timeline_api.py
+++ b/src/caretaker/admin/pr_timeline_api.py
@@ -1,0 +1,92 @@
+"""Admin API for the per-PR decision timeline.
+
+Exposes ``GET /api/admin/pr/{owner}/{repo}/{number}/timeline`` so the
+admin SPA can render the full chronological list of decisions
+caretaker made for a given PR. Reads from the
+:class:`~caretaker.state.pr_decisions.PRDecisionStore` configured at
+app startup.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime  # noqa: TC003 — pydantic resolves the annotation at runtime
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from caretaker.admin.auth import UserInfo, require_session
+
+if TYPE_CHECKING:
+    from caretaker.state.pr_decisions import PRDecisionStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin", tags=["pr-timeline"])
+
+# Module-level store handle — set during app startup via ``configure``.
+_store: PRDecisionStore | None = None
+
+
+def configure(store: PRDecisionStore | None) -> None:
+    """Install (or clear) the decision store backing the endpoint."""
+    global _store  # noqa: PLW0603 — process singleton.
+    _store = store
+
+
+# ── Response schema ──────────────────────────────────────────────────────
+
+
+class DecisionRow(BaseModel):
+    id: str
+    observed_at: datetime
+    agent: str
+    event: str
+    fields: dict[str, Any] = Field(default_factory=dict)
+    trace_id: str | None = None
+    span_id: str | None = None
+
+
+class TimelineResponse(BaseModel):
+    owner: str
+    repo: str
+    pr_number: int
+    decisions: list[DecisionRow] = Field(default_factory=list)
+
+
+# ── Endpoint ─────────────────────────────────────────────────────────────
+
+
+@router.get("/pr/{owner}/{repo}/{number}/timeline", response_model=TimelineResponse)
+async def get_pr_timeline(
+    owner: str,
+    repo: str,
+    number: int,
+    _user: UserInfo = Depends(require_session),
+) -> TimelineResponse:
+    """Return the chronological decision trail for one PR."""
+    decisions: list[DecisionRow] = []
+    if _store is not None:
+        docs = await _store.query_timeline(owner=owner, repo=repo, pr_number=number)
+        for d in docs:
+            decisions.append(
+                DecisionRow(
+                    id=str(d.get("id", "")),
+                    observed_at=d["observed_at"],
+                    agent=str(d.get("agent", "")),
+                    event=str(d.get("event", "")),
+                    fields=dict(d.get("fields") or {}),
+                    trace_id=d.get("trace_id"),
+                    span_id=d.get("span_id"),
+                )
+            )
+    return TimelineResponse(
+        owner=owner,
+        repo=repo,
+        pr_number=number,
+        decisions=decisions,
+    )
+
+
+__all__ = ["DecisionRow", "TimelineResponse", "configure", "router"]

--- a/src/caretaker/admin/pr_timeline_api.py
+++ b/src/caretaker/admin/pr_timeline_api.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime  # noqa: TC003 — pydantic resolves the annotation at runtime
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
 from caretaker.admin.auth import UserInfo, require_session
@@ -53,6 +53,8 @@ class TimelineResponse(BaseModel):
     repo: str
     pr_number: int
     decisions: list[DecisionRow] = Field(default_factory=list)
+    total_count: int = 0
+    truncated: bool = False
 
 
 # ── Endpoint ─────────────────────────────────────────────────────────────
@@ -63,12 +65,28 @@ async def get_pr_timeline(
     owner: str,
     repo: str,
     number: int,
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
     _user: UserInfo = Depends(require_session),
 ) -> TimelineResponse:
-    """Return the chronological decision trail for one PR."""
+    """Return the chronological decision trail for one PR.
+
+    ``limit``/``offset`` paginate the result. ``total_count`` is the
+    full, unfiltered count of matching decisions so the SPA can render
+    a "showing N of M" affordance; ``truncated`` is a convenience
+    boolean (= ``total_count > offset + len(decisions)``) so callers
+    don't need to recompute it client-side.
+    """
     decisions: list[DecisionRow] = []
+    total_count = 0
     if _store is not None:
-        docs = await _store.query_timeline(owner=owner, repo=repo, pr_number=number)
+        docs, total_count = await _store.query_timeline(
+            owner=owner,
+            repo=repo,
+            pr_number=number,
+            limit=limit,
+            offset=offset,
+        )
         for d in docs:
             decisions.append(
                 DecisionRow(
@@ -81,11 +99,14 @@ async def get_pr_timeline(
                     span_id=d.get("span_id"),
                 )
             )
+    truncated = total_count > offset + len(decisions)
     return TimelineResponse(
         owner=owner,
         repo=repo,
         pr_number=number,
         decisions=decisions,
+        total_count=total_count,
+        truncated=truncated,
     )
 
 

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -397,6 +397,17 @@ DEFAULT_FEATURE_MODELS_BY_PROVIDER: dict[str, dict[str, dict[str, int | str]]] =
 # Convention: prices are ``(input_per_1m_tokens, output_per_1m_tokens)``.
 # Always quote both even if the provider charges the same for input and
 # output, so a future split doesn't silently break callers.
+#
+# **Cache token caveat (Anthropic):** Anthropic charges 1.25× the input
+# rate for ``cache_write`` tokens and 0.10× for ``cache_read`` tokens,
+# but this table doesn't model that. Both are folded into
+# ``prompt_tokens`` and counted at the input rate. For a cache-heavy
+# review on Anthropic models, the recorded USD cost can drift ±10-15%
+# from the true bill. If accuracy matters more than simplicity, extend
+# the entry to a ``dataclass(input, output, cache_read=None,
+# cache_write=None)`` and update
+# :func:`caretaker.observability.metrics.record_llm_cost` to use the
+# optional fields when present.
 LLM_PRICE_TABLE: dict[str, tuple[float, float]] = {
     # Google
     "openrouter/google/gemini-2.5-flash-lite": (0.10, 0.40),

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -377,6 +377,45 @@ DEFAULT_FEATURE_MODELS_BY_PROVIDER: dict[str, dict[str, dict[str, int | str]]] =
 }
 
 
+# Per-model pricing in USD per 1 MILLION tokens (input, output).
+#
+# Source: https://openrouter.ai/models — captured 2026-05.  Update by
+# replacing the entry inline and re-running ``pytest
+# tests/test_observability_cost_tracking.py``; no other code changes
+# needed.  Models not present in this table emit a one-shot warning
+# from :func:`caretaker.observability.metrics.record_llm_cost` and skip
+# USD cost tracking — token counts are still recorded, so the dashboard
+# can show "tokens by model" even for newly-added models we haven't
+# priced yet.
+#
+# Update cadence: review each quarter, or whenever a provider changes
+# their pricing publicly. The dashboard panel using
+# ``caretaker_llm_cost_usd_total`` is approximate — any drift between
+# this table and the provider's invoice manifests as a discrepancy
+# Grafana labels "approximate (static price table)".
+#
+# Convention: prices are ``(input_per_1m_tokens, output_per_1m_tokens)``.
+# Always quote both even if the provider charges the same for input and
+# output, so a future split doesn't silently break callers.
+LLM_PRICE_TABLE: dict[str, tuple[float, float]] = {
+    # Google
+    "openrouter/google/gemini-2.5-flash-lite": (0.10, 0.40),
+    "openrouter/google/gemini-2.5-flash": (0.30, 2.50),
+    "openrouter/google/gemini-2.5-pro": (1.25, 10.00),
+    "openrouter/google/gemini-3-flash-preview": (0.30, 2.50),
+    # DeepSeek
+    "openrouter/deepseek/deepseek-v4-flash": (0.14, 0.28),
+    "openrouter/deepseek/deepseek-v4-pro": (0.55, 2.19),
+    "openrouter/deepseek/deepseek-r1": (0.55, 2.19),
+    # Anthropic via OpenRouter
+    "openrouter/anthropic/claude-haiku-4.5": (1.00, 5.00),
+    "openrouter/anthropic/claude-sonnet-4.5": (3.00, 15.00),
+    "openrouter/anthropic/claude-sonnet-4.6": (3.00, 15.00),
+    "openrouter/anthropic/claude-opus-4.6": (15.00, 75.00),
+    "openrouter/anthropic/claude-opus-4.7": (15.00, 75.00),
+}
+
+
 class FeatureModelConfig(StrictBaseModel):
     """Per-feature model override."""
 

--- a/src/caretaker/mcp_backend/health_endpoint.py
+++ b/src/caretaker/mcp_backend/health_endpoint.py
@@ -1,0 +1,201 @@
+"""Helpers for the ``/health/deep`` FastAPI endpoint in :mod:`main`.
+
+The endpoint itself does many things — load config, parse env for three
+datastores, build optional clients, shape a JSON response — and would
+otherwise dominate ``main.py``. Pulling that wiring here keeps the
+FastAPI handler ~25 LoC and makes the moving parts unit-testable.
+
+Two pieces matter:
+
+* :func:`resolve_models` parses ``MaintainerConfig`` and returns the set of
+  models the PR-reviewer plans to use, the ``opencode`` binary path, and a
+  structured ``config`` check that surfaces YAML failures at the top level
+  instead of silently degrading the model probe.
+* :func:`build_clients` is an :class:`AsyncExitStack`-based async context
+  manager that constructs Mongo + Neo4j clients on demand and *registers
+  their closers at construction time*, so an unexpected exception between
+  build and gather can never leak a TCP connection.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+
+# ── Config / model resolution ────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ResolvedModels:
+    """Output of :func:`resolve_models`."""
+
+    models: list[str]
+    """Deduplicated list of model IDs to probe; empty when the config is
+    broken or when no review models are configured."""
+
+    opencode_cli_path: str
+    """Path to the ``opencode`` CLI binary (used by the model probe)."""
+
+    config_check: dict[str, Any]
+    """``{"status": "ok"}`` on success, ``{"status": "fail", "error": ...}``
+    when ``MaintainerConfig.from_yaml`` raises. Plumbed into
+    ``gather_deep_health`` as a CORE check so a bad YAML returns 503."""
+
+
+def resolve_models() -> ResolvedModels:
+    """Load ``MaintainerConfig`` and return the model probe inputs.
+
+    Reads ``CARETAKER_CONFIG_PATH`` (default ``.github/maintainer/config.yml``).
+
+    On parse failure: returns an empty model list, the default ``opencode``
+    binary path, and a ``fail`` config check so the rollup turns 503.
+    """
+    # Local import keeps module import cheap for code paths that don't hit
+    # /health/deep (e.g. the cold-start health probe).
+    from caretaker.config import MaintainerConfig
+    from caretaker.observability.health import collect_models_to_probe
+
+    cfg_path = os.environ.get("CARETAKER_CONFIG_PATH", ".github/maintainer/config.yml")
+    try:
+        cfg = MaintainerConfig.from_yaml(cfg_path)
+    except FileNotFoundError as exc:
+        logger.warning("MaintainerConfig file missing for /health/deep: %s", exc)
+        return ResolvedModels(
+            models=[],
+            opencode_cli_path="opencode",
+            config_check={
+                "status": "fail",
+                "error": f"config file not found: {cfg_path}",
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — yaml + pydantic raise heterogeneous errors
+        logger.exception("Failed to load MaintainerConfig for /health/deep")
+        return ResolvedModels(
+            models=[],
+            opencode_cli_path="opencode",
+            config_check={
+                "status": "fail",
+                "error": f"{type(exc).__name__}: {exc}",
+            },
+        )
+
+    try:
+        models = collect_models_to_probe(
+            opencode_local=cfg.pr_reviewer.opencode_local,
+            llm=cfg.llm,
+        )
+        opencode_cli_path = cfg.pr_reviewer.opencode_local.cli_path
+    except Exception as exc:  # noqa: BLE001 — defensive against config drift
+        logger.exception("Failed to resolve models from MaintainerConfig")
+        return ResolvedModels(
+            models=[],
+            opencode_cli_path="opencode",
+            config_check={
+                "status": "fail",
+                "error": f"{type(exc).__name__}: {exc}",
+            },
+        )
+
+    return ResolvedModels(
+        models=models,
+        opencode_cli_path=opencode_cli_path,
+        config_check={"status": "ok"},
+    )
+
+
+# ── Client bundle (Mongo + Neo4j + Redis URL) ────────────────────────────
+
+
+@dataclass
+class ClientBundle:
+    """Optional clients + the resolved Redis URL for one /health/deep call.
+
+    Mongo and Neo4j are ``None`` when the corresponding env var is unset or
+    the client constructor raised; ``check_mongo`` / ``check_neo4j`` map
+    that to a ``"not configured"`` failure record.
+    """
+
+    mongo_client: Any
+    neo4j_driver: Any
+    redis_url: str
+
+
+def _resolve_redis_url() -> str:
+    """Pick the Redis URL from the env, falling back to the in-cluster default."""
+    return (
+        os.environ.get("REDIS_URL", "").strip()
+        or os.environ.get("CARETAKER_REDIS_URL", "").strip()
+        or "redis://redis:6379"
+    )
+
+
+def _parse_neo4j_auth(raw_auth: str) -> tuple[str, str]:
+    """``"user/pass"`` → ``("user", "pass")``; default user when no slash."""
+    parts = raw_auth.split("/", 1)
+    if len(parts) == 2:
+        return (parts[0], parts[1])
+    return ("neo4j", raw_auth)
+
+
+@asynccontextmanager
+async def build_clients() -> AsyncIterator[ClientBundle]:
+    """Build Mongo + Neo4j clients with eager-registered cleanup.
+
+    Uses :class:`AsyncExitStack` so each client's closer is registered the
+    moment it's constructed — closing the window where an exception between
+    construction and the ``await gather`` could leak the connection. Mongo's
+    ``AsyncIOMotorClient.close()`` is synchronous; Neo4j's
+    ``AsyncDriver.close()`` is awaitable; the stack handles both.
+    """
+    redis_url = _resolve_redis_url()
+
+    async with AsyncExitStack() as stack:
+        mongo_client: Any = None
+        mongo_url = os.environ.get("MONGODB_URL", "").strip()
+        if mongo_url:
+            try:
+                from motor.motor_asyncio import AsyncIOMotorClient
+
+                mongo_client = AsyncIOMotorClient(mongo_url, serverSelectionTimeoutMS=5000)
+                # Motor's close is synchronous (no aclose in the versions we
+                # ship). push_callback registers it for stack unwind.
+                stack.callback(mongo_client.close)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "Failed to construct mongo client for /health/deep",
+                    exc_info=True,
+                )
+                mongo_client = None
+
+        neo4j_driver: Any = None
+        neo4j_url = os.environ.get("NEO4J_URL", "").strip()
+        if neo4j_url:
+            try:
+                import neo4j
+
+                raw_auth = os.environ.get("NEO4J_AUTH", "neo4j/neo4j")
+                auth = _parse_neo4j_auth(raw_auth)
+                neo4j_driver = neo4j.AsyncGraphDatabase.driver(neo4j_url, auth=auth)
+                # Neo4j's AsyncDriver.close is awaitable.
+                stack.push_async_callback(neo4j_driver.close)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "Failed to construct neo4j driver for /health/deep",
+                    exc_info=True,
+                )
+                neo4j_driver = None
+
+        yield ClientBundle(
+            mongo_client=mongo_client,
+            neo4j_driver=neo4j_driver,
+            redis_url=redis_url,
+        )

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -664,6 +664,18 @@ async def _lifespan(application: FastAPI):  # type: ignore[no-untyped-def]
 
         await _runs_get_store().close()
 
+    # Drain the per-PR decision-timeline store so the underlying Motor
+    # client is closed cleanly on shutdown. ``configure_default_store``
+    # is also called with ``None`` so a subsequent lifespan re-entry
+    # (used by the test suite) doesn't observe a stale singleton.
+    with suppress(Exception):
+        from caretaker.state import pr_decisions as _pr_decisions
+
+        store_attr = _pr_decisions.get_default_store()
+        if store_attr is not None:
+            await store_attr.close()
+        _pr_decisions.configure_default_store(None)
+
     # Stop the metrics server side-car cleanly so tests that re-enter
     # the lifespan don't leak a port binding.
     try:

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Header, HTTPException, Request, Response
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
@@ -910,6 +910,104 @@ async def health_check() -> dict[str, str]:
         "dispatch_mode": _get_dispatcher().mode.value,
         "github_app_configured": str(_token_broker is not None).lower(),
     }
+
+
+@app.get("/health/deep")
+async def health_check_deep() -> Response:
+    """Deep dependency probe for pre-deploy / operator-triggered diagnostics.
+
+    Concurrently probes ``git`` and ``opencode`` CLIs, Redis/Mongo/Neo4j
+    connectivity, and every OpenRouter model the PR-reviewer plans to use.
+    Returns HTTP 200 with ``status=ok|degraded`` when the core stack is up,
+    or 503 when any core dependency (git, opencode, redis, mongo, neo4j) is
+    failing — model-probe failures only surface as ``degraded``.
+
+    Kubelet keeps probing the cheap ``/health`` endpoint; this one is
+    intentionally heavier and rate-limited via a 1-hour model-probe cache.
+    """
+    # TODO(observability): build a Motor + Neo4j driver pool in _lifespan
+    # so this endpoint and the Phase 2 db.client.* OTel instrumentation
+    # share long-lived clients instead of constructing per-request.
+    from caretaker.observability.health import (
+        collect_models_to_probe,
+        gather_deep_health,
+    )
+
+    # Build mongo + neo4j clients on demand. Both are normally lazy-initialised
+    # by the agents that need them, so the deep-health endpoint owns its own
+    # short-lived clients to avoid coupling to ad-hoc app.state wiring. They
+    # cost a single TCP connection each and are closed before we return.
+    mongo_client: Any = None
+    mongo_url = os.environ.get("MONGODB_URL", "").strip()
+    if mongo_url:
+        try:
+            from motor.motor_asyncio import AsyncIOMotorClient
+
+            mongo_client = AsyncIOMotorClient(mongo_url, serverSelectionTimeoutMS=5000)
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to construct mongo client for /health/deep", exc_info=True)
+
+    neo4j_driver: Any = None
+    neo4j_url = os.environ.get("NEO4J_URL", "").strip()
+    if neo4j_url:
+        try:
+            import neo4j
+
+            raw_auth = os.environ.get("NEO4J_AUTH", "neo4j/neo4j")
+            parts = raw_auth.split("/", 1)
+            auth = (parts[0], parts[1]) if len(parts) == 2 else ("neo4j", raw_auth)
+            neo4j_driver = neo4j.AsyncGraphDatabase.driver(neo4j_url, auth=auth)
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to construct neo4j driver for /health/deep", exc_info=True)
+
+    redis_url = (
+        os.environ.get("REDIS_URL", "").strip()
+        or os.environ.get("CARETAKER_REDIS_URL", "").strip()
+        or "redis://redis:6379"
+    )
+
+    # Resolve models from the operator's loaded MaintainerConfig. Falls back
+    # to defaults when no config file is present.
+    try:
+        from caretaker.config import MaintainerConfig
+
+        cfg_path = os.environ.get("CARETAKER_CONFIG_PATH", ".github/maintainer/config.yml")
+        # TODO(observability): cache the parsed MaintainerConfig with
+        # functools.lru_cache(maxsize=1) keyed on os.stat(path).st_mtime
+        # if /health/deep ever moves onto a hot kubelet probe path.
+        try:
+            cfg = MaintainerConfig.from_yaml(cfg_path)
+        except Exception:
+            cfg = MaintainerConfig()
+        models = collect_models_to_probe(
+            opencode_local=cfg.pr_reviewer.opencode_local,
+            llm=cfg.llm,
+        )
+        opencode_cli_path = cfg.pr_reviewer.opencode_local.cli_path
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to load config for /health/deep model list")
+        models = []
+        opencode_cli_path = "opencode"
+
+    try:
+        result = await gather_deep_health(
+            redis_url=redis_url,
+            mongo_client=mongo_client,
+            neo4j_driver=neo4j_driver,
+            models_to_probe=models,
+            opencode_cli_path=opencode_cli_path,
+            version=app.version,
+        )
+    finally:
+        if mongo_client is not None:
+            with suppress(Exception):
+                mongo_client.close()
+        if neo4j_driver is not None:
+            with suppress(Exception):
+                await neo4j_driver.close()
+
+    status_code = 503 if result["status"] == "fail" else 200
+    return JSONResponse(content=result, status_code=status_code)
 
 
 @app.get("/mcp/tools")

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -466,6 +466,23 @@ async def _lifespan(application: FastAPI):  # type: ignore[no-untyped-def]
             except Exception:
                 logger.warning("Failed to initialise admin webhooks API", exc_info=True)
 
+            # Per-PR decision timeline — admin endpoint reading from a
+            # MongoDB ``pr_decisions`` collection populated by the PR-
+            # reviewer pipeline. The store is also installed as the
+            # process-wide default so the lazy ``record_decision``
+            # call sites pick it up without explicit plumbing.
+            try:
+                from caretaker.admin import pr_timeline_api
+                from caretaker.state import pr_decisions as _pr_decisions
+
+                _decision_store = _pr_decisions.PRDecisionStore.from_config(maint_cfg)
+                _pr_decisions.configure_default_store(_decision_store)
+                pr_timeline_api.configure(_decision_store)
+                application.include_router(pr_timeline_api.router)
+                logger.info("Admin PR-timeline API enabled")
+            except Exception:
+                logger.warning("Failed to initialise admin PR-timeline API", exc_info=True)
+
             # Serve SPA static files
             if _ADMIN_STATIC_DIR.is_dir():
                 application.mount(

--- a/src/caretaker/mcp_backend/main.py
+++ b/src/caretaker/mcp_backend/main.py
@@ -912,15 +912,22 @@ async def health_check() -> dict[str, str]:
     }
 
 
+#: Wall-clock budget for /health/deep. Six model probes at 30s plus five
+#: core checks running in parallel can approach 30s on a cold cache; 45s
+#: gives headroom without letting one slow probe pin a worker.
+HEALTH_DEEP_TIMEOUT_SECONDS: float = 45.0
+
+
 @app.get("/health/deep")
 async def health_check_deep() -> Response:
     """Deep dependency probe for pre-deploy / operator-triggered diagnostics.
 
     Concurrently probes ``git`` and ``opencode`` CLIs, Redis/Mongo/Neo4j
-    connectivity, and every OpenRouter model the PR-reviewer plans to use.
-    Returns HTTP 200 with ``status=ok|degraded`` when the core stack is up,
-    or 503 when any core dependency (git, opencode, redis, mongo, neo4j) is
-    failing — model-probe failures only surface as ``degraded``.
+    connectivity, the parsed MaintainerConfig, and every OpenRouter model
+    the PR-reviewer plans to use. Returns HTTP 200 with
+    ``status=ok|degraded`` when the core stack is up, or 503 when any core
+    dependency (config, git, opencode, redis, mongo, neo4j) is failing —
+    model-probe failures only surface as ``degraded``.
 
     Kubelet keeps probing the cheap ``/health`` endpoint; this one is
     intentionally heavier and rate-limited via a 1-hour model-probe cache.
@@ -928,83 +935,36 @@ async def health_check_deep() -> Response:
     # TODO(observability): build a Motor + Neo4j driver pool in _lifespan
     # so this endpoint and the Phase 2 db.client.* OTel instrumentation
     # share long-lived clients instead of constructing per-request.
-    from caretaker.observability.health import (
-        collect_models_to_probe,
-        gather_deep_health,
-    )
+    from caretaker.mcp_backend.health_endpoint import build_clients, resolve_models
+    from caretaker.observability.health import gather_deep_health
 
-    # Build mongo + neo4j clients on demand. Both are normally lazy-initialised
-    # by the agents that need them, so the deep-health endpoint owns its own
-    # short-lived clients to avoid coupling to ad-hoc app.state wiring. They
-    # cost a single TCP connection each and are closed before we return.
-    mongo_client: Any = None
-    mongo_url = os.environ.get("MONGODB_URL", "").strip()
-    if mongo_url:
+    resolved = resolve_models()
+    async with build_clients() as bundle:
         try:
-            from motor.motor_asyncio import AsyncIOMotorClient
-
-            mongo_client = AsyncIOMotorClient(mongo_url, serverSelectionTimeoutMS=5000)
-        except Exception:  # noqa: BLE001
-            logger.debug("Failed to construct mongo client for /health/deep", exc_info=True)
-
-    neo4j_driver: Any = None
-    neo4j_url = os.environ.get("NEO4J_URL", "").strip()
-    if neo4j_url:
-        try:
-            import neo4j
-
-            raw_auth = os.environ.get("NEO4J_AUTH", "neo4j/neo4j")
-            parts = raw_auth.split("/", 1)
-            auth = (parts[0], parts[1]) if len(parts) == 2 else ("neo4j", raw_auth)
-            neo4j_driver = neo4j.AsyncGraphDatabase.driver(neo4j_url, auth=auth)
-        except Exception:  # noqa: BLE001
-            logger.debug("Failed to construct neo4j driver for /health/deep", exc_info=True)
-
-    redis_url = (
-        os.environ.get("REDIS_URL", "").strip()
-        or os.environ.get("CARETAKER_REDIS_URL", "").strip()
-        or "redis://redis:6379"
-    )
-
-    # Resolve models from the operator's loaded MaintainerConfig. Falls back
-    # to defaults when no config file is present.
-    try:
-        from caretaker.config import MaintainerConfig
-
-        cfg_path = os.environ.get("CARETAKER_CONFIG_PATH", ".github/maintainer/config.yml")
-        # TODO(observability): cache the parsed MaintainerConfig with
-        # functools.lru_cache(maxsize=1) keyed on os.stat(path).st_mtime
-        # if /health/deep ever moves onto a hot kubelet probe path.
-        try:
-            cfg = MaintainerConfig.from_yaml(cfg_path)
-        except Exception:
-            cfg = MaintainerConfig()
-        models = collect_models_to_probe(
-            opencode_local=cfg.pr_reviewer.opencode_local,
-            llm=cfg.llm,
-        )
-        opencode_cli_path = cfg.pr_reviewer.opencode_local.cli_path
-    except Exception:  # noqa: BLE001
-        logger.exception("Failed to load config for /health/deep model list")
-        models = []
-        opencode_cli_path = "opencode"
-
-    try:
-        result = await gather_deep_health(
-            redis_url=redis_url,
-            mongo_client=mongo_client,
-            neo4j_driver=neo4j_driver,
-            models_to_probe=models,
-            opencode_cli_path=opencode_cli_path,
-            version=app.version,
-        )
-    finally:
-        if mongo_client is not None:
-            with suppress(Exception):
-                mongo_client.close()
-        if neo4j_driver is not None:
-            with suppress(Exception):
-                await neo4j_driver.close()
+            result = await asyncio.wait_for(
+                gather_deep_health(
+                    redis_url=bundle.redis_url,
+                    mongo_client=bundle.mongo_client,
+                    neo4j_driver=bundle.neo4j_driver,
+                    models_to_probe=resolved.models,
+                    opencode_cli_path=resolved.opencode_cli_path,
+                    version=app.version,
+                    config_check=resolved.config_check,
+                ),
+                timeout=HEALTH_DEEP_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "/health/deep exceeded %.1fs wall-time budget", HEALTH_DEEP_TIMEOUT_SECONDS
+            )
+            return JSONResponse(
+                content={
+                    "status": "fail",
+                    "version": app.version,
+                    "error": (f"deep_health timed out (>{HEALTH_DEEP_TIMEOUT_SECONDS:.0f}s)"),
+                },
+                status_code=503,
+            )
 
     status_code = 503 if result["status"] == "fail" else 200
     return JSONResponse(content=result, status_code=status_code)

--- a/src/caretaker/observability/health.py
+++ b/src/caretaker/observability/health.py
@@ -1,0 +1,493 @@
+"""Deep dependency health checks for the ``/health/deep`` endpoint.
+
+Probes every external dependency caretaker needs at runtime:
+
+* ``git`` and ``opencode`` CLI binaries (must be on PATH inside the pod)
+* Redis, MongoDB, Neo4j connectivity
+* OpenRouter availability of every model the PR-reviewer plans to use
+
+The expensive piece is the OpenRouter probe: each model costs one round-trip
+of ``opencode run "ping"``, so we cache results for an hour to bound both
+wall-time and dollars when an operator (or, defensively, a kubelet) hits
+``/health/deep`` repeatedly.
+
+The other five checks are deliberately uncached — they're sub-millisecond
+pings and we always want them to reflect live state.
+
+Catches the v0.28.x-class bugs (``git`` missing from the production image,
+``gemini-3-pro-preview`` absent from OpenRouter's registry) at deploy time
+rather than letting them surface as silent reviews on real PRs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+# ── Constants ────────────────────────────────────────────────────────────
+
+MODEL_PROBE_TTL_SECONDS: float = 3600.0
+"""Cache TTL for OpenRouter model probes (1 hour)."""
+
+_GIT_VERSION_RE = re.compile(r"git\s+version\s+(\S+)", re.IGNORECASE)
+_OPENCODE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+\S*)")
+
+
+# ── Cache ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ModelProbeResult:
+    """Cached outcome of probing a single OpenRouter model."""
+
+    status: str
+    """Either ``"ok"`` or ``"fail: <reason>"``."""
+
+    probed_at: float
+    """``time.time()`` at which the probe completed (used for TTL)."""
+
+    probed_at_iso: str
+    """ISO-8601 timestamp of ``probed_at`` for human-readable surfacing."""
+
+
+_model_probe_cache: dict[str, ModelProbeResult] = {}
+
+
+def _reset_cache_for_tests() -> None:
+    """Test helper: drop all cached model probes."""
+    _model_probe_cache.clear()
+
+
+# ── Helper: subprocess with timeout ──────────────────────────────────────
+
+
+async def _run_cli(
+    *args: str,
+    timeout_seconds: float,
+) -> tuple[int, str, str]:
+    """Run a CLI command and return ``(returncode, stdout, stderr)``.
+
+    Raises ``asyncio.TimeoutError`` on wall-time overrun, ``FileNotFoundError``
+    when the binary doesn't exist on PATH, and propagates any other OSError
+    so callers can map it into a structured failure record.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(),
+            timeout=timeout_seconds,
+        )
+    except TimeoutError:
+        # Make sure we don't leak the child process on timeout.
+        with suppress(ProcessLookupError):
+            proc.kill()
+        await proc.wait()
+        raise
+    return (
+        proc.returncode if proc.returncode is not None else -1,
+        stdout_bytes.decode("utf-8", errors="replace"),
+        stderr_bytes.decode("utf-8", errors="replace"),
+    )
+
+
+# ── CLI checks ───────────────────────────────────────────────────────────
+
+
+async def check_git_cli(timeout_seconds: float = 2.0) -> dict[str, Any]:
+    """Probe ``git --version``. Returns ``{"status", "version"}`` or fail."""
+    try:
+        rc, stdout, stderr = await _run_cli(
+            "git",
+            "--version",
+            timeout_seconds=timeout_seconds,
+        )
+    except FileNotFoundError:
+        return {"status": "fail", "error": "git binary not found on PATH"}
+    except TimeoutError:
+        return {"status": "fail", "error": f"git --version timed out after {timeout_seconds}s"}
+    except OSError as exc:
+        return {"status": "fail", "error": f"git --version failed: {exc}"}
+
+    if rc != 0:
+        msg = (stderr.strip() or stdout.strip() or f"exit {rc}").splitlines()[0]
+        return {"status": "fail", "error": msg}
+
+    match = _GIT_VERSION_RE.search(stdout)
+    version = match.group(1) if match else stdout.strip().splitlines()[0]
+    return {"status": "ok", "version": version}
+
+
+async def check_opencode_cli(timeout_seconds: float = 5.0) -> dict[str, Any]:
+    """Probe ``opencode --version``. Returns ``{"status", "version"}`` or fail."""
+    try:
+        rc, stdout, stderr = await _run_cli(
+            "opencode",
+            "--version",
+            timeout_seconds=timeout_seconds,
+        )
+    except FileNotFoundError:
+        return {"status": "fail", "error": "opencode binary not found on PATH"}
+    except TimeoutError:
+        return {
+            "status": "fail",
+            "error": f"opencode --version timed out after {timeout_seconds}s",
+        }
+    except OSError as exc:
+        return {"status": "fail", "error": f"opencode --version failed: {exc}"}
+
+    if rc != 0:
+        msg = (stderr.strip() or stdout.strip() or f"exit {rc}").splitlines()[0]
+        return {"status": "fail", "error": msg}
+
+    text = (stdout or stderr).strip()
+    match = _OPENCODE_VERSION_RE.search(text)
+    version = match.group(1) if match else (text.splitlines()[0] if text else "")
+    return {"status": "ok", "version": version}
+
+
+# ── Datastore checks ─────────────────────────────────────────────────────
+
+
+async def check_redis(redis_url: str, timeout_seconds: float = 2.0) -> dict[str, Any]:
+    """Ping Redis and report latency."""
+    try:
+        from redis.asyncio import Redis as AsyncRedis
+    except ImportError:
+        return {"status": "fail", "error": "redis package not installed"}
+
+    client = AsyncRedis.from_url(
+        redis_url,
+        socket_timeout=timeout_seconds,
+        socket_connect_timeout=timeout_seconds,
+    )
+    start = time.perf_counter()
+    try:
+        await asyncio.wait_for(client.ping(), timeout=timeout_seconds)
+    except TimeoutError:
+        return {"status": "fail", "error": f"redis ping timed out after {timeout_seconds}s"}
+    except Exception as exc:  # noqa: BLE001 — surface redis.exceptions.* + connect errors
+        return {"status": "fail", "error": f"{type(exc).__name__}: {exc}"}
+    finally:
+        # Prefer ``aclose`` (redis>=5.0.1) but fall back to ``close`` for
+        # older clients. The typeshed stubs only expose ``close`` so we
+        # use ``getattr`` to keep mypy happy without a ``cast``.
+        with suppress(Exception):
+            closer = getattr(client, "aclose", client.close)
+            await closer()
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    return {"status": "ok", "latency_ms": latency_ms}
+
+
+async def check_mongo(mongo_client: Any, timeout_seconds: float = 5.0) -> dict[str, Any]:
+    """Ping MongoDB via ``admin.command("ping")`` and report latency."""
+    if mongo_client is None:
+        return {"status": "fail", "error": "mongo client not configured"}
+    start = time.perf_counter()
+    try:
+        await asyncio.wait_for(
+            mongo_client.admin.command("ping"),
+            timeout=timeout_seconds,
+        )
+    except TimeoutError:
+        return {"status": "fail", "error": f"mongo ping timed out after {timeout_seconds}s"}
+    except Exception as exc:  # noqa: BLE001 — pymongo + motor raise heterogeneous errors
+        return {"status": "fail", "error": f"{type(exc).__name__}: {exc}"}
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    return {"status": "ok", "latency_ms": latency_ms}
+
+
+async def check_neo4j(neo4j_driver: Any, timeout_seconds: float = 5.0) -> dict[str, Any]:
+    """Run a trivial Cypher query on Neo4j and report latency."""
+    if neo4j_driver is None:
+        return {"status": "fail", "error": "neo4j driver not configured"}
+    start = time.perf_counter()
+    try:
+        async with neo4j_driver.session() as session:
+            result = await asyncio.wait_for(
+                session.run("RETURN 1 AS ok"),
+                timeout=timeout_seconds,
+            )
+            await asyncio.wait_for(result.consume(), timeout=timeout_seconds)
+    except TimeoutError:
+        return {"status": "fail", "error": f"neo4j query timed out after {timeout_seconds}s"}
+    except Exception as exc:  # noqa: BLE001 — neo4j.exceptions.* surface
+        return {"status": "fail", "error": f"{type(exc).__name__}: {exc}"}
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    return {"status": "ok", "latency_ms": latency_ms}
+
+
+# ── OpenRouter model probe ──────────────────────────────────────────────
+
+
+async def _probe_single_model(
+    model: str,
+    cli_path: str,
+    timeout_seconds: float,
+) -> str:
+    """Run ``opencode run "ping" --model <model>`` once and classify the result."""
+    try:
+        rc, _stdout, stderr = await _run_cli(
+            cli_path,
+            "run",
+            "ping",
+            "--model",
+            model,
+            timeout_seconds=timeout_seconds,
+        )
+    except FileNotFoundError:
+        return "fail: opencode binary not found on PATH"
+    except TimeoutError:
+        return f"fail: timeout after {timeout_seconds}s"
+    except OSError as exc:
+        return f"fail: {exc}"
+
+    if rc == 0:
+        return "ok"
+
+    # Pattern-match the most common OpenRouter failure modes so operators
+    # can grep dashboards for "No endpoints found" and find every affected
+    # deploy at once.
+    if "No endpoints found" in stderr:
+        return "fail: No endpoints found"
+    if "Insufficient credits" in stderr or "insufficient credits" in stderr:
+        return "fail: insufficient credits"
+    first_line = next(
+        (line for line in stderr.splitlines() if line.strip()),
+        "",
+    )
+    return f"fail: {first_line}" if first_line else f"fail: exit {rc}"
+
+
+async def probe_openrouter_models(
+    models: Iterable[str],
+    cli_path: str = "opencode",
+    timeout_seconds: float = 30.0,
+    *,
+    opencode_available: bool = True,
+) -> dict[str, Any]:
+    """Probe every model concurrently, with a 1-hour result cache.
+
+    When ``opencode_available`` is False the entire check short-circuits to
+    a ``skipped`` record — there's no point firing N subprocess calls that
+    will all fail with the same "binary missing" error.
+    """
+    model_list = list(dict.fromkeys(models))  # de-dupe, preserve order
+    if not model_list:
+        return {
+            "status": "skipped",
+            "reason": "no models configured",
+            "results": {},
+        }
+
+    if not opencode_available:
+        return {
+            "status": "skipped",
+            "reason": "opencode_cli unavailable",
+            "results": dict.fromkeys(model_list, "skipped: opencode_cli unavailable"),
+        }
+
+    now = time.time()
+    to_probe: list[str] = []
+    for model in model_list:
+        cached = _model_probe_cache.get(model)
+        if cached is None or (now - cached.probed_at) >= MODEL_PROBE_TTL_SECONDS:
+            to_probe.append(model)
+
+    if to_probe:
+        coros = [_probe_single_model(m, cli_path, timeout_seconds) for m in to_probe]
+        outcomes = await asyncio.gather(*coros, return_exceptions=True)
+        finished_at = time.time()
+        finished_iso = datetime.fromtimestamp(finished_at, tz=UTC).isoformat()
+        for model, outcome in zip(to_probe, outcomes, strict=True):
+            if isinstance(outcome, BaseException):
+                status = f"fail: {type(outcome).__name__}: {outcome}"
+            else:
+                status = outcome
+            _model_probe_cache[model] = ModelProbeResult(
+                status=status,
+                probed_at=finished_at,
+                probed_at_iso=finished_iso,
+            )
+
+    results: dict[str, str] = {}
+    oldest_probed_iso: str | None = None
+    oldest_probed_at: float | None = None
+    any_fail = False
+    for model in model_list:
+        entry = _model_probe_cache.get(model)
+        if entry is None:
+            # Should not happen — defensive.
+            results[model] = "fail: probe missing from cache"
+            any_fail = True
+            continue
+        results[model] = entry.status
+        if entry.status != "ok":
+            any_fail = True
+        if oldest_probed_at is None or entry.probed_at < oldest_probed_at:
+            oldest_probed_at = entry.probed_at
+            oldest_probed_iso = entry.probed_at_iso
+
+    return {
+        "status": "fail" if any_fail else "ok",
+        "probed_at": oldest_probed_iso,
+        "results": results,
+    }
+
+
+# ── Model-list extraction ────────────────────────────────────────────────
+
+
+def collect_models_to_probe(
+    *,
+    opencode_local: Any,
+    llm: Any,
+) -> list[str]:
+    """Return the deduplicated list of model IDs to probe.
+
+    Pulls from:
+      * ``opencode_local.model``, ``opencode_local.fix_model``
+      * every value in ``opencode_local.review_models`` and ``fix_models``
+      * the ``complexity_classifier`` feature model — operator override
+        (``llm.feature_models["complexity_classifier"].model``) wins, otherwise
+        the provider default from ``DEFAULT_FEATURE_MODELS_BY_PROVIDER``,
+        otherwise the legacy ``DEFAULT_FEATURE_MODELS`` entry.
+    """
+    seen: list[str] = []
+
+    def _add(value: str | None) -> None:
+        if value and value not in seen:
+            seen.append(value)
+
+    _add(getattr(opencode_local, "model", None))
+    _add(getattr(opencode_local, "fix_model", None))
+    for value in (getattr(opencode_local, "review_models", {}) or {}).values():
+        _add(value)
+    for value in (getattr(opencode_local, "fix_models", {}) or {}).values():
+        _add(value)
+
+    # complexity_classifier resolution mirrors ClaudeClient._resolve_feature.
+    from caretaker.config import (
+        DEFAULT_FEATURE_MODELS,
+        DEFAULT_FEATURE_MODELS_BY_PROVIDER,
+    )
+
+    classifier_model: str | None = None
+    feature_models = getattr(llm, "feature_models", {}) or {}
+    override = feature_models.get("complexity_classifier")
+    if override is not None and getattr(override, "model", None):
+        classifier_model = override.model
+    if classifier_model is None:
+        provider = getattr(llm, "provider", "")
+        by_provider = DEFAULT_FEATURE_MODELS_BY_PROVIDER.get(provider, {})
+        base = by_provider.get("complexity_classifier") or DEFAULT_FEATURE_MODELS.get(
+            "complexity_classifier", {}
+        )
+        candidate = base.get("model") if isinstance(base, dict) else None
+        if isinstance(candidate, str):
+            classifier_model = candidate
+    _add(classifier_model)
+
+    return seen
+
+
+# ── Aggregator ───────────────────────────────────────────────────────────
+
+
+_CORE_CHECK_KEYS: tuple[str, ...] = ("git_cli", "opencode_cli", "redis", "mongo", "neo4j")
+
+
+def _result_from(value: Any, fallback_error: str) -> dict[str, Any]:
+    """Map a ``gather`` outcome to a structured check record."""
+    if isinstance(value, BaseException):
+        return {"status": "fail", "error": f"{type(value).__name__}: {value}"}
+    if isinstance(value, dict):
+        return value
+    return {"status": "fail", "error": fallback_error}
+
+
+async def gather_deep_health(
+    *,
+    redis_url: str,
+    mongo_client: Any,
+    neo4j_driver: Any,
+    models_to_probe: list[str],
+    opencode_cli_path: str = "opencode",
+    version: str = "",
+) -> dict[str, Any]:
+    """Run all six checks concurrently and return the combined verdict."""
+    core_results: list[Any] = await asyncio.gather(
+        check_git_cli(),
+        check_opencode_cli(),
+        check_redis(redis_url),
+        check_mongo(mongo_client),
+        check_neo4j(neo4j_driver),
+        return_exceptions=True,
+    )
+
+    git_check = _result_from(core_results[0], "git check raised")
+    opencode_check = _result_from(core_results[1], "opencode check raised")
+    redis_check = _result_from(core_results[2], "redis check raised")
+    mongo_check = _result_from(core_results[3], "mongo check raised")
+    neo4j_check = _result_from(core_results[4], "neo4j check raised")
+
+    # Model probe is sequenced AFTER opencode_cli so we can short-circuit
+    # the N subprocess calls when the binary itself is missing.
+    opencode_available = opencode_check.get("status") == "ok"
+    try:
+        models_check = await probe_openrouter_models(
+            models_to_probe,
+            cli_path=opencode_cli_path,
+            opencode_available=opencode_available,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive; never let aggregator raise
+        logger.exception("probe_openrouter_models raised unexpectedly")
+        models_check = {
+            "status": "fail",
+            "error": f"{type(exc).__name__}: {exc}",
+            "results": {},
+        }
+
+    checks: dict[str, dict[str, Any]] = {
+        "git_cli": git_check,
+        "opencode_cli": opencode_check,
+        "redis": redis_check,
+        "mongo": mongo_check,
+        "neo4j": neo4j_check,
+        "openrouter_models": models_check,
+    }
+
+    # Rollup:
+    #   any core check fail → top-level "fail" (HTTP 503 at the endpoint)
+    #   any non-core "fail" or "skipped" (e.g. model probe) → "degraded"
+    #   else → "ok"
+    core_failed = any(checks[k].get("status") != "ok" for k in _CORE_CHECK_KEYS)
+    models_status = checks["openrouter_models"].get("status")
+
+    if core_failed:
+        rollup = "fail"
+    elif models_status in ("fail", "degraded", "skipped"):
+        rollup = "degraded"
+    else:
+        rollup = "ok"
+
+    return {
+        "status": rollup,
+        "version": version,
+        "checks": checks,
+    }

--- a/src/caretaker/observability/health.py
+++ b/src/caretaker/observability/health.py
@@ -44,6 +44,15 @@ MODEL_PROBE_TTL_SECONDS: float = 3600.0
 _GIT_VERSION_RE = re.compile(r"git\s+version\s+(\S+)", re.IGNORECASE)
 _OPENCODE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+\S*)")
 
+# Brittle: depends on opencode/OpenRouter error wording. Update these
+# tokens (and the corresponding tests) if the upstream message format
+# changes. Confirmed against opencode CLI 1.14.39 / OpenRouter 2026-05.
+_OPENROUTER_NO_ENDPOINTS_TOKENS: tuple[str, ...] = ("No endpoints found",)
+_OPENROUTER_INSUFFICIENT_CREDITS_TOKENS: tuple[str, ...] = (
+    "Insufficient credits",
+    "insufficient credits",
+)
+
 
 # ── Cache ────────────────────────────────────────────────────────────────
 
@@ -62,6 +71,17 @@ class ModelProbeResult:
     """ISO-8601 timestamp of ``probed_at`` for human-readable surfacing."""
 
 
+# Module-level cache for model probe outcomes.
+#
+# Trade-offs intentionally taken:
+#
+# * No concurrency guard. Two simultaneous /health/deep requests for the same
+#   uncached model both spawn the opencode subprocess. Acceptable because the
+#   endpoint is operator-triggered and the cache TTL is one hour; if it ever
+#   moves onto a kubelet probe path, add an asyncio.Lock() per-key.
+# * Monotonic growth — entries are never evicted. Bounded by pod lifetime
+#   times the number of distinct models ever configured. Pruning is
+#   intentionally omitted.
 _model_probe_cache: dict[str, ModelProbeResult] = {}
 
 
@@ -262,10 +282,11 @@ async def _probe_single_model(
 
     # Pattern-match the most common OpenRouter failure modes so operators
     # can grep dashboards for "No endpoints found" and find every affected
-    # deploy at once.
-    if "No endpoints found" in stderr:
+    # deploy at once. Tokens are pulled from module-level constants; see
+    # the definitions for caveats on upstream wording drift.
+    if any(token in stderr for token in _OPENROUTER_NO_ENDPOINTS_TOKENS):
         return "fail: No endpoints found"
-    if "Insufficient credits" in stderr or "insufficient credits" in stderr:
+    if any(token in stderr for token in _OPENROUTER_INSUFFICIENT_CREDITS_TOKENS):
         return "fail: insufficient credits"
     first_line = next(
         (line for line in stderr.splitlines() if line.strip()),
@@ -409,7 +430,14 @@ def collect_models_to_probe(
 # ── Aggregator ───────────────────────────────────────────────────────────
 
 
-_CORE_CHECK_KEYS: tuple[str, ...] = ("git_cli", "opencode_cli", "redis", "mongo", "neo4j")
+_CORE_CHECK_KEYS: tuple[str, ...] = (
+    "config",
+    "git_cli",
+    "opencode_cli",
+    "redis",
+    "mongo",
+    "neo4j",
+)
 
 
 def _result_from(value: Any, fallback_error: str) -> dict[str, Any]:
@@ -429,8 +457,15 @@ async def gather_deep_health(
     models_to_probe: list[str],
     opencode_cli_path: str = "opencode",
     version: str = "",
+    config_check: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Run all six checks concurrently and return the combined verdict."""
+    """Run all checks concurrently and return the combined verdict.
+
+    ``config_check`` records the outcome of loading ``MaintainerConfig`` —
+    a hard-fail surface so operators can see broken YAML at the top level
+    instead of having to infer it from an empty ``openrouter_models``.
+    Defaults to ``{"status": "ok"}`` for callers that don't care.
+    """
     core_results: list[Any] = await asyncio.gather(
         check_git_cli(),
         check_opencode_cli(),
@@ -464,6 +499,7 @@ async def gather_deep_health(
         }
 
     checks: dict[str, dict[str, Any]] = {
+        "config": config_check if config_check is not None else {"status": "ok"},
         "git_cli": git_check,
         "opencode_cli": opencode_check,
         "redis": redis_check,

--- a/src/caretaker/observability/metrics.py
+++ b/src/caretaker/observability/metrics.py
@@ -1156,7 +1156,11 @@ def record_llm_cost(model: str, prompt_tokens: int, completion_tokens: int) -> N
     if price is None:
         if label_model not in _LLM_PRICE_TABLE_MISSES_WARNED:
             _LLM_PRICE_TABLE_MISSES_WARNED.add(label_model)
-            logger.info(
+            # WARNING (not INFO) so dashboard maintainers see this in
+            # their alert filters — an un-priced model means the USD
+            # cost panel under-counts. Still warn-once via the memo so
+            # a hot caller doesn't flood the log.
+            logger.warning(
                 "metrics: model %r missing from LLM_PRICE_TABLE; skipping cost "
                 "tracking (tokens still recorded). Add an entry in "
                 "caretaker.config.LLM_PRICE_TABLE to enable USD cost.",

--- a/src/caretaker/observability/metrics.py
+++ b/src/caretaker/observability/metrics.py
@@ -39,7 +39,7 @@ import logging
 import os
 import time
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
@@ -379,9 +379,29 @@ OPENCODE_OUTCOMES: tuple[str, ...] = (
     "timeout",
     "no_endpoints",
     "error",
+    # ``declined`` is the in-band sentinel ``CARETAKER_FIX_DECLINED:`` —
+    # opencode chose not to apply the requested change. Tracked
+    # separately from ``ok`` so the fix-mode success rate stays honest
+    # and the dashboard can graph "decline rate" directly.
+    "declined",
 )
 AUTO_FIX_OUTCOMES: tuple[str, ...] = ("dispatched_success", "dispatched_fail", "skipped")
-REVIEW_VERDICTS: tuple[str, ...] = ("APPROVE", "COMMENT", "REQUEST_CHANGES")
+# ``REVIEW_VERDICTS`` covers both real LLM verdicts (``APPROVE`` /
+# ``COMMENT`` / ``REQUEST_CHANGES``) **and** the terminal non-LLM
+# states emitted by the audit log (``skipped`` / ``dispatched`` /
+# ``dispatch_failed`` / ``none``). They're all bounded — letting the
+# dashboard distinguish "dispatched to opencode" from "skipped (draft)"
+# from a real "COMMENT" verdict without collapsing into a noisy
+# ``other`` bucket.
+REVIEW_VERDICTS: tuple[str, ...] = (
+    "APPROVE",
+    "COMMENT",
+    "REQUEST_CHANGES",
+    "skipped",
+    "dispatched",
+    "dispatch_failed",
+    "none",
+)
 
 PR_REVIEW_OUTCOME_TOTAL = Counter(
     "caretaker_pr_review_outcome_total",
@@ -936,6 +956,15 @@ def record_guardrail_rollback_fired(repo: str, reason: str) -> None:
     ).inc()
 
 
+# Memoises ``(value, id(allowed))`` pairs we've already warned about so
+# a hot caller passing the same off-enum value repeatedly only logs
+# once per process lifetime. The key uses ``id(allowed)`` (not the
+# tuple itself) because the canonical enum tuples are module-level
+# constants — same identity for every call — and ``id`` is O(1) where
+# the tuple equality check would walk the contents.
+_BOUND_OR_OTHER_WARNED: set[tuple[str, int]] = set()
+
+
 def _bound_or_other(value: str, allowed: tuple[str, ...]) -> str:
     """Return ``value`` when it's in ``allowed``, else ``"other"``.
 
@@ -944,14 +973,21 @@ def _bound_or_other(value: str, allowed: tuple[str, ...]) -> str:
     also never silently mints a new series — both effects are
     cardinality-eating bugs we'd rather see as a generic "other"
     bucket and a one-shot warning log.
+
+    The warning is emitted **at most once per ``(value, allowed)``
+    pair** so a hot loop that repeatedly passes the same off-enum
+    value doesn't flood the log.
     """
     if value in allowed:
         return value
-    logger.warning(
-        "metrics: enum value %r not in %s; recording under 'other'",
-        value,
-        allowed,
-    )
+    key = (value, id(allowed))
+    if key not in _BOUND_OR_OTHER_WARNED:
+        _BOUND_OR_OTHER_WARNED.add(key)
+        logger.warning(
+            "metrics: unbounded value %r for enum %s; bucketing as 'other'",
+            value,
+            allowed,
+        )
     return "other"
 
 
@@ -989,8 +1025,14 @@ def record_complexity_tier(tier: str, source: str) -> None:
     ).inc()
 
 
-def record_opencode_invocation(model: str, mode: str, outcome: str) -> None:
-    """Increment ``caretaker_opencode_invocation_total``."""
+def record_opencode_invocation(model: str, mode: Literal["review", "fix"], outcome: str) -> None:
+    """Increment ``caretaker_opencode_invocation_total``.
+
+    ``mode`` is typed as ``Literal["review", "fix"]`` so a typo at a
+    static call site is caught by mypy. The runtime
+    :func:`_bound_or_other` validation stays as defence-in-depth for
+    dynamic callers.
+    """
     OPENCODE_INVOCATION_TOTAL.labels(
         service=_SERVICE_LABEL,
         model=model or "unknown",

--- a/src/caretaker/observability/metrics.py
+++ b/src/caretaker/observability/metrics.py
@@ -348,6 +348,74 @@ INTERVENTION_REASONS: frozenset[str] = frozenset(
 )
 
 
+# ── PR-reviewer instrumentation (observability phase 1A) ────────────
+#
+# These five metrics live alongside the attribution counters above
+# because they answer the same question one layer deeper: not just
+# "did caretaker touch this PR?" but "with which backend, at what
+# tier, with what verdict, and how long did it take?".
+#
+# Cardinality budget:
+#   - ``backend`` is bounded by the registered backends (~5 entries).
+#   - ``tier`` / ``verdict`` / ``source`` / ``mode`` / ``outcome`` are
+#     all bounded by closed enums declared below.
+#   - ``model`` is the opencode model identifier — operators pin a
+#     handful (one per tier) so this stays small in practice.
+#   - ``repo`` is ``owner/repo`` (same convention as the attribution
+#     counters).
+#   - ``category`` is the auto-fix dispatcher's category (``lint``,
+#     ``format``, ``correctness``, etc.) — a closed enum from the
+#     review-payload schema.
+
+# Bounded enums for the labels above. Re-exported via ``__all__`` so
+# call-sites can refer to the canonical tuple instead of fat-fingering
+# the string and silently birthing a new series.
+COMPLEXITY_TIERS: tuple[str, ...] = ("trivial", "simple", "standard", "complex", "none")
+CLASSIFIER_SOURCES: tuple[str, ...] = ("fast_path", "llm", "heuristic_fallback")
+OPENCODE_MODES: tuple[str, ...] = ("review", "fix")
+OPENCODE_OUTCOMES: tuple[str, ...] = (
+    "ok",
+    "parse_fallback",
+    "timeout",
+    "no_endpoints",
+    "error",
+)
+AUTO_FIX_OUTCOMES: tuple[str, ...] = ("dispatched_success", "dispatched_fail", "skipped")
+REVIEW_VERDICTS: tuple[str, ...] = ("APPROVE", "COMMENT", "REQUEST_CHANGES")
+
+PR_REVIEW_OUTCOME_TOTAL = Counter(
+    "caretaker_pr_review_outcome_total",
+    "PR review outcomes by backend, tier, verdict",
+    ["service", "repo", "backend", "tier", "verdict"],
+    registry=REGISTRY,
+)
+PR_REVIEW_DURATION_SECONDS = Histogram(
+    "caretaker_pr_review_duration_seconds",
+    "End-to-end PR review duration",
+    ["service", "backend", "tier"],
+    buckets=(1, 5, 10, 30, 60, 120, 300, 600),
+    registry=REGISTRY,
+)
+COMPLEXITY_CLASSIFIER_TIER_TOTAL = Counter(
+    "caretaker_complexity_classifier_tier_total",
+    "Complexity classifier verdicts by tier and decision source",
+    ["service", "tier", "source"],
+    registry=REGISTRY,
+)
+OPENCODE_INVOCATION_TOTAL = Counter(
+    "caretaker_opencode_invocation_total",
+    "opencode CLI subprocess invocations by model and outcome",
+    ["service", "model", "mode", "outcome"],
+    registry=REGISTRY,
+)
+AUTO_FIX_DISPATCH_TOTAL = Counter(
+    "caretaker_auto_fix_dispatch_total",
+    "Auto-fix dispatcher outcomes",
+    ["service", "repo", "backend", "category", "outcome"],
+    registry=REGISTRY,
+)
+
+
 # ── LLM prompt-cache telemetry ───────────────────────────────────────
 #
 # Emitted by :mod:`caretaker.llm.provider` on every completion.  Together
@@ -868,6 +936,80 @@ def record_guardrail_rollback_fired(repo: str, reason: str) -> None:
     ).inc()
 
 
+def _bound_or_other(value: str, allowed: tuple[str, ...]) -> str:
+    """Return ``value`` when it's in ``allowed``, else ``"other"``.
+
+    Centralises the enum-validation pattern used by the PR-reviewer
+    recorders below: an unknown value never crashes the run, but it
+    also never silently mints a new series — both effects are
+    cardinality-eating bugs we'd rather see as a generic "other"
+    bucket and a one-shot warning log.
+    """
+    if value in allowed:
+        return value
+    logger.warning(
+        "metrics: enum value %r not in %s; recording under 'other'",
+        value,
+        allowed,
+    )
+    return "other"
+
+
+def record_pr_review_outcome(repo: str, backend: str, tier: str, verdict: str) -> None:
+    """Increment ``caretaker_pr_review_outcome_total``.
+
+    ``tier`` / ``verdict`` are validated against the bounded enums
+    above; unknown values are recorded under ``"other"`` so a typo
+    can't silently expand cardinality.
+    """
+    PR_REVIEW_OUTCOME_TOTAL.labels(
+        service=_SERVICE_LABEL,
+        repo=repo or "unknown",
+        backend=backend or "none",
+        tier=_bound_or_other(tier, COMPLEXITY_TIERS),
+        verdict=_bound_or_other(verdict, REVIEW_VERDICTS),
+    ).inc()
+
+
+def observe_pr_review_duration(backend: str, tier: str, seconds: float) -> None:
+    """Observe a sample on ``caretaker_pr_review_duration_seconds``."""
+    PR_REVIEW_DURATION_SECONDS.labels(
+        service=_SERVICE_LABEL,
+        backend=backend or "none",
+        tier=_bound_or_other(tier, COMPLEXITY_TIERS),
+    ).observe(max(0.0, float(seconds)))
+
+
+def record_complexity_tier(tier: str, source: str) -> None:
+    """Increment ``caretaker_complexity_classifier_tier_total``."""
+    COMPLEXITY_CLASSIFIER_TIER_TOTAL.labels(
+        service=_SERVICE_LABEL,
+        tier=_bound_or_other(tier, COMPLEXITY_TIERS),
+        source=_bound_or_other(source, CLASSIFIER_SOURCES),
+    ).inc()
+
+
+def record_opencode_invocation(model: str, mode: str, outcome: str) -> None:
+    """Increment ``caretaker_opencode_invocation_total``."""
+    OPENCODE_INVOCATION_TOTAL.labels(
+        service=_SERVICE_LABEL,
+        model=model or "unknown",
+        mode=_bound_or_other(mode, OPENCODE_MODES),
+        outcome=_bound_or_other(outcome, OPENCODE_OUTCOMES),
+    ).inc()
+
+
+def record_auto_fix_dispatch(repo: str, backend: str, category: str, outcome: str) -> None:
+    """Increment ``caretaker_auto_fix_dispatch_total``."""
+    AUTO_FIX_DISPATCH_TOTAL.labels(
+        service=_SERVICE_LABEL,
+        repo=repo or "unknown",
+        backend=backend or "none",
+        category=category or "none",
+        outcome=_bound_or_other(outcome, AUTO_FIX_OUTCOMES),
+    ).inc()
+
+
 def record_llm_cache_usage(
     *,
     provider: str,
@@ -896,10 +1038,15 @@ def record_llm_cache_usage(
 
 __all__ = [
     "APP_INFO",
+    "AUTO_FIX_DISPATCH_TOTAL",
+    "AUTO_FIX_OUTCOMES",
     "CARETAKER_ERRORS_TOTAL",
     "CARETAKER_ISSUE_OUTCOME_TOTAL",
     "CARETAKER_OPERATOR_INTERVENTION_TOTAL",
     "CARETAKER_PR_OUTCOME_TOTAL",
+    "CLASSIFIER_SOURCES",
+    "COMPLEXITY_CLASSIFIER_TIER_TOTAL",
+    "COMPLEXITY_TIERS",
     "DB_CLIENT_OPERATIONS_TOTAL",
     "DB_CLIENT_OPERATION_DURATION_SECONDS",
     "GITHUB_SCOPE_GAP_TOTAL",
@@ -915,11 +1062,17 @@ __all__ = [
     "LATENCY_BUCKETS",
     "LLM_CACHE_CREATION_TOKENS_TOTAL",
     "LLM_CACHE_READ_TOKENS_TOTAL",
+    "OPENCODE_INVOCATION_TOTAL",
+    "OPENCODE_MODES",
+    "OPENCODE_OUTCOMES",
     "ORCHESTRATOR_SOFT_FAIL_TOTAL",
     "PR_OUTCOMES",
+    "PR_REVIEW_DURATION_SECONDS",
+    "PR_REVIEW_OUTCOME_TOTAL",
     "RATE_LIMIT_COOLDOWN_SECONDS",
     "RATE_LIMIT_REMAINING",
     "REGISTRY",
+    "REVIEW_VERDICTS",
     "WEBHOOK_EVENTS_TOTAL",
     "WORKER_JOBS_TOTAL",
     "WORKER_JOB_DURATION_SECONDS",
@@ -929,6 +1082,9 @@ __all__ = [
     "get_service_label",
     "init_metrics",
     "metrics_asgi_app",
+    "observe_pr_review_duration",
+    "record_auto_fix_dispatch",
+    "record_complexity_tier",
     "record_error",
     "record_github_scope_gap",
     "record_guardrail_filter_blocked",
@@ -937,9 +1093,11 @@ __all__ = [
     "record_http_client",
     "record_issue_outcome",
     "record_llm_cache_usage",
+    "record_opencode_invocation",
     "record_operator_intervention",
     "record_orchestrator_soft_fail",
     "record_pr_outcome",
+    "record_pr_review_outcome",
     "record_webhook_event",
     "record_worker_job",
     "set_rate_limit_remaining",

--- a/src/caretaker/observability/metrics.py
+++ b/src/caretaker/observability/metrics.py
@@ -463,6 +463,44 @@ LLM_CACHE_CREATION_TOKENS_TOTAL = Counter(
     registry=REGISTRY,
 )
 
+
+# ── Per-model token + USD cost tracking (observability phase 3) ─────
+#
+# Lets a Grafana panel answer "did the v0.28 model shift away from Opus
+# actually save money?" by graphing rate(caretaker_llm_cost_usd_total)
+# split by ``model``.  Tokens are emitted by the ``opencode_local``
+# backend after parsing the ``--format json`` step_finish events; cost
+# is derived from a static price table in :data:`caretaker.config.LLM_PRICE_TABLE`.
+#
+# Cardinality: ``model`` is bounded by the price table (~12 entries for
+# the v0.28.x defaults). ``direction`` is a 2-value enum below. Models
+# we haven't priced yet still hit the tokens counter (so token usage
+# stays observable for new models) but skip the cost counter — see
+# :func:`record_llm_cost` for the warn-once behaviour.
+
+LLM_TOKEN_DIRECTIONS: tuple[str, ...] = ("prompt", "completion")
+
+LLM_TOKENS_TOTAL = Counter(
+    "caretaker_llm_tokens_total",
+    "Tokens consumed per model and direction (prompt | completion).",
+    ["service", "model", "direction"],
+    registry=REGISTRY,
+)
+
+LLM_COST_USD_TOTAL = Counter(
+    "caretaker_llm_cost_usd_total",
+    "Estimated USD cost per model (using a static price table).",
+    ["service", "model"],
+    registry=REGISTRY,
+)
+
+
+# Memoises models we've already warned about being missing from the
+# price table. Without this, a hot caller running thousands of fix
+# invocations against an un-priced model would log a warning per call
+# and drown out the rest of the log stream.
+_LLM_PRICE_TABLE_MISSES_WARNED: set[str] = set()
+
 # ── Self-heal fix ladder (Wave A3) ───────────────────────────────────
 #
 # The deterministic-first fix ladder emits one of these counters per
@@ -1078,6 +1116,75 @@ def record_llm_cache_usage(
         )
 
 
+def record_llm_tokens(model: str, prompt_tokens: int, completion_tokens: int) -> None:
+    """Record prompt/completion token counts for a single LLM call.
+
+    Non-positive values are silently dropped so callers that didn't
+    actually consume tokens in one direction (e.g. prompt-only fanout)
+    don't pollute the counter with zero increments.
+    """
+    label_model = model or "unknown"
+    if prompt_tokens > 0:
+        LLM_TOKENS_TOTAL.labels(service=_SERVICE_LABEL, model=label_model, direction="prompt").inc(
+            float(prompt_tokens)
+        )
+    if completion_tokens > 0:
+        LLM_TOKENS_TOTAL.labels(
+            service=_SERVICE_LABEL, model=label_model, direction="completion"
+        ).inc(float(completion_tokens))
+
+
+def record_llm_cost(model: str, prompt_tokens: int, completion_tokens: int) -> None:
+    """Record the estimated USD cost for a single LLM call.
+
+    Looks ``model`` up in :data:`caretaker.config.LLM_PRICE_TABLE`
+    (USD per 1M tokens) and increments the cost counter. If ``model``
+    isn't in the table, logs a one-shot warning and skips the cost
+    increment — token counters are unaffected so the dashboard still
+    shows token volume for un-priced models.
+    """
+    # Lazy import — keep the metrics module importable in environments
+    # that don't pull in the full caretaker.config (notebooks, isolated
+    # tests). Same pattern as the rate-limit collector below.
+    try:
+        from caretaker.config import LLM_PRICE_TABLE
+    except Exception:  # pragma: no cover - observability never cascades
+        return
+
+    label_model = model or "unknown"
+    price = LLM_PRICE_TABLE.get(label_model)
+    if price is None:
+        if label_model not in _LLM_PRICE_TABLE_MISSES_WARNED:
+            _LLM_PRICE_TABLE_MISSES_WARNED.add(label_model)
+            logger.info(
+                "metrics: model %r missing from LLM_PRICE_TABLE; skipping cost "
+                "tracking (tokens still recorded). Add an entry in "
+                "caretaker.config.LLM_PRICE_TABLE to enable USD cost.",
+                label_model,
+            )
+        return
+
+    input_per_1m, output_per_1m = price
+    # Prices are USD per 1,000,000 tokens; divide rather than multiply
+    # so a typo in the table (e.g. quoting per-1k by mistake) shows up
+    # as a 1000x cost spike rather than silently under-billing.
+    cost = (max(0, prompt_tokens) * input_per_1m + max(0, completion_tokens) * output_per_1m) / 1e6
+    if cost <= 0:
+        return
+    LLM_COST_USD_TOTAL.labels(service=_SERVICE_LABEL, model=label_model).inc(cost)
+
+
+def record_llm_usage(model: str, *, prompt_tokens: int, completion_tokens: int) -> None:
+    """Record both tokens and USD cost for one LLM call.
+
+    Convenience wrapper around :func:`record_llm_tokens` +
+    :func:`record_llm_cost` so backends don't have to remember to call
+    both. Safe to call with zeros — non-positive counts are no-ops.
+    """
+    record_llm_tokens(model, prompt_tokens, completion_tokens)
+    record_llm_cost(model, prompt_tokens, completion_tokens)
+
+
 __all__ = [
     "APP_INFO",
     "AUTO_FIX_DISPATCH_TOTAL",
@@ -1104,6 +1211,9 @@ __all__ = [
     "LATENCY_BUCKETS",
     "LLM_CACHE_CREATION_TOKENS_TOTAL",
     "LLM_CACHE_READ_TOKENS_TOTAL",
+    "LLM_COST_USD_TOTAL",
+    "LLM_TOKEN_DIRECTIONS",
+    "LLM_TOKENS_TOTAL",
     "OPENCODE_INVOCATION_TOTAL",
     "OPENCODE_MODES",
     "OPENCODE_OUTCOMES",
@@ -1135,6 +1245,9 @@ __all__ = [
     "record_http_client",
     "record_issue_outcome",
     "record_llm_cache_usage",
+    "record_llm_cost",
+    "record_llm_tokens",
+    "record_llm_usage",
     "record_opencode_invocation",
     "record_operator_intervention",
     "record_orchestrator_soft_fail",

--- a/src/caretaker/observability/tracer_compat.py
+++ b/src/caretaker/observability/tracer_compat.py
@@ -29,15 +29,15 @@ try:
 
     OTEL_AVAILABLE = True
 except ImportError:  # pragma: no cover - exercised only without otel extras
-    _otel_trace = None  # type: ignore[assignment]
+    _otel_trace = None  # type: ignore[assignment,unused-ignore]
     OTEL_AVAILABLE = False
 
-    class StatusCode:  # type: ignore[no-redef]
+    class StatusCode:  # type: ignore[no-redef,unused-ignore]
         OK = "ok"
         ERROR = "error"
         UNSET = "unset"
 
-    class Status:  # type: ignore[no-redef]
+    class Status:  # type: ignore[no-redef,unused-ignore]
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:
             pass
 

--- a/src/caretaker/observability/tracer_compat.py
+++ b/src/caretaker/observability/tracer_compat.py
@@ -1,0 +1,90 @@
+"""Optional-OTEL compatibility shim.
+
+The ``opentelemetry`` packages live in the ``otel`` optional install
+group. Caretaker code can still emit spans / set attributes / record
+exceptions without the SDK installed — this module exposes the same
+shape the SDK does, falling back to no-op stubs when the import fails.
+
+Usage::
+
+    from caretaker.observability.tracer_compat import get_tracer, Status, StatusCode
+    _tracer = get_tracer("caretaker.pr_reviewer")
+
+    with _tracer.start_as_current_span("op_name") as span:
+        span.set_attribute("k", "v")
+        span.record_exception(exc)
+        span.set_status(Status(StatusCode.ERROR, "..."))
+
+When OTEL is missing the calls become no-ops; behaviour is preserved.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+try:
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.trace import Status, StatusCode
+
+    OTEL_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only without otel extras
+    _otel_trace = None  # type: ignore[assignment]
+    OTEL_AVAILABLE = False
+
+    class StatusCode:  # type: ignore[no-redef]
+        OK = "ok"
+        ERROR = "error"
+        UNSET = "unset"
+
+    class Status:  # type: ignore[no-redef]
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+
+class _NullSpan:
+    """Stub span that ignores every call. Returned by the null tracer."""
+
+    def set_attribute(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def record_exception(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def set_status(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def get_span_context(self) -> None:
+        return None
+
+    def end(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+
+class _NullTracer:
+    @contextmanager
+    def start_as_current_span(self, _name: str, **_kwargs: Any):  # type: ignore[no-untyped-def]
+        yield _NullSpan()
+
+
+def get_tracer(name: str) -> Any:
+    """Return a real OTEL tracer if installed, else a no-op stub."""
+    if OTEL_AVAILABLE and _otel_trace is not None:
+        return _otel_trace.get_tracer(name)
+    return _NullTracer()
+
+
+def get_current_span() -> Any:
+    """Return the active span, or a null span when OTEL is unavailable."""
+    if OTEL_AVAILABLE and _otel_trace is not None:
+        return _otel_trace.get_current_span()
+    return _NullSpan()
+
+
+__all__ = [
+    "OTEL_AVAILABLE",
+    "Status",
+    "StatusCode",
+    "get_current_span",
+    "get_tracer",
+]

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -19,6 +19,7 @@ Idempotency is provided by ``skip_labels`` (defaults to
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
@@ -262,6 +263,37 @@ class PRReviewerAgent(BaseAgent):
                 "auto_fix_reason": auto_fix_reason or "n/a",
             },
         )
+        # Per-PR decision timeline write — fire-and-forget so the
+        # observability path never blocks the agent. Lazy import keeps
+        # the helper out of the import-cycle hot path.
+        try:
+            from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
+
+            asyncio.create_task(
+                record_decision(
+                    repo_slug,
+                    int(pr_number),
+                    "pr_reviewer",
+                    "review_completed",
+                    pr_author=pr_author,
+                    is_caretaker_owned=bool(is_caretaker_pr),
+                    routing_reason=routing_reason,
+                    verdict=verdict_label,
+                    tier=tier_label,
+                    backend=backend_label,
+                    model=model or "none",
+                    duration_ms=duration_ms,
+                    auto_fix_dispatched=bool(auto_fix_dispatched),
+                    auto_fix_reason=auto_fix_reason or "n/a",
+                )
+            )
+        except RuntimeError:
+            # No running loop (e.g. called from a sync test harness).
+            # Skip the decision-timeline write — the structured log
+            # line above is still emitted by ``logger.info``.
+            pass
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("record_decision dispatch failed", exc_info=True)
 
     async def _handle_pr(
         self,
@@ -327,9 +359,44 @@ class PRReviewerAgent(BaseAgent):
         span.set_attribute("caretaker.pr.author", pr_author)
         span.set_attribute("caretaker.pr.is_caretaker_owned", bool(is_caretaker_pr))
 
+        # Per-PR decision timeline: emit ``review_started`` for the
+        # non-skipped path (skip paths emit their own ``review_skipped``
+        # below). Lazy import keeps the helper out of the import-cycle
+        # hot path. ``await`` is safe here — we're already in the async
+        # body and the helper is fire-and-forget at the Mongo layer.
+        from caretaker.state.pr_decisions import record_decision
+
+        will_skip = bool(
+            (cfg.skip_draft and pr.get("draft", False))
+            or any(
+                lbl in cfg.skip_labels
+                for lbl in (
+                    label.get("name", "") if isinstance(label, dict) else str(label)
+                    for label in pr.get("labels", [])
+                )
+            )
+        )
+        if not will_skip:
+            await record_decision(
+                f"{owner}/{repo}",
+                int(pr_number),
+                "pr_reviewer",
+                "review_started",
+                author=pr_author,
+                is_caretaker_owned=bool(is_caretaker_pr),
+            )
+
         # Skip drafts
         if cfg.skip_draft and pr.get("draft", False):
             report.skipped.append(pr_number)
+            await record_decision(
+                f"{owner}/{repo}",
+                int(pr_number),
+                "pr_reviewer",
+                "review_skipped",
+                reason="draft",
+                author=pr_author,
+            )
             self._emit_pr_review_audit(
                 owner=owner,
                 repo=repo,
@@ -355,6 +422,14 @@ class PRReviewerAgent(BaseAgent):
         ]
         if any(lbl in cfg.skip_labels for lbl in pr_labels):
             report.skipped.append(pr_number)
+            await record_decision(
+                f"{owner}/{repo}",
+                int(pr_number),
+                "pr_reviewer",
+                "review_skipped",
+                reason="skip_label",
+                author=pr_author,
+            )
             self._emit_pr_review_audit(
                 owner=owner,
                 repo=repo,
@@ -411,6 +486,7 @@ class PRReviewerAgent(BaseAgent):
                             pr_labels=pr_labels,
                             tracking=tracking,
                             repo=f"{owner}/{repo}",
+                            pr_number=pr_number,
                         )
                         harvested_verdict = review_result.verdict
                         if fix_decision.should_dispatch:
@@ -589,6 +665,7 @@ class PRReviewerAgent(BaseAgent):
                             pr_labels=pr_labels,
                             tracking=_tracking,
                             repo=f"{owner}/{repo}",
+                            pr_number=pr_number,
                         )
                         auto_fix_reason = _decision.reason
                         if _decision.should_dispatch:
@@ -727,6 +804,7 @@ class PRReviewerAgent(BaseAgent):
             # Flash-Lite call costs ~$0.0001.
             tier = (
                 await self._classify_complexity(
+                    pr_number=pr_number,
                     pr=pr,
                     files=files,
                     pr_labels=pr_labels,
@@ -771,6 +849,7 @@ class PRReviewerAgent(BaseAgent):
                     pr_labels=pr_labels,
                     tracking=_tracking,
                     repo=f"{owner}/{repo}",
+                    pr_number=pr_number,
                 )
                 auto_fix_reason = fix_decision.reason
                 if fix_decision.should_dispatch:
@@ -967,9 +1046,10 @@ class PRReviewerAgent(BaseAgent):
         report.reviewed.append(pr_number)
         return review_result
 
-    async def _classify_complexity(
+    async def _classify_complexity(  # noqa: PLR0913 — kwargs-only callsite
         self,
         *,
+        pr_number: int | None = None,
         pr: dict[str, Any],
         files: list[dict[str, Any]],
         pr_labels: list[str],
@@ -1013,6 +1093,7 @@ class PRReviewerAgent(BaseAgent):
                 context=context,
                 claude=claude,
                 routing_decision=routing_decision,
+                pr_number=pr_number,
             )
             logger.info(
                 "pr-reviewer: complexity tier=%s (confidence=%.2f) — %s",

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -24,6 +24,8 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
+from opentelemetry import trace as _otel_trace
+
 from caretaker.agent_protocol import AgentResult, BaseAgent
 from caretaker.evolution.executor_routing import (
     ExecutorRoute,
@@ -43,6 +45,9 @@ from caretaker.pr_reviewer import handoff_review_consumer, handoff_reviewer, inl
 from caretaker.pr_reviewer.github_review import post_review
 from caretaker.pr_reviewer.routing import decide
 from caretaker.state.models import TrackedPR
+
+# Module-level tracer — re-used across all PR review handlers.
+_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer")
 
 if TYPE_CHECKING:
     from caretaker.pr_reviewer.complexity_classifier import ComplexityTier
@@ -192,6 +197,7 @@ class PRReviewerAgent(BaseAgent):
         start_monotonic: float,
         auto_fix_dispatched: bool,
         auto_fix_reason: str | None,
+        span: Any = None,
     ) -> None:
         """Emit the per-PR audit log line + metrics at every return point.
 
@@ -209,6 +215,18 @@ class PRReviewerAgent(BaseAgent):
         record_pr_review_outcome(
             repo=repo_slug, backend=backend_label, tier=tier_label, verdict=verdict_label
         )
+        if span is not None:
+            try:
+                if tier:
+                    span.set_attribute("caretaker.complexity.tier", tier_label)
+                if backend:
+                    span.set_attribute("caretaker.backend", backend_label)
+                if model:
+                    span.set_attribute("caretaker.review.model", model)
+                span.set_attribute("caretaker.review.verdict", verdict_label)
+                span.set_attribute("caretaker.auto_fix.dispatched", bool(auto_fix_dispatched))
+            except Exception:  # pragma: no cover - defensive
+                pass
         logger.info(
             "pr_review_complete repo=%s pr=%d author=%s is_caretaker_owned=%s "
             "routing=%s tier=%s backend=%s model=%s verdict=%s duration_ms=%d "
@@ -260,6 +278,40 @@ class PRReviewerAgent(BaseAgent):
         # is approaching a state-machine. Refactor into a
         # ``_PRReviewState`` dataclass once the next reviewer phase
         # adds more transitions. Out of scope for phase 1A.
+        pr_number = int(pr.get("number", 0))
+        owner = self._ctx.owner
+        repo = self._ctx.repo
+
+        # Root span for this PR review — every downstream span (complexity
+        # classifier, inline reviewer, opencode invoke, auto-fix dispatch)
+        # nests under this so a single PR review becomes one trace tree.
+        with _tracer.start_as_current_span("pr_reviewer.handle_pr") as span:
+            try:
+                span.set_attribute("caretaker.pr.repo", f"{owner}/{repo}")
+                span.set_attribute("caretaker.pr.number", int(pr_number))
+            except Exception:  # pragma: no cover - defensive
+                pass
+            try:
+                await self._handle_pr_body(pr, report, state=state, span=span)
+            except Exception as exc:
+                try:
+                    span.record_exception(exc)
+                    span.set_status(
+                        _otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200])
+                    )
+                except Exception:  # pragma: no cover
+                    pass
+                raise
+
+    async def _handle_pr_body(
+        self,
+        pr: dict[str, Any],
+        report: _PRReviewReport,
+        *,
+        state: OrchestratorState,
+        span: Any,
+    ) -> None:
+        """Real body of :meth:`_handle_pr`, wrapped by the root span."""
         cfg = self._ctx.config.pr_reviewer
         pr_number = int(pr.get("number", 0))
         owner = self._ctx.owner
@@ -278,6 +330,12 @@ class PRReviewerAgent(BaseAgent):
         auto_fix_dispatched = False
         auto_fix_reason: str | None = None
 
+        try:
+            span.set_attribute("caretaker.pr.author", pr_author)
+            span.set_attribute("caretaker.pr.is_caretaker_owned", bool(is_caretaker_pr))
+        except Exception:  # pragma: no cover - defensive
+            pass
+
         # Skip drafts
         if cfg.skip_draft and pr.get("draft", False):
             report.skipped.append(pr_number)
@@ -295,6 +353,7 @@ class PRReviewerAgent(BaseAgent):
                 start_monotonic=start_monotonic,
                 auto_fix_dispatched=auto_fix_dispatched,
                 auto_fix_reason="skipped_draft",
+                span=span,
             )
             return
 
@@ -319,6 +378,7 @@ class PRReviewerAgent(BaseAgent):
                 start_monotonic=start_monotonic,
                 auto_fix_dispatched=auto_fix_dispatched,
                 auto_fix_reason="skipped_label",
+                span=span,
             )
             return
 
@@ -413,6 +473,7 @@ class PRReviewerAgent(BaseAgent):
                     start_monotonic=start_monotonic,
                     auto_fix_dispatched=auto_fix_dispatched,
                     auto_fix_reason=auto_fix_reason,
+                    span=span,
                 )
                 return
 
@@ -438,6 +499,11 @@ class PRReviewerAgent(BaseAgent):
         )
         routing_reason = decision.reason
         logger.info("pr-reviewer: #%d routing — %s", pr_number, decision.reason)
+        try:
+            span.set_attribute("caretaker.routing.use_inline", bool(decision.use_inline))
+            span.set_attribute("caretaker.routing.score", int(decision.score))
+        except Exception:  # pragma: no cover
+            pass
 
         # Shadow-mode wrapper: compares legacy point-system verdict with
         # the LLM candidate under the ``executor_routing`` flag. The
@@ -507,6 +573,7 @@ class PRReviewerAgent(BaseAgent):
                             start_monotonic=start_monotonic,
                             auto_fix_dispatched=auto_fix_dispatched,
                             auto_fix_reason="no_head_sha",
+                            span=span,
                         )
                         return
 
@@ -579,6 +646,7 @@ class PRReviewerAgent(BaseAgent):
                         start_monotonic=start_monotonic,
                         auto_fix_dispatched=auto_fix_dispatched,
                         auto_fix_reason=auto_fix_reason,
+                        span=span,
                     )
                     return
 
@@ -650,6 +718,7 @@ class PRReviewerAgent(BaseAgent):
                         start_monotonic=start_monotonic,
                         auto_fix_dispatched=auto_fix_dispatched,
                         auto_fix_reason="backend_not_enabled",
+                        span=span,
                     )
                     return
                 logger.warning(
@@ -754,6 +823,7 @@ class PRReviewerAgent(BaseAgent):
                 start_monotonic=start_monotonic,
                 auto_fix_dispatched=auto_fix_dispatched,
                 auto_fix_reason=auto_fix_reason,
+                span=span,
             )
             return
 
@@ -787,6 +857,7 @@ class PRReviewerAgent(BaseAgent):
             start_monotonic=start_monotonic,
             auto_fix_dispatched=auto_fix_dispatched,
             auto_fix_reason=auto_fix_reason,
+            span=span,
         )
 
     async def _run_local_subprocess_backend(

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -216,17 +216,14 @@ class PRReviewerAgent(BaseAgent):
             repo=repo_slug, backend=backend_label, tier=tier_label, verdict=verdict_label
         )
         if span is not None:
-            try:
-                if tier:
-                    span.set_attribute("caretaker.complexity.tier", tier_label)
-                if backend:
-                    span.set_attribute("caretaker.backend", backend_label)
-                if model:
-                    span.set_attribute("caretaker.review.model", model)
-                span.set_attribute("caretaker.review.verdict", verdict_label)
-                span.set_attribute("caretaker.auto_fix.dispatched", bool(auto_fix_dispatched))
-            except Exception:  # pragma: no cover - defensive
-                pass
+            if tier:
+                span.set_attribute("caretaker.complexity.tier", tier_label)
+            if backend:
+                span.set_attribute("caretaker.backend", backend_label)
+            if model:
+                span.set_attribute("caretaker.review.model", model)
+            span.set_attribute("caretaker.review.verdict", verdict_label)
+            span.set_attribute("caretaker.auto_fix.dispatched", bool(auto_fix_dispatched))
         logger.info(
             "pr_review_complete repo=%s pr=%d author=%s is_caretaker_owned=%s "
             "routing=%s tier=%s backend=%s model=%s verdict=%s duration_ms=%d "
@@ -286,11 +283,8 @@ class PRReviewerAgent(BaseAgent):
         # classifier, inline reviewer, opencode invoke, auto-fix dispatch)
         # nests under this so a single PR review becomes one trace tree.
         with _tracer.start_as_current_span("pr_reviewer.handle_pr") as span:
-            try:
-                span.set_attribute("caretaker.pr.repo", f"{owner}/{repo}")
-                span.set_attribute("caretaker.pr.number", int(pr_number))
-            except Exception:  # pragma: no cover - defensive
-                pass
+            span.set_attribute("caretaker.pr.repo", f"{owner}/{repo}")
+            span.set_attribute("caretaker.pr.number", int(pr_number))
             try:
                 await self._handle_pr_body(pr, report, state=state, span=span)
             except Exception as exc:
@@ -299,7 +293,7 @@ class PRReviewerAgent(BaseAgent):
                     span.set_status(
                         _otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200])
                     )
-                except Exception:  # pragma: no cover
+                except Exception:  # pragma: no cover - defensive: never let tracer mask original
                     pass
                 raise
 
@@ -330,11 +324,8 @@ class PRReviewerAgent(BaseAgent):
         auto_fix_dispatched = False
         auto_fix_reason: str | None = None
 
-        try:
-            span.set_attribute("caretaker.pr.author", pr_author)
-            span.set_attribute("caretaker.pr.is_caretaker_owned", bool(is_caretaker_pr))
-        except Exception:  # pragma: no cover - defensive
-            pass
+        span.set_attribute("caretaker.pr.author", pr_author)
+        span.set_attribute("caretaker.pr.is_caretaker_owned", bool(is_caretaker_pr))
 
         # Skip drafts
         if cfg.skip_draft and pr.get("draft", False):
@@ -499,11 +490,8 @@ class PRReviewerAgent(BaseAgent):
         )
         routing_reason = decision.reason
         logger.info("pr-reviewer: #%d routing — %s", pr_number, decision.reason)
-        try:
-            span.set_attribute("caretaker.routing.use_inline", bool(decision.use_inline))
-            span.set_attribute("caretaker.routing.score", int(decision.score))
-        except Exception:  # pragma: no cover
-            pass
+        span.set_attribute("caretaker.routing.use_inline", bool(decision.use_inline))
+        span.set_attribute("caretaker.routing.score", int(decision.score))
 
         # Shadow-mode wrapper: compares legacy point-system verdict with
         # the LLM candidate under the ``executor_routing`` flag. The

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -24,8 +24,6 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
-from opentelemetry import trace as _otel_trace
-
 from caretaker.agent_protocol import AgentResult, BaseAgent
 from caretaker.evolution.executor_routing import (
     ExecutorRoute,
@@ -40,6 +38,7 @@ from caretaker.observability.metrics import (
     observe_pr_review_duration,
     record_pr_review_outcome,
 )
+from caretaker.observability.tracer_compat import Status, StatusCode, get_tracer
 from caretaker.pr_reviewer import auto_fix as _auto_fix
 from caretaker.pr_reviewer import handoff_review_consumer, handoff_reviewer, inline_reviewer
 from caretaker.pr_reviewer.github_review import post_review
@@ -47,7 +46,7 @@ from caretaker.pr_reviewer.routing import decide
 from caretaker.state.models import TrackedPR
 
 # Module-level tracer — re-used across all PR review handlers.
-_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer")
+_tracer = get_tracer("caretaker.pr_reviewer")
 
 if TYPE_CHECKING:
     from caretaker.pr_reviewer.complexity_classifier import ComplexityTier
@@ -313,9 +312,7 @@ class PRReviewerAgent(BaseAgent):
             except Exception as exc:
                 try:
                     span.record_exception(exc)
-                    span.set_status(
-                        _otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200])
-                    )
+                    span.set_status(Status(StatusCode.ERROR, str(exc)[:200]))
                 except Exception:  # pragma: no cover - defensive: never let tracer mask original
                     pass
                 raise

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -20,6 +20,7 @@ Idempotency is provided by ``skip_labels`` (defaults to
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -33,6 +34,10 @@ from caretaker.evolution.executor_routing import (
     route_from_pr_reviewer_legacy,
 )
 from caretaker.evolution.shadow import shadow_decision
+from caretaker.observability.metrics import (
+    observe_pr_review_duration,
+    record_pr_review_outcome,
+)
 from caretaker.pr_reviewer import auto_fix as _auto_fix
 from caretaker.pr_reviewer import handoff_review_consumer, handoff_reviewer, inline_reviewer
 from caretaker.pr_reviewer.github_review import post_review
@@ -171,6 +176,67 @@ class PRReviewerAgent(BaseAgent):
             },
         )
 
+    def _emit_pr_review_audit(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        pr_author: str,
+        is_caretaker_pr: bool,
+        routing_reason: str,
+        tier: str | None,
+        backend: str | None,
+        model: str | None,
+        verdict: str | None,
+        start_monotonic: float,
+        auto_fix_dispatched: bool,
+        auto_fix_reason: str | None,
+    ) -> None:
+        """Emit the per-PR audit log line + metrics at every return point.
+
+        Centralised so the multi-return ``_handle_pr`` doesn't grow a
+        bespoke 12-line emission block at each branch. ``"none"`` is the
+        sentinel for unset values — both the log and the metrics use it.
+        """
+        duration_seconds = max(0.0, time.monotonic() - start_monotonic)
+        duration_ms = int(duration_seconds * 1000)
+        repo_slug = f"{owner}/{repo}"
+        tier_label = tier or "none"
+        backend_label = backend or "none"
+        verdict_label = verdict or "none"
+        observe_pr_review_duration(backend=backend_label, tier=tier_label, seconds=duration_seconds)
+        record_pr_review_outcome(
+            repo=repo_slug, backend=backend_label, tier=tier_label, verdict=verdict_label
+        )
+        logger.info(
+            "pr_review_complete repo=%s pr=%d author=%s is_caretaker_owned=%s "
+            "routing=%s tier=%s backend=%s model=%s verdict=%s duration_ms=%d "
+            "auto_fix_dispatched=%s auto_fix_reason=%s",
+            repo_slug,
+            pr_number,
+            pr_author,
+            is_caretaker_pr,
+            routing_reason,
+            tier_label,
+            backend_label,
+            model or "none",
+            verdict_label,
+            duration_ms,
+            auto_fix_dispatched,
+            auto_fix_reason or "n/a",
+            extra={
+                "audit_event": "pr_review_complete",
+                "pr_number": pr_number,
+                "repo": repo_slug,
+                "verdict": verdict_label,
+                "tier": tier_label,
+                "backend": backend_label,
+                "model": model or "none",
+                "duration_ms": duration_ms,
+            },
+        )
+
     async def _handle_pr(
         self,
         pr: dict[str, Any],
@@ -183,9 +249,37 @@ class PRReviewerAgent(BaseAgent):
         owner = self._ctx.owner
         repo = self._ctx.repo
 
+        # Track wall-clock from the very top so every early-return branch
+        # records the time actually spent before bailing.
+        start_monotonic = time.monotonic()
+        pr_author = (pr.get("user") or {}).get("login", "")
+        is_caretaker_pr = _is_caretaker_owned(pr)
+        routing_reason = "n/a"
+        tier_label: str | None = None
+        backend_label: str | None = None
+        model_label: str | None = None
+        verdict_label: str | None = None
+        auto_fix_dispatched = False
+        auto_fix_reason: str | None = None
+
         # Skip drafts
         if cfg.skip_draft and pr.get("draft", False):
             report.skipped.append(pr_number)
+            self._emit_pr_review_audit(
+                owner=owner,
+                repo=repo,
+                pr_number=pr_number,
+                pr_author=pr_author,
+                is_caretaker_pr=is_caretaker_pr,
+                routing_reason="draft",
+                tier=tier_label,
+                backend=backend_label,
+                model=model_label,
+                verdict="skipped",
+                start_monotonic=start_monotonic,
+                auto_fix_dispatched=auto_fix_dispatched,
+                auto_fix_reason="skipped_draft",
+            )
             return
 
         # Skip if already reviewed by caretaker this cycle
@@ -195,6 +289,21 @@ class PRReviewerAgent(BaseAgent):
         ]
         if any(lbl in cfg.skip_labels for lbl in pr_labels):
             report.skipped.append(pr_number)
+            self._emit_pr_review_audit(
+                owner=owner,
+                repo=repo,
+                pr_number=pr_number,
+                pr_author=pr_author,
+                is_caretaker_pr=is_caretaker_pr,
+                routing_reason="skip_label",
+                tier=tier_label,
+                backend=backend_label,
+                model=model_label,
+                verdict="skipped",
+                start_monotonic=start_monotonic,
+                auto_fix_dispatched=auto_fix_dispatched,
+                auto_fix_reason="skipped_label",
+            )
             return
 
         # Harvest pass — if a hand-off agent (Claude Code, opencode)
@@ -222,9 +331,9 @@ class PRReviewerAgent(BaseAgent):
             if posted:
                 report.harvested.append(pr_number)
                 # Check if any harvested review requests changes — dispatch auto-fix.
+                harvested_verdict = posted[0].verdict if posted else None
                 for review_result in posted:
                     if review_result.verdict == "REQUEST_CHANGES":
-                        pr_author = (pr.get("user") or {}).get("login", "")
                         head_branch = (pr.get("head") or {}).get("ref", "")
                         pr_url = pr.get("html_url", "")
                         fix_decision = _auto_fix.decide_auto_fix(
@@ -233,7 +342,9 @@ class PRReviewerAgent(BaseAgent):
                             pr_author=pr_author,
                             pr_labels=pr_labels,
                             tracking=tracking,
+                            repo=f"{owner}/{repo}",
                         )
+                        harvested_verdict = review_result.verdict
                         if fix_decision.should_dispatch:
                             await _auto_fix.dispatch_auto_fix(
                                 decision=fix_decision,
@@ -247,6 +358,11 @@ class PRReviewerAgent(BaseAgent):
                                 pr_number=pr_number,
                                 tracking=tracking,
                             )
+                            auto_fix_dispatched = True
+                            auto_fix_reason = fix_decision.reason
+                            backend_label = fix_decision.backend
+                        else:
+                            auto_fix_reason = fix_decision.reason
                         break  # one REQUEST_CHANGES is enough to arm the fixer
                 # Always mark reviewed after harvest regardless of fix dispatch.
                 try:
@@ -266,6 +382,21 @@ class PRReviewerAgent(BaseAgent):
                         pr_number,
                         exc,
                     )
+                self._emit_pr_review_audit(
+                    owner=owner,
+                    repo=repo,
+                    pr_number=pr_number,
+                    pr_author=pr_author,
+                    is_caretaker_pr=is_caretaker_pr,
+                    routing_reason="harvest",
+                    tier=tier_label,
+                    backend=backend_label,
+                    model=model_label,
+                    verdict=harvested_verdict,
+                    start_monotonic=start_monotonic,
+                    auto_fix_dispatched=auto_fix_dispatched,
+                    auto_fix_reason=auto_fix_reason,
+                )
                 return
 
         # Fetch file metadata for routing
@@ -288,6 +419,7 @@ class PRReviewerAgent(BaseAgent):
             threshold=cfg.routing_threshold,
             backend=cfg.complex_reviewer,
         )
+        routing_reason = decision.reason
         logger.info("pr-reviewer: #%d routing — %s", pr_number, decision.reason)
 
         # Shadow-mode wrapper: compares legacy point-system verdict with
@@ -343,6 +475,22 @@ class PRReviewerAgent(BaseAgent):
                     if not commit_sha:
                         logger.warning("pr-reviewer: no head SHA for #%d", pr_number)
                         report.skipped.append(pr_number)
+                        # ``pr_author`` is already set at the top of _handle_pr.
+                        self._emit_pr_review_audit(
+                            owner=owner,
+                            repo=repo,
+                            pr_number=pr_number,
+                            pr_author=pr_author,
+                            is_caretaker_pr=is_caretaker_pr,
+                            routing_reason=routing_reason,
+                            tier=tier_label,
+                            backend="inline",
+                            model=model_label,
+                            verdict="skipped",
+                            start_monotonic=start_monotonic,
+                            auto_fix_dispatched=auto_fix_dispatched,
+                            auto_fix_reason="no_head_sha",
+                        )
                         return
 
                     await post_review(
@@ -355,10 +503,11 @@ class PRReviewerAgent(BaseAgent):
                         post_inline_comments=cfg.post_inline_comments,
                         force_event=cfg.review_event if cfg.review_event != "AUTO" else None,
                     )
+                    backend_label = "inline"
+                    verdict_label = result.verdict
                     # Inline path auto-fix: if the LLM says REQUEST_CHANGES, dispatch fixer.
                     if result.verdict == "REQUEST_CHANGES":
                         _tracking = state.tracked_prs.get(pr_number) or TrackedPR(number=pr_number)
-                        pr_author = (pr.get("user") or {}).get("login", "")
                         head_branch = (pr.get("head") or {}).get("ref", "")
                         pr_url = pr.get("html_url", "")
                         _decision = _auto_fix.decide_auto_fix(
@@ -367,7 +516,9 @@ class PRReviewerAgent(BaseAgent):
                             pr_author=pr_author,
                             pr_labels=pr_labels,
                             tracking=_tracking,
+                            repo=f"{owner}/{repo}",
                         )
+                        auto_fix_reason = _decision.reason
                         if _decision.should_dispatch:
                             await _auto_fix.dispatch_auto_fix(
                                 decision=_decision,
@@ -381,6 +532,7 @@ class PRReviewerAgent(BaseAgent):
                                 pr_number=pr_number,
                                 tracking=_tracking,
                             )
+                            auto_fix_dispatched = True
                             state.tracked_prs[pr_number] = _tracking
                     # Mark as reviewed
                     try:
@@ -396,6 +548,21 @@ class PRReviewerAgent(BaseAgent):
                     except Exception:
                         pass
                     report.reviewed.append(pr_number)
+                    self._emit_pr_review_audit(
+                        owner=owner,
+                        repo=repo,
+                        pr_number=pr_number,
+                        pr_author=pr_author,
+                        is_caretaker_pr=is_caretaker_pr,
+                        routing_reason=routing_reason,
+                        tier=tier_label,
+                        backend=backend_label,
+                        model=model_label,
+                        verdict=verdict_label,
+                        start_monotonic=start_monotonic,
+                        auto_fix_dispatched=auto_fix_dispatched,
+                        auto_fix_reason=auto_fix_reason,
+                    )
                     return
 
         # Hand-off path — backend chosen by ``complex_reviewer`` (Claude
@@ -408,8 +575,8 @@ class PRReviewerAgent(BaseAgent):
         # run opencode (or the configured caretaker_owned_reviewer) as a
         # local subprocess so the review is synchronous, then immediately
         # dispatch auto-fix and auto-approve within the same cycle.
-        pr_author = (pr.get("user") or {}).get("login", "")
-        is_caretaker_pr = _is_caretaker_owned(pr)
+        # ``pr_author`` and ``is_caretaker_pr`` were already populated at
+        # the top of _handle_pr; reuse them here.
         if is_caretaker_pr and cfg.caretaker_owned_reviewer:
             caretaker_backend = cfg.caretaker_owned_reviewer
             if caretaker_backend in handoff_reviewer.known_backends():
@@ -452,6 +619,21 @@ class PRReviewerAgent(BaseAgent):
                         backend,
                         cfg.enabled_backends,
                     )
+                    self._emit_pr_review_audit(
+                        owner=owner,
+                        repo=repo,
+                        pr_number=pr_number,
+                        pr_author=pr_author,
+                        is_caretaker_pr=is_caretaker_pr,
+                        routing_reason=routing_reason,
+                        tier=tier_label,
+                        backend=backend,
+                        model=model_label,
+                        verdict="skipped",
+                        start_monotonic=start_monotonic,
+                        auto_fix_dispatched=auto_fix_dispatched,
+                        auto_fix_reason="backend_not_enabled",
+                    )
                     return
                 logger.warning(
                     "pr-reviewer: backend %r is registered but not in enabled_backends=%s; "
@@ -479,6 +661,9 @@ class PRReviewerAgent(BaseAgent):
                 if is_caretaker_pr
                 else None
             )
+            tier_label = tier
+            backend_label = backend
+            model_label = self._resolve_backend_model(backend, tier=tier, mode="review")
 
             local_result = await self._run_local_subprocess_backend(
                 backend=backend,
@@ -491,6 +676,8 @@ class PRReviewerAgent(BaseAgent):
                 routing_reason=decision.reason,
                 tier=tier,
             )
+            if local_result is not None:
+                verdict_label = local_result.verdict
             # For caretaker-owned PRs: run auto-fix when reviewer says
             # REQUEST_CHANGES, then auto-approve on success.
             if (
@@ -509,7 +696,9 @@ class PRReviewerAgent(BaseAgent):
                     pr_author=pr_author,
                     pr_labels=pr_labels,
                     tracking=_tracking,
+                    repo=f"{owner}/{repo}",
                 )
+                auto_fix_reason = fix_decision.reason
                 if fix_decision.should_dispatch:
                     outcome = await _auto_fix.dispatch_auto_fix(
                         decision=fix_decision,
@@ -524,6 +713,7 @@ class PRReviewerAgent(BaseAgent):
                         tracking=_tracking,
                         tier=tier,
                     )
+                    auto_fix_dispatched = True
                     state.tracked_prs[pr_number] = _tracking
                     if outcome.success and outcome.new_head_sha:
                         await self._auto_approve_caretaker_pr(
@@ -533,8 +723,24 @@ class PRReviewerAgent(BaseAgent):
                             new_head_sha=outcome.new_head_sha,
                             fix_backend=fix_decision.backend,
                         )
+            self._emit_pr_review_audit(
+                owner=owner,
+                repo=repo,
+                pr_number=pr_number,
+                pr_author=pr_author,
+                is_caretaker_pr=is_caretaker_pr,
+                routing_reason=routing_reason,
+                tier=tier_label,
+                backend=backend_label,
+                model=model_label,
+                verdict=verdict_label,
+                start_monotonic=start_monotonic,
+                auto_fix_dispatched=auto_fix_dispatched,
+                auto_fix_reason=auto_fix_reason,
+            )
             return
 
+        backend_label = backend
         success = await handoff_reviewer.dispatch(
             backend=backend,
             github=self._ctx.github,
@@ -546,8 +752,25 @@ class PRReviewerAgent(BaseAgent):
         )
         if success:
             report.dispatched.append(pr_number)
+            verdict_label = "dispatched"
         else:
             report.errors.append(f"{backend} dispatch failed for #{pr_number}")
+            verdict_label = "dispatch_failed"
+        self._emit_pr_review_audit(
+            owner=owner,
+            repo=repo,
+            pr_number=pr_number,
+            pr_author=pr_author,
+            is_caretaker_pr=is_caretaker_pr,
+            routing_reason=routing_reason,
+            tier=tier_label,
+            backend=backend_label,
+            model=model_label,
+            verdict=verdict_label,
+            start_monotonic=start_monotonic,
+            auto_fix_dispatched=auto_fix_dispatched,
+            auto_fix_reason=auto_fix_reason,
+        )
 
     async def _run_local_subprocess_backend(
         self,
@@ -781,6 +1004,33 @@ class PRReviewerAgent(BaseAgent):
         ``NotImplementedError`` cleanly without a missing-attribute.
         """
         return getattr(self._ctx.config.pr_reviewer, backend, _EMPTY_BACKEND_CONFIG)
+
+    def _resolve_backend_model(
+        self, backend: str, *, tier: ComplexityTier | None, mode: str
+    ) -> str | None:
+        """Return the model id the backend would use for ``mode``+``tier``.
+
+        Best-effort lookup so the audit log reports the actual model the
+        backend will route to (rather than the operator-pinned default
+        even when a tier override is in play). Returns ``None`` when the
+        backend doesn't expose a tier-aware model map.
+        """
+        backend_cfg = self._resolve_local_backend_config(backend)
+        if backend == "opencode_local":
+            tier_map = getattr(
+                backend_cfg, "review_models" if mode == "review" else "fix_models", {}
+            )
+            default = (
+                getattr(backend_cfg, "model", "")
+                if mode == "review"
+                else (getattr(backend_cfg, "fix_model", "") or getattr(backend_cfg, "model", ""))
+            )
+            if tier is not None and tier_map.get(tier):
+                model: str = tier_map[tier]
+                return model
+            return str(default) if default else None
+        configured: Any = getattr(backend_cfg, "model", None)
+        return str(configured) if configured else None
 
     async def _route_via_shadow(
         self,

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from caretaker.agent_protocol import AgentResult, BaseAgent
 from caretaker.evolution.executor_routing import (
@@ -225,15 +225,26 @@ class PRReviewerAgent(BaseAgent):
             duration_ms,
             auto_fix_dispatched,
             auto_fix_reason or "n/a",
+            # Every field that appears in the format string above is
+            # also surfaced here so structured-log consumers (Loki /
+            # JSON formatter) don't lose attributes that the human
+            # message includes. Field names match the metric labels
+            # where they overlap (``backend``, ``tier``, ``verdict``,
+            # ``repo``).
             extra={
                 "audit_event": "pr_review_complete",
                 "pr_number": pr_number,
                 "repo": repo_slug,
+                "pr_author": pr_author,
+                "is_caretaker_owned": is_caretaker_pr,
+                "routing_reason": routing_reason,
                 "verdict": verdict_label,
                 "tier": tier_label,
                 "backend": backend_label,
                 "model": model or "none",
                 "duration_ms": duration_ms,
+                "auto_fix_dispatched": auto_fix_dispatched,
+                "auto_fix_reason": auto_fix_reason or "n/a",
             },
         )
 
@@ -244,6 +255,11 @@ class PRReviewerAgent(BaseAgent):
         *,
         state: OrchestratorState,
     ) -> None:
+        # TODO(state-object): the local-variable bag below
+        # (``tier_label``, ``backend_label``, ``auto_fix_dispatched`` …)
+        # is approaching a state-machine. Refactor into a
+        # ``_PRReviewState`` dataclass once the next reviewer phase
+        # adds more transitions. Out of scope for phase 1A.
         cfg = self._ctx.config.pr_reviewer
         pr_number = int(pr.get("number", 0))
         owner = self._ctx.owner
@@ -331,7 +347,8 @@ class PRReviewerAgent(BaseAgent):
             if posted:
                 report.harvested.append(pr_number)
                 # Check if any harvested review requests changes — dispatch auto-fix.
-                harvested_verdict = posted[0].verdict if posted else None
+                # We're already inside ``if posted:`` so ``posted[0]`` is safe.
+                harvested_verdict = posted[0].verdict
                 for review_result in posted:
                     if review_result.verdict == "REQUEST_CHANGES":
                         head_branch = (pr.get("head") or {}).get("ref", "")
@@ -1006,7 +1023,11 @@ class PRReviewerAgent(BaseAgent):
         return getattr(self._ctx.config.pr_reviewer, backend, _EMPTY_BACKEND_CONFIG)
 
     def _resolve_backend_model(
-        self, backend: str, *, tier: ComplexityTier | None, mode: str
+        self,
+        backend: str,
+        *,
+        tier: ComplexityTier | None,
+        mode: Literal["review", "fix"],
     ) -> str | None:
         """Return the model id the backend would use for ``mode``+``tier``.
 
@@ -1014,6 +1035,10 @@ class PRReviewerAgent(BaseAgent):
         backend will route to (rather than the operator-pinned default
         even when a tier override is in play). Returns ``None`` when the
         backend doesn't expose a tier-aware model map.
+
+        TODO(backend-dispatch): replace the ``if backend == ...``
+        ladder with a dispatch table once a second tier-aware backend
+        lands. Out of scope for the phase 1A observability PR.
         """
         backend_cfg = self._resolve_local_backend_config(backend)
         if backend == "opencode_local":

--- a/src/caretaker/pr_reviewer/agent.py
+++ b/src/caretaker/pr_reviewer/agent.py
@@ -19,7 +19,6 @@ Idempotency is provided by ``skip_labels`` (defaults to
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
@@ -182,7 +181,7 @@ class PRReviewerAgent(BaseAgent):
             },
         )
 
-    def _emit_pr_review_audit(
+    async def _emit_pr_review_audit(
         self,
         *,
         owner: str,
@@ -263,37 +262,29 @@ class PRReviewerAgent(BaseAgent):
                 "auto_fix_reason": auto_fix_reason or "n/a",
             },
         )
-        # Per-PR decision timeline write — fire-and-forget so the
-        # observability path never blocks the agent. Lazy import keeps
-        # the helper out of the import-cycle hot path.
-        try:
-            from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
+        # Per-PR decision timeline write. Plain ``await`` — the helper
+        # already swallows Mongo errors and the structured log line
+        # above ensures Loki has the record even when the Mongo write
+        # fails. Lazy import keeps the helper out of the import-cycle
+        # hot path.
+        from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
 
-            asyncio.create_task(
-                record_decision(
-                    repo_slug,
-                    int(pr_number),
-                    "pr_reviewer",
-                    "review_completed",
-                    pr_author=pr_author,
-                    is_caretaker_owned=bool(is_caretaker_pr),
-                    routing_reason=routing_reason,
-                    verdict=verdict_label,
-                    tier=tier_label,
-                    backend=backend_label,
-                    model=model or "none",
-                    duration_ms=duration_ms,
-                    auto_fix_dispatched=bool(auto_fix_dispatched),
-                    auto_fix_reason=auto_fix_reason or "n/a",
-                )
-            )
-        except RuntimeError:
-            # No running loop (e.g. called from a sync test harness).
-            # Skip the decision-timeline write — the structured log
-            # line above is still emitted by ``logger.info``.
-            pass
-        except Exception:  # pragma: no cover - defensive
-            logger.debug("record_decision dispatch failed", exc_info=True)
+        await record_decision(
+            repo_slug,
+            int(pr_number),
+            "pr_reviewer",
+            "review_completed",
+            pr_author=pr_author,
+            is_caretaker_owned=bool(is_caretaker_pr),
+            routing_reason=routing_reason,
+            verdict=verdict_label,
+            tier=tier_label,
+            backend=backend_label,
+            model=model or "none",
+            duration_ms=duration_ms,
+            auto_fix_dispatched=bool(auto_fix_dispatched),
+            auto_fix_reason=auto_fix_reason or "n/a",
+        )
 
     async def _handle_pr(
         self,
@@ -397,7 +388,7 @@ class PRReviewerAgent(BaseAgent):
                 reason="draft",
                 author=pr_author,
             )
-            self._emit_pr_review_audit(
+            await self._emit_pr_review_audit(
                 owner=owner,
                 repo=repo,
                 pr_number=pr_number,
@@ -430,7 +421,7 @@ class PRReviewerAgent(BaseAgent):
                 reason="skip_label",
                 author=pr_author,
             )
-            self._emit_pr_review_audit(
+            await self._emit_pr_review_audit(
                 owner=owner,
                 repo=repo,
                 pr_number=pr_number,
@@ -479,7 +470,7 @@ class PRReviewerAgent(BaseAgent):
                     if review_result.verdict == "REQUEST_CHANGES":
                         head_branch = (pr.get("head") or {}).get("ref", "")
                         pr_url = pr.get("html_url", "")
-                        fix_decision = _auto_fix.decide_auto_fix(
+                        fix_decision = await _auto_fix.decide_auto_fix(
                             review=review_result,
                             config=cfg.auto_fix,
                             pr_author=pr_author,
@@ -526,7 +517,7 @@ class PRReviewerAgent(BaseAgent):
                         pr_number,
                         exc,
                     )
-                self._emit_pr_review_audit(
+                await self._emit_pr_review_audit(
                     owner=owner,
                     repo=repo,
                     pr_number=pr_number,
@@ -623,7 +614,7 @@ class PRReviewerAgent(BaseAgent):
                         logger.warning("pr-reviewer: no head SHA for #%d", pr_number)
                         report.skipped.append(pr_number)
                         # ``pr_author`` is already set at the top of _handle_pr.
-                        self._emit_pr_review_audit(
+                        await self._emit_pr_review_audit(
                             owner=owner,
                             repo=repo,
                             pr_number=pr_number,
@@ -658,7 +649,7 @@ class PRReviewerAgent(BaseAgent):
                         _tracking = state.tracked_prs.get(pr_number) or TrackedPR(number=pr_number)
                         head_branch = (pr.get("head") or {}).get("ref", "")
                         pr_url = pr.get("html_url", "")
-                        _decision = _auto_fix.decide_auto_fix(
+                        _decision = await _auto_fix.decide_auto_fix(
                             review=result,
                             config=cfg.auto_fix,
                             pr_author=pr_author,
@@ -697,7 +688,7 @@ class PRReviewerAgent(BaseAgent):
                     except Exception:
                         pass
                     report.reviewed.append(pr_number)
-                    self._emit_pr_review_audit(
+                    await self._emit_pr_review_audit(
                         owner=owner,
                         repo=repo,
                         pr_number=pr_number,
@@ -769,7 +760,7 @@ class PRReviewerAgent(BaseAgent):
                         backend,
                         cfg.enabled_backends,
                     )
-                    self._emit_pr_review_audit(
+                    await self._emit_pr_review_audit(
                         owner=owner,
                         repo=repo,
                         pr_number=pr_number,
@@ -842,7 +833,7 @@ class PRReviewerAgent(BaseAgent):
                     f"https://github.com/{owner}/{repo}/pull/{pr_number}"
                 )
                 _tracking = state.tracked_prs.get(pr_number) or TrackedPR(number=pr_number)
-                fix_decision = _auto_fix.decide_auto_fix(
+                fix_decision = await _auto_fix.decide_auto_fix(
                     review=local_result,
                     config=cfg.auto_fix,
                     pr_author=pr_author,
@@ -876,7 +867,7 @@ class PRReviewerAgent(BaseAgent):
                             new_head_sha=outcome.new_head_sha,
                             fix_backend=fix_decision.backend,
                         )
-            self._emit_pr_review_audit(
+            await self._emit_pr_review_audit(
                 owner=owner,
                 repo=repo,
                 pr_number=pr_number,
@@ -910,7 +901,7 @@ class PRReviewerAgent(BaseAgent):
         else:
             report.errors.append(f"{backend} dispatch failed for #{pr_number}")
             verdict_label = "dispatch_failed"
-        self._emit_pr_review_audit(
+        await self._emit_pr_review_audit(
             owner=owner,
             repo=repo,
             pr_number=pr_number,

--- a/src/caretaker/pr_reviewer/auto_fix.py
+++ b/src/caretaker/pr_reviewer/auto_fix.py
@@ -52,6 +52,36 @@ logger = logging.getLogger(__name__)
 _tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.auto_fix")
 
 
+def _record_auto_fix_skipped(repo: str, pr_number: int, reason: str, attempt: int) -> None:
+    """Fire-and-forget per-PR-decision write for an auto-fix skip branch.
+
+    Lazy import + best-effort: never fail ``decide_auto_fix`` because
+    the timeline write threw or the loop wasn't running.
+    """
+    if not repo or pr_number <= 0:
+        return
+    try:
+        from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
+
+        asyncio.create_task(
+            record_decision(
+                repo,
+                int(pr_number),
+                "auto_fix",
+                "auto_fix_skipped",
+                reason=reason,
+                attempt=int(attempt),
+            )
+        )
+    except RuntimeError:
+        # No running loop — sync test harness. Skip silently; the
+        # structured-log line in record_decision still fires when the
+        # test eventually drives the coroutine.
+        pass
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("auto_fix: record_decision dispatch failed", exc_info=True)
+
+
 # Synthetic backend name handled in-process by :func:`run_deterministic_lint`
 # rather than dispatched to a HandoffReviewerSpec runner. Listed here so
 # the dispatcher can recognise it without importing config defaults.
@@ -127,6 +157,7 @@ def decide_auto_fix(
     pr_labels: list[str],
     tracking: TrackedPR,
     repo: str = "",
+    pr_number: int = 0,
 ) -> AutoFixDecision:
     """Return whether to dispatch a fixer for this review, and which one.
 
@@ -142,19 +173,25 @@ def decide_auto_fix(
          ``default_fixer`` when no category resolves cleanly
 
     ``repo`` is the ``owner/repo`` slug, threaded through so the
-    ``skipped`` outcome counter is attributed correctly. Defaults to
-    empty for backward-compat with older callers.
+    ``skipped`` outcome counter is attributed correctly. ``pr_number``
+    is threaded through so skip branches can record an
+    ``auto_fix_skipped`` decision-timeline event. Both default to
+    empty/0 for backward-compat with older callers.
     """
+    attempt = int(tracking.auto_fix_attempts) + 1
     if not config.enabled:
         record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
+        _record_auto_fix_skipped(repo, pr_number, "auto_fix_disabled", attempt)
         return AutoFixDecision(should_dispatch=False, reason="auto_fix.enabled is False")
     if review.verdict != "REQUEST_CHANGES":
         record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
+        _record_auto_fix_skipped(repo, pr_number, f"verdict_{review.verdict}", attempt)
         return AutoFixDecision(
             should_dispatch=False, reason=f"verdict {review.verdict!r} is not REQUEST_CHANGES"
         )
     if tracking.auto_fix_attempts >= config.max_attempts:
         record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
+        _record_auto_fix_skipped(repo, pr_number, "max_attempts_reached", attempt)
         return AutoFixDecision(
             should_dispatch=False,
             reason=(
@@ -167,6 +204,7 @@ def decide_auto_fix(
     label_eligible = config.opt_in_label in pr_labels
     if not (author_eligible or label_eligible):
         record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
+        _record_auto_fix_skipped(repo, pr_number, "author_or_label_ineligible", attempt)
         return AutoFixDecision(
             should_dispatch=False,
             reason=(
@@ -383,8 +421,23 @@ async def dispatch_auto_fix(
     tracking.auto_fix_attempts += 1
     tracking.auto_fix_last_head_sha = ""  # will be set on success below
 
+    repo_slug = f"{owner}/{repo}"
+    # Per-PR decision timeline: dispatch event. Lazy import to keep
+    # the dispatcher's hot path free of optional Mongo deps.
+    from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
+
+    await record_decision(
+        repo_slug,
+        int(pr_number),
+        "auto_fix",
+        "auto_fix_dispatched",
+        backend=str(decision.backend),
+        categories=list(decision.categories or []),
+        attempt=int(tracking.auto_fix_attempts),
+    )
+
     with _tracer.start_as_current_span("auto_fix.dispatch") as span:
-        span.set_attribute("caretaker.pr.repo", f"{owner}/{repo}")
+        span.set_attribute("caretaker.pr.repo", repo_slug)
         span.set_attribute("caretaker.pr.number", int(pr_number))
         span.set_attribute("caretaker.auto_fix.backend", str(decision.backend))
         span.set_attribute("caretaker.auto_fix.categories", list(decision.categories or []))
@@ -417,6 +470,19 @@ async def dispatch_auto_fix(
         span.set_attribute("caretaker.auto_fix.outcome", outcome_label)
         if outcome_result.new_head_sha:
             span.set_attribute("caretaker.auto_fix.new_head_sha", outcome_result.new_head_sha)
+
+        # Decision-timeline write for the completion event. Includes
+        # the new head SHA + any error so the admin SPA can show what
+        # actually shipped at the end of the cycle.
+        await record_decision(
+            repo_slug,
+            int(pr_number),
+            "auto_fix",
+            "auto_fix_complete",
+            success=bool(outcome_result.success),
+            new_head_sha=outcome_result.new_head_sha or "",
+            error=outcome_result.error or "",
+        )
         return outcome_result
 
 

--- a/src/caretaker/pr_reviewer/auto_fix.py
+++ b/src/caretaker/pr_reviewer/auto_fix.py
@@ -34,9 +34,8 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from opentelemetry import trace as _otel_trace
-
 from caretaker.observability.metrics import record_auto_fix_dispatch
+from caretaker.observability.tracer_compat import Status, StatusCode, get_tracer
 from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
 
 if TYPE_CHECKING:
@@ -49,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 # Module-level tracer — every dispatch becomes one span under the parent
 # ``pr_reviewer.handle_pr`` trace, carrying backend + categories + outcome.
-_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.auto_fix")
+_tracer = get_tracer("caretaker.pr_reviewer.auto_fix")
 
 
 async def _record_auto_fix_skipped(repo: str, pr_number: int, reason: str, attempt: int) -> None:
@@ -453,7 +452,7 @@ async def dispatch_auto_fix(
         except Exception as exc:
             try:
                 span.record_exception(exc)
-                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
+                span.set_status(Status(StatusCode.ERROR, str(exc)[:200]))
             except Exception:  # pragma: no cover - defensive: never let tracer mask original
                 pass
             raise

--- a/src/caretaker/pr_reviewer/auto_fix.py
+++ b/src/caretaker/pr_reviewer/auto_fix.py
@@ -34,6 +34,8 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from opentelemetry import trace as _otel_trace
+
 from caretaker.observability.metrics import record_auto_fix_dispatch
 from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
 
@@ -44,6 +46,10 @@ if TYPE_CHECKING:
     from caretaker.state.models import TrackedPR
 
 logger = logging.getLogger(__name__)
+
+# Module-level tracer — every dispatch becomes one span under the parent
+# ``pr_reviewer.handle_pr`` trace, carrying backend + categories + outcome.
+_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.auto_fix")
 
 
 # Synthetic backend name handled in-process by :func:`run_deterministic_lint`
@@ -377,6 +383,70 @@ async def dispatch_auto_fix(
     tracking.auto_fix_attempts += 1
     tracking.auto_fix_last_head_sha = ""  # will be set on success below
 
+    span_cm = _tracer.start_as_current_span("auto_fix.dispatch")
+    span = span_cm.__enter__()
+    try:
+        try:
+            span.set_attribute("caretaker.pr.repo", f"{owner}/{repo}")
+            span.set_attribute("caretaker.pr.number", int(pr_number))
+            span.set_attribute("caretaker.auto_fix.backend", str(decision.backend))
+            span.set_attribute("caretaker.auto_fix.categories", list(decision.categories or []))
+            span.set_attribute("caretaker.auto_fix.attempt", int(tracking.auto_fix_attempts))
+        except Exception:  # pragma: no cover - defensive
+            pass
+        outcome_result = await _dispatch_auto_fix_inner(
+            decision=decision,
+            pr_url=pr_url,
+            head_branch=head_branch,
+            review=review,
+            config=config,
+            github=github,
+            owner=owner,
+            repo=repo,
+            pr_number=pr_number,
+            tracking=tracking,
+            tier=tier,
+            auto_fix_cfg=auto_fix_cfg,
+        )
+        try:
+            outcome_label = (
+                "success"
+                if outcome_result.success
+                else ("skipped" if not outcome_result.dispatched else "failed")
+            )
+            span.set_attribute("caretaker.auto_fix.outcome", outcome_label)
+            if outcome_result.new_head_sha:
+                span.set_attribute("caretaker.auto_fix.new_head_sha", outcome_result.new_head_sha)
+        except Exception:  # pragma: no cover
+            pass
+        return outcome_result
+    except Exception as exc:
+        try:
+            span.record_exception(exc)
+            span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
+        except Exception:  # pragma: no cover
+            pass
+        raise
+    finally:
+        span_cm.__exit__(None, None, None)
+
+
+async def _dispatch_auto_fix_inner(
+    *,
+    decision: AutoFixDecision,
+    pr_url: str,
+    head_branch: str,
+    review: ReviewResult,
+    config: PRReviewerConfig,
+    github: GitHubClient,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    tracking: TrackedPR,
+    tier: str | None,
+    auto_fix_cfg: AutoFixConfig,
+) -> AutoFixOutcome:
+    """Inner body of :func:`dispatch_auto_fix`, wrapped by the OTel span."""
     workdir: str | None = None
     new_head: str = ""
     try:

--- a/src/caretaker/pr_reviewer/auto_fix.py
+++ b/src/caretaker/pr_reviewer/auto_fix.py
@@ -34,6 +34,7 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from caretaker.observability.metrics import record_auto_fix_dispatch
 from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
 
 if TYPE_CHECKING:
@@ -119,6 +120,7 @@ def decide_auto_fix(
     pr_author: str,
     pr_labels: list[str],
     tracking: TrackedPR,
+    repo: str = "",
 ) -> AutoFixDecision:
     """Return whether to dispatch a fixer for this review, and which one.
 
@@ -132,14 +134,21 @@ def decide_auto_fix(
          the opt-in label
       5. Pick a backend from category → fixer map; fall back to
          ``default_fixer`` when no category resolves cleanly
+
+    ``repo`` is the ``owner/repo`` slug, threaded through so the
+    ``skipped`` outcome counter is attributed correctly. Defaults to
+    empty for backward-compat with older callers.
     """
     if not config.enabled:
+        record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
         return AutoFixDecision(should_dispatch=False, reason="auto_fix.enabled is False")
     if review.verdict != "REQUEST_CHANGES":
+        record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
         return AutoFixDecision(
             should_dispatch=False, reason=f"verdict {review.verdict!r} is not REQUEST_CHANGES"
         )
     if tracking.auto_fix_attempts >= config.max_attempts:
+        record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
         return AutoFixDecision(
             should_dispatch=False,
             reason=(
@@ -151,6 +160,7 @@ def decide_auto_fix(
     author_eligible = pr_author in set(config.allowed_authors)
     label_eligible = config.opt_in_label in pr_labels
     if not (author_eligible or label_eligible):
+        record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
         return AutoFixDecision(
             should_dispatch=False,
             reason=(
@@ -415,6 +425,12 @@ async def dispatch_auto_fix(
                     success=False,
                     detail=outcome.detail,
                 )
+                record_auto_fix_dispatch(
+                    repo=f"{owner}/{repo}",
+                    backend=decision.backend,
+                    category=(decision.categories or ["none"])[0] or "none",
+                    outcome="dispatched_fail",
+                )
                 return outcome
         else:
             # Look up the backend's fix_run via its module. Only
@@ -477,6 +493,12 @@ async def dispatch_auto_fix(
             new_head_sha=new_head,
             success=True,
         )
+        record_auto_fix_dispatch(
+            repo=f"{owner}/{repo}",
+            backend=decision.backend,
+            category=(decision.categories or ["none"])[0] or "none",
+            outcome="dispatched_success",
+        )
         return outcome
     except Exception as exc:  # noqa: BLE001 — the dispatcher is best-effort
         logger.warning(
@@ -502,6 +524,12 @@ async def dispatch_auto_fix(
                 success=False,
                 detail=f"`{type(exc).__name__}: {exc}`",
             )
+        record_auto_fix_dispatch(
+            repo=f"{owner}/{repo}",
+            backend=decision.backend,
+            category=(decision.categories or ["none"])[0] or "none",
+            outcome="dispatched_fail",
+        )
         return outcome
     finally:
         if workdir is not None:

--- a/src/caretaker/pr_reviewer/auto_fix.py
+++ b/src/caretaker/pr_reviewer/auto_fix.py
@@ -383,52 +383,41 @@ async def dispatch_auto_fix(
     tracking.auto_fix_attempts += 1
     tracking.auto_fix_last_head_sha = ""  # will be set on success below
 
-    span_cm = _tracer.start_as_current_span("auto_fix.dispatch")
-    span = span_cm.__enter__()
-    try:
+    with _tracer.start_as_current_span("auto_fix.dispatch") as span:
+        span.set_attribute("caretaker.pr.repo", f"{owner}/{repo}")
+        span.set_attribute("caretaker.pr.number", int(pr_number))
+        span.set_attribute("caretaker.auto_fix.backend", str(decision.backend))
+        span.set_attribute("caretaker.auto_fix.categories", list(decision.categories or []))
+        span.set_attribute("caretaker.auto_fix.attempt", int(tracking.auto_fix_attempts))
         try:
-            span.set_attribute("caretaker.pr.repo", f"{owner}/{repo}")
-            span.set_attribute("caretaker.pr.number", int(pr_number))
-            span.set_attribute("caretaker.auto_fix.backend", str(decision.backend))
-            span.set_attribute("caretaker.auto_fix.categories", list(decision.categories or []))
-            span.set_attribute("caretaker.auto_fix.attempt", int(tracking.auto_fix_attempts))
-        except Exception:  # pragma: no cover - defensive
-            pass
-        outcome_result = await _dispatch_auto_fix_inner(
-            decision=decision,
-            pr_url=pr_url,
-            head_branch=head_branch,
-            review=review,
-            config=config,
-            github=github,
-            owner=owner,
-            repo=repo,
-            pr_number=pr_number,
-            tracking=tracking,
-            tier=tier,
-            auto_fix_cfg=auto_fix_cfg,
-        )
-        try:
-            outcome_label = (
-                "success"
-                if outcome_result.success
-                else ("skipped" if not outcome_result.dispatched else "failed")
+            outcome_result = await _dispatch_auto_fix_inner(
+                decision=decision,
+                pr_url=pr_url,
+                head_branch=head_branch,
+                review=review,
+                config=config,
+                github=github,
+                owner=owner,
+                repo=repo,
+                pr_number=pr_number,
+                tracking=tracking,
+                tier=tier,
+                auto_fix_cfg=auto_fix_cfg,
             )
-            span.set_attribute("caretaker.auto_fix.outcome", outcome_label)
-            if outcome_result.new_head_sha:
-                span.set_attribute("caretaker.auto_fix.new_head_sha", outcome_result.new_head_sha)
-        except Exception:  # pragma: no cover
-            pass
+        except Exception as exc:
+            try:
+                span.record_exception(exc)
+                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
+            except Exception:  # pragma: no cover - defensive: never let tracer mask original
+                pass
+            raise
+        # _dispatch_auto_fix_inner always returns dispatched=True, so the
+        # outcome is binary: success or failed.
+        outcome_label = "success" if outcome_result.success else "failed"
+        span.set_attribute("caretaker.auto_fix.outcome", outcome_label)
+        if outcome_result.new_head_sha:
+            span.set_attribute("caretaker.auto_fix.new_head_sha", outcome_result.new_head_sha)
         return outcome_result
-    except Exception as exc:
-        try:
-            span.record_exception(exc)
-            span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
-        except Exception:  # pragma: no cover
-            pass
-        raise
-    finally:
-        span_cm.__exit__(None, None, None)
 
 
 async def _dispatch_auto_fix_inner(

--- a/src/caretaker/pr_reviewer/auto_fix.py
+++ b/src/caretaker/pr_reviewer/auto_fix.py
@@ -52,34 +52,25 @@ logger = logging.getLogger(__name__)
 _tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.auto_fix")
 
 
-def _record_auto_fix_skipped(repo: str, pr_number: int, reason: str, attempt: int) -> None:
-    """Fire-and-forget per-PR-decision write for an auto-fix skip branch.
+async def _record_auto_fix_skipped(repo: str, pr_number: int, reason: str, attempt: int) -> None:
+    """Per-PR-decision write for an auto-fix skip branch.
 
-    Lazy import + best-effort: never fail ``decide_auto_fix`` because
-    the timeline write threw or the loop wasn't running.
+    Lazy import keeps the Mongo helper out of the module-import hot
+    path. ``record_decision`` already swallows persistence errors, so
+    this just plain-awaits.
     """
     if not repo or pr_number <= 0:
         return
-    try:
-        from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
+    from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
 
-        asyncio.create_task(
-            record_decision(
-                repo,
-                int(pr_number),
-                "auto_fix",
-                "auto_fix_skipped",
-                reason=reason,
-                attempt=int(attempt),
-            )
-        )
-    except RuntimeError:
-        # No running loop — sync test harness. Skip silently; the
-        # structured-log line in record_decision still fires when the
-        # test eventually drives the coroutine.
-        pass
-    except Exception:  # pragma: no cover - defensive
-        logger.debug("auto_fix: record_decision dispatch failed", exc_info=True)
+    await record_decision(
+        repo,
+        int(pr_number),
+        "auto_fix",
+        "auto_fix_skipped",
+        reason=reason,
+        attempt=int(attempt),
+    )
 
 
 # Synthetic backend name handled in-process by :func:`run_deterministic_lint`
@@ -149,7 +140,7 @@ class AutoFixDecision:
     categories: list[str] | None = None
 
 
-def decide_auto_fix(
+async def decide_auto_fix(
     *,
     review: ReviewResult,
     config: AutoFixConfig,
@@ -181,17 +172,17 @@ def decide_auto_fix(
     attempt = int(tracking.auto_fix_attempts) + 1
     if not config.enabled:
         record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
-        _record_auto_fix_skipped(repo, pr_number, "auto_fix_disabled", attempt)
+        await _record_auto_fix_skipped(repo, pr_number, "auto_fix_disabled", attempt)
         return AutoFixDecision(should_dispatch=False, reason="auto_fix.enabled is False")
     if review.verdict != "REQUEST_CHANGES":
         record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
-        _record_auto_fix_skipped(repo, pr_number, f"verdict_{review.verdict}", attempt)
+        await _record_auto_fix_skipped(repo, pr_number, f"verdict_{review.verdict}", attempt)
         return AutoFixDecision(
             should_dispatch=False, reason=f"verdict {review.verdict!r} is not REQUEST_CHANGES"
         )
     if tracking.auto_fix_attempts >= config.max_attempts:
         record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
-        _record_auto_fix_skipped(repo, pr_number, "max_attempts_reached", attempt)
+        await _record_auto_fix_skipped(repo, pr_number, "max_attempts_reached", attempt)
         return AutoFixDecision(
             should_dispatch=False,
             reason=(
@@ -204,7 +195,7 @@ def decide_auto_fix(
     label_eligible = config.opt_in_label in pr_labels
     if not (author_eligible or label_eligible):
         record_auto_fix_dispatch(repo=repo, backend="none", category="none", outcome="skipped")
-        _record_auto_fix_skipped(repo, pr_number, "author_or_label_ineligible", attempt)
+        await _record_auto_fix_skipped(repo, pr_number, "author_or_label_ineligible", attempt)
         return AutoFixDecision(
             should_dispatch=False,
             reason=(
@@ -426,6 +417,8 @@ async def dispatch_auto_fix(
     # the dispatcher's hot path free of optional Mongo deps.
     from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
 
+    # Recorded BEFORE the inner work so a pod crash mid-dispatch is
+    # visible in the timeline as a dispatched-without-complete pair.
     await record_decision(
         repo_slug,
         int(pr_number),

--- a/src/caretaker/pr_reviewer/backends/_workdir.py
+++ b/src/caretaker/pr_reviewer/backends/_workdir.py
@@ -122,17 +122,15 @@ async def prepare_workdir(
     via :func:`cleanup_workdir`.
     """
     with _tracer.start_as_current_span("pr_review.clone_workdir") as span:
-        with contextlib.suppress(Exception):  # pragma: no cover - defensive
-            span.set_attribute("caretaker.pr.url", pr_url)
-            span.set_attribute("caretaker.workdir.clone_depth", int(clone_depth))
+        span.set_attribute("caretaker.pr.url", pr_url)
+        span.set_attribute("caretaker.workdir.clone_depth", int(clone_depth))
         try:
             parsed = parse_pr_url(pr_url)
             workdir = tempfile.mkdtemp(
                 prefix=f"caretaker-pr-{parsed.repo}-{parsed.number}-",
                 dir=workdir_root or None,
             )
-            with contextlib.suppress(Exception):  # pragma: no cover
-                span.set_attribute("caretaker.workdir.path", workdir)
+            span.set_attribute("caretaker.workdir.path", workdir)
             logger.info(
                 "workdir: %s for %s/%s#%d (head_branch=%s)",
                 workdir,
@@ -157,17 +155,20 @@ async def prepare_workdir(
             await _run_git("fetch", "origin", f"{pr_ref}:{local_branch}", cwd=repo_dir)
             await _run_git("checkout", local_branch, cwd=repo_dir)
 
-            # Best-effort: capture the resolved head SHA after checkout so
-            # the parent trace can correlate with the GitHub commit URL.
-            with contextlib.suppress(Exception):  # pragma: no cover - best-effort attribute
-                head_sha = await _run_git("rev-parse", "HEAD", cwd=repo_dir)
-                head_sha = head_sha.strip()
-                if head_sha:
-                    span.set_attribute("caretaker.pr.head_sha", head_sha)
+            # Capture the resolved head SHA after checkout so the parent
+            # trace can correlate with the GitHub commit URL. rev-parse on
+            # a freshly cloned + checked-out repo should not fail; if it
+            # does, that's a real bug worth surfacing via the outer
+            # exception handler below.
+            head_sha = (await _run_git("rev-parse", "HEAD", cwd=repo_dir)).strip()
+            if head_sha:
+                span.set_attribute("caretaker.pr.head_sha", head_sha)
 
             return repo_dir, parsed
         except Exception as exc:
-            with contextlib.suppress(Exception):  # pragma: no cover
+            with contextlib.suppress(
+                Exception
+            ):  # pragma: no cover - never let tracer mask original
                 span.record_exception(exc)
                 span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
             raise

--- a/src/caretaker/pr_reviewer/backends/_workdir.py
+++ b/src/caretaker/pr_reviewer/backends/_workdir.py
@@ -10,6 +10,7 @@ and a future k8s-Job mode can swap one helper instead of two.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import re
@@ -18,9 +19,15 @@ import tempfile
 import urllib.parse
 from dataclasses import dataclass
 
+from opentelemetry import trace as _otel_trace
+
 from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
 
 logger = logging.getLogger(__name__)
+
+# Module-level tracer — both review and auto-fix flows clone via this
+# helper, so a span here lets either parent trace see the clone cost.
+_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.workdir")
 
 
 class WorkdirError(RuntimeError):
@@ -114,35 +121,56 @@ async def prepare_workdir(
     Returns ``(repo_dir, parsed)``. Caller is responsible for cleanup
     via :func:`cleanup_workdir`.
     """
-    parsed = parse_pr_url(pr_url)
-    workdir = tempfile.mkdtemp(
-        prefix=f"caretaker-pr-{parsed.repo}-{parsed.number}-",
-        dir=workdir_root or None,
-    )
-    logger.info(
-        "workdir: %s for %s/%s#%d (head_branch=%s)",
-        workdir,
-        parsed.owner,
-        parsed.repo,
-        parsed.number,
-        head_branch or "<sha-only>",
-    )
+    with _tracer.start_as_current_span("pr_review.clone_workdir") as span:
+        with contextlib.suppress(Exception):  # pragma: no cover - defensive
+            span.set_attribute("caretaker.pr.url", pr_url)
+            span.set_attribute("caretaker.workdir.clone_depth", int(clone_depth))
+        try:
+            parsed = parse_pr_url(pr_url)
+            workdir = tempfile.mkdtemp(
+                prefix=f"caretaker-pr-{parsed.repo}-{parsed.number}-",
+                dir=workdir_root or None,
+            )
+            with contextlib.suppress(Exception):  # pragma: no cover
+                span.set_attribute("caretaker.workdir.path", workdir)
+            logger.info(
+                "workdir: %s for %s/%s#%d (head_branch=%s)",
+                workdir,
+                parsed.owner,
+                parsed.repo,
+                parsed.number,
+                head_branch or "<sha-only>",
+            )
 
-    repo_dir = os.path.join(workdir, "repo")
-    await _run_git(
-        "clone",
-        "--depth",
-        str(clone_depth),
-        "--quiet",
-        clone_url(parsed, github_token=github_token),
-        repo_dir,
-    )
+            repo_dir = os.path.join(workdir, "repo")
+            await _run_git(
+                "clone",
+                "--depth",
+                str(clone_depth),
+                "--quiet",
+                clone_url(parsed, github_token=github_token),
+                repo_dir,
+            )
 
-    pr_ref = f"refs/pull/{parsed.number}/head"
-    local_branch = head_branch or "caretaker/pr-head"
-    await _run_git("fetch", "origin", f"{pr_ref}:{local_branch}", cwd=repo_dir)
-    await _run_git("checkout", local_branch, cwd=repo_dir)
-    return repo_dir, parsed
+            pr_ref = f"refs/pull/{parsed.number}/head"
+            local_branch = head_branch or "caretaker/pr-head"
+            await _run_git("fetch", "origin", f"{pr_ref}:{local_branch}", cwd=repo_dir)
+            await _run_git("checkout", local_branch, cwd=repo_dir)
+
+            # Best-effort: capture the resolved head SHA after checkout so
+            # the parent trace can correlate with the GitHub commit URL.
+            with contextlib.suppress(Exception):  # pragma: no cover - best-effort attribute
+                head_sha = await _run_git("rev-parse", "HEAD", cwd=repo_dir)
+                head_sha = head_sha.strip()
+                if head_sha:
+                    span.set_attribute("caretaker.pr.head_sha", head_sha)
+
+            return repo_dir, parsed
+        except Exception as exc:
+            with contextlib.suppress(Exception):  # pragma: no cover
+                span.record_exception(exc)
+                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
+            raise
 
 
 def cleanup_workdir(repo_dir: str, *, keep: bool = False) -> None:

--- a/src/caretaker/pr_reviewer/backends/_workdir.py
+++ b/src/caretaker/pr_reviewer/backends/_workdir.py
@@ -19,15 +19,14 @@ import tempfile
 import urllib.parse
 from dataclasses import dataclass
 
-from opentelemetry import trace as _otel_trace
-
+from caretaker.observability.tracer_compat import Status, StatusCode, get_tracer
 from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
 
 logger = logging.getLogger(__name__)
 
 # Module-level tracer — both review and auto-fix flows clone via this
 # helper, so a span here lets either parent trace see the clone cost.
-_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.workdir")
+_tracer = get_tracer("caretaker.pr_reviewer.workdir")
 
 
 class WorkdirError(RuntimeError):
@@ -170,7 +169,7 @@ async def prepare_workdir(
                 Exception
             ):  # pragma: no cover - never let tracer mask original
                 span.record_exception(exc)
-                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
+                span.set_status(Status(StatusCode.ERROR, str(exc)[:200]))
             raise
 
 

--- a/src/caretaker/pr_reviewer/backends/opencode_local.py
+++ b/src/caretaker/pr_reviewer/backends/opencode_local.py
@@ -193,9 +193,8 @@ async def _invoke_opencode(
     output and search for the ``caretaker-review`` block.
     """
     with _tracer.start_as_current_span("opencode_local.invoke") as span:
-        with contextlib.suppress(Exception):  # pragma: no cover - defensive
-            span.set_attribute("caretaker.opencode.workdir", workdir)
-            span.set_attribute("caretaker.opencode.timeout_seconds", int(config.timeout_seconds))
+        span.set_attribute("caretaker.opencode.workdir", workdir)
+        span.set_attribute("caretaker.opencode.timeout_seconds", int(config.timeout_seconds))
 
         resolved = shutil.which(config.cli_path) or config.cli_path
         if not os.path.isabs(resolved) and not shutil.which(resolved):
@@ -205,8 +204,10 @@ async def _invoke_opencode(
                 "pr_reviewer.opencode_local.cli_path). "
                 "Requires OPENROUTER_API_KEY in the environment."
             )
-            with contextlib.suppress(Exception):  # pragma: no cover
-                span.set_attribute("caretaker.opencode.outcome", "error")
+            span.set_attribute("caretaker.opencode.outcome", "error")
+            with contextlib.suppress(
+                Exception
+            ):  # pragma: no cover - never let tracer mask original
                 span.record_exception(exc)
                 span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
             raise exc
@@ -216,8 +217,7 @@ async def _invoke_opencode(
             env.update(config.extra_env)
 
         model = model_override or config.model
-        with contextlib.suppress(Exception):  # pragma: no cover
-            span.set_attribute("caretaker.opencode.model", str(model or ""))
+        span.set_attribute("caretaker.opencode.model", str(model or ""))
         # opencode CLI uses ``run`` as the non-interactive subcommand. The
         # ``-p`` flag (claude-style) just prints help. ``run`` accepts the
         # prompt as a positional and ``--model`` to pin the provider/model.
@@ -249,15 +249,16 @@ async def _invoke_opencode(
             timeout_err = OpenCodeLocalTimeoutError(
                 f"opencode timed out after {config.timeout_seconds}s"
             )
-            with contextlib.suppress(Exception):  # pragma: no cover
-                span.set_attribute("caretaker.opencode.outcome", "timeout")
+            span.set_attribute("caretaker.opencode.outcome", "timeout")
+            with contextlib.suppress(
+                Exception
+            ):  # pragma: no cover - never let tracer mask original
                 span.record_exception(timeout_err)
                 span.set_status(
                     _otel_trace.Status(_otel_trace.StatusCode.ERROR, str(timeout_err)[:200])
                 )
             raise timeout_err from exc
-        with contextlib.suppress(Exception):  # pragma: no cover
-            span.set_attribute("caretaker.opencode.exit_code", int(proc.returncode or 0))
+        span.set_attribute("caretaker.opencode.exit_code", int(proc.returncode or 0))
         if proc.returncode != 0:
             # Special-case: opencode emits ``No endpoints found`` when the
             # configured provider (OpenRouter) hasn't been wired up. We
@@ -268,8 +269,10 @@ async def _invoke_opencode(
                     f"opencode exited {proc.returncode} with No endpoints found "
                     f"(check OPENROUTER_API_KEY / model id): {stderr.strip()[:500]}"
                 )
-                with contextlib.suppress(Exception):  # pragma: no cover
-                    span.set_attribute("caretaker.opencode.outcome", "no_endpoints")
+                span.set_attribute("caretaker.opencode.outcome", "no_endpoints")
+                with contextlib.suppress(
+                    Exception
+                ):  # pragma: no cover - never let tracer mask original
                     span.record_exception(no_ep_err)
                     span.set_status(
                         _otel_trace.Status(_otel_trace.StatusCode.ERROR, str(no_ep_err)[:200])
@@ -278,15 +281,16 @@ async def _invoke_opencode(
             err = OpenCodeLocalError(
                 f"opencode exited {proc.returncode}: {stderr.strip() or stdout.strip()[:500]}"
             )
-            with contextlib.suppress(Exception):  # pragma: no cover
-                span.set_attribute("caretaker.opencode.outcome", "error")
+            span.set_attribute("caretaker.opencode.outcome", "error")
+            with contextlib.suppress(
+                Exception
+            ):  # pragma: no cover - never let tracer mask original
                 span.record_exception(err)
                 span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(err)[:200]))
             raise err
-        with contextlib.suppress(Exception):  # pragma: no cover
-            # Subprocess exited cleanly. parse_fallback (if any) is determined
-            # by :func:`run`'s output parser, not this span — see module docstring.
-            span.set_attribute("caretaker.opencode.outcome", "ok")
+        # Subprocess exited cleanly. parse_fallback (if any) is determined
+        # by :func:`run`'s output parser, not this span — see module docstring.
+        span.set_attribute("caretaker.opencode.outcome", "ok")
         return stdout
 
 

--- a/src/caretaker/pr_reviewer/backends/opencode_local.py
+++ b/src/caretaker/pr_reviewer/backends/opencode_local.py
@@ -543,15 +543,21 @@ async def run(
 
     # Lazy import — keep the per-PR-decision helper out of the
     # top-level import path so the backend module stays cheap to load.
-    from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
+    from caretaker.state.pr_decisions import DecisionEvent, record_decision  # noqa: PLC0415
 
+    # Parse the PR URL once up front. ``prepare_workdir`` parses the
+    # same URL internally, but we need ``(repo_slug, pr_number)`` for
+    # the per-PR-decision writes BEFORE workdir prep, and re-parsing
+    # the URL at every call site is wasteful.
     repo_slug, pr_number = _extract_repo_and_pr(pr_url)
 
-    async def _record(event: str, **fields: object) -> None:
+    async def _record(event: DecisionEvent, **fields: object) -> None:
         if not repo_slug or pr_number <= 0:
             return
         await record_decision(repo_slug, pr_number, "opencode_local", event, **fields)
 
+    # Recorded BEFORE _prepare_workdir succeeds so workdir-prep
+    # failures show as started+failed rather than missing entirely.
     await _record(
         "opencode_review_started",
         model=review_model,

--- a/src/caretaker/pr_reviewer/backends/opencode_local.py
+++ b/src/caretaker/pr_reviewer/backends/opencode_local.py
@@ -540,6 +540,24 @@ async def run(
     workdir: str | None = None
     success = False
     review_model = _resolve_tier_model(tier, tier_map=config.review_models, default=config.model)
+
+    # Lazy import — keep the per-PR-decision helper out of the
+    # top-level import path so the backend module stays cheap to load.
+    from caretaker.state.pr_decisions import record_decision  # noqa: PLC0415
+
+    repo_slug, pr_number = _extract_repo_and_pr(pr_url)
+
+    async def _record(event: str, **fields: object) -> None:
+        if not repo_slug or pr_number <= 0:
+            return
+        await record_decision(repo_slug, pr_number, "opencode_local", event, **fields)
+
+    await _record(
+        "opencode_review_started",
+        model=review_model,
+        tier=str(tier) if tier else "none",
+        workdir=workdir or "",
+    )
     try:
         workdir, _parsed = await _prepare_workdir(pr_url, config=config)
         stdout = await _invoke_opencode(
@@ -558,22 +576,68 @@ async def run(
             mode="review",
             outcome="parse_fallback" if used_fallback else "ok",
         )
+        await _record(
+            "opencode_review_finished",
+            model=review_model,
+            verdict=str(result.verdict),
+            fallback_parse=bool(used_fallback),
+        )
         return result
-    except OpenCodeLocalTimeoutError:
+    except OpenCodeLocalTimeoutError as exc:
         record_opencode_invocation(model=review_model, mode="review", outcome="timeout")
+        await _record(
+            "opencode_review_failed",
+            model=review_model,
+            error_kind="timeout",
+            error_message=str(exc),
+        )
         raise
-    except OpenCodeLocalNoEndpointsError:
+    except OpenCodeLocalNoEndpointsError as exc:
         record_opencode_invocation(model=review_model, mode="review", outcome="no_endpoints")
+        await _record(
+            "opencode_review_failed",
+            model=review_model,
+            error_kind="no_endpoints",
+            error_message=str(exc),
+        )
         raise
     except WorkdirError as exc:
         record_opencode_invocation(model=review_model, mode="review", outcome="error")
+        await _record(
+            "opencode_review_failed",
+            model=review_model,
+            error_kind="workdir_error",
+            error_message=str(exc),
+        )
         raise OpenCodeLocalError(str(exc)) from exc
-    except Exception:
+    except Exception as exc:
         record_opencode_invocation(model=review_model, mode="review", outcome="error")
+        await _record(
+            "opencode_review_failed",
+            model=review_model,
+            error_kind=type(exc).__name__,
+            error_message=str(exc)[:500],
+        )
         raise
     finally:
         if workdir is not None:
             cleanup_workdir(workdir, keep=(not success and config.keep_workdir_on_failure))
+
+
+def _extract_repo_and_pr(pr_url: str) -> tuple[str, int]:
+    """Best-effort parse of ``pr_url`` into ``(owner/repo, pr_number)``.
+
+    Used only to attribute decision-timeline records — the parser used
+    by :func:`run` may already have parsed this, but plumbing that
+    object through every callsite is out of scope. Returns
+    ``("", 0)`` when the URL can't be parsed so the timeline write
+    silently skips rather than crashing the review.
+    """
+    try:
+        parsed = parse_pr_url(pr_url)
+        return f"{parsed.owner}/{parsed.repo}", int(parsed.number)
+    except Exception:  # pragma: no cover - defensive
+        return "", 0
 
 
 _FIX_PROMPT_TEMPLATE = """\

--- a/src/caretaker/pr_reviewer/backends/opencode_local.py
+++ b/src/caretaker/pr_reviewer/backends/opencode_local.py
@@ -43,7 +43,7 @@ from typing import TYPE_CHECKING
 
 from opentelemetry import trace as _otel_trace
 
-from caretaker.observability.metrics import record_opencode_invocation
+from caretaker.observability.metrics import record_llm_usage, record_opencode_invocation
 from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
 from caretaker.pr_reviewer.backends._workdir import (
     WorkdirError,
@@ -178,6 +178,78 @@ def _truncate(line: str, max_len: int) -> str:
     return line[:max_len] + f"… ({len(line) - max_len} more chars)"
 
 
+def _parse_opencode_json_stream(
+    stdout: str,
+) -> tuple[str, int, int]:
+    """Parse opencode ``--format json`` stdout into (text, prompt_tokens, completion_tokens).
+
+    opencode emits one JSON object per line on stdout when invoked with
+    ``--format json``.  Three event types matter for our purposes:
+
+    * ``text``       — fragments of the assistant's response. We
+      concatenate the ``part.text`` strings in stream order to
+      reconstruct the prose+JSON-block payload the existing parser
+      expects.
+    * ``step_finish`` — emitted at the end of each agent step with a
+      ``part.tokens`` object: ``{input, output, reasoning, cache: {read, write}}``.
+      We sum ``input`` (with cache reads added back in — those are
+      still input tokens that count against the operator's bill) and
+      ``output + reasoning`` for prompt vs. completion tokens.
+    * everything else (tool_use, step_start, error, …) is ignored for
+      token-accounting purposes.
+
+    Lines that don't parse as JSON are silently skipped — opencode
+    sometimes emits a final ANSI-colored summary line on stdout even
+    in JSON mode (the ``> build · …`` banner), and we don't want a
+    parse failure there to fail the whole invocation.
+    """
+    text_parts: list[str] = []
+    prompt_tokens = 0
+    completion_tokens = 0
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            evt = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(evt, dict):
+            continue
+        evt_type = evt.get("type")
+        part = evt.get("part") if isinstance(evt.get("part"), dict) else {}
+        if evt_type == "text":
+            txt = part.get("text") if isinstance(part, dict) else None
+            if isinstance(txt, str):
+                text_parts.append(txt)
+        elif evt_type == "step_finish":
+            tokens = part.get("tokens") if isinstance(part, dict) else None
+            if not isinstance(tokens, dict):
+                continue
+            inp = tokens.get("input") or 0
+            out = tokens.get("output") or 0
+            reasoning = tokens.get("reasoning") or 0
+            cache = tokens.get("cache") if isinstance(tokens.get("cache"), dict) else {}
+            cache_read = cache.get("read") or 0 if isinstance(cache, dict) else 0
+            cache_write = cache.get("write") or 0 if isinstance(cache, dict) else 0
+            # ``input`` from opencode excludes cache reads/writes when
+            # caching is in use; we add them back so the prompt-token
+            # count matches what the provider actually billed.  Reasoning
+            # tokens are part of the model's output bill, so they go on
+            # the completion side.
+            if isinstance(inp, int | float):
+                prompt_tokens += int(inp)
+            if isinstance(cache_read, int | float):
+                prompt_tokens += int(cache_read)
+            if isinstance(cache_write, int | float):
+                prompt_tokens += int(cache_write)
+            if isinstance(out, int | float):
+                completion_tokens += int(out)
+            if isinstance(reasoning, int | float):
+                completion_tokens += int(reasoning)
+    return "".join(text_parts), prompt_tokens, completion_tokens
+
+
 async def _invoke_opencode(
     *,
     workdir: str,
@@ -185,12 +257,18 @@ async def _invoke_opencode(
     prompt: str = "",
     model_override: str = "",
 ) -> str:
-    """Spawn the opencode CLI in ``workdir`` and return its stdout text.
+    """Spawn the opencode CLI in ``workdir`` and return the assistant text.
 
-    opencode runs in print mode (``-p``): it sends the prompt, runs the
-    agent, and emits the final response to stdout when done. Unlike the
-    claude stream-json mode, this is plain text — we capture the full
-    output and search for the ``caretaker-review`` block.
+    opencode is invoked with ``--format json`` so each agent event lands
+    on stdout as a JSON object on its own line. We assemble the
+    assistant's prose + ``caretaker-review`` JSON block from the
+    ``text`` events and sum prompt/completion token counts from the
+    ``step_finish`` events for cost-tracking metrics.
+
+    The default-format banner output (``> build · …``) is replaced with
+    the structured event stream; the existing ``_parse_review_payload``
+    contract still receives a plain text string and looks for the
+    ``caretaker-review`` fence in it.
     """
     with _tracer.start_as_current_span("opencode_local.invoke") as span:
         span.set_attribute("caretaker.opencode.workdir", workdir)
@@ -218,10 +296,11 @@ async def _invoke_opencode(
 
         model = model_override or config.model
         span.set_attribute("caretaker.opencode.model", str(model or ""))
-        # opencode CLI uses ``run`` as the non-interactive subcommand. The
-        # ``-p`` flag (claude-style) just prints help. ``run`` accepts the
-        # prompt as a positional and ``--model`` to pin the provider/model.
-        args = [resolved, "run", prompt or _REVIEW_PROMPT]
+        # opencode CLI uses ``run`` as the non-interactive subcommand.
+        # ``--format json`` emits one event per stdout line which gives
+        # us per-step token counts for the cost-tracking metrics; the
+        # assistant text is reassembled by ``_parse_opencode_json_stream``.
+        args = [resolved, "run", prompt or _REVIEW_PROMPT, "--format", "json"]
         if model:
             args += ["--model", model]
 
@@ -288,10 +367,44 @@ async def _invoke_opencode(
                 span.record_exception(err)
                 span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(err)[:200]))
             raise err
+
         # Subprocess exited cleanly. parse_fallback (if any) is determined
         # by :func:`run`'s output parser, not this span — see module docstring.
         span.set_attribute("caretaker.opencode.outcome", "ok")
-        return stdout
+
+        # Parse the JSON event stream into (assistant_text, p_tokens, c_tokens).
+        # Token-extraction failures must NOT fail the run — log at DEBUG
+        # and fall back to the raw stdout. The assistant text *should*
+        # always parse out of the stream, but if opencode ever changes
+        # its output format we still want the review to land.
+        try:
+            assistant_text, prompt_tokens, completion_tokens = _parse_opencode_json_stream(stdout)
+        except Exception:  # pragma: no cover - defence in depth
+            logger.debug(
+                "opencode_local: token extraction from JSON stream failed; returning raw stdout",
+                exc_info=True,
+            )
+            return stdout
+
+        if prompt_tokens > 0 or completion_tokens > 0:
+            span.set_attribute("caretaker.llm.prompt_tokens", prompt_tokens)
+            span.set_attribute("caretaker.llm.completion_tokens", completion_tokens)
+            with contextlib.suppress(Exception):
+                record_llm_usage(
+                    model=model or "unknown",
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                )
+        else:
+            logger.debug(
+                "opencode_local: no token usage extracted from JSON stream "
+                "(model=%s); skipping LLM usage metrics",
+                model,
+            )
+
+        # Fall back to raw stdout if no text events appeared — keeps the
+        # downstream parser robust against an unusual opencode reply.
+        return assistant_text or stdout
 
 
 _RESULT_TEXT_RE = re.compile(r"```caretaker-review\s*\n(?P<json>.+?)\n\s*```", re.DOTALL)

--- a/src/caretaker/pr_reviewer/backends/opencode_local.py
+++ b/src/caretaker/pr_reviewer/backends/opencode_local.py
@@ -41,9 +41,8 @@ import re
 import shutil
 from typing import TYPE_CHECKING
 
-from opentelemetry import trace as _otel_trace
-
 from caretaker.observability.metrics import record_llm_usage, record_opencode_invocation
+from caretaker.observability.tracer_compat import Status, StatusCode, get_tracer
 from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
 from caretaker.pr_reviewer.backends._workdir import (
     WorkdirError,
@@ -68,7 +67,7 @@ logger = logging.getLogger(__name__)
 # outcome. Note: the ``parse_fallback`` outcome is a property of
 # :func:`run` (output-parsing), NOT this span — this span only reports
 # the subprocess result (ok/timeout/no_endpoints/error).
-_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.opencode_local")
+_tracer = get_tracer("caretaker.pr_reviewer.opencode_local")
 
 
 def _resolve_tier_model(
@@ -287,7 +286,7 @@ async def _invoke_opencode(
                 Exception
             ):  # pragma: no cover - never let tracer mask original
                 span.record_exception(exc)
-                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
+                span.set_status(Status(StatusCode.ERROR, str(exc)[:200]))
             raise exc
 
         env = os.environ.copy()
@@ -347,9 +346,7 @@ async def _invoke_opencode(
                 Exception
             ):  # pragma: no cover - never let tracer mask original
                 span.record_exception(timeout_err)
-                span.set_status(
-                    _otel_trace.Status(_otel_trace.StatusCode.ERROR, str(timeout_err)[:200])
-                )
+                span.set_status(Status(StatusCode.ERROR, str(timeout_err)[:200]))
             raise timeout_err from exc
         span.set_attribute("caretaker.opencode.exit_code", int(proc.returncode or 0))
         if proc.returncode != 0:
@@ -367,9 +364,7 @@ async def _invoke_opencode(
                     Exception
                 ):  # pragma: no cover - never let tracer mask original
                     span.record_exception(no_ep_err)
-                    span.set_status(
-                        _otel_trace.Status(_otel_trace.StatusCode.ERROR, str(no_ep_err)[:200])
-                    )
+                    span.set_status(Status(StatusCode.ERROR, str(no_ep_err)[:200]))
                 raise no_ep_err
             err = OpenCodeLocalError(
                 f"opencode exited {proc.returncode}: {stderr.strip() or stdout.strip()[:500]}"
@@ -379,7 +374,7 @@ async def _invoke_opencode(
                 Exception
             ):  # pragma: no cover - never let tracer mask original
                 span.record_exception(err)
-                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(err)[:200]))
+                span.set_status(Status(StatusCode.ERROR, str(err)[:200]))
             raise err
 
         # Subprocess exited cleanly. parse_fallback (if any) is determined

--- a/src/caretaker/pr_reviewer/backends/opencode_local.py
+++ b/src/caretaker/pr_reviewer/backends/opencode_local.py
@@ -317,11 +317,25 @@ async def _invoke_opencode(
             stderr=asyncio.subprocess.PIPE,
             env=env,
         )
+
+        # Classifier: ``--format json`` emits 100-500 JSON events per
+        # review; logging every ``text``/``tool_use_*`` line at INFO
+        # turns pod logs into noise. Demote those event types to DEBUG
+        # while keeping step boundaries (``step_start``/``step_finish``),
+        # errors, and any non-JSON banner output at INFO so operators
+        # still see review progress live.
+        def _stdout_log(line: str) -> None:
+            stripped = line.lstrip()
+            if stripped.startswith('{"type":"text"') or stripped.startswith('{"type":"tool_'):
+                logger.debug("opencode | %s", _truncate(line, 400))
+            else:
+                logger.info("opencode | %s", _truncate(line, 400))
+
         try:
             stdout, stderr = await stream_subprocess_output(
                 proc,
                 timeout_seconds=config.timeout_seconds,
-                stdout_log=lambda line: logger.info("opencode | %s", _truncate(line, 400)),
+                stdout_log=_stdout_log,
                 stderr_log=lambda line: logger.warning("opencode! %s", line),
             )
         except TimeoutError as exc:
@@ -389,12 +403,19 @@ async def _invoke_opencode(
         if prompt_tokens > 0 or completion_tokens > 0:
             span.set_attribute("caretaker.llm.prompt_tokens", prompt_tokens)
             span.set_attribute("caretaker.llm.completion_tokens", completion_tokens)
-            with contextlib.suppress(Exception):
+            # ``record_llm_tokens`` and ``record_llm_cost`` already handle
+            # their own failure modes (lazy-import wrap, isinstance guards),
+            # so we don't blanket-suppress here. A narrow except keeps any
+            # truly surprising regression visible at DEBUG instead of
+            # silently swallowed.
+            try:
                 record_llm_usage(
                     model=model or "unknown",
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                 )
+            except Exception:  # pragma: no cover - defence in depth
+                logger.debug("metrics: record_llm_usage failed", exc_info=True)
         else:
             logger.debug(
                 "opencode_local: no token usage extracted from JSON stream "

--- a/src/caretaker/pr_reviewer/backends/opencode_local.py
+++ b/src/caretaker/pr_reviewer/backends/opencode_local.py
@@ -40,6 +40,7 @@ import re
 import shutil
 from typing import TYPE_CHECKING
 
+from caretaker.observability.metrics import record_opencode_invocation
 from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
 from caretaker.pr_reviewer.backends._workdir import (
     WorkdirError,
@@ -78,6 +79,19 @@ def _resolve_tier_model(
 
 class OpenCodeLocalError(RuntimeError):
     """Raised when the local opencode CLI run fails (clone, invocation, parse)."""
+
+
+class OpenCodeLocalTimeoutError(OpenCodeLocalError):
+    """Raised specifically when the opencode subprocess timed out."""
+
+
+class OpenCodeLocalNoEndpointsError(OpenCodeLocalError):
+    """Raised when opencode reports ``No endpoints found`` (provider misconfig).
+
+    Distinguished from generic ``OpenCodeLocalError`` so the metrics
+    layer can attribute the failure to the right outcome bucket without
+    string-matching stderr at every callsite.
+    """
 
 
 def _parse_pr_url_wrapped(pr_url: str):  # type: ignore[no-untyped-def]
@@ -210,8 +224,19 @@ async def _invoke_opencode(
             stderr_log=lambda line: logger.warning("opencode! %s", line),
         )
     except TimeoutError as exc:
-        raise OpenCodeLocalError(f"opencode timed out after {config.timeout_seconds}s") from exc
+        raise OpenCodeLocalTimeoutError(
+            f"opencode timed out after {config.timeout_seconds}s"
+        ) from exc
     if proc.returncode != 0:
+        # Special-case: opencode emits ``No endpoints found`` when the
+        # configured provider (OpenRouter) hasn't been wired up. We
+        # surface this as its own exception type so the caller can
+        # record a specific ``no_endpoints`` outcome on the metric.
+        if "No endpoints found" in stderr:
+            raise OpenCodeLocalNoEndpointsError(
+                f"opencode exited {proc.returncode} with No endpoints found "
+                f"(check OPENROUTER_API_KEY / model id): {stderr.strip()[:500]}"
+            )
         raise OpenCodeLocalError(
             f"opencode exited {proc.returncode}: {stderr.strip() or stdout.strip()[:500]}"
         )
@@ -230,10 +255,17 @@ def _parse_review_payload(assistant_text: str) -> ReviewResult:
     match = _RESULT_TEXT_RE.search(assistant_text)
     if not match:
         logger.warning(
-            "opencode_local: no caretaker-review JSON block in opencode reply; "
-            "wrapping the prose as a COMMENT review (length=%d)",
+            "opencode_local: fallback parse used — structured caretaker-review JSON missing. "
+            "stdout_bytes=%d sample=%r",
             len(assistant_text),
+            assistant_text[:200],
         )
+        # Record under unknown model/mode because _parse_review_payload
+        # doesn't see those args; the caller (run / fix_run) will record
+        # the corresponding outcome with the real model + mode. This
+        # extra increment guarantees the warning is paired with a
+        # counter even if a future caller forgets to wrap.
+        record_opencode_invocation(model="<unknown>", mode="<unknown>", outcome="parse_fallback")
         return ReviewResult(
             summary=(
                 "**Review by opencode_local (fallback parse)**\n\n"
@@ -317,6 +349,11 @@ async def run(
     workdir: str | None = None
     success = False
     review_model = _resolve_tier_model(tier, tier_map=config.review_models, default=config.model)
+    # Track whether _parse_review_payload took the fallback path so we
+    # record the right outcome AROUND the invoke. The fallback parse
+    # itself fires a counter; we still want the run-level invocation
+    # outcome to reflect "parse_fallback" rather than "ok".
+    used_fallback = False
     try:
         workdir, _parsed = await _prepare_workdir(pr_url, config=config)
         stdout = await _invoke_opencode(
@@ -325,11 +362,30 @@ async def run(
             prompt=_REVIEW_PROMPT,
             model_override=review_model,
         )
+        # If the structured JSON block is missing, _parse_review_payload
+        # already logged + recorded the parse_fallback counter; we
+        # record the run-level outcome to match.
+        if _RESULT_TEXT_RE.search(stdout) is None:
+            used_fallback = True
         result = _parse_review_payload(stdout)
         success = True
+        if not used_fallback:
+            record_opencode_invocation(model=review_model, mode="review", outcome="ok")
+        else:
+            record_opencode_invocation(model=review_model, mode="review", outcome="parse_fallback")
         return result
+    except OpenCodeLocalTimeoutError:
+        record_opencode_invocation(model=review_model, mode="review", outcome="timeout")
+        raise
+    except OpenCodeLocalNoEndpointsError:
+        record_opencode_invocation(model=review_model, mode="review", outcome="no_endpoints")
+        raise
     except WorkdirError as exc:
+        record_opencode_invocation(model=review_model, mode="review", outcome="error")
         raise OpenCodeLocalError(str(exc)) from exc
+    except Exception:
+        record_opencode_invocation(model=review_model, mode="review", outcome="error")
+        raise
     finally:
         if workdir is not None:
             cleanup_workdir(workdir, keep=(not success and config.keep_workdir_on_failure))
@@ -404,12 +460,24 @@ async def fix_run(
         tier_map=getattr(config, "fix_models", {}),
         default=getattr(config, "fix_model", "") or config.model,
     )
-    stdout = await _invoke_opencode(
-        workdir=workdir,
-        config=config,
-        prompt=prompt,
-        model_override=fix_model,
-    )
+    try:
+        stdout = await _invoke_opencode(
+            workdir=workdir,
+            config=config,
+            prompt=prompt,
+            model_override=fix_model,
+        )
+    except OpenCodeLocalTimeoutError:
+        record_opencode_invocation(model=fix_model, mode="fix", outcome="timeout")
+        raise
+    except OpenCodeLocalNoEndpointsError:
+        record_opencode_invocation(model=fix_model, mode="fix", outcome="no_endpoints")
+        raise
+    except Exception:
+        record_opencode_invocation(model=fix_model, mode="fix", outcome="error")
+        raise
+
+    record_opencode_invocation(model=fix_model, mode="fix", outcome="ok")
     text = stdout.strip()
     if text.startswith("CARETAKER_FIX_DECLINED:"):
         raise OpenCodeLocalError(f"opencode declined to fix: {text}")

--- a/src/caretaker/pr_reviewer/backends/opencode_local.py
+++ b/src/caretaker/pr_reviewer/backends/opencode_local.py
@@ -246,8 +246,14 @@ async def _invoke_opencode(
 _RESULT_TEXT_RE = re.compile(r"```caretaker-review\s*\n(?P<json>.+?)\n\s*```", re.DOTALL)
 
 
-def _parse_review_payload(assistant_text: str) -> ReviewResult:
+def _parse_review_payload(assistant_text: str) -> tuple[ReviewResult, bool]:
     """Find the ``caretaker-review`` JSON block; fall back to a generic COMMENT review.
+
+    Returns ``(result, was_fallback)`` so the caller can record the
+    parse-fallback outcome with the real model + mode labels (instead
+    of double-counting via an in-function metric increment that loses
+    label fidelity). The WARNING log stays here — that's still useful
+    for log-based alerting independent of the metric.
 
     The fallback ensures a noisy or non-conforming opencode reply still
     produces *some* review on the PR rather than dropping the work.
@@ -260,21 +266,18 @@ def _parse_review_payload(assistant_text: str) -> ReviewResult:
             len(assistant_text),
             assistant_text[:200],
         )
-        # Record under unknown model/mode because _parse_review_payload
-        # doesn't see those args; the caller (run / fix_run) will record
-        # the corresponding outcome with the real model + mode. This
-        # extra increment guarantees the warning is paired with a
-        # counter even if a future caller forgets to wrap.
-        record_opencode_invocation(model="<unknown>", mode="<unknown>", outcome="parse_fallback")
-        return ReviewResult(
-            summary=(
-                "**Review by opencode_local (fallback parse)**\n\n"
-                "opencode did not emit a structured `caretaker-review` JSON block; "
-                "its prose response is included below.\n\n"
-                f"{assistant_text.strip()[:4000]}"
+        return (
+            ReviewResult(
+                summary=(
+                    "**Review by opencode_local (fallback parse)**\n\n"
+                    "opencode did not emit a structured `caretaker-review` JSON block; "
+                    "its prose response is included below.\n\n"
+                    f"{assistant_text.strip()[:4000]}"
+                ),
+                verdict="COMMENT",
+                comments=[],
             ),
-            verdict="COMMENT",
-            comments=[],
+            True,
         )
     raw = match.group("json").strip()
     try:
@@ -329,8 +332,11 @@ def _parse_review_payload(assistant_text: str) -> ReviewResult:
         "(opencode CLI in caretaker's pod)**\n\n"
         f"{summary or 'opencode returned no summary text.'}"
     )
-    return ReviewResult(
-        summary=body, verdict=verdict, comments=comments, issue_categories=issue_categories
+    return (
+        ReviewResult(
+            summary=body, verdict=verdict, comments=comments, issue_categories=issue_categories
+        ),
+        False,
     )
 
 
@@ -349,11 +355,6 @@ async def run(
     workdir: str | None = None
     success = False
     review_model = _resolve_tier_model(tier, tier_map=config.review_models, default=config.model)
-    # Track whether _parse_review_payload took the fallback path so we
-    # record the right outcome AROUND the invoke. The fallback parse
-    # itself fires a counter; we still want the run-level invocation
-    # outcome to reflect "parse_fallback" rather than "ok".
-    used_fallback = False
     try:
         workdir, _parsed = await _prepare_workdir(pr_url, config=config)
         stdout = await _invoke_opencode(
@@ -362,17 +363,16 @@ async def run(
             prompt=_REVIEW_PROMPT,
             model_override=review_model,
         )
-        # If the structured JSON block is missing, _parse_review_payload
-        # already logged + recorded the parse_fallback counter; we
-        # record the run-level outcome to match.
-        if _RESULT_TEXT_RE.search(stdout) is None:
-            used_fallback = True
-        result = _parse_review_payload(stdout)
+        # ``_parse_review_payload`` returns a (result, was_fallback)
+        # tuple so we record the outcome exactly once with the real
+        # model + mode labels (no in-function double-count).
+        result, used_fallback = _parse_review_payload(stdout)
         success = True
-        if not used_fallback:
-            record_opencode_invocation(model=review_model, mode="review", outcome="ok")
-        else:
-            record_opencode_invocation(model=review_model, mode="review", outcome="parse_fallback")
+        record_opencode_invocation(
+            model=review_model,
+            mode="review",
+            outcome="parse_fallback" if used_fallback else "ok",
+        )
         return result
     except OpenCodeLocalTimeoutError:
         record_opencode_invocation(model=review_model, mode="review", outcome="timeout")
@@ -477,10 +477,14 @@ async def fix_run(
         record_opencode_invocation(model=fix_model, mode="fix", outcome="error")
         raise
 
-    record_opencode_invocation(model=fix_model, mode="fix", outcome="ok")
+    # Inspect the in-band sentinel BEFORE recording the outcome so a
+    # decline doesn't pollute the success rate. ``declined`` is its
+    # own outcome bucket — see :data:`OPENCODE_OUTCOMES`.
     text = stdout.strip()
     if text.startswith("CARETAKER_FIX_DECLINED:"):
+        record_opencode_invocation(model=fix_model, mode="fix", outcome="declined")
         raise OpenCodeLocalError(f"opencode declined to fix: {text}")
+    record_opencode_invocation(model=fix_model, mode="fix", outcome="ok")
     return text or "(no summary)"
 
 

--- a/src/caretaker/pr_reviewer/backends/opencode_local.py
+++ b/src/caretaker/pr_reviewer/backends/opencode_local.py
@@ -33,12 +33,15 @@ opencode CLI non-interactive mode:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
 import re
 import shutil
 from typing import TYPE_CHECKING
+
+from opentelemetry import trace as _otel_trace
 
 from caretaker.observability.metrics import record_opencode_invocation
 from caretaker.pr_reviewer.backends._subprocess_streaming import stream_subprocess_output
@@ -59,6 +62,13 @@ if TYPE_CHECKING:
     from caretaker.pr_reviewer.complexity_classifier import ComplexityTier
 
 logger = logging.getLogger(__name__)
+
+# Module-level tracer — wraps each opencode subprocess invocation so the
+# parent ``pr_reviewer.handle_pr`` trace shows model + exit_code +
+# outcome. Note: the ``parse_fallback`` outcome is a property of
+# :func:`run` (output-parsing), NOT this span — this span only reports
+# the subprocess result (ok/timeout/no_endpoints/error).
+_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.opencode_local")
 
 
 def _resolve_tier_model(
@@ -182,65 +192,102 @@ async def _invoke_opencode(
     claude stream-json mode, this is plain text — we capture the full
     output and search for the ``caretaker-review`` block.
     """
-    resolved = shutil.which(config.cli_path) or config.cli_path
-    if not os.path.isabs(resolved) and not shutil.which(resolved):
-        raise OpenCodeLocalError(
-            f"opencode CLI not found at {config.cli_path!r}; install it "
-            "(`npm install -g opencode-ai` or pin a path in "
-            "pr_reviewer.opencode_local.cli_path). "
-            "Requires OPENROUTER_API_KEY in the environment."
-        )
+    with _tracer.start_as_current_span("opencode_local.invoke") as span:
+        with contextlib.suppress(Exception):  # pragma: no cover - defensive
+            span.set_attribute("caretaker.opencode.workdir", workdir)
+            span.set_attribute("caretaker.opencode.timeout_seconds", int(config.timeout_seconds))
 
-    env = os.environ.copy()
-    if config.extra_env:
-        env.update(config.extra_env)
-
-    model = model_override or config.model
-    # opencode CLI uses ``run`` as the non-interactive subcommand. The
-    # ``-p`` flag (claude-style) just prints help. ``run`` accepts the
-    # prompt as a positional and ``--model`` to pin the provider/model.
-    args = [resolved, "run", prompt or _REVIEW_PROMPT]
-    if model:
-        args += ["--model", model]
-
-    logger.info(
-        "opencode_local: invoking %s model=%s in %s",
-        resolved,
-        model or "(opencode default)",
-        workdir,
-    )
-    proc = await asyncio.create_subprocess_exec(
-        *args,
-        cwd=workdir,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=env,
-    )
-    try:
-        stdout, stderr = await stream_subprocess_output(
-            proc,
-            timeout_seconds=config.timeout_seconds,
-            stdout_log=lambda line: logger.info("opencode | %s", _truncate(line, 400)),
-            stderr_log=lambda line: logger.warning("opencode! %s", line),
-        )
-    except TimeoutError as exc:
-        raise OpenCodeLocalTimeoutError(
-            f"opencode timed out after {config.timeout_seconds}s"
-        ) from exc
-    if proc.returncode != 0:
-        # Special-case: opencode emits ``No endpoints found`` when the
-        # configured provider (OpenRouter) hasn't been wired up. We
-        # surface this as its own exception type so the caller can
-        # record a specific ``no_endpoints`` outcome on the metric.
-        if "No endpoints found" in stderr:
-            raise OpenCodeLocalNoEndpointsError(
-                f"opencode exited {proc.returncode} with No endpoints found "
-                f"(check OPENROUTER_API_KEY / model id): {stderr.strip()[:500]}"
+        resolved = shutil.which(config.cli_path) or config.cli_path
+        if not os.path.isabs(resolved) and not shutil.which(resolved):
+            exc = OpenCodeLocalError(
+                f"opencode CLI not found at {config.cli_path!r}; install it "
+                "(`npm install -g opencode-ai` or pin a path in "
+                "pr_reviewer.opencode_local.cli_path). "
+                "Requires OPENROUTER_API_KEY in the environment."
             )
-        raise OpenCodeLocalError(
-            f"opencode exited {proc.returncode}: {stderr.strip() or stdout.strip()[:500]}"
+            with contextlib.suppress(Exception):  # pragma: no cover
+                span.set_attribute("caretaker.opencode.outcome", "error")
+                span.record_exception(exc)
+                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
+            raise exc
+
+        env = os.environ.copy()
+        if config.extra_env:
+            env.update(config.extra_env)
+
+        model = model_override or config.model
+        with contextlib.suppress(Exception):  # pragma: no cover
+            span.set_attribute("caretaker.opencode.model", str(model or ""))
+        # opencode CLI uses ``run`` as the non-interactive subcommand. The
+        # ``-p`` flag (claude-style) just prints help. ``run`` accepts the
+        # prompt as a positional and ``--model`` to pin the provider/model.
+        args = [resolved, "run", prompt or _REVIEW_PROMPT]
+        if model:
+            args += ["--model", model]
+
+        logger.info(
+            "opencode_local: invoking %s model=%s in %s",
+            resolved,
+            model or "(opencode default)",
+            workdir,
         )
-    return stdout
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            cwd=workdir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        try:
+            stdout, stderr = await stream_subprocess_output(
+                proc,
+                timeout_seconds=config.timeout_seconds,
+                stdout_log=lambda line: logger.info("opencode | %s", _truncate(line, 400)),
+                stderr_log=lambda line: logger.warning("opencode! %s", line),
+            )
+        except TimeoutError as exc:
+            timeout_err = OpenCodeLocalTimeoutError(
+                f"opencode timed out after {config.timeout_seconds}s"
+            )
+            with contextlib.suppress(Exception):  # pragma: no cover
+                span.set_attribute("caretaker.opencode.outcome", "timeout")
+                span.record_exception(timeout_err)
+                span.set_status(
+                    _otel_trace.Status(_otel_trace.StatusCode.ERROR, str(timeout_err)[:200])
+                )
+            raise timeout_err from exc
+        with contextlib.suppress(Exception):  # pragma: no cover
+            span.set_attribute("caretaker.opencode.exit_code", int(proc.returncode or 0))
+        if proc.returncode != 0:
+            # Special-case: opencode emits ``No endpoints found`` when the
+            # configured provider (OpenRouter) hasn't been wired up. We
+            # surface this as its own exception type so the caller can
+            # record a specific ``no_endpoints`` outcome on the metric.
+            if "No endpoints found" in stderr:
+                no_ep_err = OpenCodeLocalNoEndpointsError(
+                    f"opencode exited {proc.returncode} with No endpoints found "
+                    f"(check OPENROUTER_API_KEY / model id): {stderr.strip()[:500]}"
+                )
+                with contextlib.suppress(Exception):  # pragma: no cover
+                    span.set_attribute("caretaker.opencode.outcome", "no_endpoints")
+                    span.record_exception(no_ep_err)
+                    span.set_status(
+                        _otel_trace.Status(_otel_trace.StatusCode.ERROR, str(no_ep_err)[:200])
+                    )
+                raise no_ep_err
+            err = OpenCodeLocalError(
+                f"opencode exited {proc.returncode}: {stderr.strip() or stdout.strip()[:500]}"
+            )
+            with contextlib.suppress(Exception):  # pragma: no cover
+                span.set_attribute("caretaker.opencode.outcome", "error")
+                span.record_exception(err)
+                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(err)[:200]))
+            raise err
+        with contextlib.suppress(Exception):  # pragma: no cover
+            # Subprocess exited cleanly. parse_fallback (if any) is determined
+            # by :func:`run`'s output parser, not this span — see module docstring.
+            span.set_attribute("caretaker.opencode.outcome", "ok")
+        return stdout
 
 
 _RESULT_TEXT_RE = re.compile(r"```caretaker-review\s*\n(?P<json>.+?)\n\s*```", re.DOTALL)

--- a/src/caretaker/pr_reviewer/complexity_classifier.py
+++ b/src/caretaker/pr_reviewer/complexity_classifier.py
@@ -187,13 +187,38 @@ async def classify(
     context: ExecutorRouteContext,
     claude: ClaudeClient | None,
     routing_decision: RoutingDecision | None = None,
+    pr_number: int | None = None,
 ) -> ComplexityVerdict:
     """Classify a PR's complexity, using the fast path when possible.
 
     Always returns a :class:`ComplexityVerdict`. On LLM failure or
     unavailability, falls back to a heuristic verdict so callers can
     continue without a special-case branch.
+
+    ``pr_number`` is optional and only used to attribute the
+    ``tier_classified`` decision-timeline record back to the PR. When
+    omitted, the timeline write is skipped (so non-PR call sites such
+    as eval harnesses don't pollute the timeline collection).
     """
+    # Lazy import — avoid pulling Mongo deps at module import time.
+    from caretaker.state.pr_decisions import record_decision
+
+    repo_slug = context.repo_slug or ""
+
+    async def _record(verdict: ComplexityVerdict, source: str) -> None:
+        if pr_number is None or not repo_slug:
+            return
+        await record_decision(
+            repo_slug,
+            int(pr_number),
+            "complexity_classifier",
+            "tier_classified",
+            tier=str(verdict.tier),
+            source=source,
+            confidence=float(verdict.confidence),
+            reason=verdict.reason,
+        )
+
     with _tracer.start_as_current_span("complexity_classifier.classify") as span:
         try:
             span.set_attribute("caretaker.pr.repo", context.repo_slug or "")
@@ -214,6 +239,7 @@ async def classify(
             record_complexity_tier(tier=fast, source="fast_path")
             verdict = ComplexityVerdict(tier=fast, reason="heuristic fast path", confidence=0.9)
             _stamp(verdict, "fast_path")
+            await _record(verdict, "fast_path")
             return verdict
 
         if claude is None or not getattr(claude, "available", True):
@@ -221,6 +247,7 @@ async def classify(
             verdict = _heuristic_fallback(context, reason="LLM unavailable")
             record_complexity_tier(tier=verdict.tier, source="heuristic_fallback")
             _stamp(verdict, "heuristic_fallback")
+            await _record(verdict, "heuristic_fallback")
             return verdict
 
         prompt = _build_classifier_prompt(context)
@@ -237,6 +264,7 @@ async def classify(
             fallback = _heuristic_fallback(context, reason=f"LLM error: {exc}")
             record_complexity_tier(tier=fallback.tier, source="heuristic_fallback")
             _stamp(fallback, "heuristic_fallback")
+            await _record(fallback, "heuristic_fallback")
             return fallback
         except Exception as exc:  # noqa: BLE001 — never break the caller on a classifier hiccup
             logger.warning(
@@ -246,9 +274,11 @@ async def classify(
             fallback = _heuristic_fallback(context, reason=f"classifier exception: {exc}")
             record_complexity_tier(tier=fallback.tier, source="heuristic_fallback")
             _stamp(fallback, "heuristic_fallback")
+            await _record(fallback, "heuristic_fallback")
             return fallback
         record_complexity_tier(tier=verdict.tier, source="llm")
         _stamp(verdict, "llm")
+        await _record(verdict, "llm")
         return verdict
 
 

--- a/src/caretaker/pr_reviewer/complexity_classifier.py
+++ b/src/caretaker/pr_reviewer/complexity_classifier.py
@@ -32,12 +32,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Literal
 
-from opentelemetry import trace as _otel_trace
 from pydantic import BaseModel, Field
 
 from caretaker.evolution.executor_routing import ExecutorRouteContext, _detect_sensitive_hints
 from caretaker.llm.claude import StructuredCompleteError
 from caretaker.observability.metrics import record_complexity_tier
+from caretaker.observability.tracer_compat import get_tracer
 
 if TYPE_CHECKING:
     from caretaker.llm.claude import ClaudeClient
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 # Module-level tracer — every classification gets a span so the
 # parent ``pr_reviewer.handle_pr`` trace shows tier + source attrs.
-_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.complexity_classifier")
+_tracer = get_tracer("caretaker.pr_reviewer.complexity_classifier")
 
 
 ComplexityTier = Literal["trivial", "simple", "standard", "complex"]

--- a/src/caretaker/pr_reviewer/complexity_classifier.py
+++ b/src/caretaker/pr_reviewer/complexity_classifier.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel, Field
 
 from caretaker.evolution.executor_routing import ExecutorRouteContext, _detect_sensitive_hints
 from caretaker.llm.claude import StructuredCompleteError
+from caretaker.observability.metrics import record_complexity_tier
 
 if TYPE_CHECKING:
     from caretaker.llm.claude import ClaudeClient
@@ -190,15 +191,18 @@ async def classify(
     """
     fast = fast_path_tier(context=context, routing_decision=routing_decision)
     if fast is not None:
+        record_complexity_tier(tier=fast, source="fast_path")
         return ComplexityVerdict(tier=fast, reason="heuristic fast path", confidence=0.9)
 
     if claude is None or not getattr(claude, "available", True):
         # No LLM available; pick a safe tier from heuristics.
-        return _heuristic_fallback(context, reason="LLM unavailable")
+        verdict = _heuristic_fallback(context, reason="LLM unavailable")
+        record_complexity_tier(tier=verdict.tier, source="heuristic_fallback")
+        return verdict
 
     prompt = _build_classifier_prompt(context)
     try:
-        return await claude.structured_complete(
+        verdict = await claude.structured_complete(
             prompt,
             schema=ComplexityVerdict,
             feature="complexity_classifier",
@@ -207,13 +211,19 @@ async def classify(
         )
     except StructuredCompleteError as exc:
         logger.info("complexity_classifier: structured_complete failed (%s)", exc)
-        return _heuristic_fallback(context, reason=f"LLM error: {exc}")
+        fallback = _heuristic_fallback(context, reason=f"LLM error: {exc}")
+        record_complexity_tier(tier=fallback.tier, source="heuristic_fallback")
+        return fallback
     except Exception as exc:  # noqa: BLE001 — never break the caller on a classifier hiccup
         logger.warning(
             "complexity_classifier: unexpected error (%s); falling back to heuristic",
             exc,
         )
-        return _heuristic_fallback(context, reason=f"classifier exception: {exc}")
+        fallback = _heuristic_fallback(context, reason=f"classifier exception: {exc}")
+        record_complexity_tier(tier=fallback.tier, source="heuristic_fallback")
+        return fallback
+    record_complexity_tier(tier=verdict.tier, source="llm")
+    return verdict
 
 
 def _heuristic_fallback(context: ExecutorRouteContext, *, reason: str) -> ComplexityVerdict:

--- a/src/caretaker/pr_reviewer/complexity_classifier.py
+++ b/src/caretaker/pr_reviewer/complexity_classifier.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Literal
 
+from opentelemetry import trace as _otel_trace
 from pydantic import BaseModel, Field
 
 from caretaker.evolution.executor_routing import ExecutorRouteContext, _detect_sensitive_hints
@@ -43,6 +44,10 @@ if TYPE_CHECKING:
     from caretaker.pr_reviewer.routing import RoutingDecision
 
 logger = logging.getLogger(__name__)
+
+# Module-level tracer — every classification gets a span so the
+# parent ``pr_reviewer.handle_pr`` trace shows tier + source attrs.
+_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.complexity_classifier")
 
 
 ComplexityTier = Literal["trivial", "simple", "standard", "complex"]
@@ -189,41 +194,62 @@ async def classify(
     unavailability, falls back to a heuristic verdict so callers can
     continue without a special-case branch.
     """
-    fast = fast_path_tier(context=context, routing_decision=routing_decision)
-    if fast is not None:
-        record_complexity_tier(tier=fast, source="fast_path")
-        return ComplexityVerdict(tier=fast, reason="heuristic fast path", confidence=0.9)
+    with _tracer.start_as_current_span("complexity_classifier.classify") as span:
+        try:
+            span.set_attribute("caretaker.pr.repo", context.repo_slug or "")
+            span.set_attribute("caretaker.complexity.file_count", len(context.files))
+        except Exception:  # pragma: no cover - defensive
+            pass
 
-    if claude is None or not getattr(claude, "available", True):
-        # No LLM available; pick a safe tier from heuristics.
-        verdict = _heuristic_fallback(context, reason="LLM unavailable")
-        record_complexity_tier(tier=verdict.tier, source="heuristic_fallback")
+        def _stamp(verdict: ComplexityVerdict, source: str) -> None:
+            try:
+                span.set_attribute("caretaker.complexity.tier", verdict.tier)
+                span.set_attribute("caretaker.complexity.source", source)
+                span.set_attribute("caretaker.complexity.confidence", float(verdict.confidence))
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+        fast = fast_path_tier(context=context, routing_decision=routing_decision)
+        if fast is not None:
+            record_complexity_tier(tier=fast, source="fast_path")
+            verdict = ComplexityVerdict(tier=fast, reason="heuristic fast path", confidence=0.9)
+            _stamp(verdict, "fast_path")
+            return verdict
+
+        if claude is None or not getattr(claude, "available", True):
+            # No LLM available; pick a safe tier from heuristics.
+            verdict = _heuristic_fallback(context, reason="LLM unavailable")
+            record_complexity_tier(tier=verdict.tier, source="heuristic_fallback")
+            _stamp(verdict, "heuristic_fallback")
+            return verdict
+
+        prompt = _build_classifier_prompt(context)
+        try:
+            verdict = await claude.structured_complete(
+                prompt,
+                schema=ComplexityVerdict,
+                feature="complexity_classifier",
+                system=_CLASSIFIER_SYSTEM_PROMPT,
+                max_tokens=300,
+            )
+        except StructuredCompleteError as exc:
+            logger.info("complexity_classifier: structured_complete failed (%s)", exc)
+            fallback = _heuristic_fallback(context, reason=f"LLM error: {exc}")
+            record_complexity_tier(tier=fallback.tier, source="heuristic_fallback")
+            _stamp(fallback, "heuristic_fallback")
+            return fallback
+        except Exception as exc:  # noqa: BLE001 — never break the caller on a classifier hiccup
+            logger.warning(
+                "complexity_classifier: unexpected error (%s); falling back to heuristic",
+                exc,
+            )
+            fallback = _heuristic_fallback(context, reason=f"classifier exception: {exc}")
+            record_complexity_tier(tier=fallback.tier, source="heuristic_fallback")
+            _stamp(fallback, "heuristic_fallback")
+            return fallback
+        record_complexity_tier(tier=verdict.tier, source="llm")
+        _stamp(verdict, "llm")
         return verdict
-
-    prompt = _build_classifier_prompt(context)
-    try:
-        verdict = await claude.structured_complete(
-            prompt,
-            schema=ComplexityVerdict,
-            feature="complexity_classifier",
-            system=_CLASSIFIER_SYSTEM_PROMPT,
-            max_tokens=300,
-        )
-    except StructuredCompleteError as exc:
-        logger.info("complexity_classifier: structured_complete failed (%s)", exc)
-        fallback = _heuristic_fallback(context, reason=f"LLM error: {exc}")
-        record_complexity_tier(tier=fallback.tier, source="heuristic_fallback")
-        return fallback
-    except Exception as exc:  # noqa: BLE001 — never break the caller on a classifier hiccup
-        logger.warning(
-            "complexity_classifier: unexpected error (%s); falling back to heuristic",
-            exc,
-        )
-        fallback = _heuristic_fallback(context, reason=f"classifier exception: {exc}")
-        record_complexity_tier(tier=fallback.tier, source="heuristic_fallback")
-        return fallback
-    record_complexity_tier(tier=verdict.tier, source="llm")
-    return verdict
 
 
 def _heuristic_fallback(context: ExecutorRouteContext, *, reason: str) -> ComplexityVerdict:

--- a/src/caretaker/pr_reviewer/inline_reviewer.py
+++ b/src/caretaker/pr_reviewer/inline_reviewer.py
@@ -6,10 +6,12 @@ Returns a ``ReviewResult`` that ``github_review.post_review()`` can post directl
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
+from opentelemetry import trace as _otel_trace
 from pydantic import BaseModel, Field
 
 from caretaker.llm.claude import StructuredCompleteError
@@ -19,6 +21,10 @@ if TYPE_CHECKING:
     from caretaker.llm.router import LLMRouter
 
 logger = logging.getLogger(__name__)
+
+# Module-level tracer — wraps each inline-LLM review so the parent
+# ``pr_reviewer.handle_pr`` trace shows diff_lines / model / verdict.
+_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.inline_reviewer")
 
 _REVIEW_SYSTEM = """\
 You are an expert code reviewer. Review the pull request diff below and produce
@@ -119,61 +125,88 @@ async def review(
     max_diff_lines: int = 2000,
 ) -> ReviewResult:
     """Fetch the PR diff and call the LLM for a review."""
-    diff = await github.get_pull_diff(owner, repo, pr_number)
-    if not diff:
+    with _tracer.start_as_current_span("inline_reviewer.review") as span:
+        with contextlib.suppress(Exception):  # pragma: no cover - defensive
+            span.set_attribute("caretaker.pr.repo", f"{owner}/{repo}")
+            span.set_attribute("caretaker.pr.number", int(pr_number))
+
+        diff = await github.get_pull_diff(owner, repo, pr_number)
+        if not diff:
+            with contextlib.suppress(Exception):  # pragma: no cover
+                span.set_attribute("caretaker.review.diff_lines", 0)
+                span.set_attribute("caretaker.review.verdict", "COMMENT")
+            return ReviewResult(
+                summary="Could not fetch diff — skipping inline review.",
+                verdict="COMMENT",
+            )
+
+        diff_lines = diff.splitlines()
+        bounded_lines = min(len(diff_lines), max_diff_lines)
+        if len(diff_lines) > max_diff_lines:
+            diff = "\n".join(diff_lines[:max_diff_lines]) + "\n…(diff truncated)"
+
+        with contextlib.suppress(Exception):  # pragma: no cover
+            span.set_attribute("caretaker.review.diff_lines", int(bounded_lines))
+
+        prompt = (
+            f"PR #{pr_number}: {pr_title}\n\n"
+            f"{pr_body.strip()[:500] if pr_body else '(no description)'}\n\n"
+            "---\n"
+            f"```diff\n{diff}\n```"
+        )
+
+        # Capture the model the LLM router reports for this feature, when
+        # accessible — best-effort because the router shape varies.
+        with contextlib.suppress(Exception):  # pragma: no cover
+            model_name = getattr(getattr(llm, "claude", None), "model", "") or ""
+            if model_name:
+                span.set_attribute("caretaker.review.model", str(model_name))
+
+        try:
+            payload = await llm.claude.structured_complete(
+                prompt,
+                schema=InlineReviewResult,
+                feature="pr_inline_review",
+                system=_REVIEW_SYSTEM,
+                max_tokens=2000,
+            )
+        except StructuredCompleteError as exc:
+            # Surface parse/validation failures to the caller so they can be logged
+            # loudly. The pr-reviewer agent is expected to catch and fall back to
+            # a skip / claude-code dispatch — it must not silently issue an empty
+            # COMMENT review as the old ``json.loads`` fallback did.
+            logger.exception(
+                "inline review for %s/%s#%d failed validation after retries",
+                owner,
+                repo,
+                pr_number,
+            )
+            with contextlib.suppress(Exception):  # pragma: no cover
+                span.record_exception(exc)
+                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
+            raise
+        except Exception as exc:
+            logger.warning("Inline LLM review failed for %s/%s#%d: %s", owner, repo, pr_number, exc)
+            with contextlib.suppress(Exception):  # pragma: no cover
+                span.set_attribute("caretaker.review.verdict", "COMMENT")
+            return ReviewResult(
+                summary=f"Inline review failed: {exc}",
+                verdict="COMMENT",
+            )
+
+        comments = [
+            InlineReviewComment(path=c.path, line=int(c.line), body=c.body)
+            for c in payload.comments
+            if c.path and c.body
+        ]
+
+        with contextlib.suppress(Exception):  # pragma: no cover
+            span.set_attribute("caretaker.review.verdict", str(payload.verdict))
+
         return ReviewResult(
-            summary="Could not fetch diff — skipping inline review.",
-            verdict="COMMENT",
+            summary=payload.summary,
+            verdict=payload.verdict,
+            comments=comments,
+            raw_response=payload.model_dump_json(),
+            issue_categories=list(payload.issue_categories),
         )
-
-    diff_lines = diff.splitlines()
-    if len(diff_lines) > max_diff_lines:
-        diff = "\n".join(diff_lines[:max_diff_lines]) + "\n…(diff truncated)"
-
-    prompt = (
-        f"PR #{pr_number}: {pr_title}\n\n"
-        f"{pr_body.strip()[:500] if pr_body else '(no description)'}\n\n"
-        "---\n"
-        f"```diff\n{diff}\n```"
-    )
-
-    try:
-        payload = await llm.claude.structured_complete(
-            prompt,
-            schema=InlineReviewResult,
-            feature="pr_inline_review",
-            system=_REVIEW_SYSTEM,
-            max_tokens=2000,
-        )
-    except StructuredCompleteError:
-        # Surface parse/validation failures to the caller so they can be logged
-        # loudly. The pr-reviewer agent is expected to catch and fall back to
-        # a skip / claude-code dispatch — it must not silently issue an empty
-        # COMMENT review as the old ``json.loads`` fallback did.
-        logger.exception(
-            "inline review for %s/%s#%d failed validation after retries",
-            owner,
-            repo,
-            pr_number,
-        )
-        raise
-    except Exception as exc:
-        logger.warning("Inline LLM review failed for %s/%s#%d: %s", owner, repo, pr_number, exc)
-        return ReviewResult(
-            summary=f"Inline review failed: {exc}",
-            verdict="COMMENT",
-        )
-
-    comments = [
-        InlineReviewComment(path=c.path, line=int(c.line), body=c.body)
-        for c in payload.comments
-        if c.path and c.body
-    ]
-
-    return ReviewResult(
-        summary=payload.summary,
-        verdict=payload.verdict,
-        comments=comments,
-        raw_response=payload.model_dump_json(),
-        issue_categories=list(payload.issue_categories),
-    )

--- a/src/caretaker/pr_reviewer/inline_reviewer.py
+++ b/src/caretaker/pr_reviewer/inline_reviewer.py
@@ -11,10 +11,10 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
-from opentelemetry import trace as _otel_trace
 from pydantic import BaseModel, Field
 
 from caretaker.llm.claude import StructuredCompleteError
+from caretaker.observability.tracer_compat import Status, StatusCode, get_tracer
 
 if TYPE_CHECKING:
     from caretaker.github_client.api import GitHubClient
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # Module-level tracer — wraps each inline-LLM review so the parent
 # ``pr_reviewer.handle_pr`` trace shows diff_lines / model / verdict.
-_tracer = _otel_trace.get_tracer("caretaker.pr_reviewer.inline_reviewer")
+_tracer = get_tracer("caretaker.pr_reviewer.inline_reviewer")
 
 _REVIEW_SYSTEM = """\
 You are an expert code reviewer. Review the pull request diff below and produce
@@ -183,7 +183,7 @@ async def review(
             )
             with contextlib.suppress(Exception):  # pragma: no cover
                 span.record_exception(exc)
-                span.set_status(_otel_trace.Status(_otel_trace.StatusCode.ERROR, str(exc)[:200]))
+                span.set_status(Status(StatusCode.ERROR, str(exc)[:200]))
             raise
         except Exception as exc:
             logger.warning("Inline LLM review failed for %s/%s#%d: %s", owner, repo, pr_number, exc)

--- a/src/caretaker/state/pr_decisions.py
+++ b/src/caretaker/state/pr_decisions.py
@@ -38,7 +38,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
 
-from opentelemetry import trace as _otel_trace
+from caretaker.observability.tracer_compat import get_current_span
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +111,7 @@ def _capture_trace_ids() -> tuple[str | None, str | None]:
     is the no-op fallback).
     """
     try:
-        span = _otel_trace.get_current_span()
+        span = get_current_span()
         if span is None:
             return None, None
         ctx = span.get_span_context()

--- a/src/caretaker/state/pr_decisions.py
+++ b/src/caretaker/state/pr_decisions.py
@@ -30,12 +30,13 @@ build the timeline from logs even if Mongo is down.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import os
 import uuid
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from opentelemetry import trace as _otel_trace
 
@@ -43,6 +44,30 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import motor.motor_asyncio
+
+# Bounded, mypy-strict-checked vocabularies for the agent + event
+# columns. Free-text strings would silently drift over time
+# (``auto_fix_complete`` vs ``auto_fix_completed`` vs typos), splitting
+# the timeline into orphaned events that the admin SPA can't group.
+DecisionAgent = Literal[
+    "pr_reviewer",
+    "pr_agent",
+    "auto_fix",
+    "complexity_classifier",
+    "opencode_local",
+]
+DecisionEvent = Literal[
+    "review_started",
+    "review_skipped",
+    "review_completed",
+    "tier_classified",
+    "auto_fix_dispatched",
+    "auto_fix_complete",
+    "auto_fix_skipped",
+    "opencode_review_started",
+    "opencode_review_finished",
+    "opencode_review_failed",
+]
 
 # Module-level singleton, lazily initialised by ``configure_default_store``.
 _default_store: PRDecisionStore | None = None
@@ -54,9 +79,22 @@ def configure_default_store(store: PRDecisionStore | None) -> None:
     Called at app startup once the config is loaded so call sites can
     use the :func:`record_decision` shortcut without plumbing the store
     through every layer.
+
+    If a previous store was installed and the new value is a different
+    instance (or ``None``), the old store's Mongo client is scheduled
+    for cleanup on the running event loop. This prevents leaking a
+    Motor client when the function is called multiple times during
+    hot-reload / test-suite teardown.
     """
     global _default_store  # noqa: PLW0603 — process singleton.
+    previous = _default_store
     _default_store = store
+    if previous is not None and previous is not store:
+        # Best-effort async close. If no loop is running (e.g. sync
+        # test harness) we just drop the reference — the underlying
+        # Motor client will be GC'd by the interpreter.
+        with contextlib.suppress(RuntimeError):
+            asyncio.get_running_loop().create_task(previous.close())
 
 
 def get_default_store() -> PRDecisionStore | None:
@@ -106,7 +144,7 @@ class PRDecisionStore:
 
     # ── Lifecycle ──────────────────────────────────────────────────────
 
-    async def _ensure_collection(  # noqa: E501
+    async def _ensure_collection(
         self,
     ) -> motor.motor_asyncio.AsyncIOMotorCollection[dict[str, Any]] | None:
         """Return a live Motor collection handle, or None if unavailable."""
@@ -167,8 +205,8 @@ class PRDecisionStore:
         *,
         repo: str,
         pr_number: int,
-        agent: str,
-        event: str,
+        agent: DecisionAgent,
+        event: DecisionEvent,
         fields: dict[str, Any] | None = None,
     ) -> None:
         """Persist one decision record + emit a structured log line.
@@ -216,28 +254,33 @@ class PRDecisionStore:
         repo: str,
         pr_number: int,
         limit: int = 200,
-    ) -> list[dict[str, Any]]:
-        """Return the full chronological timeline for one PR.
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Return ``(decisions, total_count)`` for one PR.
 
-        Sorted by ``observed_at`` ascending (oldest first). Returns an
-        empty list when Mongo is unreachable or the PR has no records.
+        ``decisions`` are sorted by ``observed_at`` ascending (oldest
+        first), bounded by ``limit`` and skipped past ``offset`` so the
+        admin SPA can paginate. ``total_count`` is the unfiltered count
+        of matching documents so the SPA can render a "showing N of M"
+        affordance and detect truncation.
+
+        Returns ``([], 0)`` when Mongo is unreachable or the PR has no
+        records.
         """
         col = await self._ensure_collection()
         if col is None:
-            return []
+            return [], 0
         repo_slug = f"{owner}/{repo}"
+        query = {"repo": repo_slug, "pr_number": int(pr_number)}
         try:
-            cursor = (
-                col.find({"repo": repo_slug, "pr_number": int(pr_number)})
-                .sort("observed_at", 1)
-                .limit(int(limit))
-            )
+            total_count = int(await col.count_documents(query))
+            cursor = col.find(query).sort("observed_at", 1).skip(int(offset)).limit(int(limit))
             docs: list[dict[str, Any]] = []
             async for doc in cursor:
                 # Drop Mongo's internal ``_id`` so the response is JSON-clean.
                 doc.pop("_id", None)
                 docs.append(doc)
-            return docs
+            return docs, total_count
         except Exception:
             logger.warning(
                 "PRDecisionStore: failed to query timeline for %s#%d",
@@ -245,7 +288,7 @@ class PRDecisionStore:
                 pr_number,
                 exc_info=True,
             )
-            return []
+            return [], 0
 
     # ── Internals ──────────────────────────────────────────────────────
 
@@ -297,38 +340,34 @@ class PRDecisionStore:
 async def record_decision(
     repo: str,
     pr_number: int,
-    agent: str,
-    event: str,
+    agent: DecisionAgent,
+    event: DecisionEvent,
     **fields: Any,
 ) -> None:
     """Module-level shortcut: write one decision via the default store.
 
     Lazily falls back to a disabled store (structured-log only) when
     nobody called :func:`configure_default_store` so call sites can
-    fire-and-forget without checking config first. Never raises.
+    ``await`` without checking config first. ``store.record`` already
+    swallows Mongo failures and the trace-id capture has its own
+    guard, so this wrapper deliberately does not add another
+    ``try/except`` — nothing inside should raise.
     """
     store = _default_store
     if store is None:
         store = PRDecisionStore(enabled=False)
-    try:
-        await store.record(
-            repo=repo,
-            pr_number=pr_number,
-            agent=agent,
-            event=event,
-            fields=dict(fields),
-        )
-    except Exception:  # pragma: no cover - defensive: belt-and-braces
-        logger.warning(
-            "record_decision: unexpected exception (event=%s repo=%s pr=%d)",
-            event,
-            repo,
-            pr_number,
-            exc_info=True,
-        )
+    await store.record(
+        repo=repo,
+        pr_number=pr_number,
+        agent=agent,
+        event=event,
+        fields=dict(fields),
+    )
 
 
 __all__ = [
+    "DecisionAgent",
+    "DecisionEvent",
     "PRDecisionStore",
     "configure_default_store",
     "get_default_store",

--- a/src/caretaker/state/pr_decisions.py
+++ b/src/caretaker/state/pr_decisions.py
@@ -1,0 +1,336 @@
+"""Per-PR decision-timeline writer.
+
+Companion to :mod:`caretaker.state.audit_log` but scoped to one
+``(owner, repo, pr_number)`` slug. Every decision the PR-reviewer
+pipeline makes (review_started, tier_classified, auto_fix_dispatched,
+…) is appended here so the admin SPA can render a chronological
+timeline for any PR without `kubectl logs | grep`.
+
+Storage
+-------
+Writes to a MongoDB ``pr_decisions`` collection when MongoDB is
+enabled. Indexes:
+
+* ``(repo, pr_number, observed_at)`` — efficient timeline query.
+* TTL on ``observed_at`` (30 days) — keeps the collection bounded.
+
+Both indexes are created idempotently on first write.
+
+Each record carries the OTel ``trace_id`` + ``span_id`` of the active
+span (when one exists) so the admin UI can deep-link from a timeline
+row into the corresponding Tempo trace.
+
+Reliability
+-----------
+Mongo failures NEVER propagate to the agent. Errors are logged at
+WARNING and the helper returns. A structured INFO log line is also
+emitted for every record so log-aggregation consumers (Loki) can
+build the timeline from logs even if Mongo is down.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from opentelemetry import trace as _otel_trace
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    import motor.motor_asyncio
+
+# Module-level singleton, lazily initialised by ``configure_default_store``.
+_default_store: PRDecisionStore | None = None
+
+
+def configure_default_store(store: PRDecisionStore | None) -> None:
+    """Install (or clear) the process-wide default store.
+
+    Called at app startup once the config is loaded so call sites can
+    use the :func:`record_decision` shortcut without plumbing the store
+    through every layer.
+    """
+    global _default_store  # noqa: PLW0603 — process singleton.
+    _default_store = store
+
+
+def get_default_store() -> PRDecisionStore | None:
+    """Return the process-wide default store, or ``None`` if unset."""
+    return _default_store
+
+
+def _capture_trace_ids() -> tuple[str | None, str | None]:
+    """Return ``(trace_id_hex, span_id_hex)`` for the active span, if any.
+
+    Hex format matches what OTel collectors emit so admin clients can
+    feed it directly into Tempo / Jaeger lookup URLs. Returns
+    ``(None, None)`` whenever there's no active span (or the OTel SDK
+    is the no-op fallback).
+    """
+    try:
+        span = _otel_trace.get_current_span()
+        if span is None:
+            return None, None
+        ctx = span.get_span_context()
+        if ctx is None or not ctx.is_valid:
+            return None, None
+        return f"{ctx.trace_id:032x}", f"{ctx.span_id:016x}"
+    except Exception:  # pragma: no cover - defensive
+        return None, None
+
+
+class PRDecisionStore:
+    """Append-only per-PR decision log writer."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        mongodb_url_env: str = "MONGODB_URL",
+        database_name: str = "caretaker",
+        collection_name: str = "pr_decisions",
+        ttl_seconds: int = 30 * 86400,
+    ) -> None:
+        self._enabled = enabled
+        self._mongodb_url_env = mongodb_url_env
+        self._database_name = database_name
+        self._collection_name = collection_name
+        self._ttl_seconds = ttl_seconds
+        self._client: motor.motor_asyncio.AsyncIOMotorClient[Any] | None = None
+        self._indexes_created = False
+
+    # ── Lifecycle ──────────────────────────────────────────────────────
+
+    async def _ensure_collection(  # noqa: E501
+        self,
+    ) -> motor.motor_asyncio.AsyncIOMotorCollection[dict[str, Any]] | None:
+        """Return a live Motor collection handle, or None if unavailable."""
+        if not self._enabled:
+            return None
+
+        mongodb_url = os.environ.get(self._mongodb_url_env, "").strip()
+        if not mongodb_url:
+            return None
+
+        if self._client is None:
+            try:
+                from motor.motor_asyncio import AsyncIOMotorClient
+
+                self._client = AsyncIOMotorClient(mongodb_url)
+                logger.debug("PRDecisionStore: connected to MongoDB")
+            except Exception:
+                logger.warning(
+                    "PRDecisionStore: failed to connect to MongoDB; "
+                    "decision records will not be persisted.",
+                    exc_info=True,
+                )
+                return None
+
+        col = self._client[self._database_name][self._collection_name]
+        if not self._indexes_created:
+            with contextlib.suppress(Exception):
+                import pymongo
+
+                # Compound index for query_timeline lookups.
+                await col.create_index(
+                    [
+                        ("repo", pymongo.ASCENDING),
+                        ("pr_number", pymongo.ASCENDING),
+                        ("observed_at", pymongo.ASCENDING),
+                    ],
+                    name="idx_repo_pr_observed",
+                )
+                # TTL index — Mongo will purge documents after ``ttl_seconds``.
+                await col.create_index(
+                    "observed_at",
+                    expireAfterSeconds=self._ttl_seconds,
+                    name="idx_observed_at_ttl",
+                )
+                self._indexes_created = True
+        return col
+
+    async def close(self) -> None:
+        if self._client is not None:
+            with contextlib.suppress(Exception):
+                self._client.close()
+        self._client = None
+
+    # ── Public API ─────────────────────────────────────────────────────
+
+    async def record(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        agent: str,
+        event: str,
+        fields: dict[str, Any] | None = None,
+    ) -> None:
+        """Persist one decision record + emit a structured log line.
+
+        Mongo writes never raise — failures are logged at WARNING and
+        the call returns normally so observability never fails the
+        agent run.
+        """
+        trace_id, span_id = _capture_trace_ids()
+        doc: dict[str, Any] = {
+            "id": str(uuid.uuid4()),
+            "repo": repo,
+            "pr_number": int(pr_number),
+            "observed_at": datetime.now(UTC),
+            "agent": agent,
+            "event": event,
+            "fields": fields or {},
+            "trace_id": trace_id,
+            "span_id": span_id,
+        }
+
+        # Always emit the structured log line — even when Mongo is
+        # unreachable Loki / stdout can still rebuild the timeline.
+        self._emit_log(doc)
+
+        col = await self._ensure_collection()
+        if col is None:
+            return
+        try:
+            await col.insert_one(doc)
+        except Exception:
+            logger.warning(
+                "PRDecisionStore: failed to persist decision %s for %s#%d",
+                event,
+                repo,
+                pr_number,
+                exc_info=True,
+            )
+            self._client = None  # force reconnect next time
+
+    async def query_timeline(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Return the full chronological timeline for one PR.
+
+        Sorted by ``observed_at`` ascending (oldest first). Returns an
+        empty list when Mongo is unreachable or the PR has no records.
+        """
+        col = await self._ensure_collection()
+        if col is None:
+            return []
+        repo_slug = f"{owner}/{repo}"
+        try:
+            cursor = (
+                col.find({"repo": repo_slug, "pr_number": int(pr_number)})
+                .sort("observed_at", 1)
+                .limit(int(limit))
+            )
+            docs: list[dict[str, Any]] = []
+            async for doc in cursor:
+                # Drop Mongo's internal ``_id`` so the response is JSON-clean.
+                doc.pop("_id", None)
+                docs.append(doc)
+            return docs
+        except Exception:
+            logger.warning(
+                "PRDecisionStore: failed to query timeline for %s#%d",
+                repo_slug,
+                pr_number,
+                exc_info=True,
+            )
+            return []
+
+    # ── Internals ──────────────────────────────────────────────────────
+
+    def _emit_log(self, doc: dict[str, Any]) -> None:
+        logger.info(
+            "pr_decision repo=%s pr=%d agent=%s event=%s",
+            doc["repo"],
+            doc["pr_number"],
+            doc["agent"],
+            doc["event"],
+            extra={
+                "audit_event": "pr_decision",
+                "id": doc["id"],
+                "repo": doc["repo"],
+                "pr_number": doc["pr_number"],
+                "agent": doc["agent"],
+                "event": doc["event"],
+                "fields": doc["fields"],
+                "trace_id": doc["trace_id"],
+                "span_id": doc["span_id"],
+            },
+        )
+
+    @classmethod
+    def from_config(cls, config: Any) -> PRDecisionStore:
+        """Build from a :class:`~caretaker.config.MaintainerConfig`.
+
+        Reuses the same ``mongo`` block as the audit-log writer — when
+        Mongo is disabled the store is created in disabled mode and
+        ``record`` is a no-op for persistence (the structured log line
+        is still emitted).
+        """
+        from caretaker.config import MaintainerConfig
+
+        if not isinstance(config, MaintainerConfig):
+            return cls(enabled=False)
+
+        mongo_enabled = getattr(config, "mongo", None) is not None and config.mongo.enabled
+        mongodb_url_env = config.mongo.mongodb_url_env if mongo_enabled else "MONGODB_URL"
+        database_name = config.mongo.database_name if mongo_enabled else "caretaker"
+        return cls(
+            enabled=mongo_enabled,
+            mongodb_url_env=mongodb_url_env,
+            database_name=database_name,
+            collection_name="pr_decisions",
+        )
+
+
+async def record_decision(
+    repo: str,
+    pr_number: int,
+    agent: str,
+    event: str,
+    **fields: Any,
+) -> None:
+    """Module-level shortcut: write one decision via the default store.
+
+    Lazily falls back to a disabled store (structured-log only) when
+    nobody called :func:`configure_default_store` so call sites can
+    fire-and-forget without checking config first. Never raises.
+    """
+    store = _default_store
+    if store is None:
+        store = PRDecisionStore(enabled=False)
+    try:
+        await store.record(
+            repo=repo,
+            pr_number=pr_number,
+            agent=agent,
+            event=event,
+            fields=dict(fields),
+        )
+    except Exception:  # pragma: no cover - defensive: belt-and-braces
+        logger.warning(
+            "record_decision: unexpected exception (event=%s repo=%s pr=%d)",
+            event,
+            repo,
+            pr_number,
+            exc_info=True,
+        )
+
+
+__all__ = [
+    "PRDecisionStore",
+    "configure_default_store",
+    "get_default_store",
+    "record_decision",
+]

--- a/tests/test_admin_pr_timeline_api.py
+++ b/tests/test_admin_pr_timeline_api.py
@@ -27,6 +27,10 @@ class _FakeCursor:
         self._docs = sorted(self._docs, key=lambda d: d[key], reverse=reverse)
         return self
 
+    def skip(self, n: int) -> _FakeCursor:
+        self._docs = self._docs[int(n) :]
+        return self
+
     def limit(self, n: int) -> _FakeCursor:
         self._docs = self._docs[: int(n)]
         return self
@@ -53,6 +57,9 @@ class _FakeCollection:
     def find(self, query: dict[str, Any]) -> _FakeCursor:
         matched = [d for d in self._docs if all(d.get(k) == v for k, v in query.items())]
         return _FakeCursor(matched)
+
+    async def count_documents(self, query: dict[str, Any]) -> int:
+        return sum(1 for d in self._docs if all(d.get(k) == v for k, v in query.items()))
 
 
 def _build_store() -> tuple[PRDecisionStore, _FakeCollection]:
@@ -143,6 +150,8 @@ class TestPRTimelineAPI:
         assert events == ["review_started", "tier_classified"]
         assert data["decisions"][0]["fields"]["author"] == "ianlintner"
         assert data["decisions"][0]["trace_id"] == "a" * 32
+        assert data["total_count"] == 2
+        assert data["truncated"] is False
 
     def test_get_timeline_returns_empty_when_no_decisions(
         self,
@@ -156,6 +165,8 @@ class TestPRTimelineAPI:
         data = resp.json()
         assert data["decisions"] == []
         assert data["pr_number"] == 999
+        assert data["total_count"] == 0
+        assert data["truncated"] is False
 
     def test_get_timeline_unauthorized(
         self,
@@ -164,3 +175,47 @@ class TestPRTimelineAPI:
         # Without the dependency override, the endpoint should 401/403.
         resp = client_unauthed.get("/api/admin/pr/ianlintner/caretaker-qa/108/timeline")
         assert resp.status_code in (401, 403, 503)
+
+    def test_get_timeline_pagination_reports_truncation(
+        self,
+        client_authed: TestClient,
+        store_and_col: tuple[PRDecisionStore, _FakeCollection],
+    ) -> None:
+        """When more decisions exist than the page size, the response flags it."""
+        _store, col = store_and_col
+        now = datetime.now(UTC)
+        # Insert 5 decisions oldest-first.
+        for i in range(5):
+            col._docs.append(
+                {
+                    "id": f"d{i}",
+                    "repo": "ianlintner/caretaker-qa",
+                    "pr_number": 108,
+                    "observed_at": now - timedelta(minutes=10 - i),
+                    "agent": "pr_reviewer",
+                    "event": f"event_{i}",
+                    "fields": {},
+                    "trace_id": None,
+                    "span_id": None,
+                }
+            )
+
+        # Ask for a 2-row page from the start.
+        resp = client_authed.get(
+            "/api/admin/pr/ianlintner/caretaker-qa/108/timeline?limit=2&offset=0"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["decisions"]) == 2
+        assert [d["id"] for d in data["decisions"]] == ["d0", "d1"]
+        assert data["total_count"] == 5
+        assert data["truncated"] is True
+
+        # Last page (offset=4, limit=2) — only one row left, not truncated.
+        resp = client_authed.get(
+            "/api/admin/pr/ianlintner/caretaker-qa/108/timeline?limit=2&offset=4"
+        )
+        data = resp.json()
+        assert [d["id"] for d in data["decisions"]] == ["d4"]
+        assert data["total_count"] == 5
+        assert data["truncated"] is False

--- a/tests/test_admin_pr_timeline_api.py
+++ b/tests/test_admin_pr_timeline_api.py
@@ -1,0 +1,166 @@
+"""Tests for ``GET /api/admin/pr/{owner}/{repo}/{number}/timeline``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from caretaker.admin import auth as admin_auth
+from caretaker.admin import pr_timeline_api
+from caretaker.state.pr_decisions import PRDecisionStore
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _FakeCursor:
+    def __init__(self, docs: list[dict[str, Any]]) -> None:
+        self._docs = docs
+
+    def sort(self, key: str, direction: int) -> _FakeCursor:
+        reverse = direction < 0
+        self._docs = sorted(self._docs, key=lambda d: d[key], reverse=reverse)
+        return self
+
+    def limit(self, n: int) -> _FakeCursor:
+        self._docs = self._docs[: int(n)]
+        return self
+
+    def __aiter__(self) -> _FakeCursor:
+        self._iter = iter(self._docs)
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _FakeCollection:
+    def __init__(self) -> None:
+        self._docs: list[dict[str, Any]] = []
+        self.create_index = AsyncMock(return_value="idx")
+
+    async def insert_one(self, doc: dict[str, Any]) -> None:
+        self._docs.append(doc)
+
+    def find(self, query: dict[str, Any]) -> _FakeCursor:
+        matched = [d for d in self._docs if all(d.get(k) == v for k, v in query.items())]
+        return _FakeCursor(matched)
+
+
+def _build_store() -> tuple[PRDecisionStore, _FakeCollection]:
+    """Create a PRDecisionStore wired to an in-memory fake collection."""
+    store = PRDecisionStore(enabled=True)
+    col = _FakeCollection()
+
+    async def _stub() -> _FakeCollection:
+        return col
+
+    store._ensure_collection = _stub  # type: ignore[assignment]
+    return store, col
+
+
+@pytest.fixture
+def store_and_col() -> Iterator[tuple[PRDecisionStore, _FakeCollection]]:
+    store, col = _build_store()
+    pr_timeline_api.configure(store)
+    yield store, col
+    pr_timeline_api.configure(None)
+
+
+@pytest.fixture
+def client_authed(
+    store_and_col: tuple[PRDecisionStore, _FakeCollection],
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(pr_timeline_api.router)
+
+    async def _fake_user() -> admin_auth.UserInfo:
+        return admin_auth.UserInfo(sub="u", email="u@example.com", name="U", picture=None)
+
+    app.dependency_overrides[admin_auth.require_session] = _fake_user
+    return TestClient(app)
+
+
+@pytest.fixture
+def client_unauthed(
+    store_and_col: tuple[PRDecisionStore, _FakeCollection],
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(pr_timeline_api.router)
+    return TestClient(app)
+
+
+class TestPRTimelineAPI:
+    def test_get_timeline_returns_decisions(
+        self,
+        client_authed: TestClient,
+        store_and_col: tuple[PRDecisionStore, _FakeCollection],
+    ) -> None:
+        _store, col = store_and_col
+        now = datetime.now(UTC)
+        # Two decisions, oldest first.
+        col._docs = [
+            {
+                "id": "d1",
+                "repo": "ianlintner/caretaker-qa",
+                "pr_number": 108,
+                "observed_at": now - timedelta(minutes=5),
+                "agent": "pr_reviewer",
+                "event": "review_started",
+                "fields": {"author": "ianlintner", "is_caretaker_owned": False},
+                "trace_id": "a" * 32,
+                "span_id": "b" * 16,
+            },
+            {
+                "id": "d2",
+                "repo": "ianlintner/caretaker-qa",
+                "pr_number": 108,
+                "observed_at": now - timedelta(minutes=1),
+                "agent": "complexity_classifier",
+                "event": "tier_classified",
+                "fields": {"tier": "simple", "source": "fast_path", "confidence": 0.9},
+                "trace_id": None,
+                "span_id": None,
+            },
+        ]
+
+        resp = client_authed.get("/api/admin/pr/ianlintner/caretaker-qa/108/timeline")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["owner"] == "ianlintner"
+        assert data["repo"] == "caretaker-qa"
+        assert data["pr_number"] == 108
+        assert len(data["decisions"]) == 2
+        events = [d["event"] for d in data["decisions"]]
+        assert events == ["review_started", "tier_classified"]
+        assert data["decisions"][0]["fields"]["author"] == "ianlintner"
+        assert data["decisions"][0]["trace_id"] == "a" * 32
+
+    def test_get_timeline_returns_empty_when_no_decisions(
+        self,
+        client_authed: TestClient,
+    ) -> None:
+        # No documents inserted into the fake collection. Endpoint returns
+        # an empty list rather than a 404 — matches other admin APIs that
+        # return ``[]`` for "no data" so the SPA can render an empty state.
+        resp = client_authed.get("/api/admin/pr/anyone/anywhere/999/timeline")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["decisions"] == []
+        assert data["pr_number"] == 999
+
+    def test_get_timeline_unauthorized(
+        self,
+        client_unauthed: TestClient,
+    ) -> None:
+        # Without the dependency override, the endpoint should 401/403.
+        resp = client_unauthed.get("/api/admin/pr/ianlintner/caretaker-qa/108/timeline")
+        assert resp.status_code in (401, 403, 503)

--- a/tests/test_mcp_backend_health_deep.py
+++ b/tests/test_mcp_backend_health_deep.py
@@ -1,0 +1,162 @@
+"""Integration test for ``GET /health/deep`` on the MCP backend FastAPI app.
+
+Stubs ``gather_deep_health`` (covered by unit tests in
+``test_observability_health.py``) so the endpoint test focuses on:
+
+  * 200 status code with ``status=ok``
+  * 503 status code with ``status=fail``
+  * Body shape matches the documented JSON contract
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from caretaker.mcp_backend.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stub_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Don't actually open Mongo/Neo4j clients — env vars stay blank."""
+    monkeypatch.delenv("MONGODB_URL", raising=False)
+    monkeypatch.delenv("NEO4J_URL", raising=False)
+
+
+def test_health_deep_returns_200_on_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_gather(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "version": "0.28.4",
+            "checks": {
+                "git_cli": {"status": "ok", "version": "2.47.3"},
+                "opencode_cli": {"status": "ok", "version": "1.14.39"},
+                "redis": {"status": "ok", "latency_ms": 1},
+                "mongo": {"status": "ok", "latency_ms": 1},
+                "neo4j": {"status": "ok", "latency_ms": 1},
+                "openrouter_models": {
+                    "status": "ok",
+                    "probed_at": "2026-05-06T00:00:00+00:00",
+                    "results": {},
+                },
+            },
+        }
+
+    import caretaker.observability.health as health_module
+
+    monkeypatch.setattr(health_module, "gather_deep_health", _fake_gather)
+
+    response = client.get("/health/deep")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert "checks" in body
+    assert set(body["checks"].keys()) == {
+        "git_cli",
+        "opencode_cli",
+        "redis",
+        "mongo",
+        "neo4j",
+        "openrouter_models",
+    }
+
+
+def test_health_deep_returns_503_on_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_gather(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "fail",
+            "version": "0.28.4",
+            "checks": {
+                "git_cli": {"status": "fail", "error": "git binary not found on PATH"},
+                "opencode_cli": {"status": "ok", "version": "1.14.39"},
+                "redis": {"status": "ok", "latency_ms": 1},
+                "mongo": {"status": "ok", "latency_ms": 1},
+                "neo4j": {"status": "ok", "latency_ms": 1},
+                "openrouter_models": {"status": "skipped", "results": {}},
+            },
+        }
+
+    import caretaker.observability.health as health_module
+
+    monkeypatch.setattr(health_module, "gather_deep_health", _fake_gather)
+
+    response = client.get("/health/deep")
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "fail"
+    assert body["checks"]["git_cli"]["status"] == "fail"
+
+
+def test_health_deep_returns_200_on_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A degraded model probe with healthy core stack is still 200."""
+
+    async def _fake_gather(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "degraded",
+            "version": "0.28.4",
+            "checks": {
+                "git_cli": {"status": "ok", "version": "2.47.3"},
+                "opencode_cli": {"status": "ok", "version": "1.14.39"},
+                "redis": {"status": "ok", "latency_ms": 1},
+                "mongo": {"status": "ok", "latency_ms": 1},
+                "neo4j": {"status": "ok", "latency_ms": 1},
+                "openrouter_models": {
+                    "status": "fail",
+                    "probed_at": "2026-05-06T00:00:00+00:00",
+                    "results": {"openrouter/m1": "fail: No endpoints found"},
+                },
+            },
+        }
+
+    import caretaker.observability.health as health_module
+
+    monkeypatch.setattr(health_module, "gather_deep_health", _fake_gather)
+
+    response = client.get("/health/deep")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "degraded"
+
+
+def test_health_deep_caches_model_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two back-to-back calls hit the model-probe cache; subprocess fires once."""
+    import asyncio as _asyncio
+
+    from caretaker.observability.health import _reset_cache_for_tests
+
+    _reset_cache_for_tests()
+
+    call_counter = {"n": 0}
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"pong\n", b""
+
+        async def wait(self) -> int:
+            return 0
+
+    async def _factory(*args: Any, **_kwargs: Any) -> _FakeProc:
+        # Only count "opencode run ping ..." spawns — git/opencode --version
+        # are still probed live on every request.
+        cmd = [str(a) for a in args]
+        if "run" in cmd and "ping" in cmd:
+            call_counter["n"] += 1
+        return _FakeProc()
+
+    monkeypatch.setattr(_asyncio, "create_subprocess_exec", _factory)
+
+    # First call cold-loads the cache.
+    r1 = client.get("/health/deep")
+    # Second call should hit the cache — model probe count must not increase.
+    n_after_first = call_counter["n"]
+    r2 = client.get("/health/deep")
+    assert call_counter["n"] == n_after_first
+    # Both responses should be valid (whatever the body says).
+    assert r1.status_code in (200, 503)
+    assert r2.status_code in (200, 503)

--- a/tests/test_mcp_backend_health_deep.py
+++ b/tests/test_mcp_backend_health_deep.py
@@ -6,10 +6,13 @@ Stubs ``gather_deep_health`` (covered by unit tests in
   * 200 status code with ``status=ok``
   * 503 status code with ``status=fail``
   * Body shape matches the documented JSON contract
+  * Config-load failure surfaces as ``checks.config.status = "fail"``
+  * Wall-time timeout returns 503 with a structured error
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -160,3 +163,72 @@ def test_health_deep_caches_model_probe(monkeypatch: pytest.MonkeyPatch) -> None
     # Both responses should be valid (whatever the body says).
     assert r1.status_code in (200, 503)
     assert r2.status_code in (200, 503)
+
+
+def test_health_deep_returns_503_on_config_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """A missing/malformed CARETAKER_CONFIG_PATH bubbles up as a config fail.
+
+    The aggregator treats ``config`` as a CORE check, so the rollup is
+    ``fail`` and the endpoint returns 503 with ``checks.config.status``
+    set to ``"fail"``.
+    """
+    # Point the config loader at a path that doesn't exist; resolve_models
+    # records that as the config check failure.
+    missing = tmp_path / "definitely-not-here.yml"
+    monkeypatch.setenv("CARETAKER_CONFIG_PATH", str(missing))
+
+    async def _fake_gather(**kwargs: Any) -> dict[str, Any]:
+        # The endpoint wires resolve_models() output into config_check.
+        # Confirm we received a fail entry and propagate it through the
+        # full aggregator response shape.
+        config_check = kwargs.get("config_check")
+        assert config_check is not None
+        assert config_check["status"] == "fail"
+        return {
+            "status": "fail",
+            "version": "0.28.4",
+            "checks": {
+                "config": config_check,
+                "git_cli": {"status": "ok", "version": "2.47.3"},
+                "opencode_cli": {"status": "ok", "version": "1.14.39"},
+                "redis": {"status": "ok", "latency_ms": 1},
+                "mongo": {"status": "ok", "latency_ms": 1},
+                "neo4j": {"status": "ok", "latency_ms": 1},
+                "openrouter_models": {"status": "skipped", "results": {}},
+            },
+        }
+
+    import caretaker.observability.health as health_module
+
+    monkeypatch.setattr(health_module, "gather_deep_health", _fake_gather)
+
+    response = client.get("/health/deep")
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "fail"
+    assert body["checks"]["config"]["status"] == "fail"
+    assert "not found" in body["checks"]["config"]["error"].lower()
+
+
+def test_health_deep_returns_503_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If ``gather_deep_health`` exceeds the wall-time budget, return 503."""
+
+    async def _slow_gather(**_kwargs: Any) -> dict[str, Any]:
+        # Sleep long enough that asyncio.wait_for will trip first. The
+        # endpoint patches the budget below to keep the test fast.
+        await asyncio.sleep(5)
+        return {"status": "ok", "version": "0.28.4", "checks": {}}
+
+    import caretaker.mcp_backend.main as main_module
+    import caretaker.observability.health as health_module
+
+    monkeypatch.setattr(health_module, "gather_deep_health", _slow_gather)
+    monkeypatch.setattr(main_module, "HEALTH_DEEP_TIMEOUT_SECONDS", 0.05)
+
+    response = client.get("/health/deep")
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "fail"
+    assert "timed out" in body["error"]

--- a/tests/test_observability_cost_tracking.py
+++ b/tests/test_observability_cost_tracking.py
@@ -1,0 +1,200 @@
+"""Tests for the LLM token + USD cost tracking helpers (observability phase 3).
+
+Covers the three new helpers in :mod:`caretaker.observability.metrics`:
+
+  * :func:`record_llm_tokens` — increments ``caretaker_llm_tokens_total``
+    split by ``direction`` (``prompt`` / ``completion``).
+  * :func:`record_llm_cost` — looks the model up in
+    :data:`caretaker.config.LLM_PRICE_TABLE` and increments
+    ``caretaker_llm_cost_usd_total``. Unknown models log a one-shot
+    warning and skip the cost increment.
+  * :func:`record_llm_usage` — convenience that fires both above.
+
+Each assertion reads the underlying counter via
+``REGISTRY.get_sample_value`` so the test exercises the same path
+Prometheus uses on a scrape.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from caretaker.observability import metrics as metrics_mod
+from caretaker.observability.metrics import (
+    REGISTRY,
+    get_service_label,
+    record_llm_cost,
+    record_llm_tokens,
+    record_llm_usage,
+)
+
+
+def _service() -> str:
+    return get_service_label()
+
+
+def _read_tokens(model: str, direction: str) -> float:
+    val = REGISTRY.get_sample_value(
+        "caretaker_llm_tokens_total",
+        {"service": _service(), "model": model, "direction": direction},
+    )
+    return 0.0 if val is None else float(val)
+
+
+def _read_cost(model: str) -> float:
+    val = REGISTRY.get_sample_value(
+        "caretaker_llm_cost_usd_total",
+        {"service": _service(), "model": model},
+    )
+    return 0.0 if val is None else float(val)
+
+
+# ── record_llm_tokens ─────────────────────────────────────────────────
+
+
+def test_record_llm_tokens_increments_counter() -> None:
+    model = "openrouter/test/tokens-model"
+    before_p = _read_tokens(model, "prompt")
+    before_c = _read_tokens(model, "completion")
+    record_llm_tokens(model, prompt_tokens=1234, completion_tokens=567)
+    assert _read_tokens(model, "prompt") == pytest.approx(before_p + 1234)
+    assert _read_tokens(model, "completion") == pytest.approx(before_c + 567)
+
+
+def test_record_llm_tokens_skips_non_positive_values() -> None:
+    """Zero/negative counts are no-ops so partial fanout calls don't pollute the counter."""
+    model = "openrouter/test/zeros-model"
+    before_p = _read_tokens(model, "prompt")
+    before_c = _read_tokens(model, "completion")
+    record_llm_tokens(model, prompt_tokens=0, completion_tokens=0)
+    record_llm_tokens(model, prompt_tokens=-5, completion_tokens=-1)
+    assert _read_tokens(model, "prompt") == pytest.approx(before_p)
+    assert _read_tokens(model, "completion") == pytest.approx(before_c)
+
+
+# ── record_llm_cost ───────────────────────────────────────────────────
+
+
+def test_record_llm_cost_with_known_model(monkeypatch) -> None:
+    """A known model with simple round-numbered prices yields the expected USD total.
+
+    Price (1.00 input, 2.00 output) per 1M tokens, fed prompt=1_000_000
+    + completion=500_000 → expect $1.00 (input) + $1.00 (output) =
+    $2.00 increment.
+    """
+    test_model = "openrouter/test/known-pricing"
+    monkeypatch.setitem(
+        __import__("caretaker.config", fromlist=["LLM_PRICE_TABLE"]).LLM_PRICE_TABLE,
+        test_model,
+        (1.00, 2.00),
+    )
+
+    before = _read_cost(test_model)
+    record_llm_cost(test_model, prompt_tokens=1_000_000, completion_tokens=500_000)
+    after = _read_cost(test_model)
+    assert after - before == pytest.approx(2.00, abs=1e-9)
+
+
+def test_record_llm_cost_unknown_model_skips_and_warns(caplog, monkeypatch) -> None:
+    """An unknown model logs a one-shot info-level message and skips the cost increment."""
+    # Reset the warn-once memo so this test is independent of run order.
+    monkeypatch.setattr(metrics_mod, "_LLM_PRICE_TABLE_MISSES_WARNED", set())
+
+    unknown_model = "openrouter/test/never-priced-model-xyz"
+    before = _read_cost(unknown_model)
+    with caplog.at_level(logging.INFO, logger=metrics_mod.logger.name):
+        record_llm_cost(unknown_model, prompt_tokens=10_000, completion_tokens=2_000)
+        # Second call must NOT log again (warn-once memoisation).
+        record_llm_cost(unknown_model, prompt_tokens=99, completion_tokens=99)
+    after = _read_cost(unknown_model)
+
+    # Cost counter unchanged.
+    assert after == pytest.approx(before)
+
+    # Exactly one log record for this model.
+    matching = [r for r in caplog.records if unknown_model in r.getMessage()]
+    assert len(matching) == 1, f"expected 1 log for unknown model, got {len(matching)}"
+    assert "missing from LLM_PRICE_TABLE" in matching[0].getMessage()
+
+
+def test_record_llm_cost_skips_when_total_cost_is_zero(monkeypatch) -> None:
+    """Zero-token call produces zero cost; counter stays unchanged."""
+    test_model = "openrouter/test/zero-cost"
+    monkeypatch.setitem(
+        __import__("caretaker.config", fromlist=["LLM_PRICE_TABLE"]).LLM_PRICE_TABLE,
+        test_model,
+        (1.00, 2.00),
+    )
+    before = _read_cost(test_model)
+    record_llm_cost(test_model, prompt_tokens=0, completion_tokens=0)
+    assert _read_cost(test_model) == pytest.approx(before)
+
+
+# ── record_llm_usage ──────────────────────────────────────────────────
+
+
+def test_record_llm_usage_combined_increments_both_counters(monkeypatch) -> None:
+    """``record_llm_usage`` fires both token + cost counters in one call."""
+    test_model = "openrouter/test/combined-usage"
+    monkeypatch.setitem(
+        __import__("caretaker.config", fromlist=["LLM_PRICE_TABLE"]).LLM_PRICE_TABLE,
+        test_model,
+        (3.00, 6.00),  # USD per 1M
+    )
+
+    before_p = _read_tokens(test_model, "prompt")
+    before_c = _read_tokens(test_model, "completion")
+    before_cost = _read_cost(test_model)
+
+    record_llm_usage(test_model, prompt_tokens=2_000_000, completion_tokens=1_000_000)
+
+    # Tokens recorded.
+    assert _read_tokens(test_model, "prompt") == pytest.approx(before_p + 2_000_000)
+    assert _read_tokens(test_model, "completion") == pytest.approx(before_c + 1_000_000)
+    # Cost: 2M * $3/M + 1M * $6/M = $6 + $6 = $12.
+    assert _read_cost(test_model) - before_cost == pytest.approx(12.0, abs=1e-9)
+
+
+def test_record_llm_usage_unknown_model_records_tokens_skips_cost(monkeypatch) -> None:
+    """Unknown model: token counter still moves, cost counter does not."""
+    monkeypatch.setattr(metrics_mod, "_LLM_PRICE_TABLE_MISSES_WARNED", set())
+    unknown_model = "openrouter/test/usage-no-price"
+
+    before_p = _read_tokens(unknown_model, "prompt")
+    before_c = _read_tokens(unknown_model, "completion")
+    before_cost = _read_cost(unknown_model)
+
+    record_llm_usage(unknown_model, prompt_tokens=1_000, completion_tokens=200)
+
+    assert _read_tokens(unknown_model, "prompt") == pytest.approx(before_p + 1_000)
+    assert _read_tokens(unknown_model, "completion") == pytest.approx(before_c + 200)
+    assert _read_cost(unknown_model) == pytest.approx(before_cost)
+
+
+# ── price-table coverage ──────────────────────────────────────────────
+
+
+def test_llm_price_table_covers_v028_default_models() -> None:
+    """All v0.28.x default models should be in the price table.
+
+    If this fails after adding a new default model, add the model to
+    ``LLM_PRICE_TABLE`` in ``caretaker.config`` rather than dropping it
+    from the assertion list.
+    """
+    from caretaker.config import LLM_PRICE_TABLE
+
+    expected = {
+        # review_models defaults
+        "openrouter/google/gemini-2.5-flash-lite",
+        "openrouter/google/gemini-2.5-flash",
+        "openrouter/deepseek/deepseek-v4-flash",
+        "openrouter/google/gemini-2.5-pro",
+        # fix_models defaults
+        "openrouter/anthropic/claude-haiku-4.5",
+        "openrouter/deepseek/deepseek-v4-pro",
+        "openrouter/anthropic/claude-sonnet-4.5",
+    }
+    missing = expected - set(LLM_PRICE_TABLE)
+    assert not missing, f"v0.28 default models missing from price table: {missing}"

--- a/tests/test_observability_cost_tracking.py
+++ b/tests/test_observability_cost_tracking.py
@@ -98,13 +98,13 @@ def test_record_llm_cost_with_known_model(monkeypatch) -> None:
 
 
 def test_record_llm_cost_unknown_model_skips_and_warns(caplog, monkeypatch) -> None:
-    """An unknown model logs a one-shot info-level message and skips the cost increment."""
+    """An unknown model logs a one-shot warning-level message and skips the cost increment."""
     # Reset the warn-once memo so this test is independent of run order.
     monkeypatch.setattr(metrics_mod, "_LLM_PRICE_TABLE_MISSES_WARNED", set())
 
     unknown_model = "openrouter/test/never-priced-model-xyz"
     before = _read_cost(unknown_model)
-    with caplog.at_level(logging.INFO, logger=metrics_mod.logger.name):
+    with caplog.at_level(logging.WARNING, logger=metrics_mod.logger.name):
         record_llm_cost(unknown_model, prompt_tokens=10_000, completion_tokens=2_000)
         # Second call must NOT log again (warn-once memoisation).
         record_llm_cost(unknown_model, prompt_tokens=99, completion_tokens=99)
@@ -113,9 +113,10 @@ def test_record_llm_cost_unknown_model_skips_and_warns(caplog, monkeypatch) -> N
     # Cost counter unchanged.
     assert after == pytest.approx(before)
 
-    # Exactly one log record for this model.
+    # Exactly one log record for this model, at WARNING level.
     matching = [r for r in caplog.records if unknown_model in r.getMessage()]
     assert len(matching) == 1, f"expected 1 log for unknown model, got {len(matching)}"
+    assert matching[0].levelno == logging.WARNING
     assert "missing from LLM_PRICE_TABLE" in matching[0].getMessage()
 
 

--- a/tests/test_observability_health.py
+++ b/tests/test_observability_health.py
@@ -481,6 +481,7 @@ async def test_gather_deep_health_all_ok(monkeypatch: pytest.MonkeyPatch) -> Non
     assert result["status"] == "ok"
     assert result["version"] == "0.28.4"
     assert set(result["checks"].keys()) == {
+        "config",
         "git_cli",
         "opencode_cli",
         "redis",
@@ -588,3 +589,66 @@ async def test_gather_deep_health_skips_model_probe_when_opencode_missing(
     assert result["checks"]["openrouter_models"]["status"] == "skipped"
     # Verify we never spawned an "opencode run ping" subprocess.
     assert all(cmd[0] != "opencode" or "run" not in cmd for cmd in call_log)
+
+
+@pytest.mark.asyncio
+async def test_gather_deep_health_fail_on_config_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing ``config`` check is a CORE fail → top-level ``fail``."""
+    _reset_cache_for_tests()
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(returncode=0, stdout=b"git version 2.47.3\n"),
+    )
+
+    async def _fake_probe(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"status": "ok", "probed_at": None, "results": {}}
+
+    monkeypatch.setattr(health_module, "probe_openrouter_models", _fake_probe)
+
+    import redis.asyncio as redis_async
+
+    monkeypatch.setattr(redis_async, "Redis", _FakeRedisOk)
+
+    result = await gather_deep_health(
+        redis_url="redis://fake:6379",
+        mongo_client=_FakeMongoOk(),
+        neo4j_driver=_FakeNeo4jDriverOk(),
+        models_to_probe=[],
+        config_check={"status": "fail", "error": "broken yaml"},
+    )
+    assert result["status"] == "fail"
+    assert result["checks"]["config"] == {"status": "fail", "error": "broken yaml"}
+
+
+@pytest.mark.asyncio
+async def test_gather_deep_health_defaults_config_check_to_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Callers that don't pass ``config_check`` get an implicit ``ok`` entry."""
+    _reset_cache_for_tests()
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(returncode=0, stdout=b"git version 2.47.3\n"),
+    )
+
+    async def _fake_probe(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"status": "ok", "probed_at": None, "results": {}}
+
+    monkeypatch.setattr(health_module, "probe_openrouter_models", _fake_probe)
+
+    import redis.asyncio as redis_async
+
+    monkeypatch.setattr(redis_async, "Redis", _FakeRedisOk)
+
+    result = await gather_deep_health(
+        redis_url="redis://fake:6379",
+        mongo_client=_FakeMongoOk(),
+        neo4j_driver=_FakeNeo4jDriverOk(),
+        models_to_probe=[],
+    )
+    assert result["checks"]["config"] == {"status": "ok"}
+    assert result["status"] == "ok"

--- a/tests/test_observability_health.py
+++ b/tests/test_observability_health.py
@@ -1,0 +1,590 @@
+"""Unit tests for :mod:`caretaker.observability.health`.
+
+Covers each of the six dependency-check helpers, the cache behaviour of
+``probe_openrouter_models`` (cold + warm), and the rollup logic in
+``gather_deep_health``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from caretaker.observability import health as health_module
+from caretaker.observability.health import (
+    _reset_cache_for_tests,
+    check_git_cli,
+    check_mongo,
+    check_neo4j,
+    check_opencode_cli,
+    check_redis,
+    collect_models_to_probe,
+    gather_deep_health,
+    probe_openrouter_models,
+)
+
+# ── Fakes ────────────────────────────────────────────────────────────────
+
+
+class _FakeProcess:
+    """Minimal stand-in for ``asyncio.subprocess.Process``."""
+
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+    ) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+    async def wait(self) -> int:
+        return self.returncode
+
+    def kill(self) -> None:  # pragma: no cover — only used on timeout path
+        pass
+
+
+def _fake_subprocess_factory(
+    *,
+    returncode: int = 0,
+    stdout: bytes = b"",
+    stderr: bytes = b"",
+    raise_exc: BaseException | None = None,
+) -> Any:
+    async def _factory(*_args: Any, **_kwargs: Any) -> _FakeProcess:
+        if raise_exc is not None:
+            raise raise_exc
+        return _FakeProcess(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    return _factory
+
+
+# ── git_cli ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_git_cli_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(stdout=b"git version 2.47.3\n"),
+    )
+    result = await check_git_cli()
+    assert result == {"status": "ok", "version": "2.47.3"}
+
+
+@pytest.mark.asyncio
+async def test_check_git_cli_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(raise_exc=FileNotFoundError("git")),
+    )
+    result = await check_git_cli()
+    assert result["status"] == "fail"
+    assert "not found" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_check_git_cli_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(returncode=128, stderr=b"fatal: oops\n"),
+    )
+    result = await check_git_cli()
+    assert result["status"] == "fail"
+    assert "fatal: oops" in result["error"]
+
+
+# ── opencode_cli ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_opencode_cli_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(stdout=b"opencode 1.14.39\n"),
+    )
+    result = await check_opencode_cli()
+    assert result == {"status": "ok", "version": "1.14.39"}
+
+
+@pytest.mark.asyncio
+async def test_check_opencode_cli_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(raise_exc=FileNotFoundError("opencode")),
+    )
+    result = await check_opencode_cli()
+    assert result["status"] == "fail"
+    assert "not found" in result["error"]
+
+
+# ── redis ────────────────────────────────────────────────────────────────
+
+
+class _FakeRedisOk:
+    @classmethod
+    def from_url(cls, *_args: Any, **_kwargs: Any) -> _FakeRedisOk:
+        return cls()
+
+    async def ping(self) -> bool:
+        return True
+
+    async def aclose(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+class _FakeRedisFail:
+    @classmethod
+    def from_url(cls, *_args: Any, **_kwargs: Any) -> _FakeRedisFail:
+        return cls()
+
+    async def ping(self) -> bool:
+        raise ConnectionError("nope")
+
+    async def aclose(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_check_redis_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    import redis.asyncio as redis_async
+
+    monkeypatch.setattr(redis_async, "Redis", _FakeRedisOk)
+    result = await check_redis("redis://fake:6379")
+    assert result["status"] == "ok"
+    assert isinstance(result["latency_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_check_redis_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    import redis.asyncio as redis_async
+
+    monkeypatch.setattr(redis_async, "Redis", _FakeRedisFail)
+    result = await check_redis("redis://fake:6379")
+    assert result["status"] == "fail"
+    assert "ConnectionError" in result["error"]
+
+
+# ── mongo ────────────────────────────────────────────────────────────────
+
+
+class _FakeMongoAdminOk:
+    async def command(self, _cmd: str) -> dict[str, int]:
+        return {"ok": 1}
+
+
+class _FakeMongoOk:
+    admin = _FakeMongoAdminOk()
+
+
+class _FakeMongoAdminFail:
+    async def command(self, _cmd: str) -> dict[str, int]:
+        raise ConnectionError("no mongo")
+
+
+class _FakeMongoFail:
+    admin = _FakeMongoAdminFail()
+
+
+@pytest.mark.asyncio
+async def test_check_mongo_ok() -> None:
+    result = await check_mongo(_FakeMongoOk())
+    assert result["status"] == "ok"
+    assert isinstance(result["latency_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_check_mongo_fail() -> None:
+    result = await check_mongo(_FakeMongoFail())
+    assert result["status"] == "fail"
+    assert "ConnectionError" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_check_mongo_none_client() -> None:
+    result = await check_mongo(None)
+    assert result["status"] == "fail"
+    assert "not configured" in result["error"]
+
+
+# ── neo4j ────────────────────────────────────────────────────────────────
+
+
+class _FakeNeo4jResultOk:
+    async def consume(self) -> None:
+        return None
+
+
+class _FakeNeo4jSessionOk:
+    async def __aenter__(self) -> _FakeNeo4jSessionOk:
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+    async def run(self, _query: str) -> _FakeNeo4jResultOk:
+        return _FakeNeo4jResultOk()
+
+
+class _FakeNeo4jDriverOk:
+    def session(self) -> _FakeNeo4jSessionOk:
+        return _FakeNeo4jSessionOk()
+
+
+class _FakeNeo4jSessionFail:
+    async def __aenter__(self) -> _FakeNeo4jSessionFail:
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+    async def run(self, _query: str) -> Any:
+        raise ConnectionError("graph down")
+
+
+class _FakeNeo4jDriverFail:
+    def session(self) -> _FakeNeo4jSessionFail:
+        return _FakeNeo4jSessionFail()
+
+
+@pytest.mark.asyncio
+async def test_check_neo4j_ok() -> None:
+    result = await check_neo4j(_FakeNeo4jDriverOk())
+    assert result["status"] == "ok"
+    assert isinstance(result["latency_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_check_neo4j_fail() -> None:
+    result = await check_neo4j(_FakeNeo4jDriverFail())
+    assert result["status"] == "fail"
+    assert "ConnectionError" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_check_neo4j_none_driver() -> None:
+    result = await check_neo4j(None)
+    assert result["status"] == "fail"
+
+
+# ── probe_openrouter_models ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_probe_openrouter_models_skipped_when_opencode_unavailable() -> None:
+    _reset_cache_for_tests()
+    result = await probe_openrouter_models(
+        ["openrouter/google/gemini-2.5-pro"],
+        opencode_available=False,
+    )
+    assert result["status"] == "skipped"
+    assert result["reason"] == "opencode_cli unavailable"
+    assert "openrouter/google/gemini-2.5-pro" in result["results"]
+
+
+@pytest.mark.asyncio
+async def test_probe_openrouter_models_no_endpoints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_cache_for_tests()
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(
+            returncode=1,
+            stderr=b"Error: No endpoints found for model gemini-3-pro-preview\n",
+        ),
+    )
+    result = await probe_openrouter_models(
+        ["openrouter/google/gemini-3-pro-preview"],
+        timeout_seconds=1.0,
+    )
+    assert result["results"]["openrouter/google/gemini-3-pro-preview"] == "fail: No endpoints found"
+    assert result["status"] == "fail"
+    assert result["probed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_probe_openrouter_models_insufficient_credits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_cache_for_tests()
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(
+            returncode=1,
+            stderr=b"Insufficient credits to complete this request\n",
+        ),
+    )
+    result = await probe_openrouter_models(["openrouter/x/y"], timeout_seconds=1.0)
+    assert result["results"]["openrouter/x/y"] == "fail: insufficient credits"
+
+
+@pytest.mark.asyncio
+async def test_probe_openrouter_models_other_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_cache_for_tests()
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(
+            returncode=2,
+            stderr=b"context deadline exceeded\nsecondary line\n",
+        ),
+    )
+    result = await probe_openrouter_models(["openrouter/x/y"], timeout_seconds=1.0)
+    assert result["results"]["openrouter/x/y"] == "fail: context deadline exceeded"
+
+
+@pytest.mark.asyncio
+async def test_probe_openrouter_models_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_cache_for_tests()
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(returncode=0, stdout=b"pong\n"),
+    )
+    result = await probe_openrouter_models(
+        ["openrouter/google/gemini-2.5-pro"],
+        timeout_seconds=1.0,
+    )
+    assert result["status"] == "ok"
+    assert result["results"]["openrouter/google/gemini-2.5-pro"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_probe_openrouter_models_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_cache_for_tests()
+    call_counter = {"n": 0}
+
+    async def _factory(*_args: Any, **_kwargs: Any) -> _FakeProcess:
+        call_counter["n"] += 1
+        return _FakeProcess(returncode=0, stdout=b"pong\n")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _factory)
+
+    first = await probe_openrouter_models(["openrouter/m1"], timeout_seconds=1.0)
+    assert first["status"] == "ok"
+    assert call_counter["n"] == 1
+
+    # Second call within the TTL must not re-spawn the subprocess.
+    second = await probe_openrouter_models(["openrouter/m1"], timeout_seconds=1.0)
+    assert second["status"] == "ok"
+    assert call_counter["n"] == 1
+    # probed_at survives across calls (same cache entry).
+    assert first["probed_at"] == second["probed_at"]
+
+
+# ── collect_models_to_probe ──────────────────────────────────────────────
+
+
+class _FakeOpenCodeLocal:
+    def __init__(self) -> None:
+        self.model = "openrouter/google/gemini-2.5-pro"
+        self.fix_model = "openrouter/google/gemini-2.5-pro"
+        self.review_models = {
+            "trivial": "openrouter/google/gemini-2.5-flash-lite",
+            "complex": "openrouter/google/gemini-2.5-pro",
+        }
+        self.fix_models = {
+            "complex": "openrouter/anthropic/claude-sonnet-4.5",
+        }
+
+
+class _FakeFeatureModel:
+    def __init__(self, model: str | None) -> None:
+        self.model = model
+        self.max_tokens = None
+
+
+class _FakeLLM:
+    def __init__(
+        self,
+        provider: str = "openrouter",
+        feature_models: dict[str, _FakeFeatureModel] | None = None,
+    ) -> None:
+        self.provider = provider
+        self.feature_models = feature_models or {}
+
+
+def test_collect_models_dedupes_and_includes_classifier() -> None:
+    models = collect_models_to_probe(
+        opencode_local=_FakeOpenCodeLocal(),
+        llm=_FakeLLM(),
+    )
+    # Pro appears multiple times but is deduplicated.
+    assert models.count("openrouter/google/gemini-2.5-pro") == 1
+    # Classifier resolves to provider default for openrouter.
+    assert "openrouter/google/gemini-2.5-flash-lite" in models
+    # Sonnet from fix_models is present.
+    assert "openrouter/anthropic/claude-sonnet-4.5" in models
+
+
+def test_collect_models_uses_operator_override() -> None:
+    llm = _FakeLLM(
+        feature_models={"complexity_classifier": _FakeFeatureModel("openrouter/custom/model")},
+    )
+    models = collect_models_to_probe(opencode_local=_FakeOpenCodeLocal(), llm=llm)
+    assert "openrouter/custom/model" in models
+
+
+# ── gather_deep_health rollup ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gather_deep_health_all_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_cache_for_tests()
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(returncode=0, stdout=b"git version 2.47.3\n"),
+    )
+
+    # Stub out the model probe entirely — covered above.
+    async def _fake_probe(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"status": "ok", "probed_at": "2026-05-06T00:00:00+00:00", "results": {}}
+
+    monkeypatch.setattr(health_module, "probe_openrouter_models", _fake_probe)
+
+    import redis.asyncio as redis_async
+
+    monkeypatch.setattr(redis_async, "Redis", _FakeRedisOk)
+
+    result = await gather_deep_health(
+        redis_url="redis://fake:6379",
+        mongo_client=_FakeMongoOk(),
+        neo4j_driver=_FakeNeo4jDriverOk(),
+        models_to_probe=["openrouter/m1"],
+        version="0.28.4",
+    )
+    assert result["status"] == "ok"
+    assert result["version"] == "0.28.4"
+    assert set(result["checks"].keys()) == {
+        "git_cli",
+        "opencode_cli",
+        "redis",
+        "mongo",
+        "neo4j",
+        "openrouter_models",
+    }
+
+
+@pytest.mark.asyncio
+async def test_gather_deep_health_degraded_on_model_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_cache_for_tests()
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(returncode=0, stdout=b"git version 2.47.3\n"),
+    )
+
+    async def _fake_probe(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "fail",
+            "probed_at": "2026-05-06T00:00:00+00:00",
+            "results": {"openrouter/m1": "fail: No endpoints found"},
+        }
+
+    monkeypatch.setattr(health_module, "probe_openrouter_models", _fake_probe)
+
+    import redis.asyncio as redis_async
+
+    monkeypatch.setattr(redis_async, "Redis", _FakeRedisOk)
+
+    result = await gather_deep_health(
+        redis_url="redis://fake:6379",
+        mongo_client=_FakeMongoOk(),
+        neo4j_driver=_FakeNeo4jDriverOk(),
+        models_to_probe=["openrouter/m1"],
+    )
+    assert result["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_gather_deep_health_fail_on_redis_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_cache_for_tests()
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_subprocess_factory(returncode=0, stdout=b"git version 2.47.3\n"),
+    )
+
+    async def _fake_probe(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"status": "ok", "probed_at": None, "results": {}}
+
+    monkeypatch.setattr(health_module, "probe_openrouter_models", _fake_probe)
+
+    import redis.asyncio as redis_async
+
+    monkeypatch.setattr(redis_async, "Redis", _FakeRedisFail)
+
+    result = await gather_deep_health(
+        redis_url="redis://fake:6379",
+        mongo_client=_FakeMongoOk(),
+        neo4j_driver=_FakeNeo4jDriverOk(),
+        models_to_probe=[],
+    )
+    assert result["status"] == "fail"
+    assert result["checks"]["redis"]["status"] == "fail"
+
+
+@pytest.mark.asyncio
+async def test_gather_deep_health_skips_model_probe_when_opencode_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_cache_for_tests()
+
+    # First subprocess call (git) succeeds; second (opencode) raises FileNotFoundError.
+    call_log: list[tuple[str, ...]] = []
+
+    async def _factory(*args: Any, **_kwargs: Any) -> _FakeProcess:
+        cmd = tuple(str(a) for a in args)
+        call_log.append(cmd)
+        if cmd and cmd[0] == "git":
+            return _FakeProcess(returncode=0, stdout=b"git version 2.47.3\n")
+        raise FileNotFoundError("opencode")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _factory)
+
+    import redis.asyncio as redis_async
+
+    monkeypatch.setattr(redis_async, "Redis", _FakeRedisOk)
+
+    result = await gather_deep_health(
+        redis_url="redis://fake:6379",
+        mongo_client=_FakeMongoOk(),
+        neo4j_driver=_FakeNeo4jDriverOk(),
+        models_to_probe=["openrouter/m1", "openrouter/m2"],
+    )
+    # opencode missing → core fail → top-level fail
+    assert result["status"] == "fail"
+    assert result["checks"]["opencode_cli"]["status"] == "fail"
+    # Model probe should be skipped (no per-model subprocess attempts).
+    assert result["checks"]["openrouter_models"]["status"] == "skipped"
+    # Verify we never spawned an "opencode run ping" subprocess.
+    assert all(cmd[0] != "opencode" or "run" not in cmd for cmd in call_log)

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -1,0 +1,260 @@
+"""Tests for the PR-reviewer observability helpers (phase 1A).
+
+Covers the five recorder helpers added to ``caretaker.observability.metrics``:
+
+  * :func:`record_pr_review_outcome` / :func:`observe_pr_review_duration`
+  * :func:`record_complexity_tier`
+  * :func:`record_opencode_invocation`
+  * :func:`record_auto_fix_dispatch`
+
+Each test reads back the underlying counter via ``REGISTRY.get_sample_value``
+so the assertions exercise the same path Prometheus uses on a scrape.
+"""
+
+from __future__ import annotations
+
+from caretaker.observability.metrics import (
+    REGISTRY,
+    get_service_label,
+    observe_pr_review_duration,
+    record_auto_fix_dispatch,
+    record_complexity_tier,
+    record_opencode_invocation,
+    record_pr_review_outcome,
+)
+
+
+def _service() -> str:
+    return get_service_label()
+
+
+# ── record_pr_review_outcome ──────────────────────────────────────────
+
+
+def test_record_pr_review_outcome_increments_counter() -> None:
+    record_pr_review_outcome(
+        repo="owner/repo", backend="opencode_local", tier="standard", verdict="APPROVE"
+    )
+    value = REGISTRY.get_sample_value(
+        "caretaker_pr_review_outcome_total",
+        {
+            "service": _service(),
+            "repo": "owner/repo",
+            "backend": "opencode_local",
+            "tier": "standard",
+            "verdict": "APPROVE",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+def test_record_pr_review_outcome_unknown_tier_falls_back_to_other() -> None:
+    """Unknown enum values land in the ``other`` bucket — no new series."""
+    record_pr_review_outcome(
+        repo="owner/repo",
+        backend="opencode_local",
+        tier="ULTRA-MEGA",  # not in COMPLEXITY_TIERS
+        verdict="APPROVE",
+    )
+    value = REGISTRY.get_sample_value(
+        "caretaker_pr_review_outcome_total",
+        {
+            "service": _service(),
+            "repo": "owner/repo",
+            "backend": "opencode_local",
+            "tier": "other",
+            "verdict": "APPROVE",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+def test_record_pr_review_outcome_unknown_verdict_falls_back_to_other() -> None:
+    record_pr_review_outcome(repo="owner/repo", backend="inline", tier="trivial", verdict="WAFFLE")
+    value = REGISTRY.get_sample_value(
+        "caretaker_pr_review_outcome_total",
+        {
+            "service": _service(),
+            "repo": "owner/repo",
+            "backend": "inline",
+            "tier": "trivial",
+            "verdict": "other",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+# ── observe_pr_review_duration ────────────────────────────────────────
+
+
+def test_observe_pr_review_duration_records_histogram_count() -> None:
+    observe_pr_review_duration(backend="opencode_local", tier="simple", seconds=2.5)
+    count = REGISTRY.get_sample_value(
+        "caretaker_pr_review_duration_seconds_count",
+        {"service": _service(), "backend": "opencode_local", "tier": "simple"},
+    )
+    assert count is not None
+    assert count >= 1
+
+
+def test_observe_pr_review_duration_unknown_tier_records_under_other() -> None:
+    observe_pr_review_duration(backend="opencode_local", tier="not-a-tier", seconds=1.0)
+    count = REGISTRY.get_sample_value(
+        "caretaker_pr_review_duration_seconds_count",
+        {"service": _service(), "backend": "opencode_local", "tier": "other"},
+    )
+    assert count is not None
+    assert count >= 1
+
+
+# ── record_complexity_tier ────────────────────────────────────────────
+
+
+def test_record_complexity_tier_increments_counter() -> None:
+    record_complexity_tier(tier="trivial", source="fast_path")
+    value = REGISTRY.get_sample_value(
+        "caretaker_complexity_classifier_tier_total",
+        {"service": _service(), "tier": "trivial", "source": "fast_path"},
+    )
+    assert value is not None
+    assert value >= 1
+
+
+def test_record_complexity_tier_unknown_source_falls_back_to_other() -> None:
+    record_complexity_tier(tier="trivial", source="from_outer_space")
+    value = REGISTRY.get_sample_value(
+        "caretaker_complexity_classifier_tier_total",
+        {"service": _service(), "tier": "trivial", "source": "other"},
+    )
+    assert value is not None
+    assert value >= 1
+
+
+# ── record_opencode_invocation ────────────────────────────────────────
+
+
+def test_record_opencode_invocation_increments_counter() -> None:
+    record_opencode_invocation(
+        model="openrouter/anthropic/claude-sonnet-4.5", mode="review", outcome="ok"
+    )
+    value = REGISTRY.get_sample_value(
+        "caretaker_opencode_invocation_total",
+        {
+            "service": _service(),
+            "model": "openrouter/anthropic/claude-sonnet-4.5",
+            "mode": "review",
+            "outcome": "ok",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+def test_record_opencode_invocation_unknown_outcome_falls_back_to_other() -> None:
+    record_opencode_invocation(model="some/model", mode="review", outcome="weird-status")
+    value = REGISTRY.get_sample_value(
+        "caretaker_opencode_invocation_total",
+        {
+            "service": _service(),
+            "model": "some/model",
+            "mode": "review",
+            "outcome": "other",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+def test_record_opencode_invocation_parse_fallback_outcome() -> None:
+    """The ``parse_fallback`` outcome is recorded by _parse_review_payload."""
+    record_opencode_invocation(model="<unknown>", mode="<unknown>", outcome="parse_fallback")
+    value = REGISTRY.get_sample_value(
+        "caretaker_opencode_invocation_total",
+        {
+            "service": _service(),
+            "model": "<unknown>",
+            "mode": "other",  # "<unknown>" not in OPENCODE_MODES
+            "outcome": "parse_fallback",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+# ── record_auto_fix_dispatch ──────────────────────────────────────────
+
+
+def test_record_auto_fix_dispatch_increments_counter() -> None:
+    record_auto_fix_dispatch(
+        repo="owner/repo",
+        backend="deterministic_lint",
+        category="lint",
+        outcome="dispatched_success",
+    )
+    value = REGISTRY.get_sample_value(
+        "caretaker_auto_fix_dispatch_total",
+        {
+            "service": _service(),
+            "repo": "owner/repo",
+            "backend": "deterministic_lint",
+            "category": "lint",
+            "outcome": "dispatched_success",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+def test_record_auto_fix_dispatch_skipped_with_none_backend() -> None:
+    record_auto_fix_dispatch(repo="owner/repo", backend="none", category="none", outcome="skipped")
+    value = REGISTRY.get_sample_value(
+        "caretaker_auto_fix_dispatch_total",
+        {
+            "service": _service(),
+            "repo": "owner/repo",
+            "backend": "none",
+            "category": "none",
+            "outcome": "skipped",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+def test_record_auto_fix_dispatch_unknown_outcome_falls_back_to_other() -> None:
+    record_auto_fix_dispatch(
+        repo="owner/repo",
+        backend="claude_code_local",
+        category="security",
+        outcome="not-a-real-outcome",
+    )
+    value = REGISTRY.get_sample_value(
+        "caretaker_auto_fix_dispatch_total",
+        {
+            "service": _service(),
+            "repo": "owner/repo",
+            "backend": "claude_code_local",
+            "category": "security",
+            "outcome": "other",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+# ── enum constants are exported ──────────────────────────────────────
+
+
+def test_bounded_enums_are_exported() -> None:
+    """Ensure the enum tuples are reachable from the public namespace."""
+    from caretaker.observability import metrics as m
+
+    assert "trivial" in m.COMPLEXITY_TIERS
+    assert "fast_path" in m.CLASSIFIER_SOURCES
+    assert "review" in m.OPENCODE_MODES
+    assert "ok" in m.OPENCODE_OUTCOMES
+    assert "dispatched_success" in m.AUTO_FIX_OUTCOMES
+    assert "APPROVE" in m.REVIEW_VERDICTS

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -169,15 +169,39 @@ def test_record_opencode_invocation_unknown_outcome_falls_back_to_other() -> Non
 
 
 def test_record_opencode_invocation_parse_fallback_outcome() -> None:
-    """The ``parse_fallback`` outcome is recorded by _parse_review_payload."""
-    record_opencode_invocation(model="<unknown>", mode="<unknown>", outcome="parse_fallback")
+    """The ``parse_fallback`` outcome is recorded by ``run()`` / ``fix_run()``.
+
+    ``_parse_review_payload`` no longer records the metric directly —
+    it returns a ``was_fallback`` bool and the caller records the
+    counter with the real model + mode labels. This test still
+    confirms the enum bucket exists end-to-end.
+    """
+    record_opencode_invocation(
+        model="openrouter/test/model", mode="review", outcome="parse_fallback"
+    )
     value = REGISTRY.get_sample_value(
         "caretaker_opencode_invocation_total",
         {
             "service": _service(),
-            "model": "<unknown>",
-            "mode": "other",  # "<unknown>" not in OPENCODE_MODES
+            "model": "openrouter/test/model",
+            "mode": "review",
             "outcome": "parse_fallback",
+        },
+    )
+    assert value is not None
+    assert value >= 1
+
+
+def test_record_opencode_invocation_declined_outcome() -> None:
+    """The ``declined`` outcome is bounded — fix_run records it on the sentinel branch."""
+    record_opencode_invocation(model="some/model", mode="fix", outcome="declined")
+    value = REGISTRY.get_sample_value(
+        "caretaker_opencode_invocation_total",
+        {
+            "service": _service(),
+            "model": "some/model",
+            "mode": "fix",
+            "outcome": "declined",
         },
     )
     assert value is not None
@@ -245,6 +269,32 @@ def test_record_auto_fix_dispatch_unknown_outcome_falls_back_to_other() -> None:
     assert value >= 1
 
 
+# ── _bound_or_other warn-once behaviour ──────────────────────────────
+
+
+def test_bound_or_other_warns_only_once_per_value_enum_pair(caplog) -> None:
+    """Hot-path callers passing the same off-enum value shouldn't flood the log."""
+    from caretaker.observability import metrics as m
+
+    # Reset the warn-once memo so this test is hermetic against
+    # earlier tests that may have warmed up the same key.
+    m._BOUND_OR_OTHER_WARNED.clear()
+
+    fake_enum = ("alpha", "beta")
+    with caplog.at_level("WARNING", logger="caretaker.observability.metrics"):
+        first = m._bound_or_other("nonsense", fake_enum)
+        second = m._bound_or_other("nonsense", fake_enum)
+
+    assert first == "other"
+    assert second == "other"
+    warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelname == "WARNING" and "nonsense" in rec.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
 # ── enum constants are exported ──────────────────────────────────────
 
 
@@ -256,5 +306,13 @@ def test_bounded_enums_are_exported() -> None:
     assert "fast_path" in m.CLASSIFIER_SOURCES
     assert "review" in m.OPENCODE_MODES
     assert "ok" in m.OPENCODE_OUTCOMES
+    assert "declined" in m.OPENCODE_OUTCOMES
     assert "dispatched_success" in m.AUTO_FIX_OUTCOMES
     assert "APPROVE" in m.REVIEW_VERDICTS
+    # Non-LLM terminal states are part of the bounded REVIEW_VERDICTS
+    # enum so the audit log can record them without falling through to
+    # the noisy ``other`` bucket.
+    assert "skipped" in m.REVIEW_VERDICTS
+    assert "dispatched" in m.REVIEW_VERDICTS
+    assert "dispatch_failed" in m.REVIEW_VERDICTS
+    assert "none" in m.REVIEW_VERDICTS

--- a/tests/test_observability_tracer_compat.py
+++ b/tests/test_observability_tracer_compat.py
@@ -1,0 +1,71 @@
+"""Tests for the OTEL compatibility shim.
+
+The shim must:
+* expose a ``get_tracer`` callable returning something with the right
+  ``start_as_current_span`` shape, regardless of whether the
+  ``opentelemetry`` SDK is installed;
+* yield a span object that swallows every call without raising;
+* expose ``Status`` / ``StatusCode`` symbols that can be instantiated
+  even when the real SDK is absent.
+
+The tests below exercise the no-op classes directly so they pass
+both with and without the otel extras installed.
+"""
+
+from __future__ import annotations
+
+from caretaker.observability.tracer_compat import (
+    Status,
+    StatusCode,
+    _NullSpan,
+    _NullTracer,
+    get_current_span,
+    get_tracer,
+)
+
+
+def test_get_tracer_returns_object_with_start_as_current_span() -> None:
+    """``get_tracer`` always returns an object with the SDK-shaped API."""
+    tracer = get_tracer("caretaker.test")
+    assert hasattr(tracer, "start_as_current_span")
+
+
+def test_null_span_swallows_all_calls() -> None:
+    """The no-op span must accept every SDK-shaped call without raising."""
+    span = _NullSpan()
+    # All four span methods used elsewhere in the codebase must be no-ops.
+    span.set_attribute("k", "v")
+    span.record_exception(RuntimeError("boom"))
+    span.set_status(Status(StatusCode.ERROR, "msg"))
+    # ``get_span_context`` always returns ``None`` on the null span so
+    # ``_capture_trace_ids`` short-circuits cleanly.
+    span.get_span_context()
+    span.end()
+
+
+def test_null_tracer_context_manager_yields_null_span() -> None:
+    """``with tracer.start_as_current_span(...)`` must yield a null-shaped span."""
+    tracer = _NullTracer()
+    with tracer.start_as_current_span("op") as span:
+        # The yielded span must support every call we make at usage sites.
+        span.set_attribute("caretaker.k", "v")
+        span.record_exception(ValueError("x"))
+        span.set_status(Status(StatusCode.ERROR, "y"))
+
+
+def test_status_and_statuscode_constructable_without_sdk() -> None:
+    """Status / StatusCode must always be importable + constructable."""
+    # The real SDK signature is ``Status(StatusCode.ERROR, description)``;
+    # the fallback accepts the same args and ignores them. Either way
+    # the constructor must not raise.
+    assert Status(StatusCode.ERROR, "msg") is not None
+    # All three semantic codes must exist as attributes.
+    assert StatusCode.OK is not None
+    assert StatusCode.ERROR is not None
+    assert StatusCode.UNSET is not None
+
+
+def test_get_current_span_returns_object_with_get_span_context() -> None:
+    """``get_current_span`` must always return something with ``get_span_context``."""
+    span = get_current_span()
+    assert hasattr(span, "get_span_context")

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -444,6 +444,51 @@ async def test_execute_skips_unhandled_action() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_emits_audit_log_on_skip_draft(caplog) -> None:
+    """A draft PR triggers the per-PR audit log line at INFO."""
+    from caretaker.pr_reviewer.agent import PRReviewerAgent
+
+    mock_ctx = MagicMock()
+    mock_ctx.config.pr_reviewer = PRReviewerConfig(
+        enabled=True,
+        webhook_only=False,
+        trigger_actions=["opened"],
+        skip_draft=True,
+        skip_labels=[],
+    )
+    mock_ctx.owner = "org"
+    mock_ctx.repo = "repo"
+    mock_ctx.llm_router = None
+    mock_ctx.github = MagicMock()
+
+    agent = PRReviewerAgent(mock_ctx)
+    with caplog.at_level("INFO"):
+        await agent.execute(
+            state=MagicMock(),
+            event_payload={
+                "action": "opened",
+                "pull_request": {
+                    "number": 7,
+                    "title": "Draft",
+                    "body": "",
+                    "draft": True,
+                    "head": {"sha": "deadbeef"},
+                    "labels": [],
+                    "user": {"login": "human"},
+                },
+            },
+        )
+
+    assert any(
+        "pr_review_complete" in rec.message
+        and "repo=org/repo" in rec.message
+        and "pr=7" in rec.message
+        and "verdict=skipped" in rec.message
+        for rec in caplog.records
+    ), [rec.message for rec in caplog.records]
+
+
+@pytest.mark.asyncio
 async def test_execute_processes_opened_action() -> None:
     """PR 'opened' action with trigger_actions=['opened'] → _handle_pr called."""
     from caretaker.pr_reviewer.agent import PRReviewerAgent

--- a/tests/test_pr_reviewer_auto_fix.py
+++ b/tests/test_pr_reviewer_auto_fix.py
@@ -502,3 +502,155 @@ async def test_dispatch_auto_fix_deterministic_lint_success_updates_tracking(mon
     assert tracking.auto_fix_last_head_sha == new_sha
     assert tracking.auto_fix_attempts == 1
     github.upsert_issue_comment.assert_awaited_once()
+
+
+# ── observability wire-up ────────────────────────────────────────────────────
+
+
+def _read_dispatch_counter(repo: str, backend: str, category: str, outcome: str) -> float:
+    from caretaker.observability.metrics import REGISTRY, get_service_label
+
+    val = REGISTRY.get_sample_value(
+        "caretaker_auto_fix_dispatch_total",
+        {
+            "service": get_service_label(),
+            "repo": repo,
+            "backend": backend,
+            "category": category,
+            "outcome": outcome,
+        },
+    )
+    return 0.0 if val is None else float(val)
+
+
+def test_decide_auto_fix_records_skipped_when_disabled():
+    """When the gate fails, ``skipped`` is recorded once with backend=none."""
+    from caretaker.config import AutoFixConfig
+
+    before = _read_dispatch_counter("owner/repo", "none", "none", "skipped")
+    cfg = AutoFixConfig(enabled=False)
+    review = ReviewResult(summary="x", verdict="REQUEST_CHANGES", comments=[])
+    _auto_fix.decide_auto_fix(
+        review=review,
+        config=cfg,
+        pr_author="bot[bot]",
+        pr_labels=[],
+        tracking=_make_tracking(),
+        repo="owner/repo",
+    )
+    after = _read_dispatch_counter("owner/repo", "none", "none", "skipped")
+    assert after >= before + 1
+
+
+def test_decide_auto_fix_records_skipped_when_verdict_not_request_changes():
+    before = _read_dispatch_counter("owner/repo", "none", "none", "skipped")
+    cfg = _make_config()
+    review = ReviewResult(summary="x", verdict="APPROVE", comments=[])
+    _auto_fix.decide_auto_fix(
+        review=review,
+        config=cfg,
+        pr_author="bot[bot]",
+        pr_labels=[],
+        tracking=_make_tracking(),
+        repo="owner/repo",
+    )
+    after = _read_dispatch_counter("owner/repo", "none", "none", "skipped")
+    assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_auto_fix_records_dispatched_success(monkeypatch):
+    """A successful lint fix records ``dispatched_success``."""
+    import caretaker.pr_reviewer.auto_fix as _af_mod
+    import caretaker.pr_reviewer.backends._workdir as _wd
+    from caretaker.config import PRReviewerConfig
+    from caretaker.state.models import TrackedPR
+
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(_wd, "prepare_workdir", AsyncMock(return_value=("/tmp/fake", MagicMock())))
+    monkeypatch.setattr(_wd, "cleanup_workdir", MagicMock())
+    monkeypatch.setattr(_af_mod, "run_deterministic_lint", AsyncMock(return_value=True))
+    monkeypatch.setattr(_af_mod, "commit_and_push", AsyncMock(return_value="newshaaa"))
+
+    github = MagicMock()
+    github.upsert_issue_comment = AsyncMock()
+
+    before = _read_dispatch_counter(
+        "owner/repo", "deterministic_lint", "lint", "dispatched_success"
+    )
+    await _auto_fix.dispatch_auto_fix(
+        decision=_make_dispatch_decision(),
+        pr_url="https://github.com/owner/repo/pull/9",
+        head_branch="feature/lint",
+        review=_make_dispatch_review(),
+        config=PRReviewerConfig(enabled=True),
+        github=github,
+        owner="owner",
+        repo="repo",
+        pr_number=9,
+        tracking=TrackedPR(number=9),
+    )
+    after = _read_dispatch_counter("owner/repo", "deterministic_lint", "lint", "dispatched_success")
+    assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_auto_fix_records_dispatched_fail_on_no_diff(monkeypatch):
+    """A no-changes lint result records ``dispatched_fail``."""
+    import caretaker.pr_reviewer.auto_fix as _af_mod
+    import caretaker.pr_reviewer.backends._workdir as _wd
+    from caretaker.config import PRReviewerConfig
+    from caretaker.state.models import TrackedPR
+
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(_wd, "prepare_workdir", AsyncMock(return_value=("/tmp/fake", MagicMock())))
+    monkeypatch.setattr(_wd, "cleanup_workdir", MagicMock())
+    monkeypatch.setattr(_af_mod, "run_deterministic_lint", AsyncMock(return_value=False))
+
+    github = MagicMock()
+    github.upsert_issue_comment = AsyncMock()
+
+    before = _read_dispatch_counter("owner/repo", "deterministic_lint", "lint", "dispatched_fail")
+    await _auto_fix.dispatch_auto_fix(
+        decision=_make_dispatch_decision(),
+        pr_url="https://github.com/owner/repo/pull/10",
+        head_branch="feature/lint",
+        review=_make_dispatch_review(),
+        config=PRReviewerConfig(enabled=True),
+        github=github,
+        owner="owner",
+        repo="repo",
+        pr_number=10,
+        tracking=TrackedPR(number=10),
+    )
+    after = _read_dispatch_counter("owner/repo", "deterministic_lint", "lint", "dispatched_fail")
+    assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_auto_fix_records_dispatched_fail_on_exception(monkeypatch):
+    """When the dispatcher hits an exception (no GITHUB_TOKEN), record ``dispatched_fail``."""
+    from caretaker.config import PRReviewerConfig
+    from caretaker.state.models import TrackedPR
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    github = MagicMock()
+    github.upsert_issue_comment = AsyncMock()
+
+    before = _read_dispatch_counter("owner/repo", "deterministic_lint", "lint", "dispatched_fail")
+    outcome = await _auto_fix.dispatch_auto_fix(
+        decision=_make_dispatch_decision(),
+        pr_url="https://github.com/owner/repo/pull/11",
+        head_branch="feature/fix",
+        review=_make_dispatch_review(),
+        config=PRReviewerConfig(enabled=True),
+        github=github,
+        owner="owner",
+        repo="repo",
+        pr_number=11,
+        tracking=TrackedPR(number=11),
+    )
+    assert not outcome.success
+    after = _read_dispatch_counter("owner/repo", "deterministic_lint", "lint", "dispatched_fail")
+    assert after >= before + 1

--- a/tests/test_pr_reviewer_auto_fix.py
+++ b/tests/test_pr_reviewer_auto_fix.py
@@ -67,12 +67,12 @@ def test_classify_returns_empty_when_no_match():
 # ── decide_auto_fix ───────────────────────────────────────────────────────────
 
 
-def test_decide_disabled_returns_no_dispatch():
+async def test_decide_disabled_returns_no_dispatch():
     from caretaker.config import AutoFixConfig
 
     cfg = AutoFixConfig(enabled=False)
     review = ReviewResult(summary="x", verdict="REQUEST_CHANGES", comments=[])
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="bot[bot]",
@@ -82,10 +82,10 @@ def test_decide_disabled_returns_no_dispatch():
     assert not d.should_dispatch
 
 
-def test_decide_non_request_changes_returns_no_dispatch():
+async def test_decide_non_request_changes_returns_no_dispatch():
     cfg = _make_config()
     review = ReviewResult(summary="x", verdict="APPROVE", comments=[])
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="bot[bot]",
@@ -95,11 +95,11 @@ def test_decide_non_request_changes_returns_no_dispatch():
     assert not d.should_dispatch
 
 
-def test_decide_max_attempts_reached():
+async def test_decide_max_attempts_reached():
     cfg = _make_config(max_attempts=2)
     review = ReviewResult(summary="x", verdict="REQUEST_CHANGES", comments=[])
     tracking = _make_tracking(auto_fix_attempts=2)
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="bot[bot]",
@@ -110,7 +110,7 @@ def test_decide_max_attempts_reached():
     assert "max_attempts" in d.reason
 
 
-def test_decide_author_eligible_dispatches():
+async def test_decide_author_eligible_dispatches():
     cfg = _make_config(allowed_authors=["copilot-swe-agent[bot]"])
     review = ReviewResult(
         summary="lint error",
@@ -118,7 +118,7 @@ def test_decide_author_eligible_dispatches():
         comments=[],
         issue_categories=["lint"],
     )
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="copilot-swe-agent[bot]",
@@ -129,7 +129,7 @@ def test_decide_author_eligible_dispatches():
     assert d.backend == "deterministic_lint"
 
 
-def test_decide_label_opt_in_eligible():
+async def test_decide_label_opt_in_eligible():
     cfg = _make_config(opt_in_label="caretaker:auto-fix")
     review = ReviewResult(
         summary="correctness bug",
@@ -137,7 +137,7 @@ def test_decide_label_opt_in_eligible():
         comments=[],
         issue_categories=["correctness"],
     )
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="human-dev",
@@ -147,10 +147,10 @@ def test_decide_label_opt_in_eligible():
     assert d.should_dispatch
 
 
-def test_decide_unknown_author_no_label_denied():
+async def test_decide_unknown_author_no_label_denied():
     cfg = _make_config()
     review = ReviewResult(summary="x", verdict="REQUEST_CHANGES", comments=[])
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="random-human",
@@ -160,7 +160,7 @@ def test_decide_unknown_author_no_label_denied():
     assert not d.should_dispatch
 
 
-def test_decide_routes_lint_to_deterministic():
+async def test_decide_routes_lint_to_deterministic():
     cfg = _make_config(allowed_authors=["bot[bot]"])
     review = ReviewResult(
         summary="x",
@@ -168,7 +168,7 @@ def test_decide_routes_lint_to_deterministic():
         comments=[],
         issue_categories=["lint"],
     )
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="bot[bot]",
@@ -178,7 +178,7 @@ def test_decide_routes_lint_to_deterministic():
     assert d.backend == "deterministic_lint"
 
 
-def test_decide_falls_back_to_default_fixer():
+async def test_decide_falls_back_to_default_fixer():
     cfg = _make_config(allowed_authors=["bot[bot]"], default_fixer="claude_code_local")
     review = ReviewResult(
         summary="x",
@@ -186,7 +186,7 @@ def test_decide_falls_back_to_default_fixer():
         comments=[],
         issue_categories=[],
     )
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="bot[bot]",
@@ -231,7 +231,7 @@ def test_parse_review_payload_rejects_invalid_categories():
 # ── always_run_heuristic merge logic ─────────────────────────────────────────
 
 
-def test_decide_always_run_heuristic_merges_categories():
+async def test_decide_always_run_heuristic_merges_categories():
     """always_run_heuristic=True should add heuristic matches not already in LLM categories."""
     cfg = _make_config(
         allowed_authors=["bot[bot]"],
@@ -243,7 +243,7 @@ def test_decide_always_run_heuristic_merges_categories():
         comments=[],
         issue_categories=["correctness"],  # LLM-supplied category
     )
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="bot[bot]",
@@ -256,7 +256,7 @@ def test_decide_always_run_heuristic_merges_categories():
     assert "lint" in (d.categories or [])
 
 
-def test_decide_always_run_heuristic_no_duplicates():
+async def test_decide_always_run_heuristic_no_duplicates():
     """always_run_heuristic=True must not duplicate categories already present."""
     cfg = _make_config(
         allowed_authors=["bot[bot]"],
@@ -268,7 +268,7 @@ def test_decide_always_run_heuristic_no_duplicates():
         comments=[],
         issue_categories=["lint"],  # already present — heuristic would also match "lint"
     )
-    d = _auto_fix.decide_auto_fix(
+    d = await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="bot[bot]",
@@ -523,14 +523,14 @@ def _read_dispatch_counter(repo: str, backend: str, category: str, outcome: str)
     return 0.0 if val is None else float(val)
 
 
-def test_decide_auto_fix_records_skipped_when_disabled():
+async def test_decide_auto_fix_records_skipped_when_disabled():
     """When the gate fails, ``skipped`` is recorded once with backend=none."""
     from caretaker.config import AutoFixConfig
 
     before = _read_dispatch_counter("owner/repo", "none", "none", "skipped")
     cfg = AutoFixConfig(enabled=False)
     review = ReviewResult(summary="x", verdict="REQUEST_CHANGES", comments=[])
-    _auto_fix.decide_auto_fix(
+    await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="bot[bot]",
@@ -542,11 +542,11 @@ def test_decide_auto_fix_records_skipped_when_disabled():
     assert after >= before + 1
 
 
-def test_decide_auto_fix_records_skipped_when_verdict_not_request_changes():
+async def test_decide_auto_fix_records_skipped_when_verdict_not_request_changes():
     before = _read_dispatch_counter("owner/repo", "none", "none", "skipped")
     cfg = _make_config()
     review = ReviewResult(summary="x", verdict="APPROVE", comments=[])
-    _auto_fix.decide_auto_fix(
+    await _auto_fix.decide_auto_fix(
         review=review,
         config=cfg,
         pr_author="bot[bot]",

--- a/tests/test_pr_reviewer_complexity_classifier.py
+++ b/tests/test_pr_reviewer_complexity_classifier.py
@@ -152,3 +152,82 @@ def test_resolve_tier_model_falls_back_when_tier_is_none() -> None:
 def test_resolve_tier_model_falls_back_when_entry_is_empty() -> None:
     tier_map = {"trivial": ""}
     assert _resolve_tier_model("trivial", tier_map=tier_map, default="default") == "default"
+
+
+# ── observability wire-up ───────────────────────────────────────────────────
+
+
+def _read_tier_counter(tier: str, source: str) -> float:
+    from caretaker.observability.metrics import REGISTRY, get_service_label
+
+    val = REGISTRY.get_sample_value(
+        "caretaker_complexity_classifier_tier_total",
+        {"service": get_service_label(), "tier": tier, "source": source},
+    )
+    return 0.0 if val is None else float(val)
+
+
+@pytest.mark.asyncio
+async def test_classify_records_fast_path_tier_metric() -> None:
+    """A fast-path verdict must increment the (tier, fast_path) counter."""
+    before = _read_tier_counter("trivial", "fast_path")
+    ctx = ExecutorRouteContext(
+        files=[ExecutorRouteFile(path="README.md", additions=1, deletions=1)],
+        labels=["docs"],
+    )
+    await classify(context=ctx, claude=None)
+    after = _read_tier_counter("trivial", "fast_path")
+    assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_classify_records_llm_source_metric() -> None:
+    """An LLM-supplied verdict must increment the (tier, llm) counter."""
+    before = _read_tier_counter("standard", "llm")
+    claude = MagicMock()
+    claude.available = True
+    claude.structured_complete = AsyncMock(
+        return_value=ComplexityVerdict(
+            tier="standard", reason="ordinary feature work", confidence=0.85
+        )
+    )
+    ctx = ExecutorRouteContext(
+        files=[ExecutorRouteFile(path="src/foo.py", additions=80, deletions=20)],
+    )
+    await classify(context=ctx, claude=claude)
+    after = _read_tier_counter("standard", "llm")
+    assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_classify_records_heuristic_fallback_when_llm_unavailable() -> None:
+    """No-LLM path increments the (tier, heuristic_fallback) counter."""
+    before = _read_tier_counter("standard", "heuristic_fallback")
+    ctx = ExecutorRouteContext(
+        files=[ExecutorRouteFile(path="src/foo.py", additions=80, deletions=20)],
+    )
+    await classify(context=ctx, claude=None)
+    after = _read_tier_counter("standard", "heuristic_fallback")
+    assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_classify_records_heuristic_fallback_on_llm_error() -> None:
+    """An LLM error path increments the heuristic_fallback counter, not the LLM one."""
+    from caretaker.llm.claude import StructuredCompleteError
+
+    before = _read_tier_counter("standard", "heuristic_fallback")
+    claude = MagicMock()
+    claude.available = True
+    claude.structured_complete = AsyncMock(
+        side_effect=StructuredCompleteError(
+            raw_text="bad json",
+            validation_error=ValueError("schema mismatch"),
+        )
+    )
+    ctx = ExecutorRouteContext(
+        files=[ExecutorRouteFile(path="src/foo.py", additions=200, deletions=50)],
+    )
+    await classify(context=ctx, claude=claude)
+    after = _read_tier_counter("standard", "heuristic_fallback")
+    assert after >= before + 1

--- a/tests/test_pr_reviewer_complexity_classifier.py
+++ b/tests/test_pr_reviewer_complexity_classifier.py
@@ -3,7 +3,6 @@
 Coverage:
 - fast_path_tier: deterministic short-circuits before any LLM call
 - classify: heuristic fallback when LLM is unavailable / errors
-- _resolve_tier_model: tier → model resolution with fallback
 """
 
 from __future__ import annotations
@@ -13,7 +12,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from caretaker.evolution.executor_routing import ExecutorRouteContext, ExecutorRouteFile
-from caretaker.pr_reviewer.backends.opencode_local import _resolve_tier_model
 from caretaker.pr_reviewer.complexity_classifier import (
     ComplexityVerdict,
     classify,
@@ -126,32 +124,6 @@ async def test_classify_falls_back_on_llm_error() -> None:
     verdict = await classify(context=ctx, claude=claude)
     # Heuristic kicks in: 250 LOC → standard tier.
     assert verdict.tier == "standard"
-
-
-# ── _resolve_tier_model ─────────────────────────────────────────────────────
-
-
-def test_resolve_tier_model_uses_tier_map_entry() -> None:
-    tier_map = {"trivial": "cheap-model", "standard": "expensive-model"}
-    assert _resolve_tier_model("trivial", tier_map=tier_map, default="default") == "cheap-model"
-    assert (
-        _resolve_tier_model("standard", tier_map=tier_map, default="default") == "expensive-model"
-    )
-
-
-def test_resolve_tier_model_falls_back_when_tier_missing() -> None:
-    tier_map = {"trivial": "cheap-model"}
-    assert _resolve_tier_model("complex", tier_map=tier_map, default="default") == "default"
-
-
-def test_resolve_tier_model_falls_back_when_tier_is_none() -> None:
-    tier_map = {"trivial": "cheap-model"}
-    assert _resolve_tier_model(None, tier_map=tier_map, default="default") == "default"
-
-
-def test_resolve_tier_model_falls_back_when_entry_is_empty() -> None:
-    tier_map = {"trivial": ""}
-    assert _resolve_tier_model("trivial", tier_map=tier_map, default="default") == "default"
 
 
 # ── observability wire-up ───────────────────────────────────────────────────

--- a/tests/test_pr_reviewer_opencode_local_backend.py
+++ b/tests/test_pr_reviewer_opencode_local_backend.py
@@ -1,0 +1,148 @@
+"""Tests for the opencode_local backend.
+
+Like the ``claude_code_local`` test file, the heavy paths (clone +
+opencode-CLI invocation) are out of scope for unit tests. This file
+focuses on the pure-Python parts plus the metric wire-up:
+
+  * fallback warning + ``parse_fallback`` counter from
+    :func:`_parse_review_payload`
+  * ``ok`` outcome on the happy path of :func:`run`
+  * ``no_endpoints`` outcome when stderr matches the opencode "No
+    endpoints found" sentinel
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from caretaker.pr_reviewer.backends import opencode_local
+from caretaker.pr_reviewer.backends.opencode_local import (
+    OpenCodeLocalNoEndpointsError,
+    _parse_review_payload,
+)
+
+
+def _read_invoke_counter(model: str, mode: str, outcome: str) -> float:
+    from caretaker.observability.metrics import REGISTRY, get_service_label
+
+    val = REGISTRY.get_sample_value(
+        "caretaker_opencode_invocation_total",
+        {
+            "service": get_service_label(),
+            "model": model,
+            "mode": mode,
+            "outcome": outcome,
+        },
+    )
+    return 0.0 if val is None else float(val)
+
+
+# ── _parse_review_payload fallback warning + counter ─────────────────────
+
+
+def test_parse_review_payload_fallback_records_parse_fallback_counter(caplog) -> None:
+    """When the ``caretaker-review`` JSON block is missing, log + counter fire."""
+    before = _read_invoke_counter("<unknown>", "other", "parse_fallback")
+
+    with caplog.at_level("WARNING"):
+        result = _parse_review_payload("Just prose, no JSON. Looks fine.")
+
+    assert result.verdict == "COMMENT"
+    after = _read_invoke_counter("<unknown>", "other", "parse_fallback")
+    assert after >= before + 1
+    # The warning text mentions "fallback parse" so operators can grep.
+    assert any("fallback parse" in rec.message for rec in caplog.records)
+
+
+# ── run() outcome wiring ──────────────────────────────────────────────────
+
+
+def _structured_payload() -> str:
+    return (
+        "Some prose summary.\n\n"
+        "<!-- caretaker:review-result -->\n"
+        "```caretaker-review\n"
+        '{"verdict": "APPROVE", "summary": "lgtm", "comments": []}\n'
+        "```\n"
+    )
+
+
+@pytest.fixture
+def fake_config() -> MagicMock:
+    cfg = MagicMock()
+    cfg.review_models = {}
+    cfg.fix_models = {}
+    cfg.model = "openrouter/test/model"
+    cfg.fix_model = ""
+    cfg.clone_depth = 1
+    cfg.clone_workdir_root = ""
+    cfg.timeout_seconds = 60
+    cfg.cli_path = "opencode"
+    cfg.extra_env = {}
+    cfg.keep_workdir_on_failure = False
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_run_records_ok_outcome_on_happy_path(monkeypatch, fake_config) -> None:
+    """Structured JSON parse → outcome=ok with the resolved review model."""
+    monkeypatch.setattr(
+        opencode_local,
+        "_prepare_workdir",
+        AsyncMock(return_value=("/tmp/fake", MagicMock())),
+    )
+    monkeypatch.setattr(opencode_local, "cleanup_workdir", MagicMock())
+    monkeypatch.setattr(
+        opencode_local, "_invoke_opencode", AsyncMock(return_value=_structured_payload())
+    )
+
+    before = _read_invoke_counter("openrouter/test/model", "review", "ok")
+    result = await opencode_local.run(pr_url="https://github.com/o/r/pull/1", config=fake_config)
+    after = _read_invoke_counter("openrouter/test/model", "review", "ok")
+    assert result.verdict == "APPROVE"
+    assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_run_records_parse_fallback_outcome(monkeypatch, fake_config) -> None:
+    """Missing structured JSON → outcome=parse_fallback (model-aware label)."""
+    monkeypatch.setattr(
+        opencode_local,
+        "_prepare_workdir",
+        AsyncMock(return_value=("/tmp/fake", MagicMock())),
+    )
+    monkeypatch.setattr(opencode_local, "cleanup_workdir", MagicMock())
+    # No caretaker-review fence — _parse_review_payload takes the fallback.
+    monkeypatch.setattr(
+        opencode_local, "_invoke_opencode", AsyncMock(return_value="Just prose, no JSON.")
+    )
+
+    before = _read_invoke_counter("openrouter/test/model", "review", "parse_fallback")
+    result = await opencode_local.run(pr_url="https://github.com/o/r/pull/2", config=fake_config)
+    after = _read_invoke_counter("openrouter/test/model", "review", "parse_fallback")
+    assert result.verdict == "COMMENT"
+    assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_run_records_no_endpoints_outcome(monkeypatch, fake_config) -> None:
+    """``OpenCodeLocalNoEndpointsError`` → outcome=no_endpoints, exception re-raised."""
+    monkeypatch.setattr(
+        opencode_local,
+        "_prepare_workdir",
+        AsyncMock(return_value=("/tmp/fake", MagicMock())),
+    )
+    monkeypatch.setattr(opencode_local, "cleanup_workdir", MagicMock())
+    monkeypatch.setattr(
+        opencode_local,
+        "_invoke_opencode",
+        AsyncMock(side_effect=OpenCodeLocalNoEndpointsError("No endpoints found")),
+    )
+
+    before = _read_invoke_counter("openrouter/test/model", "review", "no_endpoints")
+    with pytest.raises(OpenCodeLocalNoEndpointsError):
+        await opencode_local.run(pr_url="https://github.com/o/r/pull/3", config=fake_config)
+    after = _read_invoke_counter("openrouter/test/model", "review", "no_endpoints")
+    assert after >= before + 1

--- a/tests/test_pr_reviewer_opencode_local_backend.py
+++ b/tests/test_pr_reviewer_opencode_local_backend.py
@@ -195,6 +195,145 @@ def test_resolve_tier_model_falls_back_when_entry_is_empty() -> None:
 # ── _invoke_opencode "No endpoints found" detection ──────────────────────
 
 
+# ── _parse_opencode_json_stream + token capture wiring ──────────────────
+
+
+def test_parse_opencode_json_stream_extracts_text_and_token_totals() -> None:
+    """The JSON stream parser concatenates text events and sums step_finish tokens."""
+    from caretaker.pr_reviewer.backends.opencode_local import _parse_opencode_json_stream
+
+    stream = "\n".join(
+        [
+            '{"type":"step_start","part":{"id":"a"}}',
+            '{"type":"text","part":{"text":"Hello "}}',
+            '{"type":"text","part":{"text":"world."}}',
+            (
+                '{"type":"step_finish","part":{"tokens":'
+                '{"input":100,"output":50,"reasoning":5,'
+                '"cache":{"read":20,"write":3}}}}'
+            ),
+            (
+                '{"type":"step_finish","part":{"tokens":'
+                '{"input":200,"output":80,"reasoning":0,'
+                '"cache":{"read":0,"write":0}}}}'
+            ),
+            "> banner line that is not JSON",  # ignored
+        ]
+    )
+    text, prompt_tokens, completion_tokens = _parse_opencode_json_stream(stream)
+    assert text == "Hello world."
+    # input(100+200) + cache.read(20+0) + cache.write(3+0) = 323
+    assert prompt_tokens == 323
+    # output(50+80) + reasoning(5+0) = 135
+    assert completion_tokens == 135
+
+
+@pytest.mark.asyncio
+async def test_invoke_opencode_extracts_token_usage_from_stdout(monkeypatch, fake_config) -> None:
+    """A successful subprocess emits records on the new LLM-usage counters.
+
+    Mocks the subprocess + stream helper to return a canned JSON event
+    stream, then verifies ``record_llm_usage`` produced increments on
+    ``caretaker_llm_tokens_total`` for both directions.
+    """
+    from caretaker.observability.metrics import REGISTRY, get_service_label
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+
+    async def _fake_create_subprocess_exec(*_args, **_kwargs):
+        return fake_proc
+
+    canned_stream = "\n".join(
+        [
+            '{"type":"text","part":{"text":"Reply text from opencode."}}',
+            (
+                '{"type":"step_finish","part":{"tokens":'
+                '{"input":1000,"output":250,"reasoning":0,'
+                '"cache":{"read":0,"write":0}}}}'
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        opencode_local.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
+    )
+    monkeypatch.setattr(
+        opencode_local,
+        "stream_subprocess_output",
+        AsyncMock(return_value=(canned_stream, "")),
+    )
+    monkeypatch.setattr(opencode_local.shutil, "which", lambda _name: "/usr/bin/opencode")
+
+    model = "openrouter/test/extracted-usage-model"
+    fake_config.model = model
+
+    def _read_tokens(direction: str) -> float:
+        val = REGISTRY.get_sample_value(
+            "caretaker_llm_tokens_total",
+            {"service": get_service_label(), "model": model, "direction": direction},
+        )
+        return 0.0 if val is None else float(val)
+
+    before_p = _read_tokens("prompt")
+    before_c = _read_tokens("completion")
+
+    text = await opencode_local._invoke_opencode(
+        workdir="/tmp/fake", config=fake_config, prompt="hi", model_override=""
+    )
+
+    # Assistant text reassembled from JSON stream.
+    assert text == "Reply text from opencode."
+    # Tokens recorded against the resolved model label.
+    assert _read_tokens("prompt") - before_p == pytest.approx(1000)
+    assert _read_tokens("completion") - before_c == pytest.approx(250)
+
+
+@pytest.mark.asyncio
+async def test_invoke_opencode_skips_token_recording_when_no_step_finish(
+    monkeypatch, fake_config
+) -> None:
+    """Without ``step_finish`` events the assistant text is still returned, no tokens recorded."""
+    from caretaker.observability.metrics import REGISTRY, get_service_label
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+
+    async def _fake_create_subprocess_exec(*_args, **_kwargs):
+        return fake_proc
+
+    canned_stream = '{"type":"text","part":{"text":"Just text, no step_finish."}}'
+
+    monkeypatch.setattr(
+        opencode_local.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
+    )
+    monkeypatch.setattr(
+        opencode_local,
+        "stream_subprocess_output",
+        AsyncMock(return_value=(canned_stream, "")),
+    )
+    monkeypatch.setattr(opencode_local.shutil, "which", lambda _name: "/usr/bin/opencode")
+
+    model = "openrouter/test/no-step-finish"
+    fake_config.model = model
+
+    def _read_tokens(direction: str) -> float:
+        val = REGISTRY.get_sample_value(
+            "caretaker_llm_tokens_total",
+            {"service": get_service_label(), "model": model, "direction": direction},
+        )
+        return 0.0 if val is None else float(val)
+
+    before_p = _read_tokens("prompt")
+    before_c = _read_tokens("completion")
+
+    text = await opencode_local._invoke_opencode(
+        workdir="/tmp/fake", config=fake_config, prompt="hi", model_override=""
+    )
+    assert text == "Just text, no step_finish."
+    assert _read_tokens("prompt") == pytest.approx(before_p)
+    assert _read_tokens("completion") == pytest.approx(before_c)
+
+
 @pytest.mark.asyncio
 async def test_invoke_opencode_raises_no_endpoints_on_stderr_match(
     monkeypatch, fake_config

--- a/tests/test_pr_reviewer_opencode_local_backend.py
+++ b/tests/test_pr_reviewer_opencode_local_backend.py
@@ -21,6 +21,7 @@ from caretaker.pr_reviewer.backends import opencode_local
 from caretaker.pr_reviewer.backends.opencode_local import (
     OpenCodeLocalNoEndpointsError,
     _parse_review_payload,
+    _resolve_tier_model,
 )
 
 
@@ -42,18 +43,35 @@ def _read_invoke_counter(model: str, mode: str, outcome: str) -> float:
 # ── _parse_review_payload fallback warning + counter ─────────────────────
 
 
-def test_parse_review_payload_fallback_records_parse_fallback_counter(caplog) -> None:
-    """When the ``caretaker-review`` JSON block is missing, log + counter fire."""
-    before = _read_invoke_counter("<unknown>", "other", "parse_fallback")
+def test_parse_review_payload_fallback_returns_was_fallback_flag(caplog) -> None:
+    """When the ``caretaker-review`` JSON block is missing, the fallback flag is True.
 
+    The metric is now recorded by the caller (``run`` / ``fix_run``)
+    with the real model + mode labels — see ``run()`` for the
+    matching ``record_opencode_invocation`` call. ``_parse_review_payload``
+    only signals "I took the fallback branch" via the bool.
+    """
     with caplog.at_level("WARNING"):
-        result = _parse_review_payload("Just prose, no JSON. Looks fine.")
+        result, was_fallback = _parse_review_payload("Just prose, no JSON. Looks fine.")
 
     assert result.verdict == "COMMENT"
-    after = _read_invoke_counter("<unknown>", "other", "parse_fallback")
-    assert after >= before + 1
+    assert was_fallback is True
     # The warning text mentions "fallback parse" so operators can grep.
     assert any("fallback parse" in rec.message for rec in caplog.records)
+
+
+def test_parse_review_payload_happy_path_returns_false_fallback_flag() -> None:
+    """A well-formed reply yields ``was_fallback=False``."""
+    text = (
+        "Some prose summary.\n\n"
+        "<!-- caretaker:review-result -->\n"
+        "```caretaker-review\n"
+        '{"verdict": "APPROVE", "summary": "lgtm", "comments": []}\n'
+        "```\n"
+    )
+    result, was_fallback = _parse_review_payload(text)
+    assert result.verdict == "APPROVE"
+    assert was_fallback is False
 
 
 # ── run() outcome wiring ──────────────────────────────────────────────────
@@ -146,3 +164,71 @@ async def test_run_records_no_endpoints_outcome(monkeypatch, fake_config) -> Non
         await opencode_local.run(pr_url="https://github.com/o/r/pull/3", config=fake_config)
     after = _read_invoke_counter("openrouter/test/model", "review", "no_endpoints")
     assert after >= before + 1
+
+
+# ── _resolve_tier_model ──────────────────────────────────────────────────
+
+
+def test_resolve_tier_model_uses_tier_map_entry() -> None:
+    tier_map = {"trivial": "cheap-model", "standard": "expensive-model"}
+    assert _resolve_tier_model("trivial", tier_map=tier_map, default="default") == "cheap-model"
+    assert (
+        _resolve_tier_model("standard", tier_map=tier_map, default="default") == "expensive-model"
+    )
+
+
+def test_resolve_tier_model_falls_back_when_tier_missing() -> None:
+    tier_map = {"trivial": "cheap-model"}
+    assert _resolve_tier_model("complex", tier_map=tier_map, default="default") == "default"
+
+
+def test_resolve_tier_model_falls_back_when_tier_is_none() -> None:
+    tier_map = {"trivial": "cheap-model"}
+    assert _resolve_tier_model(None, tier_map=tier_map, default="default") == "default"
+
+
+def test_resolve_tier_model_falls_back_when_entry_is_empty() -> None:
+    tier_map = {"trivial": ""}
+    assert _resolve_tier_model("trivial", tier_map=tier_map, default="default") == "default"
+
+
+# ── _invoke_opencode "No endpoints found" detection ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_invoke_opencode_raises_no_endpoints_on_stderr_match(
+    monkeypatch, fake_config
+) -> None:
+    """A non-zero return code + ``No endpoints found`` stderr → ``OpenCodeLocalNoEndpointsError``.
+
+    Exercises the actual stderr-pattern detection (rather than mocking
+    the exception itself) so a future refactor that drops the
+    string-match doesn't slip through with green tests.
+    """
+    fake_proc = MagicMock()
+    fake_proc.returncode = 1
+
+    async def _fake_create_subprocess_exec(*_args, **_kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(
+        opencode_local.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
+    )
+    monkeypatch.setattr(
+        opencode_local,
+        "stream_subprocess_output",
+        AsyncMock(
+            return_value=(
+                "",
+                "Error: No endpoints found for model openrouter/foo/bar",
+            )
+        ),
+    )
+    # Bypass the ``shutil.which`` lookup so the binary always "exists".
+    monkeypatch.setattr(opencode_local.shutil, "which", lambda _name: "/usr/bin/opencode")
+
+    with pytest.raises(OpenCodeLocalNoEndpointsError) as excinfo:
+        await opencode_local._invoke_opencode(
+            workdir="/tmp/fake", config=fake_config, prompt="hi", model_override=""
+        )
+    assert "No endpoints found" in str(excinfo.value)

--- a/tests/test_pr_reviewer_otel_spans.py
+++ b/tests/test_pr_reviewer_otel_spans.py
@@ -12,16 +12,22 @@ behavioural tests in ``test_pr_reviewer*``. The point of this file is:
 
     "Did the production span emission survive a refactor?"
 
-The fixture installs a fresh ``TracerProvider`` per test so spans from
-earlier tests don't leak into later assertions.
+NOTE: this file uses a process-global ``TracerProvider``. OTel's
+``set_tracer_provider`` is once-per-process, so the provider + exporter
+are scoped to the *module* and only the in-memory buffer is cleared
+between tests. Do NOT run this file with pytest-xdist — concurrent
+workers would race on the shared provider and exporter buffer.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 # Skip the whole module if the OTel SDK isn't installed — these tests
 # exercise the real provider, not the no-op fallback.
@@ -34,29 +40,33 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 
-@pytest.fixture
-def span_exporter() -> Any:
-    """Install a fresh in-memory exporter on the (single) TracerProvider.
+@pytest.fixture(scope="module")
+def _tracer_provider_with_exporter() -> Iterator[InMemorySpanExporter]:
+    """Module-scoped: install one TracerProvider + exporter for the whole file.
 
-    OTel only lets ``set_tracer_provider`` succeed once per process, so
-    we attach a fresh exporter to whatever provider is currently
-    installed (or install one if none is). Each test gets its own
-    exporter via ``add_span_processor``; ``clear()`` on teardown
-    prevents spans from leaking into the next test.
+    OTel's ``set_tracer_provider`` is once-per-process, and adding a new
+    ``SpanProcessor`` per test would leak — old processors would keep
+    receiving spans and writing to dead exporters. Installing the
+    plumbing once at module scope sidesteps both issues.
     """
     exporter = InMemorySpanExporter()
     current = otel_trace.get_tracer_provider()
     if hasattr(current, "add_span_processor"):
-        # An SDK provider is already installed (likely by an earlier
-        # observability test fixture in the same session). Attach our
-        # exporter to it instead of fighting the once-set guard.
+        # An SDK provider is already installed (e.g. by an earlier
+        # module's fixture). Attach our exporter to it.
         current.add_span_processor(SimpleSpanProcessor(exporter))
     else:
         provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
         provider.add_span_processor(SimpleSpanProcessor(exporter))
         otel_trace.set_tracer_provider(provider)
     yield exporter
-    exporter.clear()
+
+
+@pytest.fixture
+def span_exporter(_tracer_provider_with_exporter: InMemorySpanExporter) -> Iterator[Any]:
+    """Function-scoped: clear the in-memory buffer between tests."""
+    yield _tracer_provider_with_exporter
+    _tracer_provider_with_exporter.clear()
 
 
 def _spans_by_name(exporter: InMemorySpanExporter, name: str) -> list[Any]:

--- a/tests/test_pr_reviewer_otel_spans.py
+++ b/tests/test_pr_reviewer_otel_spans.py
@@ -1,0 +1,449 @@
+"""Custom OTel spans for the PR-review pipeline.
+
+Each span emitted by the instrumented helpers (root ``pr_reviewer.handle_pr``
+plus the per-stage children) is exercised here using OTel's
+``InMemorySpanExporter`` so test assertions can read the live
+attributes set by the production code without touching the network or
+the OTel collector.
+
+These tests pin the *names* and *attribute keys* of the spans rather
+than every value, because the values are already covered by the
+behavioural tests in ``test_pr_reviewer*``. The point of this file is:
+
+    "Did the production span emission survive a refactor?"
+
+The fixture installs a fresh ``TracerProvider`` per test so spans from
+earlier tests don't leak into later assertions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Skip the whole module if the OTel SDK isn't installed — these tests
+# exercise the real provider, not the no-op fallback.
+pytest.importorskip("opentelemetry.sdk.trace")
+
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+@pytest.fixture
+def span_exporter() -> Any:
+    """Install a fresh in-memory exporter on the (single) TracerProvider.
+
+    OTel only lets ``set_tracer_provider`` succeed once per process, so
+    we attach a fresh exporter to whatever provider is currently
+    installed (or install one if none is). Each test gets its own
+    exporter via ``add_span_processor``; ``clear()`` on teardown
+    prevents spans from leaking into the next test.
+    """
+    exporter = InMemorySpanExporter()
+    current = otel_trace.get_tracer_provider()
+    if hasattr(current, "add_span_processor"):
+        # An SDK provider is already installed (likely by an earlier
+        # observability test fixture in the same session). Attach our
+        # exporter to it instead of fighting the once-set guard.
+        current.add_span_processor(SimpleSpanProcessor(exporter))
+    else:
+        provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        otel_trace.set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
+
+
+def _spans_by_name(exporter: InMemorySpanExporter, name: str) -> list[Any]:
+    """Return the captured spans whose ``name`` matches exactly."""
+    return [s for s in exporter.get_finished_spans() if s.name == name]
+
+
+# ── 1. Root span: pr_reviewer.handle_pr ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_pr_emits_root_span(span_exporter: InMemorySpanExporter) -> None:
+    """Happy path: ``_handle_pr`` emits one root ``pr_reviewer.handle_pr`` span."""
+    from caretaker.config import PRReviewerConfig
+    from caretaker.pr_reviewer.agent import PRReviewerAgent
+
+    mock_ctx = MagicMock()
+    mock_ctx.config.pr_reviewer = PRReviewerConfig(
+        enabled=True,
+        webhook_only=False,
+        trigger_actions=["opened"],
+        skip_draft=True,
+        skip_labels=[],
+    )
+    mock_ctx.owner = "org"
+    mock_ctx.repo = "repo"
+    mock_ctx.llm_router = None
+    mock_ctx.github = MagicMock()
+
+    agent = PRReviewerAgent(mock_ctx)
+    # Use a draft PR so handle_pr exits early without touching the github
+    # client beyond the audit emit — keeps the test simple while still
+    # exercising the span open/close.
+    await agent.execute(
+        state=MagicMock(),
+        event_payload={
+            "action": "opened",
+            "pull_request": {
+                "number": 7,
+                "title": "Draft",
+                "body": "",
+                "draft": True,
+                "head": {"sha": "deadbeef"},
+                "labels": [],
+                "user": {"login": "human"},
+            },
+        },
+    )
+
+    spans = _spans_by_name(span_exporter, "pr_reviewer.handle_pr")
+    assert len(spans) == 1, [s.name for s in span_exporter.get_finished_spans()]
+    span = spans[0]
+    assert span.attributes["caretaker.pr.repo"] == "org/repo"
+    assert span.attributes["caretaker.pr.number"] == 7
+    assert span.attributes["caretaker.pr.author"] == "human"
+    assert span.attributes["caretaker.pr.is_caretaker_owned"] is False
+    # Verdict gets stamped via _emit_pr_review_audit on the way out.
+    assert span.attributes["caretaker.review.verdict"] == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_root_span_records_exception(span_exporter: InMemorySpanExporter) -> None:
+    """When ``_handle_pr`` raises, the root span is recorded with status=ERROR."""
+    from caretaker.config import PRReviewerConfig
+    from caretaker.pr_reviewer.agent import PRReviewerAgent
+
+    mock_ctx = MagicMock()
+    mock_ctx.config.pr_reviewer = PRReviewerConfig(
+        enabled=True,
+        webhook_only=False,
+        trigger_actions=["opened"],
+        skip_draft=False,
+        skip_labels=[],
+    )
+    mock_ctx.owner = "org"
+    mock_ctx.repo = "repo"
+    mock_ctx.llm_router = None
+    mock_ctx.github = MagicMock()
+    # Make list_pull_request_files raise so _handle_pr_body proceeds with
+    # files=[] (graceful) — but to actually test exception recording we
+    # need to force a raise. Patch _is_caretaker_owned via the import to
+    # raise.
+    from caretaker.pr_reviewer import agent as agent_module
+
+    def _boom(_pr: dict[str, Any]) -> bool:
+        raise RuntimeError("boom from test")
+
+    original = agent_module._is_caretaker_owned
+    agent_module._is_caretaker_owned = _boom  # type: ignore[assignment]
+    try:
+        agent = PRReviewerAgent(mock_ctx)
+        # ``execute`` swallows the exception per-PR (logged), but the
+        # span exception/status is set inside _handle_pr before the unwind.
+        await agent.execute(
+            state=MagicMock(),
+            event_payload={
+                "action": "opened",
+                "pull_request": {
+                    "number": 11,
+                    "title": "Boom",
+                    "body": "",
+                    "draft": False,
+                    "head": {"sha": "x"},
+                    "labels": [],
+                    "user": {"login": "human"},
+                },
+            },
+        )
+    finally:
+        agent_module._is_caretaker_owned = original  # type: ignore[assignment]
+
+    spans = _spans_by_name(span_exporter, "pr_reviewer.handle_pr")
+    assert len(spans) == 1
+    span = spans[0]
+    # OTel SDK marks recorded exceptions as events on the span and sets
+    # status to ERROR on .set_status(...).
+    assert span.status.status_code == otel_trace.StatusCode.ERROR
+    assert any(evt.name == "exception" for evt in span.events)
+
+
+# ── 2. complexity_classifier.classify ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_complexity_classifier_emits_span(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """``classify`` emits a span with tier + source attributes."""
+    from caretaker.evolution.executor_routing import (
+        ExecutorRouteContext,
+        ExecutorRouteFile,
+    )
+    from caretaker.pr_reviewer.complexity_classifier import classify
+
+    context = ExecutorRouteContext(
+        task_type="pr_review",
+        files=[ExecutorRouteFile(path="src/foo.py", additions=2, deletions=1)],
+        labels=[],
+        repo_slug="org/repo",
+        title="tiny",
+        body="",
+    )
+    # Tiny diff → fast_path returns "trivial" without an LLM call.
+    verdict = await classify(context=context, claude=None)
+    assert verdict.tier == "trivial"
+
+    spans = _spans_by_name(span_exporter, "complexity_classifier.classify")
+    assert len(spans) == 1
+    attrs = spans[0].attributes
+    assert attrs["caretaker.pr.repo"] == "org/repo"
+    assert attrs["caretaker.complexity.file_count"] == 1
+    assert attrs["caretaker.complexity.tier"] == "trivial"
+    assert attrs["caretaker.complexity.source"] == "fast_path"
+    assert attrs["caretaker.complexity.confidence"] == pytest.approx(0.9)
+
+
+# ── 3. pr_review.clone_workdir ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clone_workdir_emits_span(
+    span_exporter: InMemorySpanExporter, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """``prepare_workdir`` emits ``pr_review.clone_workdir`` with attributes."""
+    from caretaker.pr_reviewer.backends import _workdir as workdir_mod
+
+    # Stub out _run_git so the test stays purely in-process.
+    async def _fake_run_git(*_args: str, **_kwargs: Any) -> str:
+        # When asked for HEAD SHA, return a fake one; otherwise empty.
+        if _args and _args[0] == "rev-parse":
+            return "abc1234567890\n"
+        return ""
+
+    monkeypatch.setattr(workdir_mod, "_run_git", _fake_run_git)
+    monkeypatch.setattr(workdir_mod.tempfile, "mkdtemp", lambda **_kw: str(tmp_path))
+    # Avoid creating ``repo`` subdir on disk since we never run real git.
+    monkeypatch.setattr(workdir_mod.os.path, "join", lambda *parts: "/".join(parts))
+
+    repo_dir, parsed = await workdir_mod.prepare_workdir(
+        "https://github.com/o/r/pull/9", clone_depth=3
+    )
+    assert parsed.number == 9
+
+    spans = _spans_by_name(span_exporter, "pr_review.clone_workdir")
+    assert len(spans) == 1
+    attrs = spans[0].attributes
+    assert attrs["caretaker.pr.url"] == "https://github.com/o/r/pull/9"
+    assert attrs["caretaker.workdir.clone_depth"] == 3
+    assert attrs["caretaker.workdir.path"] == str(tmp_path)
+    # Best-effort head SHA capture.
+    assert attrs.get("caretaker.pr.head_sha") == "abc1234567890"
+
+
+# ── 4. opencode_local.invoke ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_opencode_local_invoke_emits_span(
+    span_exporter: InMemorySpanExporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`_invoke_opencode` emits a span with model + exit_code + outcome=ok."""
+    from caretaker.pr_reviewer.backends import opencode_local
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+
+    async def _fake_create_subprocess_exec(*_args: Any, **_kwargs: Any) -> Any:
+        return fake_proc
+
+    monkeypatch.setattr(
+        opencode_local.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
+    )
+    monkeypatch.setattr(
+        opencode_local,
+        "stream_subprocess_output",
+        AsyncMock(return_value=("hello stdout", "")),
+    )
+    monkeypatch.setattr(opencode_local.shutil, "which", lambda _name: "/usr/bin/opencode")
+
+    cfg = MagicMock()
+    cfg.cli_path = "opencode"
+    cfg.extra_env = {}
+    cfg.timeout_seconds = 60
+    cfg.model = "openrouter/test/model"
+
+    out = await opencode_local._invoke_opencode(
+        workdir="/tmp/fake", config=cfg, prompt="hi", model_override=""
+    )
+    assert out == "hello stdout"
+
+    spans = _spans_by_name(span_exporter, "opencode_local.invoke")
+    assert len(spans) == 1
+    attrs = spans[0].attributes
+    assert attrs["caretaker.opencode.workdir"] == "/tmp/fake"
+    assert attrs["caretaker.opencode.timeout_seconds"] == 60
+    assert attrs["caretaker.opencode.model"] == "openrouter/test/model"
+    assert attrs["caretaker.opencode.exit_code"] == 0
+    assert attrs["caretaker.opencode.outcome"] == "ok"
+
+
+# ── 5. auto_fix.dispatch ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auto_fix_dispatch_emits_span(
+    span_exporter: InMemorySpanExporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Successful ``dispatch_auto_fix`` emits ``auto_fix.dispatch`` span."""
+    from caretaker.config import AutoFixConfig, PRReviewerConfig
+    from caretaker.pr_reviewer import auto_fix as auto_fix_mod
+    from caretaker.pr_reviewer.auto_fix import (
+        DETERMINISTIC_LINT_BACKEND,
+        AutoFixDecision,
+        dispatch_auto_fix,
+    )
+    from caretaker.pr_reviewer.inline_reviewer import ReviewResult
+    from caretaker.state.models import TrackedPR
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+
+    # Stub out the entire workdir + lint + commit chain so the test stays
+    # in-process and exercises only the span wiring around the dispatch.
+    from caretaker.pr_reviewer.backends import _workdir as workdir_mod
+
+    monkeypatch.setattr(
+        workdir_mod,
+        "prepare_workdir",
+        AsyncMock(return_value=("/tmp/fake-workdir", MagicMock())),
+    )
+    monkeypatch.setattr(workdir_mod, "cleanup_workdir", MagicMock())
+    monkeypatch.setattr(auto_fix_mod, "run_deterministic_lint", AsyncMock(return_value=True))
+    monkeypatch.setattr(auto_fix_mod, "commit_and_push", AsyncMock(return_value="newhead123"))
+    monkeypatch.setattr(auto_fix_mod, "post_dispatch_comment", AsyncMock())
+
+    config = PRReviewerConfig(auto_fix=AutoFixConfig(enabled=True))
+    decision = AutoFixDecision(
+        should_dispatch=True,
+        backend=DETERMINISTIC_LINT_BACKEND,
+        reason="test",
+        categories=["lint"],
+    )
+    review = ReviewResult(summary="x", verdict="REQUEST_CHANGES")
+    tracking = TrackedPR(number=1)
+
+    outcome = await dispatch_auto_fix(
+        decision=decision,
+        pr_url="https://github.com/o/r/pull/1",
+        head_branch="feature",
+        review=review,
+        config=config,
+        github=MagicMock(),
+        owner="o",
+        repo="r",
+        pr_number=1,
+        tracking=tracking,
+    )
+    assert outcome.success is True
+    assert outcome.new_head_sha == "newhead123"
+
+    spans = _spans_by_name(span_exporter, "auto_fix.dispatch")
+    assert len(spans) == 1
+    attrs = spans[0].attributes
+    assert attrs["caretaker.pr.repo"] == "o/r"
+    assert attrs["caretaker.pr.number"] == 1
+    assert attrs["caretaker.auto_fix.backend"] == DETERMINISTIC_LINT_BACKEND
+    assert tuple(attrs["caretaker.auto_fix.categories"]) == ("lint",)
+    assert attrs["caretaker.auto_fix.attempt"] == 1
+    assert attrs["caretaker.auto_fix.outcome"] == "success"
+    assert attrs["caretaker.auto_fix.new_head_sha"] == "newhead123"
+
+
+# ── 6. inline_reviewer.review ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inline_reviewer_emits_span(span_exporter: InMemorySpanExporter) -> None:
+    """``review`` emits ``inline_reviewer.review`` with diff_lines + verdict."""
+    from caretaker.pr_reviewer.inline_reviewer import (
+        InlineReviewResult,
+        review,
+    )
+
+    github = MagicMock()
+    github.get_pull_diff = AsyncMock(return_value="diff --git a/foo b/foo\n+added\n-removed\n")
+
+    fake_payload = InlineReviewResult(
+        summary="lgtm",
+        verdict="APPROVE",
+        comments=[],
+        issue_categories=[],
+    )
+    llm = MagicMock()
+    llm.claude.model = "claude-test-model"
+    llm.claude.structured_complete = AsyncMock(return_value=fake_payload)
+
+    result = await review(
+        github=github,
+        owner="org",
+        repo="repo",
+        pr_number=42,
+        pr_title="t",
+        pr_body="b",
+        llm=llm,
+        max_diff_lines=2000,
+    )
+    assert result.verdict == "APPROVE"
+
+    spans = _spans_by_name(span_exporter, "inline_reviewer.review")
+    assert len(spans) == 1
+    attrs = spans[0].attributes
+    assert attrs["caretaker.pr.repo"] == "org/repo"
+    assert attrs["caretaker.pr.number"] == 42
+    # 3 lines of diff in the canned response.
+    assert attrs["caretaker.review.diff_lines"] == 3
+    assert attrs["caretaker.review.model"] == "claude-test-model"
+    assert attrs["caretaker.review.verdict"] == "APPROVE"
+
+
+# ── nesting (best-effort) ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_complexity_classifier_nests_under_handle_pr(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """When called inside the root span, the classifier span has a parent."""
+    from caretaker.evolution.executor_routing import (
+        ExecutorRouteContext,
+        ExecutorRouteFile,
+    )
+    from caretaker.pr_reviewer.complexity_classifier import classify
+
+    tracer = otel_trace.get_tracer("test.parent")
+    context = ExecutorRouteContext(
+        task_type="pr_review",
+        files=[ExecutorRouteFile(path="x.py", additions=1, deletions=0)],
+        labels=[],
+        repo_slug="org/repo",
+        title="t",
+        body="",
+    )
+    with tracer.start_as_current_span("pr_reviewer.handle_pr") as parent:
+        parent_span_id = parent.get_span_context().span_id
+        await classify(context=context, claude=None)
+
+    child_spans = _spans_by_name(span_exporter, "complexity_classifier.classify")
+    assert len(child_spans) == 1
+    child = child_spans[0]
+    assert child.parent is not None
+    assert child.parent.span_id == parent_span_id

--- a/tests/test_state_pr_decisions.py
+++ b/tests/test_state_pr_decisions.py
@@ -1,0 +1,216 @@
+"""Tests for the per-PR decision-timeline writer."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from caretaker.state.pr_decisions import (
+    PRDecisionStore,
+    record_decision,
+)
+from caretaker.state.pr_decisions import (
+    configure_default_store as _configure_default_store,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Skip the trace_id test if the OTel SDK isn't installed.
+_SDK_OK = True
+try:  # pragma: no cover - import guard
+    import opentelemetry.sdk.trace  # noqa: F401
+except Exception:  # pragma: no cover - SDK absent
+    _SDK_OK = False
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_store() -> Iterator[None]:
+    """Make sure cross-test pollution of the module-level singleton can't bite."""
+    _configure_default_store(None)
+    yield
+    _configure_default_store(None)
+
+
+class _FakeCursor:
+    """Minimal AsyncIterator over an in-memory list, supporting sort + limit chains."""
+
+    def __init__(self, docs: list[dict[str, Any]]) -> None:
+        self._docs = docs
+
+    def sort(self, key: str, direction: int) -> _FakeCursor:
+        reverse = direction < 0
+        self._docs = sorted(self._docs, key=lambda d: d[key], reverse=reverse)
+        return self
+
+    def limit(self, n: int) -> _FakeCursor:
+        self._docs = self._docs[: int(n)]
+        return self
+
+    def __aiter__(self) -> _FakeCursor:
+        self._iter = iter(self._docs)
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _FakeCollection:
+    """Stand-in for an ``AsyncIOMotorCollection``."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict[str, Any]] = []
+        self.create_index = AsyncMock(return_value="idx")
+        self._fail_insert = False
+        self._docs: list[dict[str, Any]] = []
+
+    async def insert_one(self, doc: dict[str, Any]) -> Any:
+        if self._fail_insert:
+            raise RuntimeError("simulated mongo down")
+        self.inserts.append(doc)
+        self._docs.append(doc)
+        return None
+
+    def find(self, query: dict[str, Any]) -> _FakeCursor:
+        matched = [d for d in self._docs if all(d.get(k) == v for k, v in query.items())]
+        return _FakeCursor(matched)
+
+
+def _wire_fake_collection(store: PRDecisionStore, col: _FakeCollection) -> None:
+    """Stub out ``_ensure_collection`` so tests don't touch a real Mongo."""
+
+    async def _stub() -> _FakeCollection:
+        return col
+
+    store._ensure_collection = _stub  # type: ignore[assignment]
+
+
+class TestPRDecisionStore:
+    @pytest.mark.asyncio
+    async def test_record_decision_writes_document(self) -> None:
+        store = PRDecisionStore(enabled=True)
+        col = _FakeCollection()
+        _wire_fake_collection(store, col)
+        _configure_default_store(store)
+
+        await record_decision(
+            "ianlintner/caretaker-qa",
+            108,
+            "pr_reviewer",
+            "review_started",
+            author="ianlintner",
+            is_caretaker_owned=False,
+        )
+
+        assert len(col.inserts) == 1
+        doc = col.inserts[0]
+        assert doc["repo"] == "ianlintner/caretaker-qa"
+        assert doc["pr_number"] == 108
+        assert doc["agent"] == "pr_reviewer"
+        assert doc["event"] == "review_started"
+        assert doc["fields"] == {"author": "ianlintner", "is_caretaker_owned": False}
+        assert isinstance(doc["observed_at"], datetime)
+        assert isinstance(doc["id"], str) and len(doc["id"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_record_decision_when_mongo_down(self) -> None:
+        store = PRDecisionStore(enabled=True)
+        col = _FakeCollection()
+        col._fail_insert = True
+        _wire_fake_collection(store, col)
+        _configure_default_store(store)
+
+        # MUST NOT raise — observability never fails the agent run.
+        await record_decision(
+            "ianlintner/caretaker-qa",
+            108,
+            "pr_reviewer",
+            "review_started",
+            author="x",
+        )
+
+        # _client should be cleared so the next call retries the connect path.
+        assert store._client is None
+
+    @pytest.mark.skipif(not _SDK_OK, reason="OTel SDK not installed")
+    @pytest.mark.asyncio
+    async def test_record_decision_captures_active_trace_id(self) -> None:
+        from opentelemetry import trace as otel_trace
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        exporter = InMemorySpanExporter()
+        current = otel_trace.get_tracer_provider()
+        if hasattr(current, "add_span_processor"):
+            current.add_span_processor(SimpleSpanProcessor(exporter))
+        else:
+            provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+            otel_trace.set_tracer_provider(provider)
+
+        store = PRDecisionStore(enabled=True)
+        col = _FakeCollection()
+        _wire_fake_collection(store, col)
+        _configure_default_store(store)
+
+        tracer = otel_trace.get_tracer("test")
+        with tracer.start_as_current_span("test-span"):
+            await record_decision(
+                "ianlintner/caretaker-qa",
+                108,
+                "pr_reviewer",
+                "review_started",
+            )
+
+        assert len(col.inserts) == 1
+        doc = col.inserts[0]
+        # Hex-encoded trace + span ids — non-empty when an active span exists.
+        assert isinstance(doc["trace_id"], str) and len(doc["trace_id"]) == 32
+        assert isinstance(doc["span_id"], str) and len(doc["span_id"]) == 16
+
+    @pytest.mark.asyncio
+    async def test_query_timeline_returns_sorted_documents(self) -> None:
+        store = PRDecisionStore(enabled=True)
+        col = _FakeCollection()
+        _wire_fake_collection(store, col)
+
+        now = datetime.now(UTC)
+        # Insert out-of-order: middle, oldest, newest.
+        for offset_minutes, event in (
+            (5, "tier_classified"),
+            (10, "review_started"),
+            (1, "review_completed"),
+        ):
+            col._docs.append(
+                {
+                    "id": f"id-{event}",
+                    "repo": "ianlintner/caretaker-qa",
+                    "pr_number": 108,
+                    "observed_at": now - timedelta(minutes=offset_minutes),
+                    "agent": "pr_reviewer",
+                    "event": event,
+                    "fields": {},
+                    "trace_id": None,
+                    "span_id": None,
+                }
+            )
+
+        timeline = await store.query_timeline(
+            owner="ianlintner", repo="caretaker-qa", pr_number=108
+        )
+
+        assert [d["event"] for d in timeline] == [
+            "review_started",
+            "tier_classified",
+            "review_completed",
+        ]

--- a/tests/test_state_pr_decisions.py
+++ b/tests/test_state_pr_decisions.py
@@ -36,7 +36,7 @@ def _reset_default_store() -> Iterator[None]:
 
 
 class _FakeCursor:
-    """Minimal AsyncIterator over an in-memory list, supporting sort + limit chains."""
+    """Minimal AsyncIterator over an in-memory list, supporting sort/skip/limit chains."""
 
     def __init__(self, docs: list[dict[str, Any]]) -> None:
         self._docs = docs
@@ -44,6 +44,10 @@ class _FakeCursor:
     def sort(self, key: str, direction: int) -> _FakeCursor:
         reverse = direction < 0
         self._docs = sorted(self._docs, key=lambda d: d[key], reverse=reverse)
+        return self
+
+    def skip(self, n: int) -> _FakeCursor:
+        self._docs = self._docs[int(n) :]
         return self
 
     def limit(self, n: int) -> _FakeCursor:
@@ -80,6 +84,9 @@ class _FakeCollection:
     def find(self, query: dict[str, Any]) -> _FakeCursor:
         matched = [d for d in self._docs if all(d.get(k) == v for k, v in query.items())]
         return _FakeCursor(matched)
+
+    async def count_documents(self, query: dict[str, Any]) -> int:
+        return sum(1 for d in self._docs if all(d.get(k) == v for k, v in query.items()))
 
 
 def _wire_fake_collection(store: PRDecisionStore, col: _FakeCollection) -> None:
@@ -205,7 +212,7 @@ class TestPRDecisionStore:
                 }
             )
 
-        timeline = await store.query_timeline(
+        timeline, total_count = await store.query_timeline(
             owner="ianlintner", repo="caretaker-qa", pr_number=108
         )
 
@@ -214,3 +221,42 @@ class TestPRDecisionStore:
             "tier_classified",
             "review_completed",
         ]
+        assert total_count == 3
+
+    @pytest.mark.asyncio
+    async def test_query_timeline_pagination_reports_total(self) -> None:
+        """``query_timeline`` honours ``limit``/``offset`` and reports total_count."""
+        store = PRDecisionStore(enabled=True)
+        col = _FakeCollection()
+        _wire_fake_collection(store, col)
+
+        now = datetime.now(UTC)
+        # Insert 5 decisions, oldest first.
+        for i in range(5):
+            col._docs.append(
+                {
+                    "id": f"id-{i}",
+                    "repo": "ianlintner/caretaker-qa",
+                    "pr_number": 108,
+                    "observed_at": now - timedelta(minutes=10 - i),
+                    "agent": "pr_reviewer",
+                    "event": f"event_{i}",
+                    "fields": {},
+                    "trace_id": None,
+                    "span_id": None,
+                }
+            )
+
+        # First page: 2 items, total_count = 5.
+        page1, total1 = await store.query_timeline(
+            owner="ianlintner", repo="caretaker-qa", pr_number=108, limit=2, offset=0
+        )
+        assert [d["id"] for d in page1] == ["id-0", "id-1"]
+        assert total1 == 5
+
+        # Second page: 2 items at offset 2, total_count still 5.
+        page2, total2 = await store.query_timeline(
+            owner="ianlintner", repo="caretaker-qa", pr_number=108, limit=2, offset=2
+        )
+        assert [d["id"] for d in page2] == ["id-2", "id-3"]
+        assert total2 == 5


### PR DESCRIPTION
Implements phases 1-4 of [docs/plans/2026-05-06-observability-improvements.md](docs/plans/2026-05-06-observability-improvements.md), built directly from gaps surfaced during the v0.28 QA cycle. Every recommendation maps to a specific v0.28.x bug that took multiple patch releases to fix because the failure modes were silent.

## Phase 1A — Metrics + per-PR audit log

5 new Prometheus metrics with bounded-enum validation + structured per-PR audit log line emitted at every \`_handle_pr\` return path. Catches every v0.28.x failure mode at observation time:

- \`caretaker_pr_review_outcome_total{backend, tier, verdict}\`
- \`caretaker_pr_review_duration_seconds{backend, tier}\`
- \`caretaker_complexity_classifier_tier_total{tier, source}\`
- \`caretaker_opencode_invocation_total{model, mode, outcome}\` — outcomes include \`parse_fallback\`, \`no_endpoints\`, \`timeout\`, \`error\`, \`declined\`
- \`caretaker_auto_fix_dispatch_total{backend, category, outcome}\`

Wired into \`opencode_local\`, \`complexity_classifier\`, \`auto_fix.decide_auto_fix\`/\`dispatch_auto_fix\`, and \`pr_reviewer.agent._handle_pr\`. Loud WARNING + \`parse_fallback\` counter when opencode falls back to prose-wrap.

## Phase 1B — \`/health/deep\` endpoint

\`GET /health/deep\` runs 6 dependency probes concurrently and returns a structured health verdict. Catches v0.28-class image-build bugs at deploy time:

| Check | Detects |
|---|---|
| \`git_cli\` / \`opencode_cli\` | Missing CLI in image (v0.28.2 bug) |
| \`redis\` / \`mongo\` / \`neo4j\` | Backing-store outage |
| \`config\` | Malformed \`MaintainerConfig\` |
| \`openrouter_models\` | Bogus model IDs (v0.28.4 bug) — 1-hour cache for cost |

HTTP 503 on hard failures, 200 with \`status=ok\|degraded\` otherwise. 45-second hard timeout via \`asyncio.wait_for\`. Operator-triggered, not for kubelet probes.

## Phase 4 — OTEL custom spans

6 custom spans so a single PR review becomes one trace tree in Tempo:

\`\`\`
pr_reviewer.handle_pr (root)
├── complexity_classifier.classify
├── inline_reviewer.review
└── pr_review.clone_workdir → opencode_local.invoke
    └── auto_fix.dispatch
\`\`\`

Each span carries \`pr.repo\` / \`pr.number\` / \`model\` / \`tier\` / \`verdict\` attributes so trace-search by repo or by model is direct. Exception recording is consistent across spans.

## Phase 3 — Token + USD cost tracking

Switched opencode CLI to \`--format json\` to capture structured \`step_finish\` events with token counts. Added \`caretaker_llm_tokens_total{model, direction}\` and \`caretaker_llm_cost_usd_total{model}\` counters with a static \`LLM_PRICE_TABLE\` covering the v0.28.4 default model set.

Lets a Grafana panel answer "did the v0.28 model shift away from Opus actually save money?" in one chart per repo per day.

Documented limitation: Anthropic cache_write tokens are billed at 1.25× input rate; we count them at 1× → ±10-15% drift on cache-heavy reviews. Acceptable approximation; \`LLM_PRICE_TABLE\` docstring explains how to extend if accuracy matters.

## Phase 2 — Per-PR decision timeline

New \`pr_decisions\` Mongo collection (TTL 30d) + module-level \`record_decision(...)\` helper + admin endpoint \`GET /api/admin/pr/{owner}/{repo}/{number}/timeline\`. Replaces every \`kubectl logs \| grep <pr>\` investigation:

\`\`\`json
{
  "owner": "ianlintner", "repo": "caretaker-qa", "pr_number": 108,
  "decisions": [
    {"observed_at": "...", "agent": "pr_reviewer", "event": "review_started", "fields": {...}, "trace_id": "5f...", "span_id": "8a..."},
    ...
  ],
  "total_count": 17, "truncated": false
}
\`\`\`

\`agent\` and \`event\` are bounded \`Literal\` types so typo drift fails at type-check. Each row carries \`trace_id\` + \`span_id\` so the admin SPA can deep-link to Tempo. Mongo failures are logged at WARNING and never propagate; structured INFO log emitted regardless so Loki can rebuild the timeline if Mongo is down. Pagination via \`limit\` (default 200, max 1000) + \`offset\` query params.

Wire-up: \`pr_reviewer.agent\`, \`complexity_classifier\`, \`auto_fix.decide_auto_fix\` / \`dispatch_auto_fix\`, \`opencode_local.run\`.

## Test summary

- 2682 tests pass (was ~2660 on \`origin/main\`, +90+ new tests across the 5 phases)
- \`ruff format --check\`, \`ruff check\`, \`mypy --strict\` all clean
- New test files: \`test_observability_metrics.py\`, \`test_observability_health.py\`, \`test_mcp_backend_health_deep.py\`, \`test_pr_reviewer_otel_spans.py\`, \`test_pr_reviewer_opencode_local_backend.py\`, \`test_observability_cost_tracking.py\`, \`test_state_pr_decisions.py\`, \`test_admin_pr_timeline_api.py\`

## Behaviour changes operators should know about

1. **opencode CLI now uses \`--format json\`**. Pod logs see structured JSON events instead of human banner. \`text\`/\`tool_*\` events are demoted to DEBUG so the log volume is bounded.
2. **\`/health/deep\` is a new public endpoint** — 45s wall-clock budget. Don't wire kubelet probes to it; \`/health\` is still the kubelet path.
3. **\`LLM_PRICE_TABLE\` ships with 12 models**. Models not in the table emit a one-shot WARNING and skip USD cost tracking; tokens are still recorded.
4. **\`pr_decisions\` collection** is created on first write with a 30-day TTL. No migration needed.

## Documented follow-ups (not blocking merge)

- \`TODO(state-object)\` in \`agent.py\` — \`_handle_pr_body\` mutates 7 locals; future \`_PRReviewState\` dataclass refactor
- \`TODO(backend-dispatch)\` in \`agent.py:_resolve_backend_model\` — extend to a per-spec dispatch table when claude_code_local gains tier-aware models
- Phase 5 (alerting) and Phase 6 (\`caretaker debug pr-review\` CLI) deliberately out of scope per the plan
- Optional: extract a shared \`_BaseMongoWriter\` to deduplicate \`pr_decisions.py\` and \`audit_log.py\`

## Methodology

Built using the \`superpowers:subagent-driven-development\` skill: each task got a fresh implementer subagent + spec compliance reviewer + code quality reviewer + fix pass. 11 commits total (5 feat + 5 fix + 1 plan doc). Final cross-task review confirmed no branch-wide drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)