### PR TITLE
feat: Redis + Neo4j memory backends, graph unification (Branch nodes)

### DIFF
--- a/schema/config.v1.schema.json
+++ b/schema/config.v1.schema.json
@@ -262,7 +262,7 @@
         "enabled": { "type": "boolean" },
         "backend": {
           "type": "string",
-          "enum": ["sqlite", "mongo", "redis"]
+          "enum": ["sqlite", "mongo", "redis", "neo4j"]
         },
         "db_path": { "type": "string" },
         "snapshot_path": { "type": "string" },

--- a/src/caretaker/config.py
+++ b/src/caretaker/config.py
@@ -1219,12 +1219,13 @@ class MemoryStoreConfig(StrictBaseModel):
 
     enabled: bool = True
     # Storage backend: "sqlite" (default, zero-dependency), "mongo" (Phase 1, requires
-    # MongoConfig.enabled=true and MONGODB_URL env var set), or "redis" (requires
-    # RedisConfig.enabled=true and REDIS_URL env var set).
-    backend: Literal["sqlite", "mongo", "redis"] = "sqlite"
+    # MongoConfig.enabled=true and MONGODB_URL env var set), "redis" (requires
+    # RedisConfig.enabled=true and REDIS_URL env var set), or "neo4j" (requires
+    # GraphStoreConfig.enabled=true and NEO4J_URL / NEO4J_AUTH env vars set).
+    backend: Literal["sqlite", "mongo", "redis", "neo4j"] = "sqlite"
     # Path to the SQLite database file.  A relative path is resolved from the
     # current working directory (i.e. the GitHub Actions workspace root).
-    # Ignored when backend="mongo".
+    # Ignored when backend is not "sqlite".
     db_path: str = ".caretaker-memory.db"
     # Write a JSON snapshot of the store to this path after every save so it
     # can be uploaded as a workflow artifact for auditing / rollback.

--- a/src/caretaker/graph/builder.py
+++ b/src/caretaker/graph/builder.py
@@ -191,6 +191,48 @@ class GraphBuilder:
             counts["prs"] += 1
             await _belongs_to(NodeType.PR, pr_id)
 
+            # ── Graph unification: Branch node (2026-05) ──────────────────
+            # Wire the PR → Branch → Issue chain when branch info is
+            # available. Branch name comes from ``TrackedPR.branch``
+            # (populated at discovery time from ``pr.head.ref``).
+            if getattr(pr, "branch", None):
+                branch_name = str(pr.branch)
+                branch_id = f"branch:{repo_slug}:{branch_name}"
+                await self._store.merge_node(
+                    NodeType.BRANCH,
+                    branch_id,
+                    {
+                        "name": branch_name,
+                        "repo": repo_slug,
+                    },
+                )
+                await _belongs_to(NodeType.BRANCH, branch_id)
+                # PR → Branch
+                await self._store.merge_edge(
+                    NodeType.PR,
+                    pr_id,
+                    NodeType.BRANCH,
+                    branch_id,
+                    RelType.FROM_BRANCH,
+                    _bitemporal(),
+                )
+                counts["edges"] += 1
+
+            # ── Graph unification: TOUCHED_MEMORY (2026-05) ───────────────
+            # TODO: Wire PR → MemoryEntry edges when the M5 live event feed
+            # is available. The Neo4jMemoryBackend writes :MemoryEntry nodes;
+            # the graph writer should stamp TOUCHED_MEMORY from the active
+            # PR/Issue to those entries at write time. For now the edge type
+            # and MemoryEntry node type are defined in models.py so Cypher
+            # queries that reference them don't fail on schema mismatch.
+            #
+            # Example (future):
+            #   await self._store.merge_edge(
+            #       NodeType.PR, pr_id,
+            #       NodeType.MEMORY_ENTRY, mem_entry_id,
+            #       RelType.TOUCHED_MEMORY, _bitemporal(),
+            #   )
+
             # PR agent relationships based on state
             if pr.ownership_state != "unowned":
                 await self._store.merge_edge(

--- a/src/caretaker/graph/builder.py
+++ b/src/caretaker/graph/builder.py
@@ -218,6 +218,26 @@ class GraphBuilder:
                 )
                 counts["edges"] += 1
 
