### PR TITLE
docs(architecture): rewrite with 4 current-state diagrams

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,109 +1,312 @@
 # Architecture
 
-Caretaker separates **decision-making** from **code authoring**:
+Caretaker is a multi-agent GitHub-automation system that runs on AKS. The
+core split is unchanged: the orchestrator **decides**, coding backends
+**author code**, GitHub **remembers**. What has grown is the surrounding
+infrastructure — a webhook-driven control plane, a durable coding-job
+pipeline on Azure Service Bus + Kubernetes, multiple coding-agent
+backends, and a layered persistence story.
 
-- the Python orchestrator reads repository state and decides what should happen
-- GitHub Copilot executes code changes through issues, PR comments, and structured instructions
+This page is the conceptual map. Source paths are cited inline so each
+component can be verified.
 
-## Main building blocks
+## Deployable processes
 
-### Orchestrator
+| Process | Replicas | Entrypoint | Purpose |
+|---|---|---|---|
+| `mcp_backend` | 2 | [`uvicorn caretaker.mcp_backend.main:app`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/mcp_backend) | Webhook receiver, MCP tool surface, admin SPA, reconciliation scheduler |
+| `caretaker-job-dispatcher` | 1 | [`python -m caretaker.coding_jobs.dispatcher_main`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/coding_jobs) | Azure Service Bus consumer, K8s Job spawner |
+| Spawned coding-job pods | per dispatch | [`caretaker.k8s_worker`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/k8s_worker) | Per-task agent execution (opencode_local, foundry, claude-code) |
+| `caretaker` CLI | local / CI | [`caretaker.cli`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/cli.py) | Standalone orchestrator for one-off runs and bootstrap |
 
