### PR TITLE
docs: refresh README + 4 doc pages to current architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,29 @@ instructions.
 
 ## Features
 
+### Coding backends
+
+When an agent needs to make a code change, it routes through the
+`ExecutorDispatcher`, which picks one of four backends per dispatch:
+
+- **Copilot** — `@copilot` hand-off comment (the legacy default).
+- **Foundry** — in-process LLM tool loop, drives Azure AI Foundry or
+  any LiteLLM-compatible provider directly from `mcp_backend`.
+- **HandoffAgent** — tags the PR/issue and lets `claude-code-action`
+  or `opencode_local` GitHub Actions run asynchronously.
+- **K8s Job** — durable per-task pod for long-running work; brokered
+  through Azure Service Bus and the `caretaker-job-dispatcher`
+  deployment.
+
+Three labels override per-item: `agent:custom`, `agent:copilot`,
+`agent:quarantine`.
+
 ### Core Agents
+
+These eleven agents handle the day-to-day repository workload. Seven
+additional specialist agents (review, principal, refactor, perf,
+migration, test, bootstrap) are documented in
+[docs/agents.md](https://ianlintner.github.io/caretaker/agents/).
 
 #### PR Agent
 - Monitors all open PRs in real-time
@@ -99,7 +121,7 @@ instructions.
 
 #### Issue Agent
 - Triages incoming issues (bug, feature, question, duplicate, stale)
-- Dispatches implementable issues to Copilot
+- Dispatches implementable issues through the configured coding backend
 - Tracks issue → PR → merge lifecycle
 - Auto-closes answered questions and stale issues (configurable)
 - Escalates complex issues to repo owners
@@ -108,10 +130,10 @@ instructions.
 - Monitors default-branch CI failures
 - Automatically creates fix issues for build/test failures
 - Deduplicates similar issues with cooldown periods
-- Assigns work to Copilot for resolution
+- Routes fixes through the configured coding backend
 
 #### Self-Heal Agent
-- Detects backend agent failures during a run
+- Detects `mcp_backend` and dispatcher failures
 - Creates self-diagnosis issues
 - Reports bugs to upstream caretaker repository (configurable)
 - Ensures the system can maintain itself
@@ -155,7 +177,7 @@ instructions.
 
 #### Upgrade Agent
 - Detects new caretaker releases
-- Creates upgrade issues for Copilot execution
+- Creates upgrade issues for the configured coding backend to execute
 - Supports multiple strategies: auto-minor, auto-patch, latest, pinned
 - Handles breaking vs. non-breaking upgrades
 - Version pinning via `.version` file
@@ -340,19 +362,37 @@ memory_store:
 
 ## Architecture
 
+The orchestrator runs server-side on AKS, not in your repo. Three
+deployable processes split the work:
+
 ```
-Orchestrator (Python, runs in GitHub Actions)
+GitHub App webhooks
   │
-  ├── Reads config.yml
-  ├── Reads repo state (open PRs, issues, CI status)
-  ├── Decides what needs to happen
-  │
-  ├── For code changes → creates/updates issues → assigns to @copilot
-  ├── For PR fixes → posts structured comments as the `COPILOT_PAT` identity → @mentions copilot
-  └── For escalation → labels + tags repo owner
+  ▼
+mcp_backend (FastAPI x2, AKS)
+  │   ├── HMAC + allow-list
+  │   ├── dedup + rate-limit
+  │   └── Redis Streams ──► agent router ──► ExecutorDispatcher
+  │                                              │
+  │                                              ├──► Copilot @-mention (legacy)
+  │                                              ├──► Foundry  (in-process LLM tool loop)
+  │                                              ├──► HandoffAgent  (opencode_local / claude-code-action)
+  │                                              └──► Azure Service Bus ──► caretaker-job-dispatcher
+  │                                                                              │
+  │                                                                              ▼
+  │                                                                         per-task K8s Job
+  │                                                                              │
+  ▼                                                                              ▼
+MongoDB / Cosmos · Neo4j · SQLite                                          git push + PR comment
 ```
 
-The orchestrator **never writes code**. It manages Copilot, which does.
+Eighteen agents live behind the dispatcher, grouped by trigger
+(event-driven, scheduled, dispatch-time / advisory). The orchestrator
+**never writes code itself** — it routes to one of four coding backends.
+
+For diagrams of the runtime topology, webhook event pipeline, durable
+coding-job lifecycle, and full agent inventory, see
+[docs/architecture.md](https://ianlintner.github.io/caretaker/architecture/).
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,24 +1,23 @@
 # Agents
 
-Caretaker is organized as a set of focused agents coordinated by the orchestrator.
+Caretaker is organized as eighteen focused agents coordinated by a webhook
+event pipeline and a scheduled reconciliation tick. The
+[Architecture](architecture.md) page has the diagrams; this page covers
+each agent in depth.
 
-## Core agents
+Agents are grouped by trigger:
 
-| Agent            | Responsibility                                                                |
-| ---------------- | ----------------------------------------------------------------------------- |
-| PR agent         | monitors pull requests, triages CI failures, requests fixes, merges when safe |
-| Issue agent      | classifies issues and dispatches work to Copilot or escalates it              |
-| DevOps agent     | turns default-branch CI failures into actionable fix issues                   |
-| Self-heal agent  | investigates caretaker's own workflow failures                                |
-| Security agent   | triages Dependabot, code scanning, and secret scanning alerts                 |
-| Dependency agent | reviews Dependabot PRs, auto-merges safe bumps, posts digests                 |
-| Docs agent       | reconciles merged PRs into changelog/docs updates                             |
-| Charlie agent    | closes duplicate or abandoned caretaker-managed issues and PRs                |
-| Stale agent      | warns/closes stale work and prunes merged branches                            |
-| Upgrade agent    | detects new caretaker releases and opens upgrade work                         |
-| Escalation agent | creates a digest for work requiring human attention                           |
+| Tier | Triggered by | Agents |
+| --- | --- | --- |
+| **Event-driven** | GitHub webhooks | PR, PR Reviewer, PR CI Approver, Issue, Dependency, Security, DevOps |
+| **Scheduled** | Reconciliation tick (Redis lease, single-pod) | Stale, Charlie, Docs, Upgrade, Escalation, Self-Heal |
+| **Dispatch-time / advisory** | Invoked by other agents during dispatch | Review, Principal, Refactor, Perf, Migration, Test, Bootstrap |
 
-## Detailed descriptions
+## Event-driven tier
+
+These agents react to GitHub events delivered via the App webhook
+endpoint. The webhook receiver dedup'es and rate-limits, then enqueues
+to a Redis Stream consumer group that fans out to the right agent.
 
 ### PR Agent
 
@@ -50,6 +49,29 @@ pr_agent:
     flaky_retries: 1
 ```
 
+The PR agent runs ten sub-flows; see
+[pr-flows-diagrams.md](https://github.com/ianlintner/caretaker/blob/main/docs/pr-flows-diagrams.md)
+for the full state machine.
+
+### PR Reviewer
+
+**Purpose:** Inline LLM code review.
+
+Posts review comments on PRs using either an in-process LLM call or a
+hand-off to `claude-code-action` / `opencode_local`. Tier-based model
+selection picks Sonnet/Opus/Haiku based on PR size and risk. Runs as
+a separate agent from the PR agent so review decisions stay
+independent from merge decisions.
+
+### PR CI Approver
+
+**Purpose:** Surface and auto-approve stuck bot CI runs.
+
+Some workflows require manual approval for first-time contributors or
+forked PRs. This agent watches for stuck `action_required` runs from
+trusted bots (Copilot, Dependabot) and approves them so CI can complete
+without a human.
+
 ### Issue Agent
 
 **Purpose:** Triage and route incoming issues to the right destination.
@@ -74,50 +96,28 @@ issue_agent:
   auto_close_questions: true
 ```
 
-### DevOps Agent
+### Dependency Agent
 
-**Purpose:** Keep the default branch CI healthy.
+**Purpose:** Keep dependencies up to date safely.
 
 **What it does:**
 
-- Monitors default-branch (usually `main`) workflow runs
-- Detects CI failures on the latest commit
-- Creates detailed fix issues with error context
-- Deduplicates similar failures using signatures
-- Enforces cooldown periods to prevent issue spam
-- Assigns fix issues to Copilot for resolution
-- Limits max issues per run to avoid overwhelming the queue
+- Reviews all Dependabot PRs
+- Auto-merges patch updates when tests pass
+- Auto-merges minor updates when configured
+- Posts weekly digest of dependency changes
+- Uses smart merge strategies (squash/merge/rebase)
+- Coordinates with PR agent for CI checks
+- Escalates major version updates to humans
 
 **Key config:**
 
 ```yaml
-devops_agent:
-  target_branch: main
-  max_issues_per_run: 3
-  dedup_open_issues: true
-  cooldown_hours: 6
-```
-
-### Self-Heal Agent
-
-**Purpose:** Ensure caretaker itself stays operational.
-
-**What it does:**
-
-- Monitors caretaker's own workflow runs
-- Detects failures in orchestrator execution
-- Creates self-diagnosis issues with error logs
-- Optionally reports bugs upstream to caretaker repo
-- Implements cooldown to prevent duplicate reports
-- Ensures the system can maintain itself
-
-**Key config:**
-
-```yaml
-self_heal_agent:
-  report_upstream: true
-  is_upstream_repo: false # set true for caretaker repo itself
-  cooldown_hours: 6
+dependency_agent:
+  auto_merge_patch: true
+  auto_merge_minor: true
+  post_digest: true
+  merge_method: squash
 ```
 
 ### Security Agent
@@ -145,78 +145,36 @@ security_agent:
   include_secret_scanning: true
 ```
 
-### Dependency Agent
+### DevOps Agent
 
-**Purpose:** Keep dependencies up to date safely.
+**Purpose:** Keep the default branch CI healthy.
 
 **What it does:**
 
-- Reviews all Dependabot PRs
-- Auto-merges patch updates when tests pass
-- Auto-merges minor updates when configured
-- Posts weekly digest of dependency changes
-- Uses smart merge strategies (squash/merge/rebase)
-- Coordinates with PR agent for CI checks
-- Escalates major version updates to humans
+- Monitors default-branch (usually `main`) workflow runs
+- Detects CI failures on the latest commit
+- Creates detailed fix issues with error context
+- Deduplicates similar failures using signatures
+- Enforces cooldown periods to prevent issue spam
+- Routes fixes through the configured coding backend
+- Limits max issues per run to avoid overwhelming the queue
 
 **Key config:**
 
 ```yaml
-dependency_agent:
-  auto_merge_patch: true
-  auto_merge_minor: true
-  post_digest: true
-  merge_method: squash
+devops_agent:
+  target_branch: main
+  max_issues_per_run: 3
+  dedup_open_issues: true
+  cooldown_hours: 6
 ```
 
-### Docs Agent
+## Scheduled tier
 
-**Purpose:** Keep documentation synchronized with code changes.
-
-**What it does:**
-
-- Scans recently merged PRs (configurable lookback)
-- Generates changelog entries from PR metadata
-- Updates `CHANGELOG.md` with categorized changes
-- Optionally updates README or other docs
-- Creates weekly docs update branches
-- Posts summary of documentation changes
-- Handles merge conflicts gracefully
-
-**Key config:**
-
-```yaml
-docs_agent:
-  lookback_days: 7
-  changelog_path: CHANGELOG.md
-  update_readme: false
-```
-
-### Charlie Agent
-
-**Purpose:** Clean up operational clutter from caretaker's own work.
-
-**What it does:**
-
-- Detects duplicate caretaker-managed issues
-- Detects duplicate caretaker-managed PRs
-- Closes abandoned work after 14 days (shorter than general stale)
-- Prevents operational work from snowballing
-- Respects exempt labels (pinned, escalated)
-- Runs before the broader stale agent
-- Focused only on caretaker-generated content
-
-**Key config:**
-
-```yaml
-charlie_agent:
-  stale_days: 14
-  close_duplicate_issues: true
-  close_duplicate_prs: true
-  exempt_labels:
-    - pinned
-    - maintainer:escalated
-```
+Triggered by the in-cluster `ReconciliationScheduler`, which holds a
+Redis-backed lease so only one of the two `mcp_backend` replicas fans
+out work each tick. The scheduler emits a synthetic schedule event per
+installed repo so the same agent code paths run as in the webhook tier.
 
 ### Stale Agent
 
@@ -245,6 +203,55 @@ stale_agent:
     - security
 ```
 
+### Charlie Agent
+
+**Purpose:** Clean up operational clutter from caretaker's own work.
+
+**What it does:**
+
+- Detects duplicate caretaker-managed issues
+- Detects duplicate caretaker-managed PRs
+- Closes abandoned work after 14 days (shorter than general stale)
+- Prevents operational work from snowballing
+- Respects exempt labels (pinned, escalated)
+- Runs before the broader stale agent
+- Focused only on caretaker-generated content
+
+**Key config:**
+
+```yaml
+charlie_agent:
+  stale_days: 14
+  close_duplicate_issues: true
+  close_duplicate_prs: true
+  exempt_labels:
+    - pinned
+    - maintainer:escalated
+```
+
+### Docs Agent
+
+**Purpose:** Keep documentation synchronized with code changes.
+
+**What it does:**
+
+- Scans recently merged PRs (configurable lookback)
+- Generates changelog entries from PR metadata
+- Updates `CHANGELOG.md` with categorized changes
+- Optionally updates README or other docs
+- Creates weekly docs update branches
+- Posts summary of documentation changes
+- Handles merge conflicts gracefully
+
+**Key config:**
+
+```yaml
+docs_agent:
+  lookback_days: 7
+  changelog_path: CHANGELOG.md
+  update_readme: false
+```
+
 ### Upgrade Agent
 
 **Purpose:** Keep caretaker itself up to date in consumer repos.
@@ -253,7 +260,7 @@ stale_agent:
 
 - Checks GitHub releases for new caretaker versions
 - Compares against pinned `.github/maintainer/.version`
-- Creates upgrade issues for Copilot to execute
+- Creates upgrade issues for the configured backend to execute
 - Supports multiple strategies: auto-minor, auto-patch, latest, pinned
 - Handles breaking vs. non-breaking upgrades differently
 - Supports preview channel for early adopters
@@ -293,24 +300,120 @@ escalation:
   labels: ["maintainer:escalated"]
 ```
 
+### Self-Heal Agent
+
+**Purpose:** Ensure caretaker itself stays operational.
+
+**What it does:**
+
+- Monitors caretaker's own backend for runtime failures
+- Creates self-diagnosis issues with error logs
+- Optionally reports bugs upstream to caretaker repo
+- Implements cooldown to prevent duplicate reports
+- Ensures the system can maintain itself
+
+**Key config:**
+
+```yaml
+self_heal_agent:
+  report_upstream: true
+  is_upstream_repo: false # set true for caretaker repo itself
+  cooldown_hours: 6
+```
+
+## Dispatch-time / advisory tier
+
+These agents are not directly triggered by webhooks or the scheduler.
+They are invoked by other agents during dispatch — typically to grade,
+review, or supplement work — and run inside the same process or are
+hand-off targets through the `ExecutorDispatcher`.
+
+### Review Agent
+
+Grades runs, PRs, and issues against a rubric. Used by the evolution
+loop to score shadow decisions.
+
+### Principal Agent
+
+Provides architectural review on larger changes. Targeted at PRs that
+the PR agent flags as cross-cutting; routes through a higher-tier model
+(Opus by default) for deeper analysis.
+
+### Refactor Agent
+
+Long-form refactor planning and execution. Typically routed through the
+durable [coding-job pipeline](architecture.md#3-coding-job-lifecycle)
+because refactors take longer than a single FastAPI request.
+
+### Perf Agent
+
+Performance-regression triage. Reads benchmark output from CI, identifies
+hot spots, and creates fix issues with profiling artefacts attached.
+
+### Migration Agent
+
+Upgrade impact analysis. When the upgrade agent surfaces a breaking
+release, the migration agent expands the impact scope, drafts a plan,
+and (optionally) opens a tracking issue with stage gates.
+
+### Test Agent
+
+Test-coverage and test-failure heuristics. Used during CI-fix flows to
+distinguish flaky from genuinely broken tests.
+
+### Bootstrap Agent
+
+Scaffolds caretaker setup files in new repos. The
+[setup guide](https://github.com/ianlintner/caretaker/blob/main/setup-templates/SETUP_AGENT.md)
+is the human-readable version; the bootstrap agent is the
+machine-readable equivalent for automated rollouts.
+
 ## How they collaborate
 
-- the **orchestrator** decides which agent to run based on the event or scheduled mode
-- the **GitHub client** is the shared integration layer for repo state and mutations
-- the **state tracker** persists issue/PR tracking data in GitHub comments
-- the **LLM layer** adds higher-quality reasoning where configured (`ANTHROPIC_API_KEY`)
-- the **goal engine** (experimental) prioritizes agents based on quantitative goals
-- the **memory store** provides persistent deduplication across runs
+- the **webhook receiver** in `mcp_backend` dedup's, rate-limits, and
+  fans events out to a Redis Stream consumer group
+- the **agent router** maps event types to event-driven agents via
+  `EVENT_AGENT_MAP`
+- the **`ExecutorDispatcher`** picks the coding backend per dispatch:
+  label override → per-feature config provider → Copilot fallback
+- the **`ReconciliationScheduler`** drives the scheduled tier on a tick,
+  fanning out one synthetic event per installed repo
+- the **state tracker** persists tracking state in GitHub itself
+  (comments, labels), with derived state in MongoDB / Cosmos and Neo4j
+- the **goal engine** (experimental) reorders agent execution by
+  goal-impact when enabled
 
 ## Event mapping
 
-| GitHub signal                                                     | Typical agent path                                 |
-| ----------------------------------------------------------------- | -------------------------------------------------- |
-| `pull_request`, `pull_request_review`, `check_run`, `check_suite` | PR agent                                           |
-| `issues`, `issue_comment`                                         | Issue agent                                        |
-| `workflow_run`                                                    | DevOps agent + Self-heal agent                     |
-| `repository_vulnerability_alert`                                  | Security agent                                     |
-| scheduled/manual full run                                         | orchestrator invokes the broader maintenance cycle |
+| GitHub signal | Routed to |
+| --- | --- |
+| `pull_request`, `pull_request_review` | PR agent, PR reviewer |
+| `check_run`, `check_suite`, `workflow_run` | DevOps agent, PR CI approver |
+| `issues`, `issue_comment` | Issue agent |
+| `repository_vulnerability_alert`, `code_scanning_alert`, `secret_scanning_alert` | Security agent |
+| Dependabot PR | Dependency agent |
+| scheduled tick (synthetic) | Stale, Charlie, Docs, Upgrade, Escalation, Self-Heal |
+
+## Coding backends
+
+When an agent needs to make a code change, it routes through the
+`ExecutorDispatcher`, which selects one of four backends:
+
+- **Copilot** — `@copilot` hand-off comment, the legacy default
+- **Foundry** — in-process LLM tool loop, drives Azure AI Foundry or
+  any LiteLLM-compatible provider
+- **HandoffAgent** — tags PR/issue and lets `claude-code-action` or
+  `opencode_local` GitHub Actions complete the work asynchronously
+- **K8s Job** — durable per-task pod for longer-running work,
+  brokered through Azure Service Bus and the
+  `caretaker-job-dispatcher` deployment
+
+Three labels override backend selection per item:
+
+- `agent:custom` — force the custom executor (Foundry by default)
+- `agent:copilot` — force the legacy path
+- `agent:quarantine` — refuse dispatch entirely (for hostile or
+  confusing items)
 
 ## Copilot-facing instructions
 
@@ -327,4 +430,5 @@ The repo ships instruction files for Copilot-driven execution:
 - `.github/agents/security-triage.md` — security agent persona
 - `.github/agents/escalation-review.md` — escalation review agent persona
 
-Those files define how Copilot should behave when Caretaker assigns work or requests changes.
+Those files define how Copilot should behave when Caretaker assigns
+work or requests changes.

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,14 +43,16 @@ mkdocs serve
 
 ## Important directories
 
-| Path                 | Purpose                          |
-| -------------------- | -------------------------------- |
-| `src/caretaker/`     | source package                   |
-| `tests/`             | unit and integration-style tests |
-| `schema/`            | versioned config schema          |
-| `setup-templates/`   | consumer repo templates          |
-| `.github/workflows/` | CI and orchestrator automation   |
-| `docs/`              | documentation site content       |
+| Path                 | Purpose                                                  |
+| -------------------- | -------------------------------------------------------- |
+| `src/caretaker/`     | source package                                           |
+| `tests/`             | unit and integration-style tests                         |
+| `schema/`            | versioned config schema                                  |
+| `setup-templates/`   | consumer repo templates                                  |
+| `infra/k8s/`         | AKS Deployment manifests reconciled by Flux              |
+| `Dockerfile.mcp`     | image used by `mcp_backend` and `caretaker-job-dispatcher` |
+| `.github/workflows/` | CI for this repo (lint, test, image build, docs publish) |
+| `docs/`              | documentation site content                               |
 
 ## CI expectations
 
@@ -62,6 +64,12 @@ The main CI workflow validates:
 - pytest with coverage
 
 The docs workflow separately builds the MkDocs site and publishes it to GitHub Pages on `main`.
+
+A separate image-build workflow publishes
+`gabby.azurecr.io/caretaker-mcp:latest` on each merge to `main`; Flux
+then reconciles the new image into AKS for `mcp_backend` and
+`caretaker-job-dispatcher`. See [Architecture](architecture.md) for
+the runtime topology.
 
 ## Documentation publishing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,9 +73,12 @@ Optional, but strongly recommended for hands-free Copilot iteration:
 
 A configured repository typically gets:
 
-- `.github/workflows/maintainer.yml`
-- `.github/maintainer/config.yml`
-- `.github/copilot-instructions.md`
-- `.github/agents/*.md`
+- `.github/maintainer/config.yml` — repo-specific config
+- `.github/maintainer/.version` — pinned caretaker version
+- `.github/copilot-instructions.md` — global Copilot project memory
+- `.github/agents/*.md` — per-agent personas
 
-Those files define the workflow triggers, repo-specific config, and agent instructions that let the orchestrator and Copilot work together.
+No workflow file is installed. Caretaker runs server-side on AKS and
+receives GitHub App webhooks; consumer repos only ship config and
+Copilot instructions. See [Architecture](architecture.md) for the
+runtime topology.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Caretaker
 
-Caretaker is an autonomous repository-maintenance system that uses GitHub Copilot as the execution engine and a Python orchestrator as the coordinator.
+Caretaker is an autonomous repository-maintenance system. A Python control plane on AKS receives GitHub App webhooks, decides what should happen next, and dispatches code changes to one of four coding backends — GitHub Copilot, an in-process LLM tool loop (Foundry), the `opencode_local` / `claude-code-action` hand-off, or a per-task Kubernetes Job.
 
 It watches pull requests, issues, CI failures, upgrades, stale work, and security findings, then routes the right next action instead of waiting for a human to play inbox pinball.
 
@@ -16,6 +16,7 @@ It watches pull requests, issues, CI failures, upgrades, stale work, and securit
 ## Start here
 
 - [Getting started](getting-started.md)
+- [Architecture](architecture.md) — the runtime topology, webhook event pipeline, coding-job lifecycle, and 18-agent inventory
 - [Configuration reference](configuration.md)
 - [Agent overview](agents.md)
 - [Development workflow](development.md)


### PR DESCRIPTION
## Summary

Companion to [#702](https://github.com/ianlintner/caretaker/pull/702) — propagates the current architecture (webhook-driven on AKS, 18 agents in 3 tiers, 4 coding backends behind `ExecutorDispatcher`) into the most user-visible docs.

| File | Change |
|---|---|
| `README.md` | Replace stale "Architecture" ASCII (showed in-GitHub-Actions orchestrator) with webhook → mcp_backend → ExecutorDispatcher → backend block. Add Coding backends section. Light per-agent fixes where descriptions said "to Copilot" — now route through configured coding backend. Pointer to specialist agents in docs/agents.md. |
| `docs/agents.md` | Restructure to 18 agents grouped by trigger (event-driven 7 / scheduled 6 / dispatch-time advisory 7). Keeps detailed treatment of the 11 core agents, adds short entries for pr_reviewer, pr_ci_approver, review_agent, principal_agent, refactor_agent, perf_agent, migration_agent, test_agent, bootstrap_agent. Adds Coding backends section, refreshes event-mapping table. |
| `docs/index.md` | Tagline now describes the AKS control plane and four coding backends. Adds Architecture link to start-here list. |
| `docs/getting-started.md` | Removes stale claim that `.github/workflows/maintainer.yml` is installed in consumer repos (README itself says no workflow file is needed). |
| `docs/development.md` | Adds `infra/k8s/` and `Dockerfile.mcp` to important-paths table. Documents image-build → Flux reconciliation path. |

## Out of scope (deferred follow-ups)

- `docs/configuration.md` — 244 lines, needs per-key verification against `setup-templates/templates/config-default.yml`. Worth flagging: an audit suggested `auto_merge` was superseded by `merge_authority` — verified false (`auto_merge` is still the live key).
- `docs/observability.md`, `docs/pr-ownership.md`, `docs/fleet-registry.md`, `docs/fleet-opt-in-runbook.md`, `docs/github-app-phase2.md`, `docs/github-app-rollout.md`, `docs/admin-dashboard-activation.md` — operational docs closer to recent feature work; lower staleness, defer to per-feature PRs.
- `docs/goals.md`, `docs/causal-chains.md`, `docs/release-notes.md` — low staleness, no action required this pass.

## Test plan

- [x] `uv run --extra docs mkdocs build --strict` passes
- [ ] Reviewer: spot-check the new README "Architecture" ASCII matches your mental model
- [ ] Reviewer: confirm the 7 specialist agents (review/principal/refactor/perf/migration/test/bootstrap) are correctly classified as "dispatch-time / advisory" (they may also fire on schedule in some configs — happy to adjust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)