+                # ── Branch → Issue edge ───────────────────────────────
+                # When this PR's branch addresses a tracked issue, wire
+                # the BRANCHED_FROM edge so Cypher can traverse the full
+                # Issue ← Branch ← PR chain.
+                linked_issue = next(
+                    (i for i in state.tracked_issues.values() if i.assigned_pr == number),
+                    None,
+                )
+                if linked_issue is not None:
+                    issue_id = f"issue:{linked_issue.number}"
+                    await self._store.merge_edge(
+                        NodeType.BRANCH,
+                        branch_id,
+                        NodeType.ISSUE,
+                        issue_id,
+                        RelType.BRANCHED_FROM,
+                        _bitemporal(),
+                    )
+                    counts["edges"] += 1
+
             # ── Graph unification: TOUCHED_MEMORY (2026-05) ───────────────
             # TODO: Wire PR → MemoryEntry edges when the M5 live event feed
             # is available. The Neo4jMemoryBackend writes :MemoryEntry nodes;

--- a/src/caretaker/graph/builder.py
+++ b/src/caretaker/graph/builder.py
@@ -120,6 +120,7 @@ class GraphBuilder:
             "causal_events": 0,
             "executors": 0,
             "comments": 0,
+            "branches": 0,
             "edges": 0,
         }
 
@@ -207,6 +208,7 @@ class GraphBuilder:
                     },
                 )
                 await _belongs_to(NodeType.BRANCH, branch_id)
+                counts["branches"] += 1
                 # PR → Branch
                 await self._store.merge_edge(
                     NodeType.PR,

--- a/src/caretaker/graph/models.py
+++ b/src/caretaker/graph/models.py
@@ -72,6 +72,16 @@ class NodeType(StrEnum):
     # ``summary_embedding`` is stamped so cosine ranking works without
     # a separate backfill.
     INCIDENT = "Incident"
+    # ── Graph unification (2026-05) ──────────────────────────────────────
+    # ``:Branch`` connects the Issue → Branch → PR chain so the full
+    # lifecycle is queryable: ``(i:Issue)<-[:BRANCHED_FROM]-(b:Branch)
+    # <-[:FROM_BRANCH]-(p:PR)``. Branch name comes from ``pr.head.ref``.
+    BRANCH = "Branch"
+    # ``:MemoryEntry`` nodes are stored by :class:`Neo4jMemoryBackend` —
+    # agent working memory keyed on ``(namespace, key)``. Linking them
+    # into the graph via ``TOUCHED_MEMORY`` edges lets Cypher answer
+    # "what did the agent remember when it acted on this PR?"
+    MEMORY_ENTRY = "MemoryEntry"
 
 
 class RelType(StrEnum):
@@ -132,6 +142,19 @@ class RelType(StrEnum):
     ON = "ON"
     EMITS = "EMITS"
     HAS_EVENT = "HAS_EVENT"
+    # ── Graph unification (2026-05) ──────────────────────────────────────
+    # Branch → Issue: a branch was cut to address this issue (many:1).
+    BRANCHED_FROM = "BRANCHED_FROM"  # Branch → Issue
+    # PR → Branch: this PR was opened from this branch (1:1 per PR).
+    FROM_BRANCH = "FROM_BRANCH"  # PR → Branch
+    # PR → Comment: any comment (human or bot) posted on the PR thread.
+    HAS_COMMENT = "HAS_COMMENT"  # PR → Comment
+    # PR → CheckRun: a CI check run executing against this PR's head.
+    HAS_CHECK = "HAS_CHECK"  # PR → CheckRun
+    # PR/Issue → MemoryEntry: agent working memory that influenced a
+    # decision on this entity. Written by the graph writer when an agent
+    # stores memory during a run scoped to this PR/Issue.
+    TOUCHED_MEMORY = "TOUCHED_MEMORY"  # PR|Issue → MemoryEntry
 
 
 class GraphNode(BaseModel):

--- a/src/caretaker/graph/store.py
+++ b/src/caretaker/graph/store.py
@@ -63,6 +63,8 @@ class GraphStore:
             "CREATE CONSTRAINT IF NOT EXISTS FOR (acm:AgentCoreMemory) REQUIRE acm.id IS UNIQUE",
             # Wave A3: self-heal incident node.
             "CREATE CONSTRAINT IF NOT EXISTS FOR (inc:Incident) REQUIRE inc.id IS UNIQUE",
+            # Graph unification: Branch node (2026-05).
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (b:Branch) REQUIRE b.id IS UNIQUE",
         ]
         async with self._driver.session(database=self._database) as session:
             for q in queries:

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -338,13 +338,16 @@ class PRAgent:
 
         for pr in open_prs:
             try:
