### PR TITLE
fix(github_app): skip fleet heartbeat write on not_in_allowlist outcome

### DIFF
--- a/src/caretaker/eventbus/consumer.py
+++ b/src/caretaker/eventbus/consumer.py
@@ -326,7 +326,16 @@ async def _handle_webhook(*, parsed: ParsedWebhook, dispatcher: WebhookDispatche
     # v0.25.0 thin streaming workflow no longer runs ``caretaker run`` in
     # consumer CI (so consumer-side ``emit_heartbeat`` never fires for any
     # fleet repo anymore). Best-effort; failures never propagate.
-    if parsed.repository_full_name and result.outcome != "off":
+    #
+    # Skip outcomes that mean "we filtered this delivery before doing any
+    # work":
+    #   - ``off`` — dispatch mode disabled
+    #   - ``not_in_allowlist`` — repo not in fleet_gate.allowed_repos
+    #     (added in PR #687 / v0.29.x). Without this gate the heartbeat
+    #     writer kept fleet_clients / fleet_heartbeats growing for every
+    #     filtered fork, defeating the table-cleanup goal of the allow-
+    #     list (188 → 189 instead of 188 → 10).
+    if parsed.repository_full_name and result.outcome not in {"off", "not_in_allowlist"}:
         try:
             from caretaker.fleet import record_dispatch_activity
 

--- a/tests/test_fleet_dispatch_activity.py
+++ b/tests/test_fleet_dispatch_activity.py
@@ -216,3 +216,47 @@ async def test_consumer_webhook_handler_skips_record_when_dispatcher_off(
 
     client = await (get_store()).get_client("acme/demo")
     assert client is None
+
+
+@pytest.mark.asyncio
+async def test_consumer_webhook_handler_skips_record_when_outcome_not_in_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the dispatcher returns ``outcome="not_in_allowlist"`` (added
+    in PR #687 / v0.29.x for fleet_gate.allowed_repos filtering), the
+    consumer must NOT touch the fleet registry. Without this skip the
+    heartbeat writer kept writing rows for filtered forks, defeating the
+    cleanup goal of the allow-list (fleet_clients went 188 → 189 instead
+    of 188 → 10 after v0.29.1 deploy)."""
+    from caretaker.eventbus.consumer import _handle_webhook
+    from caretaker.github_app.dispatcher import DispatchMode, DispatchResult
+    from caretaker.github_app.webhooks import ParsedWebhook
+
+    parsed = ParsedWebhook(
+        event_type="pull_request",
+        delivery_id="d-1",
+        action="opened",
+        installation_id=42,
+        repository_full_name="some-fork/abandoned",
+        payload={},
+    )
+    dispatcher = AsyncMock()
+    dispatcher.mode = DispatchMode.ACTIVE
+    dispatcher.dispatch = AsyncMock(
+        return_value=DispatchResult(
+            mode=DispatchMode.ACTIVE,
+            event="pull_request",
+            delivery_id="d-1",
+            agents=(),
+            outcome="not_in_allowlist",
+            duration_seconds=0.0,
+            detail="repo 'some-fork/abandoned' not in fleet_gate.allowed_repos",
+        )
+    )
+
+    await _handle_webhook(parsed=parsed, dispatcher=dispatcher)
+
+    from caretaker.fleet.store import get_store
+
+    client = await (get_store()).get_client("some-fork/abandoned")
+    assert client is None, "fleet_clients must not be written for repos filtered by allow-list"


### PR DESCRIPTION
## Summary

Completes the fleet allow-list fix from PR #687. That PR added a `WebhookDispatcher` short-circuit returning `outcome="not_in_allowlist"` for repos outside `fleet_gate.allowed_repos`, but the downstream heartbeat writer in `caretaker.eventbus.consumer._handle_webhook` still ran for every filtered delivery — so `fleet_clients` and `fleet_heartbeats` kept growing instead of converging on the 10-repo allow-list.

This patch extends the existing skip-on-`off` gate to also skip on `not_in_allowlist`, so filtered repos never touch the fleet store.

## Why

- Live evidence after the v0.29.1 deploy (PR #687 + 10-repo allow-list):
  - `fleet_clients`: 188 → 189 (went UP, not down to 10)
  - `fleet_heartbeats`: 6,237 rows and climbing
  - ~60 `not_in_allowlist`-outcome heartbeats observed in 1 minute of logs
- The allow-list filter worked — we just kept writing rows after it fired.

## What changed

- `src/caretaker/eventbus/consumer.py` — extend the skip gate from `result.outcome != "off"` to `result.outcome not in {"off", "not_in_allowlist"}`. Comment explains the PR #687 / v0.29.x context.
- `tests/test_fleet_dispatch_activity.py` — new test `test_consumer_webhook_handler_skips_record_when_outcome_not_in_allowlist` mirroring the existing `…skips_record_when_dispatcher_off` pattern.

## Test plan

- [x] `python -m pytest tests/test_fleet_dispatch_activity.py -v` (10 passed, including new test)
- [x] `python -m pytest tests/ -q` (2710 passed)
- [x] `ruff format` + `ruff check` + `mypy --strict src/caretaker` clean
- [ ] After deploy: confirm `fleet_clients` row count drops toward 10 as the existing 189 rows age out / get garbage-collected, and no new `not_in_allowlist`-outcome rows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)