-The orchestrator is the central coordinator in [`src/caretaker/orchestrator.py`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/orchestrator.py).
+The first two are deployed via Flux from
+[`infra/k8s/caretaker-mcp-deployment.yaml`](https://github.com/ianlintner/caretaker/blob/main/infra/k8s/caretaker-mcp-deployment.yaml)
+and
+[`infra/k8s/caretaker-job-dispatcher-deployment.yaml`](https://github.com/ianlintner/caretaker/blob/main/infra/k8s/caretaker-job-dispatcher-deployment.yaml).
+Both share the [`Dockerfile.mcp`](https://github.com/ianlintner/caretaker/blob/main/Dockerfile.mcp) image
+(`gabby.azurecr.io/caretaker-mcp:latest`) with extras
+`[admin,backend,otel,asb,k8s-worker]`. Secrets live in
+`caretaker-secrets`, manually synced from Azure Key Vault
+(`openclaw-kv-301919`).
 
-It:
+## 1. Runtime topology
 
-- loads config
-- routes events to agents
-- runs scheduled maintenance passes
-- evaluates goals (when goal engine enabled)
-- records run summaries
+How the deployed pieces talk to each other and to the data plane.
 
-### GitHub client
+```mermaid
+flowchart LR
+  subgraph External["External services"]
+    GH["GitHub App<br/>(webhooks, REST)"]
+    ANT["Anthropic<br/>(Claude)"]
+    OR["OpenRouter<br/>(LiteLLM)"]
+    AKV["Azure Key Vault<br/>openclaw-kv-301919"]
+    OTEL["OTel Collector"]
+  end
 
-[`src/caretaker/github_client/api.py`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/github_client/api.py) wraps the GitHub REST API and returns typed models for issues, PRs, comments, reviews, checks, and repository metadata.
+  subgraph AKS["AKS namespace: caretaker"]
+    direction TB
+    subgraph MCP["mcp_backend Deployment (2 replicas)"]
+      FAPI["FastAPI<br/>uvicorn :8000"]
+      WEBHOOK["/webhooks/github"]
+      ADMIN["/admin SPA"]
+      MCPTOOLS["MCP tool surface"]
+      RECON["Reconciliation<br/>scheduler<br/>(Redis lease)"]
+      FAPI --- WEBHOOK
+      FAPI --- ADMIN
+      FAPI --- MCPTOOLS
+      FAPI --- RECON
+    end
+    subgraph DISP["caretaker-job-dispatcher (1 replica)"]
+      DPMAIN["coding_jobs.dispatcher_main"]
+      SPAWN["K8sJobSpawner"]
+      DPMAIN --- SPAWN
+    end
+    subgraph JOBS["Spawned K8s Jobs (per dispatch)"]
+      JOB1["agent worker pod<br/>(opencode_local / foundry / claude-code)"]
+    end
+    SECRET["Secret: caretaker-secrets<br/>(env-injected)"]
+  end
 
-Features:
+  subgraph Data["Data plane"]
+    REDIS[("Redis Streams<br/>events, status,<br/>dedup, leases")]
+    MONGO[("MongoDB / Cosmos<br/>pr_decisions, runs")]
+    NEO[("Neo4j<br/>entity graph")]
+    SQLITE[("SQLite<br/>evolution skills,<br/>fleet registry")]
+  end
 
-- Async/await HTTP calls via httpx
-- Typed response models (Pydantic)
-- In-process read cache for GET requests
-- Fast-path PR number extraction from events
-- Automatic pagination handling
+  GH -->|"webhook POST"| WEBHOOK
+  WEBHOOK --> REDIS
+  RECON --> REDIS
+  REDIS --> DPMAIN
+  DPMAIN -->|"ASB peek-lock"| ASB[["Azure Service Bus<br/>coding-tasks queue"]]
+  ASB --> DPMAIN
+  SPAWN -->|"create Job"| JOB1
+  JOB1 -->|"status events"| REDIS
+  JOB1 -->|"git push, PR comment"| GH
+  FAPI --> MONGO
+  FAPI --> NEO
+  FAPI --> SQLITE
+  FAPI -->|"LLM"| ANT
+  FAPI -->|"LLM"| OR
+  AKV -.->|"manual sync"| SECRET
+  SECRET -.-> FAPI
+  SECRET -.-> DPMAIN
+  FAPI -->|"OTLP"| OTEL
+  DPMAIN -->|"OTLP"| OTEL
+  JOB1 -->|"OTLP"| OTEL
+```
 
-### State tracker
+Key invariants worth flagging:
 
-[`src/caretaker/state/tracker.py`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/state/tracker.py) persists tracking state inside GitHub itself so runs can resume with context.
+- **Single-pod reconciliation**: the scheduler in
+  [`caretaker.scheduler`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/scheduler) takes a Redis-backed
+  lease so only one of the two `mcp_backend` replicas fans out tick work.
+- **Single-pod dispatcher**: the `caretaker-job-dispatcher` Deployment is
+  pinned to one replica; ASB peek-lock plus K8s Job idempotency keep
+  duplicate dispatches from running.
+- **GitHub is the source of truth** for PR/issue state; everything in the
+  data plane is derived (decisions, runs, learned skills, entity graph).
 
-State includes:
+## 2. Webhook event pipeline
 
-- Tracked PRs with current state (CI passing, review approved, etc.)
-- Tracked issues with current state (triaged, assigned, etc.)
-- Known failure signatures for deduplication
-- Cooldown timers for rate-limited actions
-- Goal history snapshots (when goal engine enabled)
+What happens when a GitHub event arrives. Source of truth:
+[`src/caretaker/github_app/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/github_app),
+[`src/caretaker/eventbus/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/eventbus), and
+[`ExecutorDispatcher`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/coding_agents).
 
-### Agent modules
+```mermaid
+flowchart TD
+  GH(["GitHub event<br/>(PR, issue, check_run, push, ...)"]) --> RX["POST /webhooks/github<br/>FastAPI handler<br/>(github_app/)"]
+  RX --> SIG{"HMAC signature<br/>+ allow-list<br/>(PR #687)"}
+  SIG -->|"reject"| DROP1[/"403 / not_in_allowlist"/]
+  SIG -->|"accept"| DEDUP{"dedup key<br/>seen recently?"}
+  DEDUP -->|"yes"| DROP2[/"skip"/]
+  DEDUP -->|"no"| RL{"installation<br/>rate-limit<br/>cooldown?"}
+  RL -->|"backoff"| DROP3[/"defer"/]
+  RL -->|"ok"| ENQ["XADD to Redis Stream<br/>(eventbus/)"]
+  ENQ --> CONS["Webhook consumer group<br/>(at-least-once + reaper)"]
+  CONS --> ROUTE["Agent router<br/>EVENT_AGENT_MAP"]
+  ROUTE -->|"pull_request.*"| PRA["pr_agent / pr_reviewer /<br/>pr_ci_approver"]
+  ROUTE -->|"issues.*"| ISA["issue_agent"]
+  ROUTE -->|"check_run / workflow_run"| DEV["devops_agent /<br/>ci-fix path"]
+  ROUTE -->|"security_advisory,<br/>code_scanning_alert"| SEC["security_agent"]
+  ROUTE -->|"schedule tick"| SCHED["scheduled agents:<br/>stale, charlie, docs,<br/>upgrade, escalation,<br/>self_heal"]
+  PRA --> DISP{"ExecutorDispatcher"}
+  ISA --> DISP
+  DEV --> DISP
+  DISP --> LBL{"Label override?<br/>agent:custom /<br/>agent:copilot /<br/>agent:quarantine"}
+  LBL -->|"quarantine"| DROP4[/"refuse"/]
+  LBL -->|"custom"| FOUNDRY["Foundry<br/>(in-process LLM<br/>tool loop)"]
+  LBL -->|"copilot"| COP["Copilot hand-off<br/>(@mention comment)"]
+  LBL -->|"none"| CFG{"Config provider<br/>(per-feature)"}
+  CFG -->|"foundry"| FOUNDRY
+  CFG -->|"opencode_local /<br/>claude-code-action"| HAND["HandoffAgent<br/>(BYOCA registry)"]
+  CFG -->|"k8s job"| ASB[["Enqueue ASB<br/>coding-tasks"]]
+  CFG -->|"default"| COP
+  FOUNDRY --> RESULT[/"git push +<br/>PR comment"/]
+  HAND --> RESULT
+  COP --> RESULT
+  ASB --> RESULT
+  CONS --> OBS[/"OTEL spans +<br/>Prom metrics<br/>(observability/)"/]
+```
 
-Each concern lives in its own package under `src/caretaker/`, which keeps the policy boundaries crisp and the testing surface manageable.
+The ExecutorDispatcher's selection order is:
 
-Agent packages:
+1. **Label override** — `agent:custom`, `agent:copilot`, `agent:quarantine`
+   take precedence over everything else.
+2. **Per-feature config provider** — `.github/maintainer/config.yml`
+   chooses `foundry`, `opencode_local`, `claude-code-action`, or
+   `k8s-job` for a given feature (e.g. `pr_reviewer`, `ci_fix`).
+3. **Copilot fallback** — preserves the legacy `@copilot` hand-off.
 
-- `pr_agent/` — PR monitoring and auto-merge
-- `issue_agent/` — Issue triage and dispatch
-- `devops_agent/` — Default-branch CI monitoring
-- `self_heal_agent/` — Caretaker self-diagnosis
-- `security_agent/` — Security alert triage
-- `dependency_agent/` — Dependency update management
-- `docs_agent/` — Changelog and docs reconciliation
-- `charlie_agent/` — Operational clutter cleanup
-- `stale_agent/` — Stale work closure
-- `upgrade_agent/` — Caretaker version upgrades
-- `escalation_agent/` — Human escalation digest
+## 3. Coding-job lifecycle
 
-### Goal engine
+The durable path introduced in
+[#700](https://github.com/ianlintner/caretaker/pull/700). Used when a
+coding task needs an isolated, longer-running execution environment than
+the FastAPI request can provide — shells out to a per-task Kubernetes
+Job.
 
-[`src/caretaker/goals/`](https://github.com/ianlintner/caretaker/tree/main/src/caretaker/goals) adds a quantitative goal-seeking layer on top of agent execution.
+```mermaid
+sequenceDiagram
+  participant GH as GitHub
+  participant MCP as mcp_backend (FastAPI)
+  participant ASB as Azure Service Bus<br/>coding-tasks queue
+  participant DISP as job-dispatcher pod
+  participant K8S as Kubernetes API
+  participant POD as agent worker Job
+  participant RDS as Redis Streams<br/>job-status
+  participant RP as ResultPoster
 
-It:
+  GH->>MCP: webhook (PR/issue trigger)
+  MCP->>MCP: ExecutorDispatcher selects k8s backend
+  MCP->>ASB: send CodingTask message
+  loop peek-lock consumer
+    DISP->>ASB: receive (peek-lock)
+    DISP->>K8S: create Job (image, args, env)
+    DISP->>RDS: write_status(SPAWNING)
+    K8S->>POD: schedule + run agent
+    POD->>POD: opencode_local / foundry / claude-code
+    POD->>GH: git fetch, modify, push --force-with-lease
+    POD->>GH: post PR/issue comment
+    POD->>RDS: write_status(SUCCESS or FAILED)
+    DISP->>RDS: reconciler tracks status
+    DISP->>ASB: complete (or abandon on retryable error)
+  end
+  RP->>RDS: tail job-status stream
+  RP->>GH: post final result comment
+```
 
-- evaluates repository health across measurable goals (CI health, PR lifecycle, security posture, and self-health)
-- assigns each goal a score from `0.0` to `1.0`
-- detects unhealthy trends (critical, diverging, stale)
-- produces a goal-driven dispatch plan that prioritizes agents with the highest expected impact
-- records per-goal history for trend analysis and escalation
+Failure modes worth knowing:
 
-The orchestrator still runs the mode-eligible agents, but the goal engine can reorder execution so urgent work is handled first.
+- **Lock expiry**: ASB peek-lock duration must exceed worst-case Job
+  scheduling latency, otherwise the message is redelivered while the
+  Job is still running. Idempotency key on the K8s Job name guards
+  against double-spawn.
+- **Stuck Job**: the dispatcher's reconciler tracks SPAWNING entries in
+  Redis and abandons the ASB message after a timeout so it retries.
+- **No status emitted**: if a worker dies before writing terminal status,
+  the next dispatcher tick reconciles from K8s Job state and posts a
+  failure comment via `ResultPoster`.
 
-See the [goals documentation](goals.md) for details.
+## 4. Agent inventory
 
-### Memory store
+Eighteen agents under [`src/caretaker/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker), grouped by
+how they are triggered.
 
-[`src/caretaker/state/memory.py`](https://github.com/ianlintner/caretaker/tree/main/src/caretaker/state) provides persistent, disk-backed agent memory using SQLite.
+```mermaid
+flowchart LR
+  subgraph EVT["Event-driven (webhook)"]
+    PRAGENT["pr_agent<br/>monitor PRs, auto-merge"]
+    PRREV["pr_reviewer<br/>LLM inline review"]
+    PRCI["pr_ci_approver<br/>approve stuck bot CI"]
+    ISA["issue_agent<br/>triage + dispatch"]
+    DEPA["dependency_agent<br/>Dependabot PRs"]
+    SECA["security_agent<br/>CodeQL, secret scan,<br/>Dependabot alerts"]
+    DEVA["devops_agent<br/>main-branch CI"]
+  end
 
-Features:
+  subgraph SCH["Scheduled (reconciliation tick)"]
+    STALE["stale_agent<br/>close stale items"]
+    CHAR["charlie_agent<br/>cleanup duplicates"]
+    DOCS["docs_agent<br/>changelog reconcile"]
+    UPG["upgrade_agent<br/>caretaker version bumps"]
+    ESC["escalation_agent<br/>human digest"]
+    SH["self_heal_agent<br/>backend self-diagnosis"]
+  end
 
-- Namespaced key-value storage for different agent concerns
-- Deduplication signatures that persist across runs
-- Automatic snapshot generation for auditing
-- Bounded storage with configurable limits
-- Used by DevOps and Self-Heal agents for cooldown tracking
+  subgraph DIS["Dispatch-time / advisory"]
+    REV["review_agent<br/>grade runs/PRs"]
+    PRIN["principal_agent<br/>architectural review"]
+    REFA["refactor_agent"]
+    PERF["perf_agent"]
+    MIG["migration_agent<br/>upgrade impact"]
+    TST["test_agent"]
+    BOOT["bootstrap_agent<br/>scaffold new repos"]
+  end
 
-## Workflow model
+  WH(["GitHub webhook"]) --> EVT
+  TICK(["scheduler tick<br/>(Redis lease)"]) --> SCH
+  EVT -.->|"may invoke"| DIS
+  SCH -.->|"may invoke"| DIS
+```
 
-1. GitHub emits an event or a schedule fires.
-2. The workflow runs the `caretaker` CLI.
-3. The orchestrator evaluates quantitative goals and computes urgency.
-4. The orchestrator selects an agent or full maintenance pass (goal-prioritized when enabled).
-5. The chosen agent reads repository state through the GitHub client.
-6. The agent creates labels, comments, issues, or PR actions as needed.
-7. Run state, goal history, and summaries are persisted for the next execution.
+For per-flow detail on the PR agent (10 sub-flows including triage,
+readiness, CI fix, review, merge, cascade), see
+[pr-flows-diagrams.md](pr-flows-diagrams.md).
+
+## Data plane
+
+| Store | What lives there | Module |
+|---|---|---|
+| **Redis Streams** | Webhook event bus, job-status stream, dedup keys, scheduler lease, fleet heartbeat, installation token cache | [`eventbus/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/eventbus) |
+| **MongoDB / Cosmos** | `pr_decisions` collection, archived runs (Cosmos-compatible queries — [#695](https://github.com/ianlintner/caretaker/pull/695)) | [`runs/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/runs), [`state/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/state) |
+| **Neo4j** | Entity-relationship graph across PRs, issues, agents, decisions | [`graph/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/graph) |
+| **SQLite (in-pod)** | Evolution insight store (skills, reflections), fleet registry store | [`evolution/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/evolution), [`fleet/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/fleet) |
+| **GitHub** | Authoritative PR / issue / comment / branch state | (implicit) |
+
+## Cross-cutting layers
+
+| Layer | Module | Responsibility |
+|---|---|---|
+| Observability | [`observability/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/observability) | OTEL spans per agent, Prometheus RED middleware, cost tracking, PR-timeline metrics ([#685](https://github.com/ianlintner/caretaker/pull/685)) |
+| Auth & Identity | [`auth/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/auth), [`identity/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/identity) | GitHub App JWT + installation tokens, OIDC for fleet & admin, OAuth2 service-to-service, bot-login classifier |
+| Guardrails | [`guardrails/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/guardrails) | Input sanitization (injection sigils, Unicode, byte budgets), output filtering, checkpoint-and-rollback for post-merge mutations |
+| Evolution | [`evolution/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/evolution) | Insight store, skill abstractions, reflection engine, strategy mutator, agent-file evolver, shadow-decision infrastructure |
+| Evaluation | [`eval/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/eval) | Offline harness over shadow-decision stream, Braintrust integration, nightly Prom gauges |
+| Fleet registry | [`fleet/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/fleet) | Opt-in heartbeat from consumer repos, allow-list ([#687](https://github.com/ianlintner/caretaker/pull/687)), global-skill promotion |
+| Consensus & causal | [`consensus/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/consensus), [`causal_chain.py`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/causal_chain.py) | Multi-agent consensus + causal-chain reconstruction for postmortems |
+
+## External integrations
+
+- **GitHub App** — webhook receiver, JWT signing, installation-token
+  minting (cached in Redis), comment posting via short-lived tokens
+  rather than `GITHUB_TOKEN` ([#693](https://github.com/ianlintner/caretaker/pull/693), [`58561a8`](https://github.com/ianlintner/caretaker/commit/58561a8)).
+- **Anthropic / OpenRouter / LiteLLM** — provider abstraction in
+  [`llm/`](https://github.com/ianlintner/caretaker/blob/main/src/caretaker/llm); per-feature model routing via
+  `feature_models` config; `:online` suffix for web-grounded calls.
+- **Azure Service Bus** — durable coding-task queue with peek-lock
+  consumer pattern.
+- **Azure Key Vault → caretaker-secrets** — manual sync workflow
+  (see runbook in [`docs/observability.md`](observability.md)).
+- **OpenTelemetry collector** — OTLP/gRPC from all three process types.
+- **Braintrust** (optional) — shadow-decision evaluation; fail-open
+  when SDK or API key absent.
 
 ## Why this design works
 
-- **stateless execution** at the workflow layer
-- **durable progress tracking** in GitHub itself
-- **narrow agent responsibilities** for easier reasoning and testing
-- **Copilot as executor** instead of embedding code-writing logic in the orchestrator
+- **Stateless request path, durable job path** — webhook handlers stay
+  fast (FastAPI handler does only enqueue + dedup + rate-limit); long
+  work happens out-of-band in K8s Jobs.
+- **Multiple coding backends behind one dispatcher** — Foundry,
+  Copilot, opencode_local, and claude-code-action are
+  hot-swappable per feature without touching agent code.
+- **Narrow agent responsibilities** — each `*_agent/` package owns one
+  concern; the orchestrator and ExecutorDispatcher are the only
+  cross-cutting points.
+- **GitHub remains the source of truth** — every other store is
+  derivable from GitHub state, which keeps recovery and dogfooding
+  cheap.
 
-In short: the orchestrator decides, Copilot does, GitHub remembers.
+In short: **the orchestrator decides, coding backends do, GitHub
+remembers.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,11 @@ markdown_extensions:
   - tables
   - toc:
       permalink: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 strict: true
 


### PR DESCRIPTION
## Summary

The previous `docs/architecture.md` only described the orchestrator + 11 agents and was written for the GitHub-Actions-driven era. The actual system has evolved into a webhook-driven control plane with a durable K8s coding-job pipeline (PR #700), 18 agents, four execution backends, and a five-store data plane — none of which was on the page.

This rewrites the page around four Mermaid diagrams reflecting the **current** system, plus short tables for the data plane, cross-cutting layers, and external integrations.

### What's new on the page

| # | Diagram | What it answers |
|---|---|---|
| 1 | **Runtime topology** (`flowchart LR`) | What's deployed and how do the pods, queues, and stores connect? |
| 2 | **Webhook event pipeline** (`flowchart TD`) | What happens when a GitHub event arrives, including the ExecutorDispatcher selection chain (label override → config provider → Foundry / HandoffAgent / Copilot / k8s-job)? |
| 3 | **Coding-job lifecycle** (`sequenceDiagram`) | The full ASB → dispatcher → K8s Job → Redis status → ResultPoster path from PR #700 |
| 4 | **Agent inventory** (`flowchart LR`) | All 18 agents grouped by trigger (event-driven / scheduled / dispatch-time) |

### MkDocs change

Enables Mermaid rendering via `pymdownx.superfences` custom fence — `mkdocs-material` 9.x auto-loads the Mermaid JS bundle when it sees `class: mermaid`. No new dependency needed.

## Test plan

- [x] `uv run --extra docs mkdocs build --strict` passes (verified locally)
- [x] All four diagrams validated with the Mermaid renderer (`flowchart`, `flowchart`, `sequence`, `flowchart`)
- [x] All source-tree links rewritten to absolute GitHub URLs (strict mode rejects `../src/...` relative links)
- [ ] Reviewer: spot-check that diagrams reflect your understanding of the system — especially the ExecutorDispatcher fallback chain and the agent-trigger groupings
- [ ] Reviewer: confirm Neo4j is correct as a data store (only inferred from `src/caretaker/graph/`; happy to drop if it's optional/experimental)

## Notes / follow-ups

- I attempted a FigJam export of the runtime topology via the Figma MCP `generate_diagram` tool but it requires interactively selecting a team/org plan in the widget, which I couldn't resolve from this session. The Mermaid source is portable — Figma's official Mermaid plugin imports any of these directly if you want a Figma copy.
- The data-model ER diagram (Mongo + Neo4j + SQLite + Redis schemas) was deliberately skipped per the brainstorming discussion — happy to add later if useful.
- Things this page intentionally does NOT cover but could in a follow-up: per-agent state machines (only `pr_agent` has one in [pr-flows-diagrams.md](https://github.com/ianlintner/caretaker/blob/main/docs/pr-flows-diagrams.md)), the goal-engine scoring math, the evolution/skills lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)