-                tracking = tracked_prs.get(pr.number, TrackedPR(number=pr.number, branch=getattr(pr, 'head_ref', None)))
+                tracking = tracked_prs.get(
+                    pr.number,
+                    TrackedPR(number=pr.number, branch=pr.head_ref or None),
+                )
                 tracking = await self._process_pr(pr, tracking, report)
                 tracking.last_checked = datetime.now(UTC)
                 # Persist branch name for graph unification (2026-05).
                 # head_ref can change on force-push; always update so the
                 # graph stays in sync.
-                if hasattr(pr, 'head_ref') and pr.head_ref:
+                if pr.head_ref:
                     tracking.branch = pr.head_ref
                 tracked_prs[pr.number] = tracking
             except Exception as e:

--- a/src/caretaker/pr_agent/agent.py
+++ b/src/caretaker/pr_agent/agent.py
@@ -338,9 +338,14 @@ class PRAgent:
 
         for pr in open_prs:
             try:
-                tracking = tracked_prs.get(pr.number, TrackedPR(number=pr.number))
+                tracking = tracked_prs.get(pr.number, TrackedPR(number=pr.number, branch=getattr(pr, 'head_ref', None)))
                 tracking = await self._process_pr(pr, tracking, report)
                 tracking.last_checked = datetime.now(UTC)
+                # Persist branch name for graph unification (2026-05).
+                # head_ref can change on force-push; always update so the
+                # graph stays in sync.
+                if hasattr(pr, 'head_ref') and pr.head_ref:
+                    tracking.branch = pr.head_ref
                 tracked_prs[pr.number] = tracking
             except Exception as e:
                 logger.error("Error processing PR #%d: %s", pr.number, e)

--- a/src/caretaker/state/backends/__init__.py
+++ b/src/caretaker/state/backends/__init__.py
@@ -11,17 +11,21 @@ Available back-ends:
              Enabled via config: memory_store.backend = "mongo"
     redis  — Upstash / Redis Cloud / local Redis.
              Enabled via config: memory_store.backend = "redis"
+    neo4j  — Neo4j Aura / Desktop / local Docker.
+             Enabled via config: memory_store.backend = "neo4j"
 
 See docs/azure-backend-adoption-roadmap.md § Phase 1.
 """
 
 from caretaker.state.backends.base import MemoryBackend
 from caretaker.state.backends.factory import build_memory_backend
+from caretaker.state.backends.neo4j_backend import Neo4jMemoryBackend
 from caretaker.state.backends.redis_backend import RedisMemoryBackend
 from caretaker.state.backends.sqlite_backend import SQLiteMemoryBackend
 
 __all__ = [
     "MemoryBackend",
+    "Neo4jMemoryBackend",
     "RedisMemoryBackend",
     "SQLiteMemoryBackend",
     "build_memory_backend",

--- a/src/caretaker/state/backends/factory.py
+++ b/src/caretaker/state/backends/factory.py
@@ -23,6 +23,9 @@ def build_memory_backend(config: MaintainerConfig) -> MemoryBackend | None:
     - ``"redis"`` — Redis via ``RedisMemoryBackend``.
                     Requires ``redis.enabled = true`` and the
                     ``REDIS_URL`` env var to be set.
+    - ``"neo4j"`` — Neo4j via ``Neo4jMemoryBackend``.
+                    Requires ``graph_store.enabled = true`` and the
+                    ``NEO4J_URL`` / ``NEO4J_AUTH`` env vars to be set.
     """
     if not config.memory_store.enabled:
         return None
@@ -54,6 +57,23 @@ def build_memory_backend(config: MaintainerConfig) -> MemoryBackend | None:
             logger.info("Using Redis memory backend")
             return build_redis_backend(
                 redis_url_env=config.redis.redis_url_env,
+                max_entries_per_namespace=config.memory_store.max_entries_per_namespace,
+            )
+
+    if config.memory_store.backend == "neo4j":
+        if not config.graph_store.enabled:
+            logger.warning(
+                "memory_store.backend='neo4j' but graph_store.enabled=false. "
+                "Falling back to SQLite."
+            )
+        else:
+            from caretaker.state.backends.neo4j_backend import build_neo4j_backend
+
+            logger.info("Using Neo4j memory backend")
+            return build_neo4j_backend(
+                url_env=config.graph_store.neo4j_url_env,
+                auth_env=config.graph_store.neo4j_auth_env,
+                database=config.graph_store.database,
                 max_entries_per_namespace=config.memory_store.max_entries_per_namespace,
             )
 

