### PR TITLE
fix(state): Cosmos-compatible Mongo sort queries

### DIFF
--- a/src/caretaker/evolution/backends/mongo_backend.py
+++ b/src/caretaker/evolution/backends/mongo_backend.py
@@ -246,11 +246,24 @@ class MongoEvolutionBackend:
         return _to_skill(doc) if doc else None
 
     def all_skills(self, category: str | None = None) -> list[Any]:
-        flt: dict[str, Any] = {}
         if category:
-            flt["category"] = category
-        cursor = self._skills.find(flt, sort=[("success_count", -1)])
-        return [_to_skill(doc) for doc in cursor]
+            # With ``category`` set, ``idx_skills_success`` (``category
+            # ASC, success_count DESC``) covers the sort directly and
+            # Cosmos accepts the OrderBy.
+            cursor = self._skills.find(
+                {"category": category},
+                sort=[("success_count", -1)],
+            )
+            return [_to_skill(doc) for doc in cursor]
+        # Without a category filter the leading-prefix rule fails on
+        # Azure Cosmos DB ("The index path corresponding to the
+        # specified order-by item is excluded") because no index has
+        # ``success_count`` as a leading column. Skill counts are
+        # bounded (low thousands across all categories), so fetch
+        # unsorted and sort in Python — same wire result, Cosmos-safe.
+        rows = list(self._skills.find({}))
+        rows.sort(key=lambda d: d.get("success_count", 0), reverse=True)
+        return [_to_skill(doc) for doc in rows]
 
     def delete_skills(self, skill_ids: list[str]) -> int:
         if not skill_ids:

--- a/src/caretaker/fleet/mongo_store.py
+++ b/src/caretaker/fleet/mongo_store.py
@@ -94,6 +94,16 @@ class MongoFleetRegistryStore:
                 unique=True,
                 name="idx_fleet_clients_repo",
             )
+            # Sort index for ``list_clients`` (admin + fleet API). Azure
+            # Cosmos DB's MongoDB API rejects ``find().sort('last_seen')``
+            # without an explicit index on the sort field — a generic
+            # ``find({})`` cannot lean on the unique-on-repo index above.
+            # Stored as ISO-8601 strings (see ``_client_to_doc``) so
+            # lexicographic ordering matches chronological ordering.
+            await db[_COL_CLIENTS].create_index(
+                [("last_seen", pymongo.DESCENDING)],
+                name="idx_fleet_clients_last_seen",
+            )
             await db[_COL_HEARTBEATS].create_index(
                 [("repo", pymongo.ASCENDING), ("_id", pymongo.ASCENDING)],
                 name="idx_fleet_heartbeats_repo_id",

--- a/src/caretaker/runs/store.py
+++ b/src/caretaker/runs/store.py
@@ -206,6 +206,30 @@ class RunsStore:
                     [("started_at", pymongo.DESCENDING)],
                     name="idx_started_at",
                 )
+                # Compound indexes for ``list_runs`` queries that filter +
+                # sort. Azure Cosmos DB's MongoDB API enforces a strict
+                # OrderBy contract: a ``find({status: ...}).sort(started_at)``
+                # is only legal when an index covers ``(status, started_at)``
+                # exactly — a single-field index on ``started_at`` is not
+                # enough. The stalled-run sweeper hits this every 60s in
+                # production (status=RUNNING + sort by started_at), so
+                # without these compounds the deployed backend raises
+                # ``OperationFailure: index path corresponding to the
+                # specified order-by item is excluded`` on every sweep.
+                await col.create_index(
+                    [
+                        ("status", pymongo.ASCENDING),
+                        ("started_at", pymongo.DESCENDING),
+                    ],
+                    name="idx_status_started_at",
+                )
+                await col.create_index(
+                    [
+                        ("repository", pymongo.ASCENDING),
+                        ("started_at", pymongo.DESCENDING),
+                    ],
+                    name="idx_repository_started_at",
+                )
                 self._index_created = True
         return col
 

--- a/src/caretaker/state/backends/mongo_backend.py
+++ b/src/caretaker/state/backends/mongo_backend.py
@@ -198,20 +198,32 @@ class MongoMemoryBackend:
     # ── Maintenance ───────────────────────────────────────────────────────
 
     def _enforce_namespace_limit(self, namespace: str) -> None:
