### PR TITLE
chore(maintainer): remediate escalated Dependabot security findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ backend = [
 admin = [
     "fastapi>=0.100,<1",
     "uvicorn>=0.23,<1",
-    "authlib>=1.3,<2",           # OIDC/OAuth2 client
+    "authlib>=1.7.2,<2",         # OIDC/OAuth2 client (security: OIDC redirect validation fixes)
     "itsdangerous>=2.1,<3",      # session cookie signing
     "neo4j>=5.0,<6",             # Neo4j async driver
     "redis[asyncio]>=5,<6",      # session storage
@@ -96,7 +96,7 @@ admin = [
 # Anthropic SDK remains the default; install this extra and set
 # ``llm.provider: litellm`` in config to enable other backends.
 llm-multi = [
-    "litellm>=1.83.7,<2",
+    "litellm>=1.83.11,<2",  # security: fixes custom-code guardrail sandbox escape
     "aiohttp>=3.13.5",  # security: CVE-2026-34516 multipart header bypass + CVE-2024-52304 zip bomb
 ]
 # Phase 3 custom coding agent — on-demand Kubernetes Job worker. See
@@ -223,5 +223,5 @@ ignore_missing_imports = true
 # that fixes CVE-2025-14974 (symlink following in set_key/unset_key).
 override-dependencies = [
     "python-dotenv>=1.2.2",
-    "gitpython>=3.1.49",
+    "gitpython>=3.1.50",
 ]

--- a/src/caretaker/observability/bootstrap.py
+++ b/src/caretaker/observability/bootstrap.py
@@ -126,6 +126,16 @@ def _redact_authorization_request_hook(span: Any, request: Any) -> None:
         pass
 
 
+async def _aredact_authorization_request_hook(span: Any, request: Any) -> None:
+    """Async variant for newer httpx instrumentor hook API.
+
+    Some ``opentelemetry-instrumentation-httpx`` versions await the async
+    request hook for ``AsyncClient`` transports. Reuse the same redaction
+    logic so behavior stays identical across SDK versions.
+    """
+    _redact_authorization_request_hook(span, request)
+
+
 def bootstrap_observability(service_name: str) -> None:
     """Initialise tracing + metrics + log enrichment for one process.
 
@@ -138,9 +148,18 @@ def bootstrap_observability(service_name: str) -> None:
     def _httpx() -> None:
         from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-        HTTPXClientInstrumentor().instrument(
-            request_hook=_redact_authorization_request_hook,
-        )
+        instrumentor = HTTPXClientInstrumentor()
+        try:
+            # Newer instrumentation SDKs split sync/async hooks.
+            instrumentor.instrument(
+                request_hook=_redact_authorization_request_hook,
+                async_request_hook=_aredact_authorization_request_hook,
+            )
+        except TypeError:
+            # Older SDKs only accept ``request_hook``.
+            instrumentor.instrument(
+                request_hook=_redact_authorization_request_hook,
+            )
 
     _safe("httpx", _httpx)
 

--- a/src/caretaker/observability/metrics.py
+++ b/src/caretaker/observability/metrics.py
@@ -39,7 +39,7 @@ import logging
 import os
 import time
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
@@ -270,7 +270,7 @@ class _LiveRateLimitCooldownCollector:
 # :class:`Gauge`) bound to the collector so external code that introspects
 # via the registry continues to work.
 RATE_LIMIT_COOLDOWN_SECONDS = _LiveRateLimitCooldownCollector()
-REGISTRY.register(RATE_LIMIT_COOLDOWN_SECONDS)
+REGISTRY.register(cast("Any", RATE_LIMIT_COOLDOWN_SECONDS))
 
 
 RATE_LIMIT_REMAINING = Gauge(

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.14"
 
 [manifest]
 overrides = [
-    { name = "gitpython", specifier = ">=3.1.49" },
+    { name = "gitpython", specifier = ">=3.1.50" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
@@ -149,15 +149,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.7.1"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/f2/e05664d5275ce811fd4e9df0a2b3f0086ee19a8a80358d95499fa82fd50c/authlib-1.7.1.tar.gz", hash = "sha256:8c09b0f9d080c823e594b52316af70f79a1fa4eed64d0363a076233c04ef063a", size = 175884, upload-time = "2026-05-04T08:11:25.033Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/730650ee5e5b598b7bfdc291b784bc2f6fe02a5671695485403365101088/authlib-1.7.1-py2.py3-none-any.whl", hash = "sha256:8470f4aa6b5590ac41bd81d6e6ee12448ce36a0da0af19bbed69fb53fb4e8ad9", size = 258826, upload-time = "2026-05-04T08:11:23.208Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -340,7 +340,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.9" },
     { name = "aiohttp", marker = "extra == 'llm-multi'", specifier = ">=3.13.5" },
     { name = "anthropic", specifier = ">=0.40,<1" },
-    { name = "authlib", marker = "extra == 'admin'", specifier = ">=1.3,<2" },
+    { name = "authlib", marker = "extra == 'admin'", specifier = ">=1.7.2,<2" },
     { name = "azure-identity", marker = "extra == 'asb'", specifier = ">=1.16" },
     { name = "azure-identity", marker = "extra == 'dev'", specifier = ">=1.16" },
     { name = "azure-servicebus", marker = "extra == 'asb'", specifier = ">=7.11" },
@@ -357,7 +357,7 @@ requires-dist = [
     { name = "itsdangerous", marker = "extra == 'admin'", specifier = ">=2.1,<3" },
     { name = "kubernetes", marker = "extra == 'dev'", specifier = ">=30,<34" },
     { name = "kubernetes", marker = "extra == 'k8s-worker'", specifier = ">=30,<34" },
-    { name = "litellm", marker = "extra == 'llm-multi'", specifier = ">=1.83.7,<2" },
+    { name = "litellm", marker = "extra == 'llm-multi'", specifier = ">=1.83.11,<2" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5,<10" },
     { name = "motor", marker = "extra == 'backend'", specifier = ">=3.3,<4" },
@@ -766,14 +766,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.49"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -1095,7 +1095,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.7"
+version = "1.84.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1111,9 +1111,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/2b/b58bf6bbcbc3d0e55d0a84fdf9128e5b1436517f46fce89b1cd8948ebb81/litellm-1.83.7.tar.gz", hash = "sha256:e2f2cb99df2e2b2eab63f1354faa45c88dd7c8d40c18eb648afb1b349c689633", size = 17791694, upload-time = "2026-04-13T17:35:01.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/e9/8941b7e72a187000561d932c0f2f2ed2b0fd080dfc33ba6e05961d45ca7d/litellm-1.84.0.tar.gz", hash = "sha256:b8ad0cbea11a5941b18d5af973017a340abd3d3ab41cb86e5401b970626d71a6", size = 15103206, upload-time = "2026-05-14T05:45:53.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/80/caeb4cdcad96451ba83ad3ba2a9da08b1e1a915fa845c489f56ea044488b/litellm-1.83.7-py3-none-any.whl", hash = "sha256:5784a1d9a9a4a8acd6ca1e347003a5e2e1b3c749b4d41e7da4904577adade111", size = 16069807, upload-time = "2026-04-13T17:34:58.36Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/77fa1bbf5e42eb596b06318b3f7e6af5d0f44028046d1d598c6a595d028f/litellm-1.84.0-py3-none-any.whl", hash = "sha256:2a58d6041e6aa27d1a28dc8d8828ab500fef1a00ef74ca65e60899035010c2f2", size = 16735062, upload-time = "2026-05-14T05:45:49.927Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump minimum safe versions in `pyproject.toml`:
  - `authlib>=1.7.2,<2`
  - `litellm>=1.83.11,<2`
  - `gitpython>=3.1.50` (via uv override)
- regenerate `uv.lock` to resolve to patched releases:
  - authlib 1.7.2
  - litellm 1.84.0
  - gitpython 3.1.50
  - urllib3 2.7.0
- fix HTTPX OpenTelemetry hook compatibility for newer instrumentation API (`async_request_hook`)
- fix a strict mypy registry registration typing mismatch in metrics collector registration

## Validation
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy src/`
- `pytest tests/ -q`

All passed locally.

Closes #714
Closes #711
Closes #710
Closes #709
Closes #704
Closes #689
