### PR TITLE
fix(k8s): reduce event bus MAXLEN to 500 and pin dispatcher managed identity

### DIFF
--- a/infra/k8s/caretaker-job-dispatcher-deployment.yaml
+++ b/infra/k8s/caretaker-job-dispatcher-deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "caretaker-job-dispatcher"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-collector.default.svc.cluster.local:4317"
+            - name: AZURE_CLIENT_ID
+              value: "e502213f-1f15-4f03-9fb4-b546f51aafe9"
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:

--- a/infra/k8s/caretaker-mcp-deployment.yaml
+++ b/infra/k8s/caretaker-mcp-deployment.yaml
@@ -212,11 +212,10 @@ spec:
             # consumer task per replica drains the stream. Survives pod
             # restart; load-balanced across replicas via consumer group.
             - name: CARETAKER_EVENT_BUS_MAXLEN
-              # Keep the Redis stream comfortably below the 400Mi Redis
-              # maxmemory cap. Large scheduler payloads previously filled
-              # Redis before reaching 100k entries, causing login session
-              # writes to fail with OutOfMemoryError.
-              value: "5000"
+              # Keep the Redis stream well below the 1Gi Redis maxmemory cap.
+              # Each caretaker:events entry averages ~260 KiB; 500 entries ≈ 130 MiB.
+              # Previously 5000 caused OOM (5000 × 260 KiB ≈ 1.3 GiB > 1 GiB limit).
+              value: "500"
             - name: CARETAKER_EVENT_BUS_CLAIM_IDLE_MS
               value: "300000"
             - name: CARETAKER_EVENT_BUS_REAPER_INTERVAL_SECONDS


### PR DESCRIPTION
## Summary

Two production K8s deployment fixes applied after live incident debugging.

### 1. Redis OOM — caretaker-mcp MAXLEN 5000 → 500

**Root cause:** `CARETAKER_EVENT_BUS_MAXLEN=5000` with ~260 KiB average entry size results in ~1.3 GiB of stream data, exceeding the 1 GiB Redis `maxmemory` limit. The `volatile-lru` eviction policy cannot evict stream entries (no TTL), so Redis rejected all writes with OOM errors, cascading to consumer timeout failures.

**Fix:** Reduce MAXLEN to 500 (≈ 130 MiB), leaving ~87% of Redis headroom for sessions, config cache, and other keys.

**Verified:** Stream trimmed live (`XTRIM caretaker:events MAXLEN 500`); Redis memory dropped from 1.07 GiB → 94 MiB. New pods now enforce MAXLEN=500 via the env var.

### 2. Azure IMDS 400 / Service Bus auth — dispatcher AZURE_CLIENT_ID

**Root cause:** AKS nodes have 3 user-assigned managed identities (`azurekeyvaultsecretsprovider-bigboy`, `bigboy-agentpool`, `ext-ab18b3e58a3b1bb5106ced208a8bd460-bigboy`). IMDS returns HTTP 400 ("Multiple user assigned identities exist") when no `client_id` hint is provided.

**Fix:** Pin `AZURE_CLIENT_ID=e502213f-1f15-4f03-9fb4-b546f51aafe9` (`bigboy-agentpool`) which holds `Azure Service Bus Data Owner` on the `thebiggestboy` namespace.

**Verified:** New dispatcher pod logs show `DefaultAzureCredential acquired a token from ManagedIdentityCredential` and Service Bus AMQP link state `ATTACHED`.

## Testing

All CI checks pass locally:
- `ruff check src/ tests/` ✅
- `ruff format --check src/ tests/` ✅  
- `mypy src/` ✅
- `pytest tests/ -q` → 2707 passed ✅

Changes already applied to live cluster and verified healthy.