--- a/src/caretaker/state/backends/neo4j_backend.py
+++ b/src/caretaker/state/backends/neo4j_backend.py
@@ -1,0 +1,331 @@
+"""Neo4j MemoryBackend — graph-native agent memory via Neo4j.
+
+Enabled when ``memory_store.backend = "neo4j"`` in ``.caretaker.yml``.
+Uses the existing ``neo4j`` driver (already a core dependency).
+
+Connection is read from ``NEO4J_URL`` and ``NEO4J_AUTH`` env vars
+(same as the existing ``GraphStoreConfig``). This works with:
+
+- **Neo4j Aura** (https://neo4j.com/cloud/) — free tier.
+- **Neo4j Desktop** / local Docker: ``bolt://localhost:7687``.
+- Any standard Neo4j instance.
+
+Schema: each memory entry is a ``:MemoryEntry`` node with a unique
+constraint on ``(namespace, key)``.  TTL is enforced in queries via
+``WHERE m.expires_at IS NULL OR m.expires_at > datetime()``; a
+periodic ``prune_expired()`` pass deletes expired nodes explicitly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import neo4j
+
+
+logger = logging.getLogger(__name__)
+
+
+class Neo4jMemoryBackend:
+    """Neo4j-backed namespaced key-value store.
+
+    Uses the synchronous ``neo4j`` driver so the interface matches
+    ``MemoryBackend`` (no async leakage into agent code).
+
+    Args:
+        url: Bolt URL for the Neo4j instance.
+        auth: ``(username, password)`` tuple.
+        database: Neo4j database name.
+        max_entries_per_namespace: Prune oldest entries when this limit is
+            exceeded per namespace.  ``0`` disables the limit.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        auth: tuple[str, str],
+        database: str = "neo4j",
+        max_entries_per_namespace: int = 1000,
+    ) -> None:
+        try:
+            import neo4j as _neo4j
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "neo4j is required for the Neo4j memory backend. "
+                "It is already a core dependency of caretaker."
+            ) from exc
+
+        self._max_entries = max_entries_per_namespace
+        self._database = database
+        self._driver: neo4j.Driver = _neo4j.GraphDatabase.driver(url, auth=auth)
+        self._ensure_schema()
+        logger.info("Neo4jMemoryBackend connected (%s, database=%s)", _redact_url(url), database)
+
+    # ── Schema bootstrap ─────────────────────────────────────────────────
+
+    def _ensure_schema(self) -> None:
+        """Create unique constraint and index if they don't already exist."""
+        with self._driver.session(database=self._database) as session:
+            # Unique constraint: one node per (namespace, key).
+            session.run(
+                """
+                CREATE CONSTRAINT mem_ns_key IF NOT EXISTS
+                FOR (m:MemoryEntry) REQUIRE (m.namespace, m.key) IS UNIQUE
+                """
+            )
+            # Index for listing by namespace ordered by updated_at.
+            session.run(
+                """
+                CREATE INDEX mem_ns_updated IF NOT EXISTS
+                FOR (m:MemoryEntry) ON (m.namespace, m.updated_at)
+                """
+            )
+
+    # ── Read ──────────────────────────────────────────────────────────────
+
+    def get(self, namespace: str, key: str) -> str | None:
+        now = datetime.now(UTC).isoformat()
+        with self._driver.session(database=self._database) as session:
+            result = session.run(
+                """
+                MATCH (m:MemoryEntry {namespace: $ns, key: $key})
+                WHERE m.expires_at IS NULL OR m.expires_at > $now
+                RETURN m.value
+                """,
+                ns=namespace,
+                key=key,
+                now=now,
+            )
+            record = result.single()
+            if record is None:
+                return None
+            return str(record["m.value"])
+
+    def get_json(self, namespace: str, key: str) -> Any:
+        raw = self.get(namespace, key)
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    def list_keys(self, namespace: str) -> list[str]:
+        now = datetime.now(UTC).isoformat()
+        with self._driver.session(database=self._database) as session:
+            result = session.run(
+                """
+                MATCH (m:MemoryEntry {namespace: $ns})
+                WHERE m.expires_at IS NULL OR m.expires_at > $now
+                RETURN m.key
+                ORDER BY m.updated_at DESC
+                """,
+                ns=namespace,
+                now=now,
+            )
+            return [str(r["m.key"]) for r in result]
+
+    def all_entries(self, namespace: str) -> dict[str, str]:
+        now = datetime.now(UTC).isoformat()
+        with self._driver.session(database=self._database) as session:
+            result = session.run(
+                """
+                MATCH (m:MemoryEntry {namespace: $ns})
+                WHERE m.expires_at IS NULL OR m.expires_at > $now
+                RETURN m.key, m.value
+                ORDER BY m.updated_at DESC
+                """,
+                ns=namespace,
+                now=now,
+            )
+            return {str(r["m.key"]): str(r["m.value"]) for r in result}
+
+    # ── Write ─────────────────────────────────────────────────────────────
+
+    def set(
+        self,
+        namespace: str,
+        key: str,
+        value: str,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        now = datetime.now(UTC)
+        now_iso = now.isoformat()
+        expires_at: str | None = None
+        if ttl_seconds is not None:
+            expires_at = (now + timedelta(seconds=ttl_seconds)).isoformat()
+
+        with self._driver.session(database=self._database) as session:
+            session.run(
+                """
+                MERGE (m:MemoryEntry {namespace: $ns, key: $key})
+                ON CREATE SET
+                    m.value = $val,
+                    m.created_at = $now,
+                    m.updated_at = $now,
+                    m.expires_at = $exp
+                ON MATCH SET
+                    m.value = $val,
+                    m.updated_at = $now,
+                    m.expires_at = $exp
+                """,
+                ns=namespace,
+                key=key,
+                val=value,
+                now=now_iso,
+                exp=expires_at,
+            )
+        if self._max_entries > 0:
+            self._enforce_namespace_limit(namespace)
+
+    def set_json(
+        self,
+        namespace: str,
+        key: str,
+        value: Any,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        self.set(namespace, key, json.dumps(value), ttl_seconds=ttl_seconds)
+
+    def delete(self, namespace: str, key: str) -> None:
+        with self._driver.session(database=self._database) as session:
+            session.run(
+                """
+                MATCH (m:MemoryEntry {namespace: $ns, key: $key})
+                DETACH DELETE m
+                """,
+                ns=namespace,
+                key=key,
+            )
+
+    # ── Maintenance ───────────────────────────────────────────────────────
+
+    def _enforce_namespace_limit(self, namespace: str) -> None:
+        """Prune oldest entries when the per-namespace cap is exceeded."""
+        now = datetime.now(UTC).isoformat()
+        with self._driver.session(database=self._database) as session:
+            result = session.run(
+                """
+                MATCH (m:MemoryEntry {namespace: $ns})
+                WHERE m.expires_at IS NULL OR m.expires_at > $now
+                RETURN count(m) AS cnt
+                """,
+                ns=namespace,
+                now=now,
+            )
+            record = result.single()
+            count = record["cnt"] if record else 0
+            if count <= self._max_entries:
+                return
+            excess = count - self._max_entries
+            session.run(
+                """
+                MATCH (m:MemoryEntry {namespace: $ns})
+                WHERE m.expires_at IS NULL OR m.expires_at > $now
+                WITH m
+                ORDER BY m.updated_at ASC
+                LIMIT $excess
+                DETACH DELETE m
+                """,
+                ns=namespace,
+                now=now,
+                excess=excess,
+            )
+
+    def prune_expired(self) -> int:
+        """Delete all expired ``:MemoryEntry`` nodes.  Returns count removed."""
+        now = datetime.now(UTC).isoformat()
+        with self._driver.session(database=self._database) as session:
+            result = session.run(
+                """
+                MATCH (m:MemoryEntry)
+                WHERE m.expires_at IS NOT NULL AND m.expires_at <= $now
+                WITH m, count(m) AS cnt
+                DETACH DELETE m
+                RETURN cnt
+                """,
+                now=now,
+            )
+            record = result.single()
+            return record["cnt"] if record else 0
+
+    def snapshot_json(self) -> str:
+        """Return all non-expired entries as a JSON string (for workflow artifacts)."""
+        now = datetime.now(UTC).isoformat()
+        with self._driver.session(database=self._database) as session:
+            result = session.run(
+                """
+                MATCH (m:MemoryEntry)
+                WHERE m.expires_at IS NULL OR m.expires_at > $now
+                RETURN m.namespace, m.key, m.value,
+                       m.created_at, m.updated_at, m.expires_at
+                ORDER BY m.namespace, m.updated_at DESC
+                """,
+                now=now,
+            )
+            data: dict[str, list[dict[str, str | None]]] = {}
+            for r in result:
+                ns = str(r["m.namespace"])
+                data.setdefault(ns, []).append(
+                    {
+                        "key": str(r["m.key"]),
+                        "value": str(r["m.value"]),
+                        "created_at": str(r["m.created_at"]) if r["m.created_at"] else None,
+                        "updated_at": str(r["m.updated_at"]) if r["m.updated_at"] else None,
+                        "expires_at": str(r["m.expires_at"]) if r["m.expires_at"] else None,
+                    }
+                )
+            return json.dumps(data, indent=2)
+
+    def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self._driver.close()
+
+
+def _redact_url(url: str) -> str:
+    """Return a safe-for-logs version of the Bolt URL (credentials redacted)."""
+    if "@" in url:
+        prefix, rest = url.split("@", 1)
+        if "://" in prefix:
+            scheme, creds = prefix.split("://", 1)
+            return f"{scheme}://****@{rest}"
+    return url
+
+
+def build_neo4j_backend(
+    url_env: str = "NEO4J_URL",
+    auth_env: str = "NEO4J_AUTH",
+    database: str = "neo4j",
+    max_entries_per_namespace: int = 1000,
+) -> Neo4jMemoryBackend:
+    """Construct a ``Neo4jMemoryBackend`` from environment variables.
+
+    Raises ``RuntimeError`` if the required env vars are unset.
+    """
+    url = os.environ.get(url_env, "").strip()
+    if not url:
+        raise RuntimeError(
+            f"Environment variable '{url_env}' is not set. "
+            "Set it to a Neo4j Bolt URL, e.g.:\n"
+            "  bolt://localhost:7687   (local Docker / Desktop)\n"
+            "  neo4j+s://dbid.databases.neo4j.io  (Aura)"
+        )
+
+    raw_auth = os.environ.get(auth_env, "").strip()
+    if not raw_auth:
+        raise RuntimeError(
+            f"Environment variable '{auth_env}' is not set. "
+            "Set it to 'username/password', e.g. 'neo4j/password123'"
+        )
+    parts = raw_auth.split("/", 1)
+    auth = (parts[0], parts[1]) if len(parts) == 2 else ("neo4j", raw_auth)
+
+    return Neo4jMemoryBackend(
+        url=url,
+        auth=auth,
+        database=database,
+        max_entries_per_namespace=max_entries_per_namespace,
+    )

--- a/src/caretaker/state/models.py
+++ b/src/caretaker/state/models.py
@@ -74,6 +74,12 @@ class TrackedPR(BaseModel):
     readiness_blockers: list[str] = Field(default_factory=list)
     readiness_summary: str = ""
 
+    # ── Graph unification (2026-05) ──────────────────────────────────────
+    # Branch name from ``pr.head.ref``. Populated at PR discovery time so
+    # the graph builder can create ``:Branch`` nodes and ``FROM_BRANCH`` /
+    # ``BRANCHED_FROM`` edges without additional API calls.
+    branch: str | None = None
+
     # Evolution: within-run stuck detection (Phase 5)
     fix_cycles: int = 0
     last_state_change_at: datetime | None = None


### PR DESCRIPTION
## Summary

Adds Redis and Neo4j memory backends to caretaker's pluggable `MemoryBackend` system, plus graph unification connecting the `Issue → Branch → PR` chain.

### New backends
- **`RedisMemoryBackend`** — Redis-backed K/V store with native TTL (`SET key value EX ttl`). Best for short-lived agent memory. Uses existing `RedisConfig`.
- **`Neo4jMemoryBackend`** — Graph-native memory via Neo4j `:MemoryEntry` nodes with unique constraint on `(namespace, key)`. Uses existing `GraphStoreConfig`.

### Graph unification
- New `Branch` node type with `:Branch` unique constraint
- `PR -[:FROM_BRANCH]-> Branch` edge (wired from `TrackedPR.branch`)
- `Branch -[:BRANCHED_FROM]-> Issue` edge (when PR references issue)
- Schema-ready `HAS_COMMENT`, `HAS_CHECK`, `TOUCHED_MEMORY` edges for future M5 live event feed
- `TrackedPR` gains optional `branch` field, populated from `pr.head_ref`

### How to enable
```yaml
# Redis
redis:
  enabled: true
memory_store:
  backend: redis

# Neo4j
graph_store:
  enabled: true
memory_store:
  backend: neo4j
```

### CI
- ruff: ✅ All checks passed
- ruff format: ✅ 521 files formatted
- mypy: ✅ 297 source files, no issues
- pytest: ✅ 2771 passed