-        """Prune the oldest entries when the per-namespace cap is exceeded."""
+        """Prune the oldest entries when the per-namespace cap is exceeded.
+
+        Sort happens in Python rather than in Mongo because Azure Cosmos
+        DB's MongoDB API rejects ``sort('updated_at', 1)`` here: the only
+        compound index covering ``updated_at`` is ``(namespace ASC,
+        updated_at DESC)`` (``idx_ns_updated``), and Cosmos won't reuse a
+        descending index to satisfy an ascending OrderBy. By the
+        ``_max_entries`` contract the namespace holds at most a few
+        thousand docs, so reading ``(_id, updated_at)`` projections and
+        sorting in-process is cheap and avoids needing a parallel
+        ``(namespace, updated_at ASC)`` index just for prune.
+        """
         count = self._col.count_documents({"namespace": namespace})
         if count <= self._max_entries:
             return
         excess = count - self._max_entries
-        # Find the oldest entry IDs to delete.
-        oldest = list(
+        rows = list(
             self._col.find(
                 {"namespace": namespace},
-                {"_id": 1},
-                sort=[("updated_at", 1)],
-                limit=excess,
+                {"_id": 1, "updated_at": 1},
             )
         )
+        # Tolerate missing/None ``updated_at`` (legacy rows): treat as
+        # epoch-zero so they prune first.
+        rows.sort(key=lambda d: d.get("updated_at") or datetime.min.replace(tzinfo=UTC))
+        oldest = rows[:excess]
         if oldest:
             ids = [doc["_id"] for doc in oldest]
             self._col.delete_many({"_id": {"$in": ids}})

--- a/tests/test_evolution_mongo_backend.py
+++ b/tests/test_evolution_mongo_backend.py
@@ -184,8 +184,24 @@ class TestMongoEvolutionBackendSkills:
         skills_col.find.return_value = [_make_skill_doc()]
 
         results = b.all_skills()
-        skills_col.find.assert_called_once_with({}, sort=[("success_count", -1)])
+        # Cosmos-safe: with no category filter we must NOT pass ``sort=``
+        # to ``find()`` (no compound index has ``success_count`` as a
+        # leading column). The sort happens in Python instead.
+        skills_col.find.assert_called_once_with({})
+        call_kwargs = skills_col.find.call_args[1]
+        assert "sort" not in call_kwargs
         assert len(results) == 1
+
+    def test_all_skills_no_filter_sorts_in_python(self, backend):
+        b, skills_col, _ = backend
+        # Return docs in non-sorted order to verify the in-Python sort.
+        low = _make_skill_doc(success_count=2, signature="low")
+        high = _make_skill_doc(success_count=10, signature="high")
+        mid = _make_skill_doc(success_count=5, signature="mid")
+        skills_col.find.return_value = [low, high, mid]
+
+        results = b.all_skills()
+        assert [s.signature for s in results] == ["high", "mid", "low"]
 
     def test_all_skills_with_category(self, backend):
         b, skills_col, _ = backend
@@ -194,6 +210,10 @@ class TestMongoEvolutionBackendSkills:
         b.all_skills(category="build")
         call_args = skills_col.find.call_args
         assert call_args[0][0] == {"category": "build"}
+        # Cosmos-safe path with category: ``idx_skills_success`` covers
+        # ``(category, success_count DESC)`` so we DO push the sort
+        # into Mongo here.
+        assert call_args[1].get("sort") == [("success_count", -1)]
 
     def test_delete_skills_empty_list_returns_zero(self, backend):
         b, skills_col, _ = backend

--- a/tests/test_memory_backends.py
+++ b/tests/test_memory_backends.py
@@ -73,3 +73,63 @@ class TestSQLiteBackend:
         from caretaker.state.backends.base import MemoryBackend
 
         assert isinstance(sqlite_backend, MemoryBackend)
+
+
+class TestMongoBackendCosmosCompat:
+    """Cosmos-DB-specific shape checks for MongoMemoryBackend.
+
+    These don't need a live Mongo — we wire a MagicMock collection
+    and assert on the call shape, because the bug class we're
+    guarding against is "the Mongo call uses ``sort=`` on a field
+    Cosmos hasn't indexed", not "Mongo returned the wrong rows".
+    """
+
+    def test_enforce_namespace_limit_does_not_pass_sort_to_find(self) -> None:
+        """``_enforce_namespace_limit`` must not push a sort on
+        ``updated_at`` ASC into Mongo: the only compound covering
+        ``updated_at`` (``idx_ns_updated``) is DESC, and Cosmos's strict
+        OrderBy contract refuses to satisfy an ASC sort with a DESC
+        index. Sort happens in Python instead.
+        """
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock
+
+        from caretaker.state.backends.mongo_backend import MongoMemoryBackend
+
+        b = MongoMemoryBackend.__new__(MongoMemoryBackend)
+        b._max_entries = 2
+        col = MagicMock()
+        col.count_documents.return_value = 5
+
+        # 5 docs with ascending updated_at — oldest two should be deleted.
+        rows = [
+            {"_id": f"id-{i}", "updated_at": datetime(2024, 1, i + 1, tzinfo=UTC)} for i in range(5)
+        ]
+        col.find.return_value = rows
+        b._col = col
+
+        b._enforce_namespace_limit("ns")
+
+        # Find must be called WITHOUT ``sort=`` (Cosmos-safe).
+        find_kwargs = col.find.call_args.kwargs
+        assert "sort" not in find_kwargs
+
+        # 5 docs, cap=2, so excess=3 → the three oldest (lowest
+        # updated_at) ids must be deleted.
+        delete_args = col.delete_many.call_args.args[0]
+        assert delete_args == {"_id": {"$in": ["id-0", "id-1", "id-2"]}}
+
+    def test_enforce_namespace_limit_under_cap_is_noop(self) -> None:
+        from unittest.mock import MagicMock
+
+        from caretaker.state.backends.mongo_backend import MongoMemoryBackend
+
+        b = MongoMemoryBackend.__new__(MongoMemoryBackend)
+        b._max_entries = 100
+        col = MagicMock()
+        col.count_documents.return_value = 5
+        b._col = col
+
+        b._enforce_namespace_limit("ns")
+        col.find.assert_not_called()
+        col.delete_many.assert_not_called()

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -59,6 +59,53 @@ def _isolated() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fleet_clients_creates_last_seen_index() -> None:
+    """``_ensure_indexes`` must register a ``last_seen`` index on
+    ``fleet_clients``.
+
+    Regression: ``MongoFleetRegistryStore.list_clients`` calls
+    ``find({}).sort('last_seen', -1)`` and Azure Cosmos DB's MongoDB
+    API rejects sorts on fields without an explicit index ("The index
+    path corresponding to the specified order-by item is excluded").
+    Without this index every admin/fleet-API list-clients call fails.
+    """
+    from caretaker.fleet.mongo_store import MongoFleetRegistryStore
+
+    created: list[tuple[Any, dict[str, Any]]] = []
+
+    def _capture(spec: Any, **kwargs: Any) -> str:
+        created.append((spec, kwargs))
+        return kwargs.get("name", "idx")
+
+    fake_clients = MagicMock()
+    fake_clients.create_index = AsyncMock(side_effect=_capture)
+    fake_heartbeats = MagicMock()
+    fake_heartbeats.create_index = AsyncMock(side_effect=_capture)
+
+    fake_db = {
+        "fleet_clients": fake_clients,
+        "fleet_heartbeats": fake_heartbeats,
+    }
+
+    store = MongoFleetRegistryStore(mongodb_url="mongodb://stub")
+
+    async def _fake_db_accessor() -> Any:
+        return fake_db
+
+    store._db = _fake_db_accessor  # type: ignore[method-assign]
+    await store._ensure_indexes()
+
+    names = {kwargs.get("name") for _spec, kwargs in created}
+    assert "idx_fleet_clients_repo" in names
+    assert "idx_fleet_clients_last_seen" in names
+    assert "idx_fleet_heartbeats_repo_id" in names
+
+    by_name = {kwargs["name"]: spec for spec, kwargs in created if "name" in kwargs}
+    last_seen_spec = by_name["idx_fleet_clients_last_seen"]
+    assert last_seen_spec[0][0] == "last_seen"
+
+
+@pytest.mark.asyncio
 async def test_recent_heartbeats_pushes_limit_into_mongo() -> None:
     """The cursor must be sorted descending and limited at the DB layer."""
     from caretaker.fleet.mongo_store import MongoFleetRegistryStore

--- a/tests/test_runs/test_store.py
+++ b/tests/test_runs/test_store.py
@@ -8,6 +8,8 @@ replay, and the live-tail iterator without external dependencies.
 from __future__ import annotations
 
 import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -113,3 +115,53 @@ async def test_list_runs_filters(store: RunsStore) -> None:
 
     succeeded = await store.list_runs(status=RunStatus.SUCCEEDED)
     assert {r.run_id for r in succeeded} == {b.run_id}
+
+
+@pytest.mark.asyncio
+async def test_collection_creates_cosmos_safe_compound_indexes() -> None:
+    """``_collection`` registers ``(status, started_at)`` and
+    ``(repository, started_at)`` compounds so ``list_runs`` filter+sort
+    queries don't trip Azure Cosmos DB's strict OrderBy contract.
+
+    Regression for the production stalled-run sweeper, which calls
+    ``list_runs(status=RUNNING).sort('started_at', -1)`` every 60s and
+    failed under Cosmos when only the single-field ``idx_started_at``
+    existed.
+    """
+    created: list[tuple[Any, dict[str, Any]]] = []
+
+    fake_collection = MagicMock()
+
+    async def _capture(spec: Any, **kwargs: Any) -> str:
+        created.append((spec, kwargs))
+        return kwargs.get("name", "idx")
+
+    fake_collection.create_index = AsyncMock(side_effect=_capture)
+
+    fake_db = MagicMock()
+    fake_db.__getitem__.return_value = fake_collection
+
+    fake_client = MagicMock()
+    fake_client.__getitem__.return_value = fake_db
+
+    rs = RunsStore(mongodb_url="mongodb://stub")
+    rs._mongo_client = fake_client  # bypass connect
+
+    col = await rs._collection()
+    assert col is fake_collection
+
+    names = {kwargs.get("name") for _spec, kwargs in created}
+    # Pre-existing single-field/uniqueness indexes still present.
+    assert "idx_run_id" in names
+    assert "idx_natural_key" in names
+    assert "idx_started_at" in names
+    # New Cosmos-safe compounds.
+    assert "idx_status_started_at" in names
+    assert "idx_repository_started_at" in names
+
+    # Verify the leading-prefix shape so the sort is actually covered.
+    by_name = {kwargs["name"]: spec for spec, kwargs in created if "name" in kwargs}
+    assert by_name["idx_status_started_at"][0][0] == "status"
+    assert by_name["idx_status_started_at"][1][0] == "started_at"
+    assert by_name["idx_repository_started_at"][0][0] == "repository"
+    assert by_name["idx_repository_started_at"][1][0] == "started_at"


### PR DESCRIPTION
## What we hit

We hit ``OperationFailure: ... "Errors":["The index path corresponding to the specified order-by item is excluded."]`` from Azure CosmosDB's MongoDB API on an ad-hoc ``fleet_heartbeats.find().sort('run_at', -1)`` query. CosmosDB's OrderBy contract is stricter than vanilla MongoDB: a ``find().sort()`` is only legal when the sort field is part of a composite index registered against the collection. Single-field auto-indexes that "just work" on a stock ``mongod`` get rejected.

The user-issued query was a one-off, but it surfaces a class of bug that *also* exists in code paths caretaker runs in production.

## Audit results

I grepped every ``.sort(...)`` and ``sort=`` call site in ``src/caretaker/`` and checked each against the writer-side ``create_index`` calls. Cursor-attached sort sites:

| File:Line | Collection | Filter | Sort | Status |
|---|---|---|---|---|
| ``state/pr_decisions.py:277`` | ``pr_decisions`` | ``(repo, pr_number)`` | ``observed_at`` ASC | indexed (compound ``(repo, pr_number, observed_at)`` covers it) |
| ``runs/store.py:342`` | ``runs`` | ``repository?, status?, started_at?`` | ``started_at`` DESC | **fixed** — added ``(status, started_at)`` and ``(repository, started_at)`` |
| ``fleet/mongo_store.py:160,182,196`` | ``fleet_heartbeats`` | ``repo`` | ``_id`` DESC | indexed (``(repo, _id)``) |
| ``fleet/mongo_store.py:206`` | ``fleet_clients`` | ``{}`` | ``last_seen`` DESC | **fixed** — added single-field ``last_seen DESC`` index |
| ``state/backends/mongo_backend.py:136`` | ``agent_memory`` | ``namespace + expires_at`` | ``updated_at`` DESC | indexed (``(namespace, updated_at DESC)``) |
| ``state/backends/mongo_backend.py:211`` | ``agent_memory`` | ``namespace`` | ``updated_at`` ASC | **fixed** — sort moved to Python (DESC index can't satisfy ASC OrderBy under Cosmos) |
| ``state/backends/mongo_backend.py:232`` | ``agent_memory`` | ``expires_at`` | ``(namespace, updated_at DESC)`` | indexed (exact compound match) |
| ``evolution/backends/mongo_backend.py:237`` | ``evolution_skills`` | ``category`` | ``success_count`` DESC | indexed (``(category, success_count DESC)``) |
| ``evolution/backends/mongo_backend.py:252`` | ``evolution_skills`` | ``category?`` | ``success_count`` DESC | **fixed** — when ``category`` is None, sort moved to Python |
| ``evolution/backends/mongo_backend.py:288`` | ``evolution_mutations`` | ``{}`` | ``started_at`` DESC | indexed (single-field ``started_at DESC``) |

All other ``.sort(...)`` calls in the tree operate on Python lists (already in-memory), not Mongo cursors — out of scope.

## Production impact of the bugs found

- **``runs/store.py``** is hit by the stalled-run sweeper (``mcp_backend.main`` schedules ``build_sweeper_task`` which calls ``list_runs(status=RUNNING)`` every 60s) and by the admin runs API. The ``status``-filtered sort would have failed on every sweep under Cosmos.
- **``fleet/mongo_store.py``** is hit by ``state_loader`` (admin sync) and the fleet API (``fleet/api.py``). Same failure mode for the unfiltered ``last_seen`` sort.
- **``state/backends/mongo_backend.py``** prune is a slow-path background concern; the fix ensures it doesn't blow up under Cosmos.
- **``evolution/backends/mongo_backend.py``** ``all_skills()`` is called from the evolver (per-run agent path) and ``fleet/graph.py`` global-skill promotion.

## Tests

Added 4 new tests, one per fix:

- ``test_collection_creates_cosmos_safe_compound_indexes`` — runs sweeper indexes registered with the right shape.
- ``test_fleet_clients_creates_last_seen_index`` — fleet_clients ``last_seen`` index registered.
- ``test_enforce_namespace_limit_does_not_pass_sort_to_find`` (+``_under_cap_is_noop``) — Mongo ``find()`` is called WITHOUT ``sort=`` and the prune still picks the oldest entries (Python sort).
- ``test_all_skills_no_filter_sorts_in_python`` (+ updated existing test) — when ``category`` is None, the wire call has no ``sort=``; with ``category`` it still does.

Updated ``test_all_skills_no_filter`` to match the new wire shape.

Full suite: 2715 passed, 0 failed.

Pre-commit clean: ruff format, ruff check, mypy strict.

## Bundling

Goes out with the heartbeat-skip fix (#694) as v0.29.2.

## Test plan

- [ ] CI passes ``pytest`` + ``mypy`` + ``ruff``
- [ ] Verify in deployed backend logs that the periodic stalled-run sweeper stops emitting Cosmos OrderBy errors
- [ ] Verify ``/api/admin/fleet`` / ``GET /api/fleet/clients`` still returns the client list sorted newest-first
- [ ] Verify the admin SPA's PR timeline view (``query_timeline``) still loads ordered ascending by ``observed_at``

🤖 Generated with [Claude Code](https://claude.com/claude-code)